### PR TITLE
A vote notification prints what that voter added, not the praxis total

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -425,7 +425,7 @@ export const mockFeedItems: Record<string, ActivityFeedItem> = {
   friend_completion: makeFeedItem({ type: 'friend_completion' }),
   vote_on_mine: makeFeedItem({
     type: 'vote_on_mine',
-    payload: { praxis_id: 501, praxis_title: 'Charcoal study, north portico', points_earned: 12 },
+    payload: { praxis_id: 501, praxis_title: 'Charcoal study, north portico', value: 4 },
   }),
   global_task: makeFeedItem({
     type: 'global_task',

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5981,7 +5981,7 @@
         "type": "object"
       },
       "VoteChangedOnMineItem": {
-        "description": "A voter went back and re-rated the viewer's praxis (#1712).\n\nSame payload as ``VoteOnMineItem`` — ``value``/``points_earned`` are the\nnumbers that stand *now* — and deliberately no \"changed from\" fields: no\nprior value is stored. The two are distinct types rather than one type with\na flag because the item KEY has to differ, so archiving the original cannot\nsilence the change.",
+        "description": "A voter went back and re-rated the viewer's praxis (#1712).\n\nSame payload as ``VoteOnMineItem`` — ``value`` is the vote that stands\n*now* — and deliberately no \"changed from\" fields: no prior value is\nstored, so the row can print what the vote is worth but never the size of\nthe change. The two are distinct types rather than one type with\na flag because the item KEY has to differ, so archiving the original cannot\nsilence the change.",
         "properties": {
           "actor_avatar_url": {
             "anyOf": [
@@ -6141,19 +6141,8 @@
       },
       "VoteOnMinePayload": {
         "additionalProperties": false,
-        "description": "Someone voted on the viewer's praxis.\n\n``points_earned`` is the praxis's **whole current score** — the same number\n``PraxisOut.score`` publishes, same type, off the same scoring path\n(ADR-0014/0053). It is what the author sees when they click the row through,\nwhich is the promise #2199 was filed about: the row used to print\n``value × task_point_value``, a product where the score is a sum, and\nannounced 120 points against a praxis worth 34.\n\nOptional because it is filled in a **second pass**: scoring is async and\nbatched, so the per-row mapper that builds this payload cannot reach it (see\n``services.activity_feed._score_vote_items``). A praxis that cannot be scored\nleaves it ``None`` and the row prints no number — never an invented one.",
+        "description": "Someone voted on the viewer's praxis.\n\n``value`` is the whole story the row needs: the \"+N pts\" it prints is the\nstars this voter gave, which is **exactly** what their vote added to the\npraxis (#2402). ``points_from_votes`` is a plain ``sum(Vote.value)`` and\n``Contribution`` adds it *after* the faction and duel multipliers, so a\nsingle vote's contribution depends on nothing else — not the other votes,\nthe author's faction, the task's points, a metatask or a duel.\n\nSo this is a delta, not a total, and there is no ``points_earned`` here.\n#2199 put the praxis's whole score on this payload, filled by a second\nscoring pass, because the per-vote number then in use was *invented*\n(``value × task_point_value``, a product where the score is a sum, which\nannounced 120 points against a praxis worth 34). The delta is not a\nrestated formula though — it is the raw input the sum is over — so it\ncannot diverge from the scoring path the way that arithmetic did, and the\npass that read the total is gone.",
         "properties": {
-          "points_earned": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Points Earned"
-          },
           "praxis_id": {
             "title": "Praxis Id",
             "type": "integer"
@@ -6187,8 +6176,7 @@
           "value",
           "praxis_id",
           "praxis_title",
-          "task_point_value",
-          "points_earned"
+          "task_point_value"
         ],
         "title": "VoteOnMinePayload",
         "type": "object"

--- a/backend/schemas/activity_feed.py
+++ b/backend/schemas/activity_feed.py
@@ -39,17 +39,21 @@ class FeedPayloadBase(WireModel):
 class VoteOnMinePayload(FeedPayloadBase):
     """Someone voted on the viewer's praxis.
 
-    ``points_earned`` is the praxis's **whole current score** — the same number
-    ``PraxisOut.score`` publishes, same type, off the same scoring path
-    (ADR-0014/0053). It is what the author sees when they click the row through,
-    which is the promise #2199 was filed about: the row used to print
-    ``value × task_point_value``, a product where the score is a sum, and
-    announced 120 points against a praxis worth 34.
+    ``value`` is the whole story the row needs: the "+N pts" it prints is the
+    stars this voter gave, which is **exactly** what their vote added to the
+    praxis (#2402). ``points_from_votes`` is a plain ``sum(Vote.value)`` and
+    ``Contribution`` adds it *after* the faction and duel multipliers, so a
+    single vote's contribution depends on nothing else — not the other votes,
+    the author's faction, the task's points, a metatask or a duel.
 
-    Optional because it is filled in a **second pass**: scoring is async and
-    batched, so the per-row mapper that builds this payload cannot reach it (see
-    ``services.activity_feed._score_vote_items``). A praxis that cannot be scored
-    leaves it ``None`` and the row prints no number — never an invented one.
+    So this is a delta, not a total, and there is no ``points_earned`` here.
+    #2199 put the praxis's whole score on this payload, filled by a second
+    scoring pass, because the per-vote number then in use was *invented*
+    (``value × task_point_value``, a product where the score is a sum, which
+    announced 120 points against a praxis worth 34). The delta is not a
+    restated formula though — it is the raw input the sum is over — so it
+    cannot diverge from the scoring path the way that arithmetic did, and the
+    pass that read the total is gone.
     """
 
     vote_id: int
@@ -58,7 +62,6 @@ class VoteOnMinePayload(FeedPayloadBase):
     # Praxis.title is nullable in the model, so a praxis genuinely can have none.
     praxis_title: Optional[str] = None
     task_point_value: int
-    points_earned: Optional[float] = None
 
 
 class CompletionPayload(FeedPayloadBase):
@@ -312,9 +315,10 @@ class VoteOnMineItem(FeedItemBase):
 class VoteChangedOnMineItem(FeedItemBase):
     """A voter went back and re-rated the viewer's praxis (#1712).
 
-    Same payload as ``VoteOnMineItem`` — ``value``/``points_earned`` are the
-    numbers that stand *now* — and deliberately no "changed from" fields: no
-    prior value is stored. The two are distinct types rather than one type with
+    Same payload as ``VoteOnMineItem`` — ``value`` is the vote that stands
+    *now* — and deliberately no "changed from" fields: no prior value is
+    stored, so the row can print what the vote is worth but never the size of
+    the change. The two are distinct types rather than one type with
     a flag because the item KEY has to differ, so archiving the original cannot
     silence the change.
     """

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -48,7 +48,6 @@ from models.praxis import ModerationStatus, Praxis, PraxisInvite, PraxisInviteSt
 from services.block_service import blocked_counterpart_ids
 from services.meta_task import character_sees_metatasks
 from services.praxis import praxis_visibility_condition
-from services.praxis_out import author_contributions_for
 from models.character_stats import CharacterStats
 from models.task import Task, TaskStatus, TaskType
 from models.taunt_message import TauntMessage
@@ -419,89 +418,15 @@ def _vote_item_factory(item_type: str) -> Callable[[Any], ActivityFeedItemDC]:
                 praxis_id=row.praxis_id,
                 praxis_title=row.praxis_title,
                 task_point_value=row.task_point_value,
-                # points_earned is deliberately absent here — see
-                # `_score_vote_items`, which fills it from the scoring path once
-                # per page. This mapper is sync and per-row; it has no honest way
-                # to reach a total, and the arithmetic it used to invent
-                # (`value * task_point_value`) was #2199.
+                # The row prints `value` and nothing else (#2402). One vote's
+                # contribution to the praxis total IS its star value —
+                # `points_from_votes` is a plain `sum(Vote.value)` that
+                # `Contribution` adds AFTER the multipliers — so this mapper
+                # needs no total, no second pass and no arithmetic of its own.
             ),
         )
 
     return build
-
-
-VOTE_ITEM_TYPES: frozenset[str] = frozenset(
-    {FEED_ITEM_TYPE_VOTE_ON_MINE, FEED_ITEM_TYPE_VOTE_CHANGED_ON_MINE}
-)
-
-
-async def _score_vote_items(
-    items: list[ActivityFeedItemDC],
-    session: AsyncSession,
-) -> list[ActivityFeedItemDC]:
-    """Fill every vote row's ``points_earned`` with the praxis's real score (#2199).
-
-    The number a vote notification prints is the number the author finds when
-    they follow it, so it is not computed here — it is *read* from the one
-    scoring path, :func:`services.praxis_out.author_contributions_for`, which is
-    what the praxis card and the praxis detail page already publish as ``score``
-    (ADR-0014/0053). Restating "base + stars" at this seam would agree with that
-    path today and diverge the moment a metatask, a Coven collab modifier or a
-    duel outcome joins the sum — which is the class of bug this replaced.
-
-    Why a second pass rather than a column on the vote query: the total needs a
-    vote tally, the author's faction and level, metatask points, the duel
-    outcome and the stamped habit bonus. That is a batched async gather, and a
-    ``FeedSource``'s ``to_item`` is sync and sees one row. So the mapper builds
-    the payload without the number and this fills it, once, for the whole page.
-
-    The cost is real and is paid ONLY when the page carries a vote row: the
-    praxis fetch plus ``author_contributions_for``'s own bulk queries, every one
-    of them flat in the number of vote rows. ``test_activity_feed_query_count``
-    pins the total so it cannot regrow quietly.
-
-    ponytail: four of those statements are ``Praxis``'s ``selectin`` loaders
-    (``task``, ``created_by``, ``members``, and members' characters) firing for
-    relationships nothing on this path reads. The obvious ``.options(lazyload(
-    "*"))`` is NOT taken: it would put relationship-less ``Praxis`` instances in
-    the session's identity map, and ``/me/sidebar`` builds praxis cards off the
-    same session and the same rows — a card reaching ``praxis.task`` on one of
-    them raises ``MissingGreenlet``. The upgrade path is a scoring entry point
-    that takes praxis IDs instead of ORM instances, which would drop the fetch
-    and its tail together and serve ``services.era`` and ``character_stats``
-    equally well.
-
-    A praxis with no contribution (its author gone, or unscoreable) keeps
-    ``points_earned=None`` and the row renders without a figure. The one thing
-    this must never do is guess.
-    """
-    praxis_ids = {
-        item.payload.praxis_id for item in items if item.type in VOTE_ITEM_TYPES
-    }
-    if not praxis_ids:
-        return items
-
-    praxes_result = await session.execute(
-        select(Praxis).where(Praxis.id.in_(praxis_ids))
-    )
-    contributions = await author_contributions_for(
-        list(praxes_result.scalars()), session
-    )
-
-    def scored(item: ActivityFeedItemDC) -> ActivityFeedItemDC:
-        if item.type not in VOTE_ITEM_TYPES:
-            return item
-        contribution = contributions.get(item.payload.praxis_id)
-        if contribution is None:
-            return item
-        return replace(
-            item,
-            payload=item.payload.model_copy(
-                update={"points_earned": contribution.total}
-            ),
-        )
-
-    return [scored(item) for item in items]
 
 
 def _completions_query_factory(character_ids_attr: str) -> Callable[[FeedContext], Select]:
@@ -1696,15 +1621,16 @@ async def _fetch_sources(
 
     Order is irrelevant: the caller sorts the merged list by timestamp.
 
-    The one post-pass is :func:`_score_vote_items` (#2199), here rather than in
-    either entry point because both the Updates page and the rail's activity
-    panel route through this function — a fix at one caller would leave the
-    other printing the old number.
+    There is no post-pass. #2199 added one — a praxis fetch plus the whole
+    scoring path — purely to stamp a total onto vote rows, and #2402 took the
+    total off the row: what a vote notification prints is that voter's own star
+    value, which the vote query already selects. Thirteen statements per page
+    carrying a vote row went with it.
     """
     items: list[ActivityFeedItemDC] = []
     for source in sources:
         items.extend(await _run_source_fetch(source, ctx, archive_view, session))
-    return await _score_vote_items(items, session)
+    return items
 
 
 async def _count_sources(

--- a/backend/tests/integration/test_activity_feed_query_count.py
+++ b/backend/tests/integration/test_activity_feed_query_count.py
@@ -19,8 +19,8 @@ Two numbers, and they are different things:
 The fixture deliberately satisfies every pre-fetch need (a friend, a foe, an
 in-progress praxis, a vote on it), because a source whose context is empty is
 skipped without a round trip — a viewer with no relationships would understate
-the fan-out, and a viewer nobody has voted for would miss the scoring pass
-(#2199) entirely.
+the fan-out, and a viewer nobody has voted for would leave the two vote sources
+returning nothing.
 """
 from contextlib import contextmanager
 
@@ -56,15 +56,11 @@ from services.activity_feed import (
 #: are one ``UNION ALL`` however many sources there are, which is the property
 #: the two constants below exist to hold.
 #:
-#: 20 → 33 in #2199: a page carrying a vote row pays one scoring pass
-#: (``_score_vote_items``) so the "+N pts" it prints is the praxis's real score
-#: rather than arithmetic invented at the payload. Thirteen statements — the
-#: praxis fetch, its four ``selectin`` loaders (see the ``ponytail`` note on
-#: that function), and ``author_contributions_for``'s own bulk queries — every
-#: one **flat** in the number of vote rows, and zero when the page has none.
-#: The fixture below seeds a vote deliberately: pinning the cheap page would
-#: have left the expensive one unpinned, which is how a per-row scoring
-#: regression would get in unseen.
+#: 20 → 33 in #2199: a page carrying a vote row paid for one scoring pass
+#: (``_score_vote_items``) so the "+N pts" it printed was the praxis's real
+#: score rather than arithmetic invented at the payload. Thirteen statements —
+#: the praxis fetch, its four ``selectin`` loaders, and
+#: ``author_contributions_for``'s own bulk queries.
 #:
 #: 33 → 34 in #2280: a sixth pre-fetch round trip for the reader's level, which
 #: answers ``services.meta_task.character_sees_metatasks`` once per call so
@@ -75,7 +71,15 @@ from services.activity_feed import (
 #: not a comparison: stating it in SQL would put a second copy of
 #: ``era.level_to_see_metatasks`` next to an identically-numbered apply
 #: threshold that a faction perk bends and this one does not.
-EXPECTED_FEED_LOAD_STATEMENTS = 34
+#:
+#: 34 → 21 in #2402: all thirteen come back off. The row prints what THAT voter
+#: added, which is their star value exactly — ``points_from_votes`` is a plain
+#: ``sum(Vote.value)`` added after the multipliers — and the vote query already
+#: selects it, so the praxis's total is neither shown nor fetched. The whole
+#: post-pass is gone, not made conditional. The fixture below still seeds a
+#: vote: the two vote sources are part of the fan-out this number pins, and a
+#: scoring pass creeping back onto them would show up here first.
+EXPECTED_FEED_LOAD_STATEMENTS = 21
 
 #: Round trips the six tab badges cost. One ``UNION ALL`` over the same windowed
 #: Selects the fetch fan-out runs, whatever the registry's size (#1532). Was 15.

--- a/backend/tests/integration/test_activity_feed_vote_changed.py
+++ b/backend/tests/integration/test_activity_feed_vote_changed.py
@@ -100,10 +100,9 @@ async def test_changing_a_vote_replaces_the_original_row_with_a_changed_one(
     changed = _of_type(after, "vote_changed_on_mine")
     assert len(changed) == 1, f"expected one changed-vote item, got: {after}"
     assert changed[0]["payload"]["value"] == second
-    # The praxis's whole score, not a per-vote figure and not the product this
-    # used to assert (#2199). One voter, no metatask, ×1.0 — so base + stars.
-    # The surface-to-surface pin lives in test_activity_feed_vote_points.py.
-    assert changed[0]["payload"]["points_earned"] == active_task.point_value + second
+    # `value` is the whole number the row prints (#2402): what this voter added,
+    # which is their star value exactly. The praxis's total is not on the
+    # payload. The measured pin lives in test_activity_feed_vote_points.py.
     assert changed[0]["payload"]["praxis_id"] == praxis_id
     assert changed[0]["actor_display_name"] == character2.display_name
 

--- a/backend/tests/integration/test_activity_feed_vote_points.py
+++ b/backend/tests/integration/test_activity_feed_vote_points.py
@@ -1,19 +1,21 @@
-"""#2199 — the vote notification's number must be the number on the praxis.
+"""#2402 — the vote notification's number is what THAT voter added.
 
 **The seam under test** is ``GET /activity-feed`` →
-:func:`services.activity_feed.get_activity_feed`, specifically the
-``points_earned`` field of the ``vote_on_mine`` / ``vote_changed_on_mine``
-payload — the "+N pts" the row prints.
+:func:`services.activity_feed.get_activity_feed`, specifically the ``value``
+field of the ``vote_on_mine`` / ``vote_changed_on_mine`` payload — the number
+the row's "+N pts" prints.
 
-The defect was arithmetic invented at the payload: ``value * task_point_value``,
-a product where the score is a sum. The reporter was told 120 and found 34.
+The reported defect was a row reading ``+19 pts`` under "voted on your praxis"
+when the voter had given somewhere between one and five stars: 19 was the
+praxis's whole current score (#2199's ``points_earned``, now gone).
 
-The assertion is deliberately NOT ``points_earned == base + stars``: that is the
-same class of mistake, a formula restated at a second site, and it would go
-quietly wrong the moment a metatask, a faction modifier or a duel outcome joins
-the sum. The praxis detail route already publishes the authoritative total
-(``PraxisOut.score``, ADR-0053), so these tests pin the two surfaces *to each
-other* — which is exactly what the reporter did by clicking through.
+These tests restate no formula. Each one **measures** the praxis's score on the
+authoritative surface (``PraxisOut.score``, ADR-0053) either side of a vote and
+pins the row's number to the movement it caused — so what is under test is the
+claim the fix rests on: ``points_from_votes`` is a plain ``sum(Vote.value)``
+added after the multipliers, therefore one vote's contribution to the total is
+its own star value, exactly. If a metatask, a faction modifier or a duel
+outcome ever made that false, these go red.
 """
 
 import pytest
@@ -56,7 +58,7 @@ async def _file_praxis(
 
 
 @pytest.mark.asyncio
-async def test_vote_notification_prints_the_praxis_score_not_a_product(
+async def test_the_row_prints_what_the_vote_added_not_the_praxis_total(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -64,8 +66,9 @@ async def test_vote_notification_prints_the_praxis_score_not_a_product(
     auth_headers: dict,
     auth_headers2: dict,
 ):
-    """The bell and the praxis page agree — the whole of #2199."""
+    """The number on the row is the movement that vote caused — the whole of #2402."""
     praxis_id = await _file_praxis(client, active_task, auth_headers, "Rated once")
+    before = await _praxis_score(client, praxis_id, auth_headers)
 
     stars = 4
     vote = await client.post(
@@ -74,19 +77,21 @@ async def test_vote_notification_prints_the_praxis_score_not_a_product(
     assert vote.status_code == 200, vote.text
 
     row = await _one_vote_row(client, auth_headers, "vote_on_mine")
-    score = await _praxis_score(client, praxis_id, auth_headers)
+    after = await _praxis_score(client, praxis_id, auth_headers)
 
-    assert row["payload"]["points_earned"] == score, (
-        "the notification and the praxis page must print the same total; "
-        f"feed said {row['payload']['points_earned']}, praxis says {score}"
+    assert row["payload"]["value"] == stars
+    assert after - before == pytest.approx(stars), (
+        "a vote adds exactly its star value to the praxis score; "
+        f"score moved {before} -> {after} on a {stars}-star vote"
     )
-    # The product this replaced, spelled out so the regression cannot creep back
-    # in behind an equality that a coincidence also satisfies.
-    assert row["payload"]["points_earned"] != stars * active_task.point_value
+    # The praxis total is not on the payload at all any more: it is a different
+    # number from the one this row is about, and printing it was the bug.
+    assert "points_earned" not in row["payload"]
+    assert row["payload"]["value"] != after
 
 
 @pytest.mark.asyncio
-async def test_a_changed_vote_reprints_the_score_that_now_stands(
+async def test_a_changed_vote_prints_the_value_that_now_stands(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -94,8 +99,15 @@ async def test_a_changed_vote_reprints_the_score_that_now_stands(
     auth_headers: dict,
     auth_headers2: dict,
 ):
-    """The other half of the vote partition (#1712) reads the same total."""
+    """The other half of the vote partition (#1712).
+
+    ponytail: the ceiling is that this row can only ever say what the vote is
+    worth now, never that it rose by two — no prior value is stored anywhere.
+    The upgrade path is a ``previous_value`` column on ``Vote`` set in
+    ``cast_or_update_vote``; deliberately out of scope for #2402.
+    """
     praxis_id = await _file_praxis(client, active_task, auth_headers, "Rated twice")
+    before = await _praxis_score(client, praxis_id, auth_headers)
 
     for value in (3, 5):
         vote = await client.post(
@@ -104,14 +116,16 @@ async def test_a_changed_vote_reprints_the_score_that_now_stands(
         assert vote.status_code == 200, vote.text
 
     row = await _one_vote_row(client, auth_headers, "vote_changed_on_mine")
-    score = await _praxis_score(client, praxis_id, auth_headers)
+    after = await _praxis_score(client, praxis_id, auth_headers)
 
     assert row["payload"]["value"] == 5
-    assert row["payload"]["points_earned"] == score
+    assert after - before == pytest.approx(5), (
+        "a re-rate replaces the vote, it does not add a second one"
+    )
 
 
 @pytest.mark.asyncio
-async def test_the_total_counts_every_voter_not_just_the_one_that_notified(
+async def test_two_voters_get_two_different_numbers(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -121,13 +135,15 @@ async def test_the_total_counts_every_voter_not_just_the_one_that_notified(
     auth_headers2: dict,
     auth_headers3: dict,
 ):
-    """Two voters, one row each — and both rows print the praxis's whole score.
+    """Each row is about its own voter — the assertion #2199's total inverted.
 
-    This is the assertion a restated ``base + this vote`` would fail: the second
-    voter's stars are already in the total the first voter's row prints, because
-    the number is the praxis's score and not a per-vote share.
+    Under the praxis-total payload both rows printed the same figure, each one
+    silently including the other voter's stars. Two voters who gave different
+    ratings must reach the author as two different numbers, and the pair of them
+    must account for the whole rise in the score.
     """
     praxis_id = await _file_praxis(client, active_task, auth_headers, "Rated by two")
+    before = await _praxis_score(client, praxis_id, auth_headers)
 
     for headers, value in ((auth_headers2, 4), (auth_headers3, 2)):
         vote = await client.post(
@@ -138,5 +154,7 @@ async def test_the_total_counts_every_voter_not_just_the_one_that_notified(
     rows = await _vote_rows(client, auth_headers, "vote_on_mine")
     assert len(rows) == 2, rows
 
-    score = await _praxis_score(client, praxis_id, auth_headers)
-    assert {row["payload"]["points_earned"] for row in rows} == {score}
+    after = await _praxis_score(client, praxis_id, auth_headers)
+    printed = sorted(row["payload"]["value"] for row in rows)
+    assert printed == [2, 4]
+    assert after - before == pytest.approx(sum(printed))

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -4472,9 +4472,10 @@ export interface components {
          * VoteChangedOnMineItem
          * @description A voter went back and re-rated the viewer's praxis (#1712).
          *
-         *     Same payload as ``VoteOnMineItem`` — ``value``/``points_earned`` are the
-         *     numbers that stand *now* — and deliberately no "changed from" fields: no
-         *     prior value is stored. The two are distinct types rather than one type with
+         *     Same payload as ``VoteOnMineItem`` — ``value`` is the vote that stands
+         *     *now* — and deliberately no "changed from" fields: no prior value is
+         *     stored, so the row can print what the vote is worth but never the size of
+         *     the change. The two are distinct types rather than one type with
          *     a flag because the item KEY has to differ, so archiving the original cannot
          *     silence the change.
          */
@@ -4553,21 +4554,23 @@ export interface components {
          * VoteOnMinePayload
          * @description Someone voted on the viewer's praxis.
          *
-         *     ``points_earned`` is the praxis's **whole current score** — the same number
-         *     ``PraxisOut.score`` publishes, same type, off the same scoring path
-         *     (ADR-0014/0053). It is what the author sees when they click the row through,
-         *     which is the promise #2199 was filed about: the row used to print
-         *     ``value × task_point_value``, a product where the score is a sum, and
-         *     announced 120 points against a praxis worth 34.
+         *     ``value`` is the whole story the row needs: the "+N pts" it prints is the
+         *     stars this voter gave, which is **exactly** what their vote added to the
+         *     praxis (#2402). ``points_from_votes`` is a plain ``sum(Vote.value)`` and
+         *     ``Contribution`` adds it *after* the faction and duel multipliers, so a
+         *     single vote's contribution depends on nothing else — not the other votes,
+         *     the author's faction, the task's points, a metatask or a duel.
          *
-         *     Optional because it is filled in a **second pass**: scoring is async and
-         *     batched, so the per-row mapper that builds this payload cannot reach it (see
-         *     ``services.activity_feed._score_vote_items``). A praxis that cannot be scored
-         *     leaves it ``None`` and the row prints no number — never an invented one.
+         *     So this is a delta, not a total, and there is no ``points_earned`` here.
+         *     #2199 put the praxis's whole score on this payload, filled by a second
+         *     scoring pass, because the per-vote number then in use was *invented*
+         *     (``value × task_point_value``, a product where the score is a sum, which
+         *     announced 120 points against a praxis worth 34). The delta is not a
+         *     restated formula though — it is the raw input the sum is over — so it
+         *     cannot diverge from the scoring path the way that arithmetic did, and the
+         *     pass that read the total is gone.
          */
         VoteOnMinePayload: {
-            /** Points Earned */
-            points_earned: number | null;
             /** Praxis Id */
             praxis_id: number;
             /** Praxis Title */

--- a/frontend/src/components/__tests__/albescentFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/albescentFeedFrame.test.tsx
@@ -61,7 +61,7 @@ const FAT_PAYLOAD = {
   task_title: 'Reforest the verge',
   task_point_value: 40,
   task_level_required: 2,
-  points_earned: 12,
+  value: 4,
   praxis_title: 'A returned proof',
   praxis_type: 'collab',
   from_character_id: 4,

--- a/frontend/src/components/__tests__/feedChassis.test.tsx
+++ b/frontend/src/components/__tests__/feedChassis.test.tsx
@@ -77,7 +77,7 @@ const FAT_PAYLOAD = {
   task_title: 'Reforest the verge',
   task_point_value: 40,
   task_level_required: 2,
-  points_earned: 12,
+  value: 4,
   praxis_title: 'A returned proof',
   praxis_type: 'collab',
   from_character_id: 4,

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -198,7 +198,7 @@ describe('normalizeFeedItem', () => {
   // "voted on your praxis" beside `+25 pts` is the bug with extra steps.
 
   it('says the vote CHANGED, and shows the points that stand now', () => {
-    const payload = { vote_id: 4, value: 5, praxis_id: 9, praxis_title: 'Reforest', task_point_value: 5, points_earned: 25 }
+    const payload = { vote_id: 4, value: 5, praxis_id: 9, praxis_title: 'Reforest', task_point_value: 5 }
     const changed = normalizeFeedItem(item('vote_changed_on_mine', payload))!
     const cast = normalizeFeedItem(item('vote_on_mine', payload))!
 
@@ -206,8 +206,29 @@ describe('normalizeFeedItem', () => {
     expect(changed.action).not.toBe(cast.action)
     // Everything else is the vote row verbatim — one sentence is the whole delta.
     expect({ ...changed, action: null }).toEqual({ ...cast, action: null })
-    expect(changed.points).toBe('+25 pts')
+    expect(changed.points).toBe('+5 pts')
     expect(changed.headlineHref).toBe('/praxis/9')
+  })
+
+  // ── the number is the DELTA (#2402) ──────────────────────────────────────
+  //
+  // A row read `+19 pts` under "voted on your praxis" when the voter gave three
+  // stars — 19 was the praxis's whole score. `points_from_votes` is a plain
+  // `sum(Vote.value)` added AFTER the multipliers, so one voter's contribution
+  // is their own `value`, exactly: no dependence on the other votes, the
+  // author's faction, the task's points, a metatask or a duel.
+
+  it('prints the stars this voter gave, not the praxis total', () => {
+    const row = normalizeFeedItem(
+      item('vote_on_mine', {
+        vote_id: 4,
+        value: 3,
+        praxis_id: 9,
+        praxis_title: 'Reforest',
+        task_point_value: 5,
+      }),
+    )!
+    expect(row.points).toBe('+3 pts')
   })
 
   it('renders the changed row rather than dropping it', () => {

--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -46,7 +46,7 @@ const FAT_PAYLOAD = {
   task_title: 'Reforest the verge',
   task_point_value: 40,
   task_level_required: 2,
-  points_earned: 12,
+  value: 4,
   praxis_title: 'A returned proof',
   praxis_type: 'collab',
   from_character_id: 4,

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -355,12 +355,23 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
       }
     case 'vote_on_mine':
     case 'vote_changed_on_mine':
-      // One row shape, two sentences. The payload is identical — `points_earned`
-      // is the score that stands right now either way — and the ONLY thing that
+      // One row shape, two sentences. The payload is identical — `value` is the
+      // vote that stands right now either way — and the ONLY thing that
       // differs is whether this is news of a vote or news of a vote moving
       // (#1712). The changed row must not pose as a fresh vote: the author has
       // already been told a number, and "voted on your praxis" beside a
       // different one is the silent rewrite this type exists to end.
+      //
+      // The number is what THIS voter added, not the praxis's whole score
+      // (#2402, reversing #2199): `points_from_votes` is a plain `sum(
+      // Vote.value)` added after the multipliers, so a single vote's
+      // contribution to the total is its own `value`, exactly — the raw input
+      // the sum is over, not arithmetic restated at this seam.
+      //
+      // ponytail: a *changed* vote can only print the value that stands now,
+      // never the size of the change, because no prior value is stored. The
+      // upgrade path is a `previous_value` column on `Vote` set in
+      // `cast_or_update_vote` (see `_vote_item_factory`).
       return {
         slug,
         actor,
@@ -375,9 +386,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineHref: p.praxis_id != null ? `/praxis/${p.praxis_id}` : null,
         headlineQuoted: false,
         points:
-          p.points_earned != null
-            ? i18n.t('feed:row.pointsEarned', { points: p.points_earned })
-            : null,
+          p.value != null ? i18n.t('feed:row.pointsEarned', { points: p.value }) : null,
         level: null,
         actions: [],
       }

--- a/frontend/src/components/layout/__tests__/sidebarRecentActivity.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarRecentActivity.test.tsx
@@ -65,7 +65,7 @@ const WIDENED_FEED: ActivityFeedItem[] = [
     type: 'vote_on_mine',
     item_key: 'vote_on_mine:7',
     actor_display_name: 'Dr. Vale',
-    payload: { praxis_id: 42, praxis_title: 'The tool library', points_earned: 12 },
+    payload: { praxis_id: 42, praxis_title: 'The tool library', value: 4 },
   }),
   item({
     type: 'friend_completion',
@@ -163,8 +163,8 @@ describe('the panel carries the whole live feed, not just global news', () => {
     expect(html).toContain('href="/praxis/55"')
   })
 
-  it('shows what a vote was worth', () => {
-    expect(render()).toContain(i18n.t('feed:row.pointsEarned', { points: 12 }))
+  it('shows the stars that voter gave, not the praxis total (#2402)', () => {
+    expect(render()).toContain(i18n.t('feed:row.pointsEarned', { points: 4 }))
   })
 
   it('never prints the deleted placeholder title', () => {


### PR DESCRIPTION
Closes #2402

A vote notification printed the praxis's whole current score. It now prints what that voter added — which is their star value, exactly.

## The seam under test

`normalizeFeedItem` for `vote_on_mine` / `vote_changed_on_mine` — the field the row's `"+{{points}} pts"` reads. The loop went red there first: a vote row built from a payload carrying `value: 3` printed nothing at all, because the number the row read was a total filled in by a separate backend pass.

Behind it, `GET /activity-feed` → `get_activity_feed`, where the backend tests now **measure** the praxis score on `PraxisOut.score` either side of a vote and pin the row's number to the movement it caused. That is the claim the fix rests on, tested rather than restated: `points_from_votes` is a plain `sum(Vote.value)` and `Contribution` adds it *after* the multipliers, so one vote's contribution to the total is its own `value` and depends on nothing else — not the other votes, the author's faction, the task's points, a metatask or a duel.

## What changed

- **`normalizeFeedItem.ts`** renders `p.value`. The copy string is untouched and still true.
- **`_score_vote_items` is deleted** — the praxis fetch, its four `selectin` loaders, and `author_contributions_for`'s bulk queries behind it. `points_earned` had exactly one runtime consumer and it is the line above, so the pass had nothing left to fill. `_run_sources` returns its items directly; there is no post-pass at all now.
- **`points_earned` comes off `VoteOnMinePayload` entirely** rather than lingering as an unused optional, so `backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` are regenerated by `scripts/regen_api_client.py` in the same commit (#1584).
- **`EXPECTED_FEED_LOAD_STATEMENTS` 34 → 21**, lowered, not relaxed — exactly the thirteen statements #2199 added, back off. The fixture still seeds a vote so the two vote sources stay inside the number this test pins.
- Docstrings on `VoteOnMinePayload`, `VoteChangedOnMineItem`, `_vote_item_factory` and `_run_sources` rewritten; each of them asserted the old "whole current score" reading and explained why it was right.
- Frontend fixtures that carried `points_earned` now carry `value`; the sidebar's "shows what a vote was worth" assertion moves with them.

## This reverses #2199, deliberately

#2199 replaced an *invented* per-vote formula (`value × task_point_value`) with the praxis total, and it was right that the arithmetic was wrong. It concluded the per-vote number was unstateable. It isn't: the delta is not a restated formula, it is the raw input the sum is over, so it cannot diverge from the scoring path the way that product did. Owner ruling on #2402 is the delta **alone**, not the delta beside the total.

## Ceilings left in place

- A **changed** vote can only ever print the value that stands now, never the size of the change — no prior value is stored. Marked `ponytail:` in `normalizeFeedItem` and in the test, with the same upgrade path `_vote_item_factory` already names (`previous_value` on `Vote`, set in `cast_or_update_vote`). Not added here.
- The changed row still must not pose as a fresh vote (#1712). Switching which number is shown does not touch that rule, and the test that guards the two sentences apart still passes.

## Verification

Every step in `.github/workflows/test.yml`, locally:

- backend `pytest` — 1509 passed (dedicated DB `wz2402_test`); coverage run clean
- `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync` — clean
- `npm test` — 392 files, 6988 passed
- `npm run build` — clean; `npm run budget` — JS ok
- `ruff check` from `backend/` — allowlist test green, no file's count raised

**Visual QA is outstanding.** I have no browser tools, so nothing here was seen rendered: what a real feed row looks like with a 1–5 number where a 2-digit one used to sit is unverified.

Note on the byte budget: it reports **CSS WARN at 22.2 KB against a 22.2 KB warn line**. This branch touches no CSS — the warning is on `main` already.

## What to eyeball

- A vote row on **Updates**: "voted on your praxis" beside `+N pts` where N is 1–5, and the praxis page it links to showing its own, larger, score. Those two numbers now differ on purpose.
- The **changed-vote** row: still says "changed their vote on your praxis", and prints the value that stands now.
- The **rail's recent-activity panel** (same normalizer, narrower column) — a one-digit points chip where a two-digit one used to sit.
- Vote rows on the faction feed frames (Albescent / WOW / S.N.I.D.E. chassis) — same slot, faction-specific ink.
- A vote row in the **archive** view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
