### PR TITLE
The backend preview says out loud that it needs a venv, and no worktree has one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ Python conventions live in `backend/CLAUDE.md`; frontend conventions in
 - DB: `docker-compose up -d`; `alembic upgrade head` after pulling
 - Tests: `pytest --cov=. --cov-fail-under=80` from `/backend`
 
+Every backend command above needs `backend/.venv` activated, and the backend
+preview does **not** work from a worktree — worktrees carry no venv. Read
+`docs/agents/running-locally.md` before starting the stack.
+
 ## Agent skills
 
 This repo is configured for the engineering skill set (`triage`, `qa`, `review`, `tdd`, etc.). Details live in `docs/agents/`.

--- a/docs/agents/running-locally.md
+++ b/docs/agents/running-locally.md
@@ -1,0 +1,48 @@
+# Running the stack locally
+
+What the commands in CLAUDE.md's "Running locally" section assume, and the two
+things that make them fail silently. Read this before starting the backend.
+
+## The backend needs the venv on `PATH`
+
+`.claude/launch.json`'s **Backend (FastAPI)** entry runs `python -m uvicorn`.
+`python` resolves off `PATH`. uvicorn is installed in `backend/.venv`, not
+globally, so on a shell with an unactivated venv the preview dies instantly:
+
+    ...\Python313\python.exe: No module named uvicorn
+
+**Activate `backend/.venv` before starting the backend preview** — and before
+running `uvicorn main:app --reload`, `pytest`, or `alembic` by hand.
+
+The entry stays as `"python"` on purpose (#2408). Pointing it at the venv means
+committing `Scripts/python.exe` (Windows) or `bin/python` (POSIX), which fixes
+one platform and breaks the other; and it would be wrong in a worktree anyway,
+for the reason below.
+
+## The backend preview does not work from a git worktree
+
+CLAUDE.md tells agents to work in an isolated worktree for any non-trivial
+change, so this is the common case, not the edge one.
+
+`launch.json` is read relative to the session's cwd, so a worktree session reads
+*the worktree's* copy — and **no worktree under `.claude/worktrees/` carries a
+`backend/.venv`**. There is no interpreter there with uvicorn on it, whatever
+the config points at.
+
+The missing venv is the whole of the problem — nothing deeper is broken. A venv
+already on `PATH` is a real workaround: a worktree session that inherits an
+activated environment (the main checkout's, or any venv holding the backend's
+dependencies) starts the backend fine.
+
+Making this work *by default* from a worktree needs a venv strategy — a shared
+venv on `PATH`, or a bootstrap step that creates one per worktree. That is a
+separate issue, not a path edit to `launch.json`.
+
+## `--reload` does not notice a branch switch
+
+`uvicorn --reload` watches for file writes. A `git checkout` of another branch
+rewrites the working tree, and the reloader does **not** reliably pick it up —
+you can read a response produced by the code you just checked out *away* from,
+and mistake it for a bug on the branch you are now on.
+
+**Restart the backend after changing branches.**


### PR DESCRIPTION
Closes #2408

Documentation only. `.claude/launch.json` is **unchanged**, per the ruling — there is no runtime change and nothing to eyeball in the app.

## Seam

None in code. The defect is a knowledge gap, not a behaviour: the committed config is correct as written and the failure is in what the reader knows before running it. So the seam is the doc itself, and there is no test to write — the change adds no logic and touches no importable file. Two Markdown files, no Python, no TS, no CSS, so no CI job can be affected by it.

## What lands

New `docs/agents/running-locally.md`, with three sections:

1. **The backend needs the venv on `PATH`.** `python -m uvicorn` resolves off `PATH`; uvicorn lives in `backend/.venv`, so an unactivated shell dies with `No module named uvicorn`. Notes why the entry stays `"python"` — a committed path is `Scripts/python.exe` on Windows and `bin/python` on POSIX, so it fixes one platform and breaks the other.
2. **The backend preview does not work from a git worktree.** Stated outright, since CLAUDE.md sends agents to worktrees for any non-trivial change: `launch.json` is read relative to the session's cwd, and no worktree carries a `backend/.venv`. Records that the missing venv is the *whole* problem — a venv already on `PATH` is a real workaround — and that making it work by default is a separate issue needing a venv strategy, not a path edit.
3. **`--reload` does not notice a branch switch.** Included on the owner's first-hand report from today: a stale response read after a `git checkout` nearly got filed as a bug. Judged in scope — the issue scopes out *changing* `launch.json` and *making the backend worktree-runnable*, not doc content, and this is the same class of trap (the local backend lying about which code it is serving) with no other home in the repo. Four lines; easy to drop if you disagree.

Findability: `CLAUDE.md`'s "Running locally" section gains a three-line pointer that names both failures, so an agent that never opens the doc still learns the two facts that bite. No routing-table row — CLAUDE.md asks to stay thin, and the section the ruling named is where a reader running the stack already is.

## Not done

- `.claude/launch.json` — untouched, deliberately.
- No launcher script.
- No `.github/workflows/**`.

## Verification

`git show --stat` confirms the diff is `CLAUDE.md` (+4) and `docs/agents/running-locally.md` (+48) and nothing else. Doc-only, so there is no local test run to report and no visual QA to be outstanding.
