### PR TITLE
A filter change says so: the bar goes busy and the stale list dims (#2431)

### DIFF
--- a/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
@@ -47,6 +47,9 @@ import {
   type SegmentBox,
 } from '../filterState'
 import type { FactionOut } from '../../../../api/factions'
+// The catalog itself, not a hardcoded string: the assertion has to fail if the
+// key is missing, not merely if the words drift.
+import common from '../../../../locales/en/common.json'
 
 const sortRail = (value: string, onChange = () => {}): FilterRail => ({
   key: 'sort',
@@ -434,5 +437,50 @@ describe('selectedFirst / toggleOption', () => {
     expect(toggleOption(selected, 'coven')).toEqual(['ua', 'coven'])
     expect(toggleOption(selected, 'ua')).toEqual([])
     expect(selected).toEqual(['ua'])
+  })
+})
+
+/**
+ * #2431 — a filter change has to say something before the rows arrive.
+ *
+ * `useResource` keeps the previous rows in `data` for the whole flight (that is
+ * what stops the list flashing empty), and every list surface spells its
+ * loading branch as `loading && items.length === 0` — so after first paint a
+ * facet click changed nothing on screen at all. The bar is the one component
+ * both mounting pages share, so the pending signal lives here.
+ *
+ * This is the props-level seam, and it is the ONLY one this harness can reach:
+ * `renderToStaticMarkup` runs no effects, so a `useResource`-driven render is
+ * always `data: null, loading: true` — the empty branch. `busy` passed directly
+ * is exactly what `TaskFilterBar`/`PraxisFilterBar` do with their `loading`.
+ */
+describe('the bar states a read in flight (#2431)', () => {
+  const SUMMARY = 'Showing 12 tasks'
+  const render = (busy?: boolean) =>
+    renderToStaticMarkup(
+      <FilterBar
+        rails={[eraRail('current')]}
+        facets={[]}
+        onClearAll={() => {}}
+        summary={SUMMARY}
+        busy={busy}
+      />,
+    )
+
+  it("states the caller's summary, and claims nothing, while idle", () => {
+    const html = render()
+    expect(html).toContain(SUMMARY)
+    expect(html).not.toContain('aria-busy')
+    expect(html).not.toContain(common.filters.bar.updating)
+  })
+
+  it('marks the region busy and swaps the count for the updating copy', () => {
+    // Replaces rather than joins: the count in `summary` is the STALE one until
+    // the flight lands, so printing it beside "Updating…" would state a number
+    // the bar is in the middle of disproving.
+    const html = render(true)
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain(common.filters.bar.updating)
+    expect(html).not.toContain(SUMMARY)
   })
 })

--- a/frontend/src/components/ui/FilterBar/index.tsx
+++ b/frontend/src/components/ui/FilterBar/index.tsx
@@ -25,6 +25,13 @@ export interface FilterBarProps {
   onClearAll: () => void
   /** "Showing N tasks" — the page owns the count, the bar only states it. */
   summary?: string
+  /**
+   * A read is in flight and the rows on screen are the PREVIOUS filter's
+   * (#2431). The bar marks itself `aria-busy` and its summary slot says so —
+   * `summary` still states a count, but a stale one, so the two swap rather
+   * than stack.
+   */
+  busy?: boolean
   search?: {
     value: string
     onChange: (value: string) => void
@@ -75,6 +82,7 @@ export default function FilterBar({
   facets,
   onClearAll,
   summary,
+  busy,
   search,
 }: FilterBarProps) {
   const { t } = useTranslation('common')
@@ -84,13 +92,26 @@ export default function FilterBar({
   // the player just opened, which is the behaviour we want anyway.
   const [open, setOpen] = useState(formFactor === 'desktop')
   const chips = deriveChips({ rails, facets })
+  // ponytail: `busy` goes true the instant the read starts, so a warm backend
+  // can swap these words in and out inside ~100ms and read as a flicker rather
+  // than as feedback. The upgrade path is a ~120ms grace before it flips, held
+  // in `useResource` so all four surfaces inherit it — not built here, because
+  // the reported symptom is a wait long enough to read as broken and a
+  // threshold is a tuning knob with no measurement behind it yet (#2431).
+  const summaryText = busy ? t('filters.bar.updating') : summary
 
   return (
-    <section className="filter-bar" aria-label={t('filters.bar.region')}>
+    <section
+      className="filter-bar"
+      aria-label={t('filters.bar.region')}
+      aria-busy={busy ? 'true' : undefined}
+    >
       <div className="filter-bar__spectrum" aria-hidden="true" />
       <div className="filter-bar__body">
         <div className="filter-bar__head">
-          {summary && <span className="filter-bar__summary">{summary}</span>}
+          {summaryText && (
+            <span className="filter-bar__summary">{summaryText}</span>
+          )}
           <button
             type="button"
             className="filter-bar__toggle"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7577,6 +7577,26 @@
   --filter-popover-shadow: 0 24px 48px -18px rgba(0, 0, 0, 0.8);
 }
 
+/* A list showing the PREVIOUS filter's rows while the next read is in flight
+   (#2431). `useResource` deliberately keeps the old rows in `data` so the list
+   cannot flash empty, and every surface's `loading && length === 0` branch is
+   therefore false on every filter change after first paint — so without this
+   the stale cards stayed fully lit and fully clickable, and clicking a facet
+   changed nothing on screen at all. `pointer-events: none` is the substance:
+   these rows are about to be replaced and must not be navigable meanwhile. The
+   filter bar states the same fact in words, in `aria-busy` and its summary. */
+[data-stale='true'] {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+/* The dimming itself applies to everyone; only the FADE is opt-in. */
+@media (prefers-reduced-motion: no-preference) {
+  [data-stale='true'] {
+    transition: opacity 150ms;
+  }
+}
+
 .filter-bar {
   border: 1px solid var(--color-border);
   border-radius: var(--space-md);

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -245,6 +245,7 @@
       "region": "Filters",
       "show": "Filters",
       "hide": "Hide filters",
+      "updating": "Updating…",
       "filteringBy": "Filtering by",
       "clearAll": "Clear all",
       "clearAllFilters": "Clear all filters",

--- a/frontend/src/pages/Praxes.tsx
+++ b/frontend/src/pages/Praxes.tsx
@@ -73,7 +73,12 @@ function DesktopPraxes({ state }: { state: PraxesFeedState }) {
         <PraxisFeedEmpty kind={emptyState} onClearAll={clearAllFilters} />
       ) : (
         <>
-          <div className="flex flex-wrap gap-4 items-start">
+          <div
+            className="flex flex-wrap gap-4 items-start"
+            /* The previous filter's rows until the read lands (#2431) — dimmed
+               and inert, with "Load more" outside as its own sibling. */
+            data-stale={loading && items.length > 0 ? 'true' : undefined}
+          >
             {items.map((p) => (
               <PraxisCard key={`praxis-${p.id}`} praxis={p} />
             ))}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -83,7 +83,10 @@ function DesktopTasks({ state }: { state: TasksState }) {
             /* Metatasks are informational — the issuing faction's seal look
                (#928), stacked read-only; no sign-up CTA (they're applied to a
                praxis via the picker). */
-            <div style={{ maxWidth: 640 }}>
+            <div
+              style={{ maxWidth: 640 }}
+              data-stale={loading && tasks.length > 0 ? 'true' : undefined}
+            >
               <MetataskSeal metatasks={tasks} />
             </div>
           ) : (
@@ -94,7 +97,16 @@ function DesktopTasks({ state }: { state: TasksState }) {
                chain that carries it down to each skin's frame — the display and
                the wrap live there too, because an inline `display` here would
                beat every rule in that chain. */
-            <div className="task-card-row" style={{ gap: 'var(--space-lg)' }}>
+            <div
+              className="task-card-row"
+              style={{ gap: 'var(--space-lg)' }}
+              /* These are the PREVIOUS filter's cards until the read lands, so
+                 they dim and stop taking clicks (#2431). Only when there is
+                 something to go stale — an empty list takes the loading branch
+                 above. "Load more" is a SIBLING of this row and stays one, so
+                 it is outside the dimming. */
+              data-stale={loading && tasks.length > 0 ? 'true' : undefined}
+            >
               {/* `onSignup` is offered to any signed-in viewer. Whether the slot
                   it produces is a claim or a statement of why not is the CARD's
                   call, off `task.signup_reason` (#1976) — gating it on

--- a/frontend/src/pages/praxes/MobilePraxisFeed.tsx
+++ b/frontend/src/pages/praxes/MobilePraxisFeed.tsx
@@ -86,7 +86,16 @@ export default function MobilePraxisFeed({ state }: { state: PraxesFeedState }) 
       ) : isEmpty ? (
         <PraxisFeedEmpty kind={emptyState} onClearAll={clearAllFilters} />
       ) : (
-        <div className="flex flex-wrap gap-4 items-start">
+        /* Stale rows dim and stop taking taps until the read lands (#2431).
+           Unlike the desktop page, "Load more" is a CHILD of this wrap
+           container rather than a sibling — re-parenting it would take it out
+           of the flex flow it is laid out by — so it dims with the rows. That
+           is the right behaviour here anyway: growing the window mid-flight
+           only starts a second read over the first. */
+        <div
+          className="flex flex-wrap gap-4 items-start"
+          data-stale={loading && items.length > 0 ? 'true' : undefined}
+        >
           {items.map((p) => (
             <PraxisCard key={`praxis-${p.id}`} praxis={p} />
           ))}

--- a/frontend/src/pages/praxes/PraxisFilterBar.tsx
+++ b/frontend/src/pages/praxes/PraxisFilterBar.tsx
@@ -104,8 +104,9 @@ export default function PraxisFilterBar({ state }: { state: PraxesFeedState }) {
       summary={t(hasMore ? 'listPage.countWindowed' : 'listPage.count', {
         count: items.length,
       })}
-      // See `TaskFilterBar` — same flag, same reason (#2431).
-      busy={loading}
+      // The list's own `data-stale` condition, not bare `loading` — see
+      // `TaskFilterBar` for why a first load is not an "update" (#2431).
+      busy={loading && items.length > 0}
       search={{
         value: state.query,
         onChange: state.setQuery,

--- a/frontend/src/pages/praxes/PraxisFilterBar.tsx
+++ b/frontend/src/pages/praxes/PraxisFilterBar.tsx
@@ -29,8 +29,16 @@ import type { PraxesFeedState, SortOrder, VotedFilter, EraScope } from './usePra
 export default function PraxisFilterBar({ state }: { state: PraxesFeedState }) {
   const { t } = useTranslation('praxis')
   const { t: tc } = useTranslation('common')
-  const { items, filters, setFilters, clearAllFilters, canFilterByVote, factions, hasMore } =
-    state
+  const {
+    items,
+    loading,
+    filters,
+    setFilters,
+    clearAllFilters,
+    canFilterByVote,
+    factions,
+    hasMore,
+  } = state
 
   const rails: FilterRail[] = [
     {
@@ -96,6 +104,8 @@ export default function PraxisFilterBar({ state }: { state: PraxesFeedState }) {
       summary={t(hasMore ? 'listPage.countWindowed' : 'listPage.count', {
         count: items.length,
       })}
+      // See `TaskFilterBar` — same flag, same reason (#2431).
+      busy={loading}
       search={{
         value: state.query,
         onChange: state.setQuery,

--- a/frontend/src/pages/tasks/TaskFilterBar.tsx
+++ b/frontend/src/pages/tasks/TaskFilterBar.tsx
@@ -190,10 +190,16 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
       summary={t(hasMore ? 'listPage.countWindowed' : 'listPage.count', {
         count: tasks.length,
       })}
-      // The same `loading` the list branches on (#2431). While it is true the
-      // count above is the PREVIOUS filter's, so the bar says it is updating
-      // instead of restating a number it is about to replace.
-      busy={loading}
+      // The same condition the list's `data-stale` uses, NOT bare `loading`
+      // (#2431): busy means "rows on screen belong to the previous filter", so
+      // the count above is stale and the bar says it is updating instead of
+      // restating a number it is about to replace. A FIRST load has no such
+      // rows — `loading && tasks.length === 0` is the list's own branch and it
+      // already prints "Loading tasks…", so bare `loading` would state the wait
+      // twice and call an empty first read an "update". It would also blank the
+      // count on every page-level render in a harness that runs no effects,
+      // which is what #2262's guard caught.
+      busy={loading && tasks.length > 0}
       search={{
         value: query,
         onChange: setQuery,

--- a/frontend/src/pages/tasks/TaskFilterBar.tsx
+++ b/frontend/src/pages/tasks/TaskFilterBar.tsx
@@ -73,6 +73,7 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
   const {
     user,
     tasks,
+    loading,
     hasMore,
     factions,
     statusFilters,
@@ -189,6 +190,10 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
       summary={t(hasMore ? 'listPage.countWindowed' : 'listPage.count', {
         count: tasks.length,
       })}
+      // The same `loading` the list branches on (#2431). While it is true the
+      // count above is the PREVIOUS filter's, so the bar says it is updating
+      // instead of restating a number it is about to replace.
+      busy={loading}
       search={{
         value: query,
         onChange: setQuery,

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -93,6 +93,12 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
           <div
             className={`flex flex-col gap-3${isMetatask ? '' : ' items-center'}`}
             data-testid="mobile-tasks-results"
+            /* Stale rows dim and stop taking taps until the read lands
+               (#2431). "Load more" is a CHILD of this column rather than a
+               sibling, as it is on the desktop page — it is laid out by this
+               flex flow, so it dims with the rows rather than being
+               re-parented out of it. */
+            data-stale={loading && tasks.length > 0 ? 'true' : undefined}
           >
             {isMetatask ? (
               <MetataskSeal metatasks={tasks} />


### PR DESCRIPTION
Clicking a faction facet changed nothing on screen until the fetch landed. Not broken — silent. `useResource` deliberately keeps the previous rows in `data` for the whole flight (that is what stops the list flashing empty), and every list surface spells its loading branch as `loading && items.length === 0`, so on any filter change after first paint that branch is false: the stale, pre-filter cards stayed fully lit and still clickable, with no pending signal anywhere.

Closes #2431

## The seam under test

**`FilterBar` at the props level** — `busy` passed directly, which is exactly what `TaskFilterBar`/`PraxisFilterBar` do with their `loading`. That is the only seam this harness can reach: `renderToStaticMarkup` runs no effects, so a `useResource`-driven render is always `data: null, loading: true` (the *empty* branch), and the stale branch is unreachable through the real hook. The new tests in `filterState.test.tsx` went red on the real defect first (`expected … to contain 'aria-busy="true"'`), then green.

## What changed

- **`components/ui/FilterBar/index.tsx`** — new `busy?: boolean`. When true the `<section className="filter-bar">` carries `aria-busy="true"` and the summary slot renders `filters.bar.updating` **instead of** the caller's summary (the caller's count is the stale one, so the two swap rather than stack). No `aria-live` — per the ruling.
- **`locales/en/common.json`** — `filters.bar.updating` = "Updating…". Chrome copy, in the catalog the bar already reads; not duplicated into `tasks.json`/`praxis.json`. Only that one key is added; nothing under `fieldDesk.*` is touched (#2451 is editing this file in the same batch).
- **`pages/tasks/TaskFilterBar.tsx`, `pages/praxes/PraxisFilterBar.tsx`** — pass `busy` through from `state`.
- **The four list surfaces** — `data-stale={loading && items.length > 0 ? 'true' : undefined}` on the existing list container: `Tasks.tsx` (both branches — the `.task-card-row` and the metatask-seal column), `tasks/mobileArchetypes/DefaultTasks.tsx`, `Praxes.tsx`, `praxes/MobilePraxisFeed.tsx`.
- **`index.css`** — one rule beside the filter-bar block: `[data-stale='true'] { opacity: 0.55; pointer-events: none; }`, with the opacity **transition** inside `@media (prefers-reduced-motion: no-preference)`. The dimming applies regardless; only the fade is opt-in. `pointer-events: none` is the substance — rows about to be replaced must not be navigable.

No skeletons, no debounce, no dropped `&& length === 0` guard, no caching or client-side filtering (the round-trip cost is #2432).

## One deviation from the issue text, and why

The issue says `busy={loading}`. Shipped as **`busy={loading && items.length > 0}`** — the same condition as `data-stale`. Bare `loading` broke two existing assertions in `pages/praxes/__tests__/praxisFilterBar.test.tsx` (the #2262 "the count prints once, in the bar" guard), and the failure was pointing at something real rather than at the harness:

- On a **first** load the list itself already prints "Loading praxis…". With bare `loading` the bar would print "Updating…" beside it — the wait stated twice, and an empty first read called an "update".
- Because the harness runs no effects, every page-level render is `loading: true`, so bare `loading` blanks the count out of the bar in **all** page-level tests and #2262's guard could no longer be asserted anywhere.

Nothing goes silent under the narrower flag: with an empty list, `loading && items.length === 0` is the list's own branch and it prints the loading paragraph. Busy now means precisely "the rows on screen belong to the previous filter", which is what the copy claims. Happy to flip it back to bare `loading` in one line if the ruling meant it literally.

Also noted: on both **mobile** surfaces "Load more" is a *child* of the wrap container, not a sibling as it is on desktop, so it dims with the rows. Re-parenting it would take it out of the flex flow that lays it out — and growing the window mid-flight only starts a second read over the first, so being inert there is the right behaviour. Desktop keeps "Load more" outside the dimmed container, as the ruling requires.

`ponytail:` comment left where `busy` is consumed — a warm backend can flip these words in and out inside ~100ms and read as a flicker; the upgrade path is a ~120ms grace before `busy` goes true, held in `useResource` so all four surfaces inherit it. Not built: no measurement behind a threshold yet.

## Checks

Every step in `.github/workflows/test.yml`'s `frontend` job, locally:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **392 files / 7001 passed**, 1 skipped
- `npm run build` — clean
- `npm run budget` — CSS **WARN**, and it is **pre-existing**: I rebuilt `origin/main`'s `index.css` to measure it. Baseline 22 827 B gzipped, this branch 22 858 B — **+31 B**, both round to 22.3 KB against a 22.2 KB warn line that main is already over. Fail line is 24.4 KB.

No backend, route, `response_model` or Pydantic schema touched, so `api-schema` and the backend `test` job are unaffected.

## What to eyeball

I have no browser tools and no dev stack — **visual QA is outstanding.** Concretely:

1. **Tasks, desktop** — with results on screen, click a faction facet. The card row should dim to 55% and stop taking clicks; the bar's summary should read "Updating…" and the section should carry `aria-busy="true"`; both should clear when the rows land. "Load more" must stay bright and clickable throughout.
2. **Tasks, desktop, metatask rail** — same, on the seal column (`?type=metatask`, viewer with `can_apply_metatask`).
3. **Tasks, mobile** — same filter change on the phone archetype. The results column dims *including* the "Load more" button — check that reads as deliberate and not as a broken button.
4. **Praxes, desktop** and **5. Praxes, mobile** — same two checks on the praxis feed.
6. **Filter change onto an empty list** — pick a facet combination with no results, then change filters again from there. There are no stale rows, so nothing dims and the bar keeps its count; the list swaps to the "Loading…" paragraph. Confirm that still reads as feedback rather than as a freeze.
7. **First load of each page** — the bar should print the count, not "Updating…", while the list prints its own loading line. One statement of the wait, not two.
8. **`prefers-reduced-motion: reduce`** — the dim still happens, just without the 150ms fade.
9. **Dark mode** — the rule is opacity only, no colour, so it should be identical, but worth one glance on a dark card ground.

`index.css` is normally `frontend-style`'s file; the rule here is the one dictated verbatim in the issue and involves no design judgement of mine, but flagging it for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
