### PR TITLE
A new life is written on the vellum leaf, and clearing the calling hands the page back (#2348)

### DIFF
--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -106,7 +106,7 @@ const BESPOKE: Record<string, string[]> = {
   // anyway: every Albescent registration is a WRAPPER rather than a skin
   // (ADR-0027), so it renders `DefaultCreateCharacter`, WHICH IS the na kit. The
   // `leaves %s to the surface Default` row below covers it either way.
-  createCharacter: ['ephemerists', 'snide', 'wow'],
+  createCharacter: ['ephemerists', 'snide', 'wow', 'ua'],
   // Was `mobileFactionPage` with this exact slug list until ADR-0078 collapsed
   // faction detail to one responsive component per faction. Same move the
   // praxis-card row made below: the row follows the surviving surface rather

--- a/frontend/src/factions/ua.ts
+++ b/frontend/src/factions/ua.ts
@@ -14,6 +14,7 @@ import { lazyArchetype } from './lazyArchetype'
 const UaAvatar = lazyArchetype(() => import('../components/avatar/UaAvatar'))
 const UaBackdrop = lazyArchetype(() => import('../components/backdrop/UaBackdrop'))
 const UaComment = lazyArchetype(() => import('../components/comments/voices/UaComment'))
+const UaCreateCharacter = lazyArchetype(() => import('../pages/characterPaths/archetypes/UaCreateCharacter'))
 const UaDuelSealConfirm = lazyArchetype(() => import('../components/duel/UaDuelSealConfirm'))
 const UaEditPraxis = lazyArchetype(() => import('../pages/editPraxis/archetypes/UaEditPraxis'))
 const UaFactionBody = lazyArchetype(() => import('../pages/factionDetail/archetypes/UaFactionBody'))
@@ -49,6 +50,7 @@ export const UA_MANIFEST: FactionManifest = {
   taskDetail: () => UaTaskDetail,
   praxisDetail: () => UaPraxisDetail,
   editPraxis: () => UaEditPraxis,
+  createCharacter: () => UaCreateCharacter,
   factionHero: () => UaFactionHero,
   factionBody: () => UaFactionBody,
   profileBody: () => UaProfileBody,

--- a/frontend/src/pages/characterPaths/__tests__/uaCreateCharacterContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/uaCreateCharacterContrast.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The UA create-character leaf's inks, measured on the ground that is actually
+ * behind them (#2348).
+ *
+ * WHY THIS FILE EXISTS WHEN `factionContrast.test.ts` ALREADY MEASURES UA. That
+ * file's own note rules UA's composer covered because it "draws entirely from
+ * `--faction-ua-{card-bg,panel}`" — true of the TOKENS and not of the GROUND.
+ * The sheet carries a lotus and an ensō washed over it at
+ * `--faction-ua-card-lotus-opacity`, so the stock under a label is
+ * `--faction-ua-card-lotus` composited onto `--faction-ua-card-bg`, not the bare
+ * token. That is the difference the acceptance criterion names in as many words,
+ * and it is the difference #2346 found on the na page, where
+ * `--faction-default-composer-faint` reads 4.49 flat and 3.50 under the wash.
+ *
+ * It is measured here rather than appended to `factionContrast.test.ts` because
+ * that file's `ARCHETYPE_PAIRS` is a shared registry asserted BOTH ways — five
+ * sibling archetypes are in flight behind #2346 and each restating it drops the
+ * others (its own #1179 note records exactly that, twice). This is the same
+ * split `createCharacterContrast.test.ts` already made for the na kit.
+ *
+ * THE WASH IS THE WORST CASE, DELIBERATELY. The lotus is petals with gaps and
+ * per-ring opacities and the ensō is a brush stroke; the ground under a given
+ * line of type is somewhere between the bare sheet and a fully-inked petal at
+ * the layer's opacity. The fully-inked petal is the honest floor, so that is
+ * what is composited — no line of type on this page can land on anything darker.
+ *
+ * WHAT IS NOT MEASURED HERE. The fields' own inks land on `--faction-ua-panel`,
+ * which is an opaque token laid OVER the wash, and every one of those pairings is
+ * in `factionContrast.test.ts`'s sun-bleached block. Restating them would be a
+ * second name for one measurement, which that file warns against. What is here
+ * is the set that is new: everything on the washed sheet, the CTA band's pair,
+ * and the error banner's ink under the danger veil ON the washed sheet — a
+ * tighter reading than the bare-sheet row that file already carries.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import {
+  AA_NORMAL,
+  compositeOver,
+  contrastRatio,
+  formatRatio,
+  parseColor,
+  type Rgba,
+} from '../../../utils/contrast'
+import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
+
+const CSS_PATH = fileURLToPath(new URL('../../../index.css', import.meta.url))
+const THEMES = readThemes(readFileSync(CSS_PATH, 'utf8'))
+const BOTH_THEMES: Theme[] = ['light', 'dark']
+
+function resolve(token: string, theme: Theme): Rgba {
+  const raw = resolveVar(token, theme, THEMES)
+  expect(raw, `${token} resolves in ${theme}`).not.toBeNull()
+  const parsed = parseColor(raw!)
+  expect(parsed, `${token} is a colour in ${theme}`).not.toBeNull()
+  return parsed!
+}
+
+/** A token laid over a ground at an alpha the stylesheet names. */
+function wash(token: string, alphaToken: string, ground: Rgba, theme: Theme): Rgba {
+  const alpha = Number(resolveVar(alphaToken, theme, THEMES))
+  expect(alpha, `${alphaToken} is a number in ${theme}`).toBeGreaterThan(0)
+  return compositeOver({ ...resolve(token, theme), a: alpha }, ground)
+}
+
+/** The sheet under the ornament layer — what a label on this page really sits on. */
+function washedSheet(theme: Theme): Rgba {
+  return wash(
+    '--faction-ua-card-lotus',
+    '--faction-ua-card-lotus-opacity',
+    resolve('--faction-ua-card-bg', theme),
+    theme,
+  )
+}
+
+/** Every ink this archetype puts straight on that washed sheet, and what draws it. */
+const SHEET_INKS: Array<{ what: string; token: string }> = [
+  { what: 'the heading and a picker row not picked', token: '--faction-ua-card-text' },
+  // `-card-body` and NOT `-card-muted`, which is the one real finding of this
+  // file — see the archetype's own note and the failing row below.
+  {
+    what: 'labels, counters, @handle, the calling hint, cancel and starts-at',
+    token: '--faction-ua-card-body',
+  },
+  { what: 'a counter at its cap', token: '--faction-ua-card-alarm' },
+]
+
+describe('the UA leaf clears AA under its own lotus wash', () => {
+  for (const theme of BOTH_THEMES) {
+    for (const { what, token } of SHEET_INKS) {
+      it(`${what} — ${theme}`, () => {
+        const ratio = contrastRatio(resolve(token, theme), washedSheet(theme))
+        expect(
+          ratio,
+          `${token} on the washed --faction-ua-card-bg is ${formatRatio(ratio)}`,
+        ).toBeGreaterThanOrEqual(AA_NORMAL)
+      })
+    }
+  }
+
+  it.each(BOTH_THEMES)(
+    'and `-card-muted` — the composer\'s own quiet tier — does not, in %s',
+    (theme) => {
+      // THE LOAD-BEARING HALF OF THE INK CHOICE, and the reason this file is not
+      // decoration. `UaEditPraxis` sets its labels, counters and exits in
+      // `--faction-ua-card-muted` over this same washed ground, and that is what
+      // this archetype was first written with. Muted clears on the BARE sheet
+      // (5.45 / 5.64, and `factionContrast.test.ts` measures exactly that) and
+      // misses on the composite in BOTH themes. Walk muted far enough to clear
+      // the wash and this row goes red — which is the outcome worth catching,
+      // because then the quiet tier can go back to where the kit puts it.
+      const ratio = contrastRatio(resolve('--faction-ua-card-muted', theme), washedSheet(theme))
+      expect(
+        ratio,
+        `--faction-ua-card-muted on the washed sheet is ${formatRatio(ratio)}`,
+      ).toBeLessThan(AA_NORMAL)
+    },
+  )
+
+  it.each(BOTH_THEMES)('the wash is the tighter reading, not the flatterer — %s', (theme) => {
+    // The guard that makes the rows above mean something. If the composite were
+    // ever LIGHTER than the bare token in light, measuring it would be the
+    // optimistic reading rather than the honest one, and this file would be
+    // proving the wrong thing.
+    const ink = resolve('--faction-ua-card-muted', theme)
+    const flat = contrastRatio(ink, resolve('--faction-ua-card-bg', theme))
+    const washed = contrastRatio(ink, washedSheet(theme))
+    expect(washed, `flat ${formatRatio(flat)} vs washed ${formatRatio(washed)}`).toBeLessThan(flat)
+  })
+})
+
+describe('the cast band and the picked calling carry the fill pair', () => {
+  // The submit band and a selected picker row are both `--faction-ua` filled,
+  // and the ink on them is `--faction-ua-on-fill`. The fill is opaque, so the
+  // wash does not reach either.
+  it.each(BOTH_THEMES)('%s', (theme) => {
+    const ratio = contrastRatio(
+      resolve('--faction-ua-on-fill', theme),
+      resolve('--faction-ua', theme),
+    )
+    expect(ratio, `on-fill on the fill is ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(AA_NORMAL)
+  })
+})
+
+describe('the error banner clears AA under the veil AND the wash', () => {
+  // `ErrorBanner` fills with the neutral `--color-danger-veil` (ADR-0061), and
+  // that fill lands on the washed sheet rather than on the bare token — two
+  // layers, which is one more than `factionContrast.test.ts`'s row for this
+  // banner composites. The alarm ink is what UA passes it (#1231): the neutral
+  // `--color-danger` is 3.71:1 on this sheet in light before the wash is counted.
+  it.each(BOTH_THEMES)('%s', (theme) => {
+    const veiled = compositeOver(resolve('--color-danger-veil', theme), washedSheet(theme))
+    const ratio = contrastRatio(resolve('--faction-ua-card-alarm', theme), veiled)
+    expect(
+      ratio,
+      `--faction-ua-card-alarm under the veil on the washed sheet is ${formatRatio(ratio)}`,
+    ).toBeGreaterThanOrEqual(AA_NORMAL)
+  })
+
+  it.each(BOTH_THEMES)('and the neutral danger ink still would not — %s', (theme) => {
+    // The load-bearing half of passing an ink at all. If `--color-danger` ever
+    // clears this ground, the override is dead weight and this row says so.
+    const veiled = compositeOver(resolve('--color-danger-veil', theme), washedSheet(theme))
+    const neutral = contrastRatio(resolve('--color-danger', theme), veiled)
+    if (theme === 'light') {
+      expect(neutral, `--color-danger is ${formatRatio(neutral)}`).toBeLessThan(AA_NORMAL)
+    } else {
+      // Dark was never the miss (#1231): the note is recorded, not asserted as a
+      // failure, so this half only pins that the dark reading is still the one
+      // that would have been fine.
+      expect(neutral).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('keeps the ornament layer in step with the stylesheet', () => {
+  // Transcribed grounds rot. The wash above is only the real ground for as long
+  // as the archetype still paints `--faction-ua-card-lotus` at
+  // `--faction-ua-card-lotus-opacity`; repaint either and the measurement must
+  // be re-run rather than silently keep asserting the old stock.
+  const source = readFileSync(
+    fileURLToPath(new URL('../archetypes/UaCreateCharacter.tsx', import.meta.url)),
+    'utf8',
+  )
+
+  it('the leaf still washes its ground with the token this file measures', () => {
+    expect(source).toContain('var(--faction-ua-card-lotus)')
+    expect(source).toContain('var(--faction-ua-card-lotus-opacity)')
+  })
+})

--- a/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
@@ -1,0 +1,519 @@
+/**
+ * The UA character-creation archetype — THE VELLUM LEAF, ruled for a new life
+ * (#2348, epic #2346).
+ *
+ * NO DESIGN WAS DRAWN FOR THIS, and none was needed: the owner's ruling is that
+ * the two surfaces UA already ships carry the whole register between them.
+ * `components/taskCard/UaTaskCard` holds the ground, inks, rules and faces;
+ * `pages/editPraxis/archetypes/UaEditPraxis` holds the same kit applied to a
+ * FORM — labelled fields, counters, a primary commit, a cancel path — which is
+ * structurally what this page is. This file is that dress over this page's
+ * fields, and it draws no new mark: the lotus and the ensō are the two the
+ * practice already has (WORLD_ZERO_STYLE §6, "one primitive").
+ *
+ * ## The chassis is the composer's, not a second one
+ *
+ * `ComposerPage` / `ComposerSheet` / `ComposerSection` / `ComposerRule` /
+ * `ComposerFooter` / `ErrorBanner` are geometry with no praxis in them, so this
+ * page mounts the same blocks `UaEditPraxis` does rather than restating a sheet
+ * and a footer row. The CONTROLS in `editPraxis/archetypes/controls.tsx` are the
+ * half that does not fit — every one of them takes an `EditPraxisState` — and so
+ * is `bodyEditorTheme.ts`, which themes a CodeMirror this page has no equivalent
+ * of. The fields below are therefore plain inputs wearing `fieldBox`, which is
+ * the same geometry row (`radius 7`, a 1px neutral hairline, the inset panel)
+ * that file's fields wear.
+ *
+ * Nothing under `pages/editPraxis/` is written to. It is read as the reference
+ * the issue names it as.
+ *
+ * ## UA draws no masthead
+ *
+ * It is the one faction in the set with no top band — the GROUND carries the
+ * identity instead, so `ComposerSheet` gets a `ground` and no `masthead`. That
+ * absence is the dress decision the composer already made, not an omission here.
+ *
+ * The ground is the composer's, element for element: a lotus bleeding off the
+ * top-left corner and an ensō off the bottom-right, both clipped by
+ * `ComposerSheet`'s own `overflow: hidden` (#1028). The ensō turns on `.ep-spin`
+ * at 200s, re-timed through the shared `--ep-spin-dur` hook rather than a second
+ * keyframe. It is a CLASS: the keyframes live in `index.css` behind the
+ * `prefers-reduced-motion` guard, and an inline `animation:` would bypass that
+ * guard (#1003). Nothing was added to `index.css` for this file.
+ *
+ * ## One responsive component, no mobile twin
+ *
+ * `useComposerSizes()` reads `useFormFactor()` and picks the size set; there is
+ * one tree at two widths and no second file. Every fixed number here is ornament
+ * geometry, never a layout grid (SPEC-faction-ui-profile §1a).
+ *
+ * ## Copy — none of its own
+ *
+ * Every string is an existing `forms:createCharacter.*` key, unchanged and
+ * un-reordered: chosen name → about → tagline → portrait → answer a calling →
+ * commit / cancel.
+ *
+ * ONE FIELD-SET DEVIATION FROM THE DEFAULT, the same one `EphemeristsCreateCharacter`
+ * flagged and for the same reason. The na kit's PHONE branch deliberately carries
+ * no prose fields — it is framed as "Step 1 of 2 · Identity" and has never
+ * offered `bio`, with `tagline` following `bio` so the two stay a pair (#1628).
+ * This leaf offers all six fields at both widths, because #2348 states the field
+ * list once and unconditionally, and because the two-step framing is the na
+ * phone skin's own chrome rather than something the leaf wears.
+ *
+ * ## Colour
+ *
+ * Every value is a `--faction-ua-*` token, so both themes come from the
+ * `[data-theme="dark"]` cascade and no theme ternary stands in for it (#851's
+ * standing guard). `--faction-ua-glow` is ORNAMENT — the ensō stroke and the
+ * lotus wash — and never an ink.
+ *
+ * The error banner takes `--faction-ua-card-alarm` rather than the neutral
+ * `--color-danger`, which is the same deviation `UaEditPraxis` keeps and for the
+ * same measured reason: the neutral ink is 3.71:1 under its own veil on this
+ * sheet in light (#1231).
+ *
+ * The pairings this page introduces are measured in
+ * `__tests__/uaCreateCharacterContrast.test.ts` on the COMPOSITE — the sheet
+ * under the lotus wash, not the bare `-card-bg` token.
+ *
+ * ## Presentation only
+ *
+ * `useCreateCharacter` stays the single source of state for every archetype.
+ * Nothing here touches the submit path, the payload, `PortraitPicker` or
+ * `useAvatarPicker`, and THE PICKER STAYS VISIBLE in this skin — a player must
+ * be able to change their mind, or clear the pick and be born unaffiliated,
+ * which returns the page to the Default archetype.
+ */
+import { useRef, type CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import CredentialCard from '../../../components/CredentialCard'
+import FactionSigil from '../../../components/sigil/FactionSigil'
+import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
+import PortraitPicker from '../PortraitPicker'
+import {
+  NAME_MAX,
+  BIO_MAX,
+  TAGLINE_MAX,
+  type CreateCharacterState,
+} from '../useCreateCharacter'
+import {
+  ComposerFooter,
+  ComposerGround,
+  ComposerPage,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ErrorBanner,
+  composerBandStyle,
+  composerLabelStyle,
+  useComposerSizes,
+} from '../../editPraxis/archetypes/shared'
+import { Lotus } from '../../../components/factionMarks'
+import { UaSigil } from '../../../components/sigil/UaSigil'
+import { UA_DISPLAY, UA_TEXT } from '../../../components/factionMarks/uaAtoms'
+
+const SLUG = 'ua'
+
+/* The practice's inks, named for the ROLE each plays — the same constants, the
+ * same tokens, as `UaEditPraxis` names. Every one carries both themes. */
+const SHEET = 'var(--faction-ua-card-bg)' /* the sun-bleached sheet */
+const FIELD = 'var(--faction-ua-panel)' /* inset panel — fields, wells */
+const INK = 'var(--faction-ua-card-text)'
+const MUTED = 'var(--faction-ua-card-muted)'
+const ACCENT = 'var(--faction-ua-card-accent)' /* the design's accentDeep */
+const RULE = 'var(--faction-ua-rule)' /* the neutral hairline */
+const HAIR = 'var(--faction-ua-hair)' /* the faintest divider, below -rule */
+const FILL = 'var(--faction-ua)'
+const ON_FILL = 'var(--faction-ua-on-fill)'
+const ALARM = 'var(--faction-ua-card-alarm)'
+
+/** Geometry the kit pins: radius 7, a 2px border. Ornament, not spacing. */
+const RADIUS = 7
+const BORDER_WIDTH = 2
+
+/** The ensō's turn, re-timed off the shared `--ep-spin-dur` hook. */
+const GROUND_SPIN = '200s'
+
+/** The mark each calling wears in the picker — the size every other chooser draws (#2223). */
+const PICKER_SIGIL = 18
+
+export default function UaCreateCharacter({ state }: { state: CreateCharacterState }) {
+  const { t } = useTranslation('forms')
+  const navigate = useNavigate()
+  const sizes = useComposerSizes()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const {
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    tagline,
+    setTagline,
+    factionSlug,
+    setFactionSlug,
+    invited,
+    avatarFile,
+    avatarPreview,
+    avatarSource,
+    setAvatarSource,
+    avatarError,
+    setAvatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+    error,
+    submitting,
+    canSubmit,
+    handleSubmit,
+    handle,
+    showPicker,
+  } = state
+
+  /* Ornament geometry, in raw px because a drawn figure is neither type nor
+   * spacing (WORLD_ZERO_STYLE §4a). The phone gets the same two marks, smaller
+   * and pulled in — conditional ornament, not a second layout. The numbers are
+   * the composer's own pair, unchanged. */
+  const groundGeometry = sizes.isMobile
+    ? { lotus: 300, lotusLeft: -122, lotusTop: -94, enso: 208, ensoRight: -66, ensoBottom: -58 }
+    : { lotus: 420, lotusLeft: -170, lotusTop: -130, enso: 300, ensoRight: -96, ensoBottom: -84 }
+
+  /* The label tier's face and colour are the skin's; its geometry (uppercase,
+   * 0.14em, --text-lg) is the layout's and is inherited untouched. */
+  const labelStyle = { fontFamily: UA_TEXT, color: MUTED }
+
+  const fieldBox = {
+    width: '100%',
+    background: FIELD,
+    color: INK,
+    border: `1px solid ${RULE}`,
+    borderRadius: RADIUS,
+    padding: 'var(--space-md)',
+    outline: 'none',
+    boxSizing: 'border-box',
+    fontFamily: UA_TEXT,
+    fontSize: 'var(--text-content)',
+  } as const
+
+  /** The counter row under a field: quiet, and alarmed on the cap. */
+  const counter = (used: number, max: number) => (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', fontFamily: UA_TEXT, fontSize: 'var(--text-lg)' }}>
+      <span style={{ color: used >= max ? ALARM : MUTED }}>
+        {t('createCharacter.charsLeft', { count: max - used })}
+      </span>
+    </div>
+  )
+
+  const sheetStyle = {
+    background: SHEET,
+    border: `${BORDER_WIDTH}px solid ${ACCENT}`,
+    borderRadius: RADIUS,
+  }
+
+  /* NO masthead. UA is the one faction that draws no top band — the ground is
+     the identity, and it is the composer's own, element for element. */
+  const ground = (
+    <ComposerGround inset={0} opacity="var(--faction-ua-card-lotus-opacity)">
+      <Lotus
+        size={groundGeometry.lotus}
+        color="var(--faction-ua-card-lotus)"
+        style={{
+          position: 'absolute',
+          left: groundGeometry.lotusLeft,
+          top: groundGeometry.lotusTop,
+        }}
+      />
+      {/* The ensō turns once every 200s — re-timed through the shared hook, so
+          no second keyframe and no inline `animation:`. This is the FACTION
+          mark, the ensō's one sanctioned use here: there is no score on this
+          page for it to carry, and the count of drawn marks stays at two. */}
+      <span
+        className="ep-spin"
+        style={
+          {
+            position: 'absolute',
+            right: groundGeometry.ensoRight,
+            bottom: groundGeometry.ensoBottom,
+            '--ep-spin-dur': GROUND_SPIN,
+          } as CSSProperties
+        }
+      >
+        <UaSigil width={groundGeometry.enso} height={groundGeometry.enso} />
+      </span>
+    </ComposerGround>
+  )
+
+  return (
+    <ComposerPage sizes={sizes} style={{ fontFamily: UA_TEXT, color: INK }}>
+      {/* A REAL `<form>`, not a bare button with an onClick. The Default skin
+          submits through one and so must this: it is what makes Enter commit
+          from a text field, and what gives the browser's own required-field
+          behaviour something to attach to. `handleSubmit` calls
+          `preventDefault()` itself. */}
+      <form onSubmit={handleSubmit} data-skin={SLUG}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} ground={ground}>
+          {/* The page's own question, in the practice's display cut. The leaf
+              draws no mark beside it: the ensō in the ground is already the
+              faction mark, and a second one here would be the third drawn
+              figure on a sheet whose whole voice is quiet. */}
+          <h1
+            style={{
+              fontFamily: UA_DISPLAY,
+              fontWeight: 600,
+              fontSize: sizes.titleSize,
+              color: INK,
+              lineHeight: 1.1,
+              margin: 0,
+            }}
+          >
+            {t('createCharacter.heading')}
+          </h1>
+
+          {/* The life being written, live. The card dispatches its own faction
+              dress, so it is already wearing this leaf the moment the calling is
+              picked — the same value this whole page reskins on. */}
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <CredentialCard
+              displayName={displayName || t('createCharacter.previewFallbackName')}
+              handle={handle}
+              factionSlug={factionSlug || null}
+              level={1}
+              score={0}
+              avatarUrl={avatarPreview}
+              onAvatarClick={() => fileInputRef.current?.click()}
+            />
+          </div>
+
+          {/* Chosen name */}
+          <ComposerSection rule={false} label={t('createCharacter.nameLabel')} labelStyle={labelStyle}>
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              maxLength={NAME_MAX}
+              placeholder={t('createCharacter.namePlaceholder')}
+              autoFocus
+              style={{ ...fieldBox, fontFamily: UA_DISPLAY, fontWeight: 600 }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: UA_TEXT, fontSize: 'var(--text-lg)' }}>
+              <span style={{ color: MUTED }}>@{handle}</span>
+              <span style={{ color: displayName.length >= NAME_MAX ? ALARM : MUTED }}>
+                {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
+              </span>
+            </div>
+          </ComposerSection>
+
+          {/* About */}
+          <ComposerSection rule={false} label={t('createCharacter.aboutLabel')} labelStyle={labelStyle}>
+            <textarea
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              maxLength={BIO_MAX}
+              placeholder={t('createCharacter.aboutPlaceholder')}
+              rows={3}
+              style={{ ...fieldBox, resize: 'vertical', lineHeight: 1.7 }}
+            />
+            {counter(bio.length, BIO_MAX)}
+          </ComposerSection>
+
+          {/* Tagline — a slogan line, not a short bio (#1628). Its counter turns
+              alarm on the cap the way the name field's does: this is the field
+              the profile header's identity slot is laid out against, so running
+              out of room is worth seeing before the text stops appearing. */}
+          <ComposerSection rule={false} label={t('createCharacter.taglineLabel')} labelStyle={labelStyle}>
+            <textarea
+              value={tagline}
+              onChange={(e) => setTagline(e.target.value)}
+              maxLength={TAGLINE_MAX}
+              placeholder={t('createCharacter.taglinePlaceholder')}
+              rows={2}
+              style={{ ...fieldBox, resize: 'vertical', lineHeight: 1.7 }}
+            />
+            {counter(tagline.length, TAGLINE_MAX)}
+          </ComposerSection>
+
+          {/* Portrait — the shared picker owns the hidden input and the "what's
+              chosen" readout (#1149); the credential card above opens the same
+              input through `fileInputRef`. Dressed rather than left in site
+              chrome: `.btn-outline` brings its own near-white ground and neutral
+              ink, which reads as a browser control dropped on the leaf. The
+              error ink is passed for the measured reason the banner's is. */}
+          <ComposerSection
+            rule={false}
+            label={
+              <>
+                {t('createCharacter.portraitLabel')}{' '}
+                <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.optional')}</span>
+              </>
+            }
+            labelStyle={labelStyle}
+          >
+            <PortraitPicker
+              inputRef={fileInputRef}
+              onChange={handleAvatarChange}
+              chosenFile={avatarFile}
+              error={avatarError}
+              buttonStyle={composerLabelStyle({
+                fontFamily: UA_TEXT,
+                cursor: 'pointer',
+                borderRadius: RADIUS,
+                padding: 'var(--space-sm) var(--space-lg)',
+                background: FIELD,
+                color: INK,
+                border: `1px solid ${RULE}`,
+              })}
+              statusStyle={{ fontFamily: UA_TEXT, color: MUTED }}
+              errorStyle={{ color: ALARM }}
+            />
+          </ComposerSection>
+
+          {/* Answer a calling — only when the account holds invitations (ADR-0019).
+              It stays drawn in this skin: tapping the leaf's own faction must not
+              be a one-way door, and clearing the pick returns the page to the
+              Default archetype. */}
+          {showPicker && (
+            <ComposerSection
+              rule={false}
+              label={
+                <>
+                  {t('createCharacter.callingLabel')}{' '}
+                  <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.callingOptional')}</span>
+                </>
+              }
+              labelStyle={labelStyle}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
+                {invited.map((slug) => {
+                  const selected = factionSlug === slug
+                  return (
+                    <button
+                      key={slug}
+                      type="button"
+                      onClick={() => setFactionSlug(selected ? '' : slug)}
+                      /* NOT `composerLabelStyle` — it forces `uppercase` and its
+                         own tracking, and both would be inherited by the name
+                         below. A calling wears its OWN card face at its own
+                         case, which is what every other chooser draws. */
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 'var(--space-md)',
+                        width: '100%',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        borderRadius: RADIUS,
+                        padding: 'var(--space-md) var(--space-lg)',
+                        background: selected ? FILL : FIELD,
+                        border: `1px solid ${selected ? FILL : RULE}`,
+                        // The faction's own hue as a RING, never as ink (§3) —
+                        // the row's type stays on the leaf's measured pair.
+                        boxShadow: selected ? `0 0 0 2px ${factionCssVar(slug)}` : 'none',
+                      }}
+                    >
+                      {/* The faction's own mark, from the dispatcher every other
+                          chooser draws (#2223). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                      <span
+                        style={{
+                          fontFamily: factionCssVar(slug, 'card-font'),
+                          fontSize: 'var(--text-content)',
+                          color: selected ? ON_FILL : INK,
+                        }}
+                      >
+                        {factionName(slug)}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+              <p
+                style={{
+                  fontFamily: UA_TEXT,
+                  fontStyle: 'italic',
+                  fontSize: 'var(--text-content)',
+                  color: MUTED,
+                  margin: 0,
+                  lineHeight: 1.55,
+                }}
+              >
+                {t('createCharacter.callingHint')}
+              </p>
+            </ComposerSection>
+          )}
+
+          <ErrorBanner message={error ?? ''} style={{ color: ALARM }} />
+
+          {/* The leaf's faintest rule, drawn ONCE above the footer (#1707) — the
+              same `-hair` the task card rules its two divisions with. */}
+          <ComposerRule style={{ background: HAIR }} />
+
+          {/* [Cancel] … [Create] — the global order from #646, with the cast as a
+              full-bleed band (#1828), which is what UA's composer already casts
+              through. */}
+          <ComposerFooter
+            band
+            start={
+              <>
+                <button
+                  type="button"
+                  onClick={() => navigate('/')}
+                  style={composerLabelStyle({
+                    fontFamily: UA_TEXT,
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    color: MUTED,
+                  })}
+                >
+                  {t('createCharacter.cancel')}
+                </button>
+                <span style={{ fontFamily: UA_TEXT, fontSize: 'var(--text-content)', color: MUTED }}>
+                  {t('createCharacter.startsAt')}
+                </span>
+              </>
+            }
+            end={
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                style={{
+                  ...composerBandStyle(sizes, {
+                    fontFamily: UA_TEXT,
+                    /* The composer's band: 13 / 600 / 0.14em. 13 sits between
+                       the label rung (12) and --text-xl (14); the band takes the
+                       rung ABOVE the label it has to outrank (§4a). 600 rather
+                       than 500 because `index.html` loads EB Garamond at 400 and
+                       600 only, and CSS font matching resolves a requested 500
+                       DOWN to 400 (`fontsLoaded.test.ts`, #1294). */
+                    fontSize: 'var(--text-xl)',
+                    fontWeight: 600,
+                    frame: ACCENT,
+                    color: ON_FILL,
+                    background: FILL,
+                  }),
+                  cursor: submitting ? 'wait' : 'pointer',
+                  opacity: canSubmit ? 1 : 0.5,
+                }}
+              >
+                {submitting ? t('createCharacter.submitBusy') : t('createCharacter.submitIdle')}
+              </button>
+            }
+          />
+        </ComposerSheet>
+      </form>
+
+      {/* Portrait crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+          onError={setAvatarError}
+        />
+      )}
+    </ComposerPage>
+  )
+}

--- a/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
@@ -122,7 +122,22 @@ const SLUG = 'ua'
 const SHEET = 'var(--faction-ua-card-bg)' /* the sun-bleached sheet */
 const FIELD = 'var(--faction-ua-panel)' /* inset panel — fields, wells */
 const INK = 'var(--faction-ua-card-text)'
-const MUTED = 'var(--faction-ua-card-muted)'
+/* THE QUIET TIER IS `-card-body`, NOT `-card-muted`, AND THAT IS MEASURED (#2348).
+ *
+ * `UaEditPraxis` sets its labels, counters and exits in `--faction-ua-card-muted`
+ * and this file started as a copy of that. On the BARE sheet muted is right —
+ * 5.45 light / 5.64 dark, and `factionContrast.test.ts` measures exactly that.
+ * But this sheet is not bare: `ComposerGround` washes the lotus and the ensō
+ * over it at `--faction-ua-card-lotus-opacity`, and on that COMPOSITE muted
+ * reads 4.38 / 3.79 — under AA in both themes. `-card-body` is the same family
+ * one rung up and reads 5.74 / 6.78 there, so the quiet type takes it. Every
+ * number is in `__tests__/uaCreateCharacterContrast.test.ts`.
+ *
+ * This is §3's "same ink, second ground", not a preference: nothing about the
+ * ink changed, the ground gained a layer. The FIELDS keep muted's own tier
+ * available because `--faction-ua-panel` is opaque and sits above the wash —
+ * but nothing on this page needs it, so the constant is not declared. */
+const BODY = 'var(--faction-ua-card-body)'
 const ACCENT = 'var(--faction-ua-card-accent)' /* the design's accentDeep */
 const RULE = 'var(--faction-ua-rule)' /* the neutral hairline */
 const HAIR = 'var(--faction-ua-hair)' /* the faintest divider, below -rule */
@@ -181,7 +196,7 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
 
   /* The label tier's face and colour are the skin's; its geometry (uppercase,
    * 0.14em, --text-lg) is the layout's and is inherited untouched. */
-  const labelStyle = { fontFamily: UA_TEXT, color: MUTED }
+  const labelStyle = { fontFamily: UA_TEXT, color: BODY }
 
   const fieldBox = {
     width: '100%',
@@ -199,7 +214,7 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
   /** The counter row under a field: quiet, and alarmed on the cap. */
   const counter = (used: number, max: number) => (
     <div style={{ display: 'flex', justifyContent: 'flex-end', fontFamily: UA_TEXT, fontSize: 'var(--text-lg)' }}>
-      <span style={{ color: used >= max ? ALARM : MUTED }}>
+      <span style={{ color: used >= max ? ALARM : BODY }}>
         {t('createCharacter.charsLeft', { count: max - used })}
       </span>
     </div>
@@ -296,8 +311,8 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
               style={{ ...fieldBox, fontFamily: UA_DISPLAY, fontWeight: 600 }}
             />
             <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: UA_TEXT, fontSize: 'var(--text-lg)' }}>
-              <span style={{ color: MUTED }}>@{handle}</span>
-              <span style={{ color: displayName.length >= NAME_MAX ? ALARM : MUTED }}>
+              <span style={{ color: BODY }}>@{handle}</span>
+              <span style={{ color: displayName.length >= NAME_MAX ? ALARM : BODY }}>
                 {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
               </span>
             </div>
@@ -362,7 +377,7 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
                 color: INK,
                 border: `1px solid ${RULE}`,
               })}
-              statusStyle={{ fontFamily: UA_TEXT, color: MUTED }}
+              statusStyle={{ fontFamily: UA_TEXT, color: BODY }}
               errorStyle={{ color: ALARM }}
             />
           </ComposerSection>
@@ -431,7 +446,7 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
                   fontFamily: UA_TEXT,
                   fontStyle: 'italic',
                   fontSize: 'var(--text-content)',
-                  color: MUTED,
+                  color: BODY,
                   margin: 0,
                   lineHeight: 1.55,
                 }}
@@ -463,12 +478,12 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
                     border: 'none',
                     padding: 0,
                     cursor: 'pointer',
-                    color: MUTED,
+                    color: BODY,
                   })}
                 >
                   {t('createCharacter.cancel')}
                 </button>
-                <span style={{ fontFamily: UA_TEXT, fontSize: 'var(--text-content)', color: MUTED }}>
+                <span style={{ fontFamily: UA_TEXT, fontSize: 'var(--text-content)', color: BODY }}>
                   {t('createCharacter.startsAt')}
                 </span>
               </>


### PR DESCRIPTION
Closes #2348

The character-creation page gains UA's dress. Pick **University of Asthmatics** in "Answer a calling" and the whole page becomes the vellum leaf — live, on the same field the preview card already reads. Clear the pick and it goes back to the `na` kit.

## The seam, and the test written at it first

The seam is `factionSlug` → archetype, the one the chassis (#2346/#2347) already cut. So the first commit appends `ua` to the `createCharacter` row in `factions/__tests__/surfaceDispatch.test.ts` and goes **red** — `expected undefined to be defined` — because nothing fills the slot yet. The second commit registers `UaCreateCharacter` in `factions/ua.ts` and it goes green.

Everything else in `createCharacterDispatch.test.tsx` is derived from `surfaceMap('createCharacter')` rather than listed, so registering the slug is what enrols this archetype in the existing rows: it renders at both widths, it still draws the invited callings, and clearing the pick still lands on `DefaultCreateCharacter`.

## What it is

`components/taskCard/UaTaskCard` gave the register; `pages/editPraxis/archetypes/UaEditPraxis` gave the same kit applied to a form, and this file mounts the same shared blocks it does — `ComposerPage` / `ComposerSheet` / `ComposerSection` / `ComposerRule` / `ComposerFooter` / `ErrorBanner` / `composerLabelStyle` / `composerBandStyle` / `useComposerSizes`. Nothing under `pages/editPraxis/` is written to.

`controls.tsx` and `bodyEditorTheme.ts` were read and are **not** reused, for a stated reason rather than an oversight: every control in `controls.tsx` takes an `EditPraxisState`, and `bodyEditorTheme.ts` themes a CodeMirror this page has no equivalent of. The fields are plain inputs wearing the same `fieldBox` geometry those controls wear (radius 7, a 1px neutral hairline, the inset panel).

- **UA draws no masthead** — it is the one faction with no top band, so the sheet gets a `ground` and no `masthead`. The ground is the composer's element for element: the lotus off the top-left, the ensō off the bottom-right turning on `.ep-spin` at 200s through the shared `--ep-spin-dur` hook. No inline `animation:`, nothing added to `index.css`.
- **Two marks, and the count is the point.** The ensō here is the FACTION mark — there is no score on this page for it to carry — so no third figure was drawn and no mark stands beside the heading.
- **One responsive component.** `useComposerSizes()` reads `useFormFactor()`; one tree at two widths, no second file, every fixed number ornament geometry.
- **Presentation only.** `useCreateCharacter`, `PortraitPicker` and `useAvatarPicker` are untouched.
- **The picker stays drawn**, and tapping the picked calling again clears it back to Default.

## One real defect found: the lotus wash eats the composer's quiet tier

This is the "measure the composite, not the declared token" criterion earning its keep.

`UaEditPraxis` sets its labels, counters and exits in `--faction-ua-card-muted`, and this file started as a copy of that. On the **bare** sheet muted is right — 5.45 light / 5.64 dark, which is exactly what `factionContrast.test.ts` measures, and its own note rules UA's composer covered because it "draws entirely from `--faction-ua-{card-bg,panel}`". True of the tokens; not true of the ground. `ComposerGround` washes the lotus and the ensō over the sheet at `--faction-ua-card-lotus-opacity`, and on that composite muted reads:

| ink | flat light | washed light | flat dark | washed dark |
|---|---|---|---|---|
| `--faction-ua-card-muted` | 5.45 | **4.38** | 5.64 | **3.79** |
| `--faction-ua-card-body` | 7.15 | 5.74 | 10.09 | 6.78 |
| `--faction-ua-card-text` | 12.02 | 9.65 | 13.58 | 9.12 |
| `--faction-ua-card-alarm` | 6.85 | 5.50 | 8.69 | 5.83 |

So the quiet tier here takes `--faction-ua-card-body`, the same family one rung up. That is §3's "same ink, second ground" — nothing about the ink changed, the ground gained a layer.

`__tests__/uaCreateCharacterContrast.test.ts` measures every pairing this page introduces on its real composited ground, both themes, and it asserts **both ways**: the inks that are used clear AA, and `-card-muted` still misses on the washed sheet — so if muted is ever walked far enough, the row goes red and the quiet tier can go back where the kit puts it. It also composites the error banner's `--color-danger-veil` **on top of** the wash, which is one layer more than the row `factionContrast.test.ts` already carries for this banner.

**Ratios are not appended to `factionContrast.test.ts`** on purpose: `ARCHETYPE_PAIRS` is a shared registry asserted both ways, five sibling archetypes are in flight behind #2346, and that file's own #1179 note records two red-mains from exactly that. Same split `createCharacterContrast.test.ts` already made for the `na` kit.

### Reported, not fixed here

**`UaEditPraxis` has the same pairing on the same washed ground.** Its labels, counters, `Save draft`, `Drop` and its roster quiet ink are all `--faction-ua-card-muted` over the identical `ComposerGround`, so the 4.38 / 3.79 reading applies there too. It is out of this issue's file scope and a sibling agent is not on it — worth its own issue.

## Shared files

- `factions/__tests__/surfaceDispatch.test.ts` — **one slug appended** to the `createCharacter` array. The list is not restated, re-sorted or reformatted.
- `.design-sync/config.json` — **not touched.** `EphemeristsCreateCharacter` has no preview entry either, so there is nothing to keep in step.
- `frontend/.ds-kit/index.tsx` — **not touched**, so `dsKitBarrelGenerated.test.ts` has nothing to say.

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 397 files, 7073 passed, 1 skipped
- `npm run build` — clean
- `npm run budget` — JS ok; **CSS warns at 22.3 KB against a 22.2 KB warn line, and that is pre-existing.** This diff touches no `.css` at all (`git diff --stat`: two tests, one manifest line, one new `.tsx`).

`api-schema` is not implicated: no route, `response_model` or Pydantic schema is touched.

**The payload is unchanged by construction.** `buildCreatePayload` lives in `useCreateCharacter.ts` and is not touched; no archetype builds a payload, so this skin reads the same state and calls the same setters. The one field-set difference from the na kit is the same one #2347 flagged: the na PHONE branch deliberately offers no `bio` and no `tagline` ("Step 1 of 2 · Identity", #1628), and this leaf offers all six fields at both widths — so a UA player on a phone is offered prose at creation and an unaffiliated one is not. Consistent with the Ephemerists plate; flagged rather than settled.

## What to eyeball — human-verifiable, still open

I cannot produce these images and have not tried to claim otherwise: the in-app Browser pane cannot screenshot (CDP `captureScreenshot` times out) and real Chrome's `resize_window` reports success without resizing. `docs/agents/design-fidelity.md`: *"a human does the mobile looking. Nothing in the toolchain covers it."* The acceptance checkbox stays unticked.

- [ ] **UA picked**, light and dark, at desktop: the sheet's sienna border, the lotus bleeding off the top-left, the ensō turning slowly off the bottom-right, and whether the walked-up quiet tier reads as quiet or as prose next to the ink.
- [ ] **The live transition from Default**: pick UA, then tap it again to clear. The page should become the leaf and go back to the `na` kit with nothing typed lost, and the credential-card preview should change dress in the same beat.
- [ ] **375px**: the whole column, the calling rows, and the full-bleed Create band — that it reaches both sheet edges and that the exits row above it has not wrapped into something ugly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
