### PR TITLE
The composer's score stamp learns the number the seal mutation already sent

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -11102,7 +11102,7 @@
     },
     "/praxes/{praxis_id}/metatasks/{task_id}": {
       "delete": {
-        "description": "Detach a previously applied metatask from a praxis.",
+        "description": "Detach a previously applied metatask from a praxis.\n\nAnswers with the re-scored praxis, like its apply sibling (#2464). Peeling a\nseal off changes ``score`` and ``metatask_points``, and ``remove_metatask``\nhas already recomputed both — a bare 204 left the composer's score stamp\nprinting the higher total until a reload.",
         "operationId": "remove_metatask_route_praxes__praxis_id__metatasks__task_id__delete",
         "parameters": [
           {
@@ -11141,7 +11141,14 @@
           }
         ],
         "responses": {
-          "204": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PraxisOut"
+                }
+              }
+            },
             "description": "Successful Response"
           },
           "422": {

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -737,19 +737,25 @@ async def apply_metatask_route(
     return await build_praxis_out(praxis, session, viewer=character)
 
 
-@router.delete("/{praxis_id}/metatasks/{task_id}", status_code=204)
+@router.delete("/{praxis_id}/metatasks/{task_id}", response_model=PraxisOut)
 async def remove_metatask_route(
     praxis_id: int,
     task_id: int,
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    """Detach a previously applied metatask from a praxis."""
-    await remove_metatask(
+    """Detach a previously applied metatask from a praxis.
+
+    Answers with the re-scored praxis, like its apply sibling (#2464). Peeling a
+    seal off changes ``score`` and ``metatask_points``, and ``remove_metatask``
+    has already recomputed both — a bare 204 left the composer's score stamp
+    printing the higher total until a reload.
+    """
+    praxis = await remove_metatask(
         praxis_id=praxis_id,
         task_id=task_id,
         character_id=character.id,
         session=session,
         era=CURRENT_ERA,
     )
-    return Response(status_code=204)
+    return await build_praxis_out(praxis, session, viewer=character)

--- a/backend/tests/integration/test_praxis_metatask_routes.py
+++ b/backend/tests/integration/test_praxis_metatask_routes.py
@@ -1,0 +1,91 @@
+"""Both metatask mutations answer with the re-scored praxis (#2464).
+
+The composer's score stamp prints ``praxis.score`` / ``praxis.metatask_points``.
+Sealing or peeling a metatask changes both numbers, and the server has already
+computed them by the time it answers — ``apply_metatask`` and ``remove_metatask``
+are both typed ``-> Praxis`` and both re-run ``recalculate_members_stats``.
+
+So the contract these tests pin is that the *route* hands that praxis back.
+``POST`` always did. ``DELETE`` declared ``204`` and threw the service's return
+value away, which left the client with no way to learn the new total short of a
+refetch — a third statement of a number the server just sent (#1382 / #2402).
+
+The reported symptom was a base of 10 with a +100 metatask sealed and a stamp
+still reading 10, so 10/110 are the numbers used here.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.praxis import PraxisStatus
+from models.task import TaskType
+from tests.integration.factories import make_solo_praxis, make_task
+
+BASE_POINTS = 10
+META_POINTS = 100
+
+
+@pytest_asyncio.fixture
+async def sealable(db_session: AsyncSession, character2: Character):
+    """A level-5 author's in-progress draft, plus a metatask worth +100.
+
+    ``character2`` is the fixture that already sits at ``metatask_apply_level``
+    (5 in Era 1); ``character`` is level 0 and would be refused at the gate.
+    """
+    task = await make_task(db_session, character2, point_value=BASE_POINTS)
+    metatask = await make_task(
+        db_session,
+        character2,
+        title="a metatask",
+        point_value=META_POINTS,
+        task_type=TaskType.metatask,
+    )
+    praxis = await make_solo_praxis(
+        db_session, task, character2, status=PraxisStatus.in_progress
+    )
+    await db_session.commit()
+    return praxis, metatask
+
+
+@pytest.mark.asyncio
+async def test_sealing_answers_with_the_new_total(
+    client: AsyncClient, auth_headers2: dict, sealable
+):
+    praxis, metatask = sealable
+
+    response = await client.post(
+        f"/praxes/{praxis.id}/metatasks",
+        json={"task_id": metatask.id},
+        headers=auth_headers2,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["metatask_points"] == META_POINTS
+    assert body["score"] == BASE_POINTS + META_POINTS
+
+
+@pytest.mark.asyncio
+async def test_peeling_answers_with_the_total_it_falls_back_to(
+    client: AsyncClient, auth_headers2: dict, sealable
+):
+    """The regression: DELETE used to answer 204 with no body at all."""
+    praxis, metatask = sealable
+    sealed = await client.post(
+        f"/praxes/{praxis.id}/metatasks",
+        json={"task_id": metatask.id},
+        headers=auth_headers2,
+    )
+    assert sealed.status_code == 201
+
+    response = await client.delete(
+        f"/praxes/{praxis.id}/metatasks/{metatask.id}", headers=auth_headers2
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["metatask_points"] == 0
+    assert body["score"] == BASE_POINTS

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1400,6 +1400,11 @@ export interface paths {
         /**
          * Remove Metatask Route
          * @description Detach a previously applied metatask from a praxis.
+         *
+         *     Answers with the re-scored praxis, like its apply sibling (#2464). Peeling a
+         *     seal off changes ``score`` and ``metatask_points``, and ``remove_metatask``
+         *     has already recomputed both — a bare 204 left the composer's score stamp
+         *     printing the higher total until a reload.
          */
         delete: operations["remove_metatask_route_praxes__praxis_id__metatasks__task_id__delete"];
         options?: never;
@@ -7063,11 +7068,13 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            204: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PraxisOut"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -524,10 +524,11 @@ export async function applyMetatask(praxisId: number, taskId: number): Promise<P
   return data
 }
 
-export async function removeMetatask(praxisId: number, taskId: number): Promise<void> {
-  await apiDelete('/praxes/{praxis_id}/metatasks/{task_id}', {
+export async function removeMetatask(praxisId: number, taskId: number): Promise<PraxisOut> {
+  const { data } = await apiDelete('/praxes/{praxis_id}/metatasks/{task_id}', {
     params: { path: { praxis_id: praxisId, task_id: taskId } },
   })
+  return data
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/editPraxis/__tests__/metataskStampFreshness.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/metataskStampFreshness.test.ts
@@ -1,0 +1,71 @@
+/**
+ * #2464 — a seal mutation's answer is never discarded.
+ *
+ * The composer's score stamp reads `praxis.score` and `praxis.metatask_points`.
+ * `useMetataskApply` used to update only `appliedMetataskList`, so sealing a
+ * +100 metatask onto a task worth 10 left the stamp printing 10 until a reload
+ * — and peeling one off left it printing the higher total. Both mutations
+ * answer with the re-scored praxis, so the fix is to write that answer back.
+ *
+ * WHY THIS IS A SOURCE ASSERTION
+ * ------------------------------
+ * vitest runs in the `node` environment here — no jsdom, no `renderHook` (see
+ * `hooks/__tests__/useTheme.test.tsx` and `searchQueryParamAdoption.test.ts`,
+ * which take the same posture for the same reason). A hook whose whole defect
+ * is *which state cell a callback writes* cannot be rendered to observe it, so
+ * the available check is the one below: every mutation call in the hook is
+ * consumed rather than awaited into the void.
+ *
+ * The compiler already covers the other half. `applyMetatask`/`removeMetatask`
+ * are typed `Promise<PraxisOut>`, and `useMetataskApply` takes `setPraxis` as a
+ * required property — so a mount that forgets to thread it, or a client that
+ * stops returning a praxis, fails `tsc` rather than needing a test here. What
+ * `tsc` cannot see is a call written back as a bare `await`, which is exactly
+ * the state this file found the hook in.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const HOOK_SOURCE = readFileSync(
+  fileURLToPath(new URL("../useMetataskApply.ts", import.meta.url)),
+  "utf8",
+);
+
+/** Every line that calls one of the two mutations, comments and imports aside. */
+function mutationCallLines(): string[] {
+  return HOOK_SOURCE.split("\n")
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        !line.startsWith("*") &&
+        !line.startsWith("//") &&
+        !line.startsWith("import") &&
+        /\b(applyMetatask|removeMetatask)\(/.test(line),
+    );
+}
+
+describe("useMetataskApply keeps the praxis each mutation returns", () => {
+  /**
+   * Four, not three: `toggleMetatask` has an apply branch AND a remove branch,
+   * and the remove branch is the one a test is most likely to skip. `>=` rather
+   * than `===` so a fifth path is held to the rule below rather than failing
+   * here for existing.
+   */
+  it("still has all four mutation call sites", () => {
+    expect(mutationCallLines().length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("writes every one of them back through setPraxis", () => {
+    const discarded = mutationCallLines().filter(
+      (line) => !/setPraxis\(await (apply|remove)Metatask\(/.test(line),
+    );
+
+    expect(discarded,
+      "These calls throw away the re-scored praxis the server just sent, so " +
+        "the score stamp keeps printing the pre-mutation total until a reload " +
+        "(#2464). Write each one back — `setPraxis(await applyMetatask(...))` " +
+        "— and do NOT reach for a refetch: the number is already on the wire.",
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -164,7 +164,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     confirmRemoveMetatask,
     cancelRemoveMetatask,
     seedApplied: seedAppliedMetatasks,
-  } = useMetataskApply(praxis, setError);
+  } = useMetataskApply({ praxis, setPraxis, setError });
 
   const [switchingMode, setSwitchingMode] = useState<PraxisType | null>(null);
   // One-shot post-publish beat for the member whose cast closed the gate (#591).

--- a/frontend/src/pages/editPraxis/useMetataskApply.ts
+++ b/frontend/src/pages/editPraxis/useMetataskApply.ts
@@ -39,10 +39,20 @@ export interface MetataskApply {
   seedApplied: (applied: TaskOut[]) => void;
 }
 
-export function useMetataskApply(
-  praxis: PraxisOut | null,
-  setError: (message: string) => void,
-): MetataskApply {
+/**
+ * Both mutations answer with the re-scored praxis, so all three paths below
+ * write it back through `setPraxis` (#2464). The seal stack alone is not the
+ * whole state a seal changes: the composer's score stamp reads `praxis.score`
+ * and `praxis.metatask_points`, and leaving those at whatever the initial load
+ * returned is why sealing a +100 metatask onto a task worth 10 kept printing
+ * 10. Not a refetch — the server already sent the number (#1382 / #2402).
+ */
+export function useMetataskApply(options: {
+  praxis: PraxisOut | null;
+  setPraxis: (praxis: PraxisOut) => void;
+  setError: (message: string) => void;
+}): MetataskApply {
+  const { praxis, setPraxis, setError } = options;
   // The applied metatasks as full rows (source of truth for the seal stack);
   // `appliedMetatasks` (the id Set) is derived from it below.
   const [appliedMetataskList, setAppliedMetataskList] = useState<TaskOut[]>([]);
@@ -66,12 +76,12 @@ export function useMetataskApply(
       setError("");
       try {
         if (appliedMetatasks.has(mt.id)) {
-          await removeMetatask(praxis.id, mt.id);
+          setPraxis(await removeMetatask(praxis.id, mt.id));
           setAppliedMetataskList((previous) =>
             previous.filter((m) => m.id !== mt.id),
           );
         } else {
-          await applyMetatask(praxis.id, mt.id);
+          setPraxis(await applyMetatask(praxis.id, mt.id));
           setAppliedMetataskList((previous) => [...previous, mt]);
         }
       } catch (err) {
@@ -82,7 +92,7 @@ export function useMetataskApply(
         setApplyingMetatask(null);
       }
     },
-    [praxis, applyingMetatask, appliedMetatasks, setError],
+    [praxis, setPraxis, applyingMetatask, appliedMetatasks, setError],
   );
 
   // Section D: the picker seals one metatask at a time, then closes.
@@ -96,7 +106,7 @@ export function useMetataskApply(
       setApplyingMetatask(mt.id);
       setError("");
       try {
-        await applyMetatask(praxis.id, mt.id);
+        setPraxis(await applyMetatask(praxis.id, mt.id));
         setAppliedMetataskList((previous) => [...previous, mt]);
         setMetataskPickerOpen(false);
       } catch (err) {
@@ -107,7 +117,7 @@ export function useMetataskApply(
         setApplyingMetatask(null);
       }
     },
-    [praxis, applyingMetatask, appliedMetatasks, setError],
+    [praxis, setPraxis, applyingMetatask, appliedMetatasks, setError],
   );
 
   // Section E: the seal's × asks first — open the confirm for that metatask.
@@ -131,7 +141,7 @@ export function useMetataskApply(
     setApplyingMetatask(target.id);
     setError("");
     try {
-      await removeMetatask(praxis.id, target.id);
+      setPraxis(await removeMetatask(praxis.id, target.id));
       setAppliedMetataskList((previous) =>
         previous.filter((mt) => mt.id !== target.id),
       );
@@ -143,7 +153,7 @@ export function useMetataskApply(
     } finally {
       setApplyingMetatask(null);
     }
-  }, [praxis, metataskRemovalTarget, setError]);
+  }, [praxis, setPraxis, metataskRemovalTarget, setError]);
 
   // Clear first: the picker now prints `error` itself (#2382), and the composer
   // shares one error slot, so a failure from publish or a duel would otherwise


### PR DESCRIPTION
Closes #2464

Seal a metatask in the composer and the score stamp kept printing the old total — a task worth 10 with a +100 metatask sealed still read 10. The stamp was already mounted and already correct; it was being handed a stale praxis.

## The seam under test

**The mutation's return value, on both sides of the wire.** Not the stamp, not `scoreBreakdown`, and not a refetch: `applyMetatask` and `remove_metatask` both already compute the new total, and the fix is to stop dropping it. Same shape as #1382 / #2402.

Two red loops, both verified red before the fix:

- **Backend** — `backend/tests/integration/test_praxis_metatask_routes.py`. There were no route-level tests for either metatask endpoint. Failed on `assert 204 == 200`: the DELETE answered with no body at all. Its sibling POST test **passed from the start**, which is the confirmation that 110 was already on the wire and the client was the one discarding it.
- **Frontend** — `frontend/src/pages/editPraxis/__tests__/metataskStampFreshness.test.ts`. Run against the pre-fix hook it reported all four discarded call sites by name, **including both `toggleMetatask` branches**.

## What changed

**Backend — the peel-off answers with the praxis it already re-scored.** `services.praxis_metatask.remove_metatask` is typed `-> Praxis` and returns one; `routers/praxes.py` declared `status_code=204` and threw it away. Now `response_model=PraxisOut`, returning through `build_praxis_out` exactly like its apply sibling. One line of behaviour.

**Frontend — the hook keeps what it is handed.** `useMetataskApply` updated only `appliedMetataskList`, so `praxis.score` and `praxis.metatask_points` stayed at whatever the initial load returned. All four mutation sites now write the returned `PraxisOut` back through `setPraxis`, threaded as an options object in the same shape as the sibling `useComposerDuel({ praxis, setPraxis, ... })` rather than inventing a callback. `removeMetatask` returns `Promise<PraxisOut>` like `applyMetatask`.

No refetch anywhere — the number is already on the wire on both paths.

`backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` regenerated by `python scripts/regen_api_client.py`, and the `api-schema` gate re-run afterwards: `git diff --exit-code` clean.

## Why the frontend check is a source assertion

vitest runs in the `node` environment here — no jsdom, no `renderHook` (same posture as `useTheme.test.tsx` and `searchQueryParamAdoption.test.ts`). A hook whose entire defect is *which state cell a callback writes* cannot be rendered to observe it. `tsc` covers the other half for free: the mutations are typed `Promise<PraxisOut>` and `setPraxis` is a required property, so a mount that forgets to thread it fails to compile. What the compiler cannot see is a call rewritten as a bare `await` — which is exactly the state the hook was in, and exactly what the guard catches.

## Verification

Every step in `.github/workflows/test.yml`, run locally:

- `test` — migrations `upgrade head` clean on a fresh DB; **1547 passed, 94.38% coverage** (gate 80). Backend tests used the dedicated `wz2464_test`.
- `api-schema` — regen + `git diff --exit-code`: clean.
- `frontend` — lint, `typecheck`, `typecheck:design-sync`, **7017 tests / 394 files passed**, build, budget.

The byte budget prints a CSS **WARN** (22.3 KB vs a 22.2 KB warn line). It is inherited from `main`, not from this PR — the diff touches **zero** `.css` files. Non-blocking either way.

## What to eyeball

**Visual QA is outstanding** — this branch was built with no browser and no dev stack, so nothing below has been seen, only proven by tests. All of it must happen **without a page reload**; a reload has always shown the right number, which is why this survived.

Open a draft praxis on a task worth 10, in the composer:

1. **Seal a metatask worth +100 through the picker.** The score stamp should go from **10** to **110** the moment the picker closes, and the stamp's **meta row should appear** (it is gated on `metatask_points > 0`, so it is absent before the seal by design).
2. **Peel that same seal off** via the seal's `×` and confirm. The stamp should fall back to **10** and the **meta row should disappear** again.
3. Watch that the stamp does not flicker to a wrong intermediate number, and that a failed mutation still leaves the old total standing rather than a blank.
4. Worth a glance across a couple of faction skins, since `ScoreStamp` dispatches per faction through `surfaceMap("scoreStamp")`.

## Flagged, not decided — out of scope

**The seal card's own `+100 PTS` is now a duplicate on screen.** Confirmed while verifying: the seal skins print `detail.seal.bonus` with `metatask.point_value` (`AlbescentSeal.tsx:93`, `CovenSeal.tsx:115`, `DefaultSeal.tsx:94` and siblings). Now that the stamp prints a meta row, **+100 appears twice on one screen in two registers** — "what this seal is worth" versus "the praxis total". Whether that is a duplicate worth cutting (#2245's shape) or two genuinely different facts is a copy/design call, so it is flagged here and deliberately left alone.

Also untouched, as the issue directs: `PraxisWaitingSurface.tsx`'s deliberate `mark={dress.mark}` override, and `scoreBreakdown` row selection — it was right all along, it was just being fed a stale praxis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
