### PR TITLE
The Field Desk stops saying it twice: the shoes figure once, and no pill for a slot that could not be shut (#2451)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -109,12 +109,11 @@
     "headingFirstLife": "Nothing in the drawer yet.",
     "loading": "Pulling your lives from the drawer…",
     "stepInto": "Step into {{name}}",
-    "footer": "A life is a pair of shoes. Lace up an old one, or cut a new pair from whole cloth.",
-    "footerFirstLife": "A life is a pair of shoes. Cut your first pair from whole cloth.",
-    "footerNoNewSelf": "A life is a pair of shoes. Lace up whichever pair the day calls for.",
+    "footer": "Lace up an old one, or cut a new pair from whole cloth.",
+    "footerFirstLife": "Cut your first pair from whole cloth.",
+    "footerNoNewSelf": "Lace up whichever pair the day calls for.",
     "beginNewSelfTitle": "Begin a new self",
     "beginNewSelf": "Begin a new self",
-    "slotOpen": "✓ slot open — start a new life",
     "home": {
       "title": "FieldDesk",
       "switcher": {

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -298,7 +298,6 @@ function NewSelfDossier({ onBegin }: { onBegin: () => void }) {
       <div className="content-title" style={dossierTitle}>
         {t('fieldDesk.beginNewSelf')}
       </div>
-      <div style={slotOpen}>{t('fieldDesk.slotOpen')}</div>
     </button>
   )
 }
@@ -703,13 +702,4 @@ const medallion: CSSProperties = {
   fontSize: 28,
   color: 'var(--color-text-primary)',
   marginBottom: 'var(--space-lg)',
-}
-const slotOpen: CSSProperties = {
-  fontSize: 'var(--text-md)',
-  letterSpacing: '0.14em',
-  textTransform: 'uppercase',
-  color: 'var(--color-success)',
-  marginTop: 'var(--space-lg)',
-  borderTop: '1px solid var(--color-border-strong)',
-  paddingTop: 'var(--space-md)',
 }


### PR DESCRIPTION
Closes #2451

Two independent copy edits on the Field Desk, both deletions.

## The seam

The seam is **the `fieldDesk.*` copy catalog meeting its two Field Desk render
sites** — `NewSelfDossier`'s markup, and the roster's closing `<p>`. Both edits
live entirely on the value side of that seam: no selection logic moves.

That is also why nothing new is asserted here, and the issue says so directly
("Add nothing new"). The defect is *a fact stated three times* and *a figure
introduced twice* — neither is a proposition a renderer can be red about. What
**is** mechanically checkable already exists, and I leaned on it rather than
writing a twin:

- `tsconfig.json` sets `noUnusedLocals: true`, so deleting the `<div>` and
  leaving the `slotOpen` `CSSProperties` block behind (or the reverse) fails
  `tsc --noEmit`. The half-deletion is the only way this change can be wrong
  in a way a machine can see, and it is already covered.
- `fieldDeskRosterGate.test.tsx:210–222` pin `rosterFooterKey`'s three branches
  **by key name**, so a value edit provably cannot reach them — which is the
  property that makes this safe as a pure copy edit.
- `fieldDeskRosterGate.test.tsx:132` asserts a pre-gate player's page does not
  contain `'cut a new pair from whole cloth'`. That phrase survives verbatim in
  `fieldDesk.footer`, so the assertion still means exactly what it meant.

## 1. `fieldDesk.slotOpen` goes entirely

`NewSelfDossier` has no locked face (#1560): the caller mounts it when the slot
is open and omits it when it is not. `✓ slot open — start a new life` was
therefore a label whose condition is its own existence, and its second half
restated the `beginNewSelf` title sitting directly above it. The `+` medallion
and the title stay — the card's identity and its affordance. Only the third
statement goes.

Deleted all three sites, grepped clean beforehand (repo-wide, including
`.design-sync/`, which had no reference):

- the `<div style={slotOpen}>` in `NewSelfDossier`
- the `slotOpen` `CSSProperties` block
- `"slotOpen"` in `frontend/src/locales/en/common.json`

## 2. The footer loses its first sentence and keeps the rest

`fieldDesk.heading` already asks "Whose shoes today?". Every footer variant then
opened "A life is a pair of shoes." — the figure introduced twice on one screen,
the second time to a reader who has just read the first.

Values only. **`rosterFooterKey` and its three key names are untouched**; the
three-way split is #1560's fix and stays, so each half of the offer still drops
out when the offer does.

| key | now reads |
|---|---|
| `fieldDesk.footer` | Lace up an old one, or cut a new pair from whole cloth. |
| `fieldDesk.footerFirstLife` | Cut your first pair from whole cloth. |
| `fieldDesk.footerNoNewSelf` | Lace up whichever pair the day calls for. |

## One instruction I did not carry out, deliberately

The issue asks me to update `fieldDeskRosterGate.test.tsx:8`, "or it becomes a
comment describing copy that no longer exists." **I checked, and it does not.**
Line 7–8 read:

> `* choice, the "N life in play" chip, and the closing line offering to "cut a new`
> `* pair from whole cloth".`

The quoted fragment is the *second* sentence of the old value, which is the half
that survives — the same observation the issue itself makes one bullet earlier
about the `:132` assertion. The comment is still literally true, so editing it
would only make it less accurate. Same for the two quotes in `FieldDesk.tsx`
(`:59`, `:274`); `:274` quotes the footer as *"Lace up an old one, or cut a new
pair from whole cloth"*, which used to be a fragment of the value and is now the
whole of it.

I grepped every fragment I removed (`A life is`, `start a new life`, `slotOpen`,
`slot open`) across `frontend/src` — nothing anywhere else refers to the deleted
copy. Say the word if you want the header reworded anyway and I will.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **392 files / 6999 passed, 1 skipped**, including
  `fieldDeskRosterGate.test.tsx` (15/15) green **as-is, unmodified**
- `npm run build` — clean
- `npm run budget` — JS ok; CSS `WARN` at 22.3 KB vs a 22.2 KB warn line. This
  is **pre-existing and untouched by this PR** — no `.css` file is in the diff,
  and the only bytes this change moves are *removed* JS. Not blocking.

`api-schema` needs nothing: no route, `response_model`, or Pydantic schema is
touched, so `backend/openapi.json` and `schema.d.ts` are unchanged.

## What to eyeball

I have no browser tools and no dev stack, so **visual QA is outstanding.** Three
footer states, each selected by a different roster shape, plus the dossier:

1. **First life** → `fieldDesk.footerFirstLife`, "Cut your first pair from whole
   cloth." Selected when `lives.length === 0`, regardless of the gate — an
   account carrying no character at all. The heading above it is
   `headingFirstLife`, "Nothing in the drawer yet.", so check this one reads
   right *without* "Whose shoes today?" overhead: it is the one state where the
   shoes figure now appears only in the footer.
2. **Slot open** → `fieldDesk.footer`, "Lace up an old one, or cut a new pair
   from whole cloth." Selected when `lives.length >= 1` **and**
   `can_create_additional_character` is true. This is the state that also shows
   `NewSelfDossier`, so it is where **both** edits land at once: confirm the
   dossier now ends at its "Begin a new self" title with no rule and no green
   line under it, and that losing that bottom border does not leave the card
   looking unbalanced against the credential cards beside it.
3. **No new self** → `fieldDesk.footerNoNewSelf`, "Lace up whichever pair the
   day calls for." Selected when `lives.length >= 1` and the gate is shut — the
   commonest state on the site. No dossier renders here.

The dossier's removed block carried a `borderTop` and its own `marginTop`, so
the card is now shorter by roughly a rule plus two spacing steps. If it needs
re-balancing against the roster row, that is a styling call for `frontend-style`
and not something I should decide from the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
