### PR TITLE
An admin sees Albescent without earning it, and still cannot join it (#2400)

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
 from dependencies import (
+    account_has_admin_role,
     get_current_account_optional,
     get_current_character,
     get_current_character_optional,
@@ -72,8 +73,12 @@ async def list_characters(
         ),
         # Optional auth, and only the reveal flag is read from it: a revealed
         # caller may ask for the Albescent roster directly (#2422). Anonymous
-        # callers are unaffected — `account` is None and the fold stands.
+        # callers are unaffected — `account` is None and the fold stands. An
+        # admin counts as revealed for that question and no other (#2400).
         viewer_account=account,
+        viewer_is_admin=(
+            account is not None and await account_has_admin_role(account.id, session)
+        ),
         limit=limit,
         offset=offset,
     )

--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
 from dependencies import (
+    account_has_admin_role,
     get_current_account_optional,
     get_current_character,
 )
@@ -31,6 +32,19 @@ from services.faction_service import (
 router = APIRouter()
 
 
+async def _viewer_is_admin(
+    account: Account | None, session: AsyncSession
+) -> bool:
+    """Admin status for the optional viewer of a reveal-gated listing (#2400).
+
+    An admin is treated as revealed to Albescent so moderation can read the
+    surfaces it moderates without inflating its own progress — the bypass is
+    defined once in :func:`services.albescent_reveal.is_albescent_revealed` and
+    only fed from here. Anonymous callers never reach the role query.
+    """
+    return account is not None and await account_has_admin_role(account.id, session)
+
+
 @router.get("", response_model=list[FactionOut])
 async def list_factions(
     account: Account | None = Depends(get_current_account_optional),
@@ -46,7 +60,9 @@ async def list_factions(
         select(Faction).where(Faction.status == FactionStatus.visible).order_by(Faction.slug)
     )
     factions = result.scalars().all()
-    reveal_albescent = is_albescent_revealed(account)
+    reveal_albescent = is_albescent_revealed(
+        account, is_admin=await _viewer_is_admin(account, session)
+    )
     return [
         FactionOut.model_validate(faction)
         for faction in factions
@@ -99,13 +115,16 @@ async def get_faction_status(
     status_map, letters = await get_invitation_status(
         character.id, era_row.id, session
     )
+    reveal_albescent = is_albescent_revealed(
+        account, is_admin=await _viewer_is_admin(account, session)
+    )
     all_factions = [
         FactionStatusOut(
             slug=slug,
             status=status,
         )
         for slug, status in status_map.items()
-        if slug != ALBESCENT_FACTION_SLUG or is_albescent_revealed(account)
+        if slug != ALBESCENT_FACTION_SLUG or reveal_albescent
     ]
     return FactionPageOut(
         current_faction_slug=character.faction_slug,

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from dependencies import get_current_account_optional
+from db import get_db
+from dependencies import account_has_admin_role, get_current_account_optional
 from game_config import CURRENT_ERA
 from models.account import Account
 from schemas.game_config import (
@@ -17,6 +19,7 @@ router = APIRouter()
 @router.get("", response_model=GameConfigOut)
 async def get_game_config(
     account: Account | None = Depends(get_current_account_optional),
+    session: AsyncSession = Depends(get_db),
 ) -> GameConfigOut:
     # NOTE — this docstring ships verbatim to the PUBLIC ``/openapi.json``, so
     # it says what the route does without naming what it hides. The reason lives
@@ -25,8 +28,12 @@ async def get_game_config(
 
     Optional auth — anonymous callers stay anonymous and get the public answer.
     The account is read only to decide which level-ladder rungs this caller may
-    be told about (``services.progression.visible_level_profiles``).
+    be told about (``services.progression.visible_level_profiles``), including
+    whether it holds a moderation role.
     """
+    is_admin = account is not None and await account_has_admin_role(
+        account.id, session
+    )
     factions = [
         FactionConfigOut(
             slug=faction.slug,
@@ -49,7 +56,7 @@ async def get_game_config(
                 for unlock in profile.unlocks
             ],
         )
-        for profile in visible_level_profiles(account)
+        for profile in visible_level_profiles(account, is_admin=is_admin)
     ]
 
     return GameConfigOut(

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -28,9 +28,11 @@ async def get_game_config(
 
     Optional auth — anonymous callers stay anonymous and get the public answer.
     The account is read only to decide which level-ladder rungs this caller may
-    be told about (``services.progression.visible_level_profiles``), including
-    whether it holds a moderation role.
+    be told about (``services.progression.visible_level_profiles``).
     """
+    # Deliberately outside the docstring, per the NOTE above: the reason a
+    # moderation role is read here is #2400, and naming it publicly would name
+    # what it unhides. `services.albescent_reveal` holds the reason.
     is_admin = account is not None and await account_has_admin_role(
         account.id, session
     )

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import get_current_account_optional
+from dependencies import account_has_admin_role, get_current_account_optional
 from models.account import Account
 from schemas.character import CharacterOut
 from services.character import build_character_outs, list_characters_for_viewer
@@ -25,12 +25,16 @@ async def get_leaderboard(
     Auth is **optional** and always was in effect — this is a public board and
     anonymous callers must keep getting an answer. The account is read for one
     thing: a caller revealed to Albescent may ask for that roster directly
-    rather than getting the Unaffiliated fold (#2422).
+    rather than getting the Unaffiliated fold (#2422) — which an admin is, for
+    that question and no other (#2400).
     """
     rows = await list_characters_for_viewer(
         session,
         faction_slug=faction,
         viewer_account=account,
+        viewer_is_admin=(
+            account is not None and await account_has_admin_role(account.id, session)
+        ),
         limit=limit,
         offset=offset,
     )

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -25,13 +25,13 @@ async def get_leaderboard(
     Auth is **optional** and always was in effect — this is a public board and
     anonymous callers must keep getting an answer. The account is read for one
     thing: a caller revealed to Albescent may ask for that roster directly
-    rather than getting the Unaffiliated fold (#2422) — which an admin is, for
-    that question and no other (#2400).
+    rather than getting the Unaffiliated fold (#2422).
     """
     rows = await list_characters_for_viewer(
         session,
         faction_slug=faction,
         viewer_account=account,
+        # An admin counts as revealed for that question and no other (#2400).
         viewer_is_admin=(
             account is not None and await account_has_admin_role(account.id, session)
         ),

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import selectinload
 from config import settings
 from db import get_db
 from dependencies import (
+    account_has_admin_role,
     get_current_account_optional,
     get_current_character,
     get_current_character_optional,
@@ -217,8 +218,12 @@ async def list_praxes_route(
         voted=voted_filter,
         viewer_id=viewer.id if viewer else None,
         viewer_account_id=viewer.account_id if viewer else None,
-        # Optional auth; only the Albescent reveal flag is read from it (#2422).
+        # Optional auth; only the Albescent reveal flag is read from it (#2422),
+        # for which an admin counts as revealed (#2400).
         viewer_account=account,
+        viewer_is_admin=(
+            account is not None and await account_has_admin_role(account.id, session)
+        ),
         limit=limit,
         offset=offset,
     )

--- a/backend/services/albescent_reveal.py
+++ b/backend/services/albescent_reveal.py
@@ -19,11 +19,36 @@ Anonymous callers are unrevealed by definition — fail closed.
 from models.account import Account
 
 
-def is_albescent_revealed(account: Account | None) -> bool:
+def is_albescent_revealed(account: Account | None, *, is_admin: bool = False) -> bool:
     """True when this account may be told the society exists.
 
     ``Account.albescent_revealed`` is sticky: it flips the first time any
     character on the account joins Albescent (``services.faction_service``) and
     is never unset, so it survives age-out and character switches.
+
+    ``is_admin`` short-circuits it (#2400). Moderation has to be able to read
+    the surfaces it moderates, and the only other way in was for an admin to
+    inflate their own progress until they qualified — cheating, to do the job.
+    It is a **read-side** bypass and deliberately nothing else: no caller writes
+    ``albescent_revealed`` for an admin, so an admin who later loses the role
+    loses the reveal with it, and the column keeps meaning "earned".
+
+    **Seeing is not joining, and that split is what keeps this safe.**
+    ``can_start_as_albescent`` and ``defect_to_faction``'s Albescent guard never
+    consult admin status: an admin joins by qualifying like anyone else. Compare
+    ``services.character_capabilities.can_apply_metatask``, which pointedly does
+    *not* short-circuit on ``is_admin`` because ``apply_metatask`` has no admin
+    escape hatch — a capability flag saying yes where enforcement says no is
+    drift. Here there is no such claim to drift from: this predicate governs
+    only what is *shown*, the join gate is a separate flag on the same payload
+    (``CurrentUser.can_start_as_albescent``), and no caller on either side of
+    the wire derives one from the other. Keep it that way.
+
+    Caller-supplied rather than resolved here: admin status is an
+    ``account_role`` row (``dependencies.account_has_admin_role``), so looking
+    it up would make this async and force a session on every reader — including
+    ``services.progression``, which is otherwise pure config filtering. Every
+    call site already resolves or receives the flag. It defaults to ``False``,
+    so a reader that does not pass it gets the unprivileged answer.
     """
-    return account is not None and account.albescent_revealed
+    return account is not None and (is_admin or account.albescent_revealed)

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -615,6 +615,10 @@ async def list_characters_for_viewer(
     exclude_active_task_id: Optional[int] = None,
     exclude_account_id: Optional[int] = None,
     viewer_account: Optional[Account] = None,
+    # Resolved by the route, not here: it is an ``account_role`` row, and an
+    # admin is treated as revealed (#2400). Defaults False, so a caller that
+    # does not ask keeps the unprivileged answer.
+    viewer_is_admin: bool = False,
     limit: int = 50,
     offset: int = 0,
     era: EraConfig = CURRENT_ERA,
@@ -635,11 +639,11 @@ async def list_characters_for_viewer(
     picker asks for it so it does not have to re-derive the roster client-side
     (#1385); the duel service remains the enforcement.
 
-    ``viewer_account`` is the optional caller behind ``GET /characters`` and
-    ``GET /leaderboard``, and is consulted for one thing: whether an explicit
-    ``?faction=albescent`` is the faction page's roster question or a prober's
-    (#2422). ``None`` — anonymous, or a caller who passed none — keeps the
-    anti-oracle answer.
+    ``viewer_account`` (with ``viewer_is_admin``) is the optional caller behind
+    ``GET /characters`` and ``GET /leaderboard``, and is consulted for one
+    thing: whether an explicit ``?faction=albescent`` is the faction page's
+    roster question or a prober's (#2422). ``None`` — anonymous, or a caller who
+    passed none — keeps the anti-oracle answer.
     """
     from services.praxis import multi_membership_faction_slugs
 
@@ -695,7 +699,10 @@ async def list_characters_for_viewer(
     # fold is the shared helper's answer, not this route's — including whether
     # this viewer has been revealed and may ask for Albescent alone (#2422).
     roster_faction_slugs = faction_filter_slugs(
-        [faction_slug], reveal_albescent=is_albescent_revealed(viewer_account)
+        [faction_slug],
+        reveal_albescent=is_albescent_revealed(
+            viewer_account, is_admin=viewer_is_admin
+        ),
     )
     if roster_faction_slugs:
         query = query.where(Character.faction_slug.in_(roster_faction_slugs))

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -19,6 +19,7 @@ from dependencies import account_has_admin_role
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
 from schemas.auth import CurrentUser
+from services.albescent_reveal import is_albescent_revealed
 from services.character import (
     AccountEligibility,
     build_character_out,
@@ -80,7 +81,16 @@ async def build_current_user(
         is_admin=is_admin,
         can_create_additional_character=eligibility.can_create_additional_character,
         can_start_as_albescent=eligibility.can_start_as_albescent,
-        albescent_revealed=account.albescent_revealed,
+        # Through the seam, not off the column (#2400): an admin is *shown* the
+        # order without having earned it, and this is the field the whole
+        # frontend dresses off — the faction page gate, and the mask that
+        # decides whether the word "Albescent" is ever printed. Nothing writes
+        # the column, so the reveal goes when the role does.
+        #
+        # Seeing, not joining: `can_start_as_albescent` above is the join gate
+        # and never consults `is_admin`, so the two flags on this payload stay
+        # the two separate answers they are.
+        albescent_revealed=is_albescent_revealed(account, is_admin=is_admin),
         second_character_level_required=era.second_character_level_required,
         era_name=era.name,
         **asdict(capabilities),

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -299,6 +299,9 @@ async def list_praxes(
     # this is the row whose sticky reveal flag decides whether an explicit
     # ?faction=albescent is answered literally (#2422).
     viewer_account: Optional[Account] = None,
+    # Resolved by the route: admin status is an ``account_role`` row, and an
+    # admin is treated as revealed (#2400).
+    viewer_is_admin: bool = False,
     limit: int = 50,
     offset: int = 0,
     era: EraConfig = CURRENT_ERA,
@@ -358,7 +361,10 @@ async def list_praxes(
     # slugs on both, Albescent included (#1975) — and so a revealed viewer's
     # explicit ask un-folds on both, too (#2422).
     faction_slugs = faction_filter_slugs(
-        faction, reveal_albescent=is_albescent_revealed(viewer_account)
+        faction,
+        reveal_albescent=is_albescent_revealed(
+            viewer_account, is_admin=viewer_is_admin
+        ),
     )
     if faction_slugs:
         query = query.where(Task.primary_faction_slug.in_(faction_slugs))

--- a/backend/services/progression.py
+++ b/backend/services/progression.py
@@ -35,17 +35,23 @@ HIDDEN_UNTIL_REVEALED_UNLOCK_KEY = "join_albescent"
 def visible_level_profiles(
     account: Account | None,
     era: EraConfig = CURRENT_ERA,
+    *,
+    is_admin: bool = False,
 ) -> list[LevelProfile]:
     """The era's level profiles with rungs this account may not be told about removed.
 
     Anonymous callers (``account is None``) are unrevealed by definition, so the
     public answer is the filtered one — fail closed.
 
+    ``is_admin`` is passed through to the reveal seam, which treats an admin as
+    revealed (#2400). Resolved by the caller: admin status is a DB row, and this
+    function stays sync and session-free config filtering.
+
     Profiles are never dropped, only rungs: a level keeps its rank and its other
     unlocks, so the ladder stays index-aligned with ``era.level_thresholds`` and
     the level-up pop-up still fires at the level it always did.
     """
-    if is_albescent_revealed(account):
+    if is_albescent_revealed(account, is_admin=is_admin):
         return list(era.level_profiles)
 
     return [

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -630,7 +630,8 @@ async def list_tasks(
     skip_level_check: bool = False,
     # Deliberately not folded into `skip_level_check`: that one answers "may this
     # viewer see tasks above their level", this one answers "may they see the
-    # moderation queue". They happen to be true together today.
+    # moderation queue" — and, since #2400, "is this viewer treated as revealed
+    # to Albescent". They happen to be true together today.
     is_admin: bool = False,
     era: EraConfig = CURRENT_ERA,
 ) -> list[Task]:
@@ -879,7 +880,8 @@ async def list_tasks(
     # with the praxis feed and the character roster — including the one direction
     # a revealed viewer may un-fold (#2422).
     faction_slugs = faction_filter_slugs(
-        faction, reveal_albescent=is_albescent_revealed(viewer_account)
+        faction,
+        reveal_albescent=is_albescent_revealed(viewer_account, is_admin=is_admin),
     )
     if faction_slugs:
         query = query.where(Task.primary_faction_slug.in_(faction_slugs))

--- a/backend/tests/integration/test_albescent_admin_reveal.py
+++ b/backend/tests/integration/test_albescent_admin_reveal.py
@@ -1,0 +1,307 @@
+"""#2400 — an admin SEES Albescent without earning it, and still cannot JOIN it.
+
+The seam is ``services.albescent_reveal.is_albescent_revealed``: one predicate,
+short-circuited by ``is_admin``. These tests drive it through every route that
+consults it, because the risk of this change is not the predicate — it is a
+reader that inlines the column instead and drifts:
+
+* ``GET /factions``          → ``routers.factions.list_factions``
+* ``GET /factions/status``   → ``routers.factions.get_faction_status``
+* ``GET /game-config``       → ``services.progression.visible_level_profiles``
+* ``GET /auth/me``           → ``services.current_user.build_current_user``
+* ``GET /characters``, ``/leaderboard``, ``/praxes``, ``/tasks`` with
+  ``?faction=albescent`` → the #2422 roster/list fold
+
+And the half that must NOT move: ``POST /factions/choose`` still refuses an
+unqualified admin, and ``can_start_as_albescent`` still answers False. Seeing is
+not doing. The last test pins the scope note in the issue — the sticky column is
+never written for an admin, so the reveal goes when the role does.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from errors import ErrorCode
+from faction_slugs import ALBESCENT_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
+from models.account import Account
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from services.auth import create_jwt
+from services.progression import HIDDEN_UNTIL_REVEALED_UNLOCK_KEY
+from tests.integration.factories import (
+    make_admin,
+    make_character,
+    make_solo_praxis,
+    make_task,
+)
+
+#: A faction that is neither half of the unaffiliated bucket.
+OTHER_FACTION_SLUG = "ua"
+
+
+@pytest_asyncio.fixture
+async def faction_albescent(db_session: AsyncSession, faction_ua: Faction) -> Faction:
+    """The Albescent ``Faction`` row — ``visible``, exactly as ``seed.py`` makes it.
+
+    Secrecy is per-viewer, not a faction status: seeding it hidden would excuse
+    the bug, since ``list_factions`` drops non-visible rows before the reveal
+    filter ever runs.
+    """
+    existing = await db_session.scalar(
+        select(Faction).where(Faction.slug == ALBESCENT_FACTION_SLUG)
+    )
+    if existing is not None:
+        return existing
+    row = Faction(slug=ALBESCENT_FACTION_SLUG, status=FactionStatus.visible)
+    db_session.add(row)
+    await db_session.commit()
+    return await db_session.scalar(
+        select(Faction).where(Faction.slug == ALBESCENT_FACTION_SLUG)
+    )
+
+
+@pytest_asyncio.fixture
+async def admin(db_session: AsyncSession, era: Era, faction_albescent: Faction) -> dict:
+    """An admin who has never joined Albescent: role granted, column still False.
+
+    Level 0 and no coverage, so ``can_start_as_albescent`` is emphatically
+    False — which is the point. Everything this account can see, it sees on the
+    strength of the role alone.
+    """
+    character = await make_character(
+        db_session,
+        era,
+        username="reveal_admin",
+        faction_slug=OTHER_FACTION_SLUG,
+        level=0,
+    )
+    account = await db_session.get(Account, character.account_id)
+    await make_admin(db_session, account, commit=False)
+    await db_session.commit()
+    return {
+        "account_id": account.id,
+        "character_id": character.id,
+        "headers": {"Authorization": f"Bearer {create_jwt(account.id)}"},
+    }
+
+
+@pytest_asyncio.fixture
+async def plain(db_session: AsyncSession, era: Era, faction_albescent: Faction) -> dict:
+    """The control: same shape, no role, no reveal."""
+    character = await make_character(
+        db_session,
+        era,
+        username="reveal_plain",
+        faction_slug=OTHER_FACTION_SLUG,
+        level=0,
+    )
+    await db_session.commit()
+    return {
+        "account_id": character.account_id,
+        "headers": {"Authorization": f"Bearer {create_jwt(character.account_id)}"},
+    }
+
+
+@pytest_asyncio.fixture
+async def world(db_session: AsyncSession, era: Era, faction_albescent: Faction) -> dict:
+    """One row of each faction on every axis the #2422 fold filters."""
+    rows: dict[str, dict[str, int]] = {"tasks": {}, "praxes": {}, "characters": {}}
+    for slug in (UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG, OTHER_FACTION_SLUG):
+        character = await make_character(
+            db_session, era, username=f"admreveal_{slug}", faction_slug=slug
+        )
+        task = await make_task(
+            db_session, character, title=f"{slug} task", faction_slug=slug
+        )
+        praxis = await make_solo_praxis(
+            db_session, task, character, title=f"{slug} praxis"
+        )
+        rows["characters"][slug] = character.id
+        rows["tasks"][slug] = task.id
+        rows["praxes"][slug] = praxis.id
+    await db_session.commit()
+    return rows
+
+
+async def _ids(client: AsyncClient, url: str, headers: dict) -> set[int]:
+    resp = await client.get(url, headers=headers)
+    assert resp.status_code == 200, resp.text
+    return {row["id"] for row in resp.json()}
+
+
+def _unlock_keys(payload: dict) -> set[str]:
+    return {
+        unlock["key"]
+        for profile in payload["level_profiles"]
+        for unlock in profile["unlocks"]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Seeing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_faction_listing_shows_albescent_to_an_admin(
+    client: AsyncClient, admin: dict, plain: dict
+):
+    admin_resp = await client.get("/factions", headers=admin["headers"])
+    plain_resp = await client.get("/factions", headers=plain["headers"])
+    admin_slugs = {f["slug"] for f in admin_resp.json()}
+    plain_slugs = {f["slug"] for f in plain_resp.json()}
+    assert ALBESCENT_FACTION_SLUG in admin_slugs
+    assert ALBESCENT_FACTION_SLUG not in plain_slugs
+
+
+@pytest.mark.asyncio
+async def test_faction_status_page_lists_albescent_for_an_admin(
+    client: AsyncClient, admin: dict, plain: dict
+):
+    admin_resp = await client.get("/factions/status", headers=admin["headers"])
+    plain_resp = await client.get("/factions/status", headers=plain["headers"])
+    assert admin_resp.status_code == 200, admin_resp.text
+    assert plain_resp.status_code == 200, plain_resp.text
+    assert ALBESCENT_FACTION_SLUG in {
+        f["slug"] for f in admin_resp.json()["all_factions"]
+    }
+    assert ALBESCENT_FACTION_SLUG not in {
+        f["slug"] for f in plain_resp.json()["all_factions"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_level_ladder_announces_the_rung_to_an_admin(
+    client: AsyncClient, admin: dict, plain: dict
+):
+    """``/game-config`` names the unlock — the one rung that says the order exists."""
+    admin_resp = await client.get("/game-config", headers=admin["headers"])
+    plain_resp = await client.get("/game-config", headers=plain["headers"])
+    assert HIDDEN_UNTIL_REVEALED_UNLOCK_KEY in _unlock_keys(admin_resp.json())
+    assert HIDDEN_UNTIL_REVEALED_UNLOCK_KEY not in _unlock_keys(plain_resp.json())
+
+
+@pytest.mark.asyncio
+async def test_anonymous_game_config_is_unchanged(client: AsyncClient, admin: dict):
+    """No account, no reveal — the public answer must not have moved."""
+    resp = await client.get("/game-config")
+    assert resp.status_code == 200, resp.text
+    assert HIDDEN_UNTIL_REVEALED_UNLOCK_KEY not in _unlock_keys(resp.json())
+
+
+@pytest.mark.asyncio
+async def test_auth_me_reports_the_admin_as_revealed(
+    client: AsyncClient, admin: dict, plain: dict
+):
+    """The field the whole frontend dresses off — the page gate and the name mask."""
+    admin_me = (await client.get("/auth/me", headers=admin["headers"])).json()
+    plain_me = (await client.get("/auth/me", headers=plain["headers"])).json()
+    assert admin_me["is_admin"] is True
+    assert admin_me["albescent_revealed"] is True
+    assert plain_me["albescent_revealed"] is False
+
+
+@pytest.mark.parametrize(
+    "key,url",
+    [
+        ("characters", "/characters?faction={slug}"),
+        ("characters", "/leaderboard?faction={slug}"),
+        ("praxes", "/praxes?faction={slug}"),
+        ("tasks", "/tasks?faction={slug}"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_roster_filters_un_fold_for_an_admin(
+    client: AsyncClient, admin: dict, plain: dict, world: dict, key: str, url: str
+):
+    """#2422's ruling: one rule for revealed — the word and the roster together.
+
+    An admin who can open ``/factions/albescent`` but gets that page's roster
+    folded with every unaffiliated row in the game is looking at exactly the bug
+    #2422 fixed.
+    """
+    admin_ids = await _ids(
+        client, url.format(slug=ALBESCENT_FACTION_SLUG), admin["headers"]
+    )
+    assert world[key][ALBESCENT_FACTION_SLUG] in admin_ids
+    assert world[key][UNAFFILIATED_FACTION_SLUG] not in admin_ids
+
+
+@pytest.mark.parametrize(
+    "key,url",
+    [
+        ("characters", "/characters?faction={slug}"),
+        ("characters", "/leaderboard?faction={slug}"),
+        ("praxes", "/praxes?faction={slug}"),
+        ("tasks", "/tasks?faction={slug}"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_non_admin_still_gets_the_anti_oracle_answer(
+    client: AsyncClient, plain: dict, world: dict, key: str, url: str
+):
+    """The prober's answer is untouched: ``albescent`` still answers ``na``."""
+    guessed = await _ids(
+        client, url.format(slug=ALBESCENT_FACTION_SLUG), plain["headers"]
+    )
+    folded = await _ids(
+        client, url.format(slug=UNAFFILIATED_FACTION_SLUG), plain["headers"]
+    )
+    assert guessed == folded
+
+
+# ---------------------------------------------------------------------------
+# Not joining
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_admin_is_still_not_eligible_to_join(
+    client: AsyncClient, admin: dict
+):
+    """``can_start_as_albescent`` never consults the role. Seeing is not doing."""
+    me = (await client.get("/auth/me", headers=admin["headers"])).json()
+    assert me["can_start_as_albescent"] is False
+
+
+@pytest.mark.asyncio
+async def test_choosing_albescent_is_still_refused_for_an_unqualified_admin(
+    client: AsyncClient, admin: dict
+):
+    """The capability-flag drift guard, at the wire.
+
+    ``can_apply_metatask`` is this repo's recorded failure of the same shape: a
+    flag saying yes where enforcement says no. It stays safe here only while the
+    join gate keeps answering 403 to the account the reveal now says yes to.
+    """
+    resp = await client.post(
+        "/factions/choose",
+        json={"faction_slug": ALBESCENT_FACTION_SLUG},
+        headers=admin["headers"],
+    )
+    assert resp.status_code == 403, resp.text
+    assert (
+        resp.json()["detail"]["code"]
+        == ErrorCode.faction_albescent_not_eligible.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_sticky_column_is_never_written_for_an_admin(
+    client: AsyncClient, db_session: AsyncSession, admin: dict
+):
+    """The bypass is a READ.
+
+    An admin who later loses the role must lose the reveal with it, which is
+    only true while nothing persists it. Walk every reveal-gated surface, then
+    look at the column.
+    """
+    for url in ("/factions", "/factions/status", "/game-config", "/auth/me"):
+        assert (await client.get(url, headers=admin["headers"])).status_code == 200
+
+    account = await db_session.get(Account, admin["account_id"])
+    await db_session.refresh(account)
+    assert account.albescent_revealed is False

--- a/backend/tests/unit/test_albescent_reveal.py
+++ b/backend/tests/unit/test_albescent_reveal.py
@@ -1,0 +1,51 @@
+"""The one definition of "revealed" — including #2400's admin bypass.
+
+Every surface that hides Albescent asks
+:func:`services.albescent_reveal.is_albescent_revealed`, so this is the seam
+where "an admin is treated as revealed" is decided once. The bypass is a READ:
+nothing here writes ``Account.albescent_revealed``, which stays sticky and
+earned (ADR-0027 / #390).
+
+Seeing is not joining. ``can_start_as_albescent`` and ``defect_to_faction``'s
+guard never consult admin status, and the integration counterpart
+(``tests/integration/test_albescent_admin_reveal.py``) pins that an admin who
+can see the order is still refused by it.
+"""
+
+from models.account import Account
+from services.albescent_reveal import is_albescent_revealed
+
+
+def _account(*, revealed: bool) -> Account:
+    return Account(email="a@example.com", albescent_revealed=revealed)
+
+
+def test_unrevealed_non_admin_is_not_revealed():
+    assert is_albescent_revealed(_account(revealed=False)) is False
+
+
+def test_revealed_non_admin_is_revealed():
+    assert is_albescent_revealed(_account(revealed=True)) is True
+
+
+def test_unrevealed_admin_is_revealed():
+    """#2400: an admin sees the order without having earned it."""
+    assert is_albescent_revealed(_account(revealed=False), is_admin=True) is True
+
+
+def test_anonymous_caller_is_never_revealed_even_flagged_admin():
+    """No account, no reveal — the module's fail-closed promise outranks the flag.
+
+    ``is_admin=True`` with ``account=None`` is unreachable through the app (the
+    flag is derived from an account), so this pins the guard rather than a
+    behaviour anyone relies on.
+    """
+    assert is_albescent_revealed(None) is False
+    assert is_albescent_revealed(None, is_admin=True) is False
+
+
+def test_admin_bypass_does_not_write_the_sticky_column():
+    """The bypass lives at the read. The column must be untouched by asking."""
+    account = _account(revealed=False)
+    is_albescent_revealed(account, is_admin=True)
+    assert account.albescent_revealed is False


### PR DESCRIPTION
Closes #2400

An admin **sees** Albescent without earning it. An admin still **joins** it only by qualifying.

> *"admins should be able to see albescent for the same reasons that they should be able to see comments early. Admins shouldn't have to cheat/inflate points in order to do their job."* — and — *"Joining albescent early would be cheating."*

## The seam I tested at

`backend/services/albescent_reveal.py::is_albescent_revealed` — the one definition of "revealed", introduced by #2422. The short-circuit lives there and nowhere else, so there is still exactly one answer to "is this viewer revealed" and no parallel registry to drift.

```python
def is_albescent_revealed(account: Account | None, *, is_admin: bool = False) -> bool:
    return account is not None and (is_admin or account.albescent_revealed)
```

The failing test came first, at that seam (`backend/tests/unit/test_albescent_reveal.py`), then at the wire. **Reverting just the `is_admin or` turns exactly the eight "seeing" integration cases red and leaves all eight "must not move" cases green** — I ran that both ways.

## Shape chosen for threading `is_admin`, and why

**`is_admin` is passed into the seam as a keyword argument, resolved by the caller.** Not an async seam, not a second wrapper function.

`is_admin` is not a column on `Account` — it is `account_has_admin_role(account.id, session)`, async and session-taking. Three ways out; I took the cheapest that holds:

- **Async seam (rejected).** Would force a session onto `services.progression.visible_level_profiles`, which is otherwise pure, sync, session-free config filtering — and would add a *second* admin query on `GET /tasks`, whose route already resolves `is_admin` and passes it down.
- **A second, differently-named wrapper (rejected).** That is the parallel-registry failure #2422 exists to prevent; a call site would eventually pick the wrong one.
- **A `bool` parameter (taken).** It matches what this repo already does: `services.task.list_tasks` has taken `is_admin: bool` from `routers/tasks.py` for a while, and `services.character_capabilities.compute_capabilities` takes one too. `list_tasks` therefore needed **no new parameter at all** — the flag it already had is now also fed to the reveal. Default is `False`, so a reader that forgets gets the *unprivileged* answer: fail-closed, same posture as `reveal_albescent` itself.

## Seven readers, not the three the issue names

#2422 shipped after the issue was written and added three roster/list folds. I also found a seventh the issue does not mention. All now route through the seam:

| reader | how it gets `is_admin` |
|---|---|
| `routers/factions.py` `GET /factions` | new `_viewer_is_admin` helper in that router |
| `routers/factions.py` `GET /factions/status` | same helper |
| `services/progression.py` `visible_level_profiles` | new kwarg; `routers/game_config.py` resolves it (route gained a `session` dep) |
| `services/character.py` (`/characters`, `/leaderboard`) | new `viewer_is_admin` kwarg from both routers |
| `services/praxis.py` (`/praxes`) | new `viewer_is_admin` kwarg |
| `services/task.py` (`/tasks`) | **free** — `is_admin` was already threaded |
| `services/current_user.py` (`GET /auth/me`) | **free** — `is_admin` was already computed two lines above |

**`/auth/me` is the load-bearing one and it was reading `account.albescent_revealed` off the column directly, bypassing the seam.** It is what `App.tsx:113` gates the whole `/factions/albescent` page on, and what feeds `setAlbescentRevealed()` — the module-level mask in `frontend/src/utils/factions.ts` that decides whether the *word* "Albescent" is ever printed. Without this one, an admin would get the faction row in `GET /factions` and still be shown the sealed placeholder.

**On whether the roster filters should short-circuit too — yes, and here is the check I was asked to make.** The un-fold is one-directional (`na` still expands to both slugs for everyone), so nothing about the *non-admin* answer changes shape or timing: `test_a_non_admin_still_gets_the_anti_oracle_answer` asserts `?faction=albescent` and `?faction=na` still return identical id sets on all four surfaces. A prober cannot infer anything from another account's privilege.

## The `can_apply_metatask` trap — verified, on both sides of the wire

`can_apply_metatask` deliberately does *not* short-circuit on `is_admin`, because `apply_metatask` answers 403 and a flag saying yes where enforcement says no is drift. That does not apply here **only because nothing derives "can join" from "is revealed"**. I checked:

- **Backend:** `can_start_as_albescent` (`services/character.py`) and `defect_to_faction`'s Albescent guard (`services/faction_service.py`) are untouched and never consult admin status. `character_stats` untouched. No migration.
- **Frontend:** the join CTA on the faction page comes from `resolveMembershipState`, which reads `GET /factions/status`'s per-slug status. An admin who never joined is `not_invited` -> `"gate"` -> the soft *"keep doing tasks"* copy. **No Join button is offered.** The `AlbescentInvitation` component gates on `can_start_as_albescent` alone. The four consumers of `isFactionHiddenFromChoosers` are TheArray readout, the filter facet, the admin task-faction `<select>` and the players facet — all *seeing* surfaces, none of them a join chooser. Nothing calls `chooseFaction()` off `albescent_revealed`.
- **And pinned at the wire anyway:** `POST /factions/choose {albescent}` as an unqualified admin still returns 403 `FACTION_ALBESCENT_NOT_ELIGIBLE`, and `/auth/me` still reports `can_start_as_albescent: false` for that same admin.

## The bypass is a read, never a write

Nothing sets `albescent_revealed` for an admin, so an admin who later loses the role loses the reveal with it and the column keeps meaning "earned". `test_the_sticky_column_is_never_written_for_an_admin` walks `/factions`, `/factions/status`, `/game-config` and `/auth/me` as an admin and then asserts the column is still `False`.

## Tests

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://.../wz2400_test \
  pytest --cov=. --cov-report=term --cov-fail-under=80 -q
```
**1546 passed, coverage 94.31%** (gate is 80). Dedicated DB `wz2400_test`, not the shared one.

New: `backend/tests/unit/test_albescent_reveal.py` (5) and `backend/tests/integration/test_albescent_admin_reveal.py` (16 — eight prove the reveal, eight prove nothing else moved).

`python -m ruff check --no-cache .` run from `backend/`: no new findings, allowlist unchanged (one pre-existing `I001` I introduced in `current_user.py` was fixed, not allowlisted).

## api-schema

`python scripts/regen_api_client.py` from the repo root produces **no diff** — `backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` are byte-identical to `main`, so nothing to commit. My first pass *did* move two route docstrings into the public schema; I pulled both back out. `/game-config`'s docstring carries a NOTE saying it ships verbatim to the public `/openapi.json`, so the reason a moderation role is read there is a `#` comment, not prose in the payload.

## Out of scope, untouched

ADR-0027 / #390 secrecy. **#2399** (the gate re-cut): `can_start_as_albescent`, `defect_to_faction` and `character_stats` are not touched by this branch, so it changes only who may *see* and can land in either order.

## Cost note

Four routes (`/factions`, `/factions/status`, `/game-config`, `/characters`, `/leaderboard`, `/praxes`) now run one extra indexed `account_role` join per *authenticated* request. `/tasks` and `/auth/me` pay nothing new. Anonymous callers never reach the query.

---

## Visual QA is outstanding

**I have no browser tools and no dev stack.** Everything above is verified by pytest and by reading the frontend source. Nothing on the frontend was changed, so this is entirely about what an admin now sees where they previously saw a sealed door.

### What to eyeball

Sign in as an **admin who has never joined Albescent** (`albescent_revealed` still `false` in the DB — worth confirming in psql first):

1. **`/factions/albescent`** renders the real faction detail page, not `AlbescentSecretPlaceholder`.
2. That page's **join block** shows the soft *"keep doing tasks"* gate — **not** a Join button. If a Join button appears, stop: that is the `can_apply_metatask` drift and it means `/factions/status` is reporting something other than `not_invited`.
3. That page's **member roster** shows Albescent members only — not every unaffiliated character in the game.
4. **The factions directory** lists Albescent among the cards.
5. **The word "Albescent"** now prints wherever an Albescent member is labelled (praxis bylines, task cards, the character switcher) instead of masking to "Unaffiliated".
6. **The level ladder / progression surfaces** name the level-8 `join_albescent` unlock.
7. **The faction filter facet** on Players / Tasks / Praxes offers Albescent as an option, and picking it returns the order alone.
8. **Sign out, or sign in as a non-admin, and confirm every one of the above is sealed again** — the placeholder, the mask, no rung, no facet option.
9. If you can revoke the admin role on that account and reload: the reveal should **disappear**, since it was never written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
