### PR TITLE
Character creation compiles a life at a terminal, and the caption tier comes off the scanned chassis (#2353)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
@@ -143,6 +143,11 @@ describe("the lamp cluster is declared once, and in the kit (#1979)", () => {
     expect(mounts.map((file) => rel(file.path)).sort()).toEqual([
       "components/cardMasthead/factionBands.tsx",
       "components/feed/SingularityFeedFrame.tsx",
+      // The sixth window bar (#2353): character creation, dressed as a terminal
+      // session. It mounts the cluster and NOT `SingularityProcessLight` — the
+      // bar it wears is this frame's and the card band's rather than the
+      // composer's, because a page with no session has no process to light.
+      "pages/characterPaths/archetypes/SingularityCreateCharacter.tsx",
       "pages/editPraxis/archetypes/SingularityEditPraxis.tsx",
       "pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx",
       "pages/taskDetail/archetypes/SingularityTaskDetail.tsx",

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -106,7 +106,7 @@ const BESPOKE: Record<string, string[]> = {
   // anyway: every Albescent registration is a WRAPPER rather than a skin
   // (ADR-0027), so it renders `DefaultCreateCharacter`, WHICH IS the na kit. The
   // `leaves %s to the surface Default` row below covers it either way.
-  createCharacter: ['ephemerists', 'snide', 'wow', 'ua', 'everymen', 'coven'],
+  createCharacter: ['ephemerists', 'snide', 'wow', 'ua', 'everymen', 'coven', 'singularity'],
   // Was `mobileFactionPage` with this exact slug list until ADR-0078 collapsed
   // faction detail to one responsive component per faction. Same move the
   // praxis-card row made below: the row follows the surviving surface rather

--- a/frontend/src/factions/singularity.ts
+++ b/frontend/src/factions/singularity.ts
@@ -14,6 +14,7 @@ import { lazyArchetype } from './lazyArchetype'
 const SingularityAvatar = lazyArchetype(() => import('../components/avatar/SingularityAvatar'))
 const SingularityBackdrop = lazyArchetype(() => import('../components/backdrop/SingularityBackdrop'))
 const SingularityComment = lazyArchetype(() => import('../components/comments/voices/SingularityComment'))
+const SingularityCreateCharacter = lazyArchetype(() => import('../pages/characterPaths/archetypes/SingularityCreateCharacter'))
 const SingularityDuelSealConfirm = lazyArchetype(() => import('../components/duel/SingularityDuelSealConfirm'))
 const SingularityEditPraxis = lazyArchetype(() => import('../pages/editPraxis/archetypes/SingularityEditPraxis'))
 const SingularityFactionBody = lazyArchetype(() => import('../pages/factionDetail/archetypes/SingularityFactionBody'))
@@ -48,6 +49,11 @@ export const SINGULARITY_MANIFEST: FactionManifest = {
   taskDetail: () => SingularityTaskDetail,
   praxisDetail: () => SingularityPraxisDetail,
   editPraxis: () => SingularityEditPraxis,
+  // The terminal dresses character creation (#2353, epic #2346). The slug this
+  // dispatches on is the calling being PICKED, not a loaded record, so the page
+  // reskins to this chassis live and returns to the Default the moment the pick
+  // is cleared.
+  createCharacter: () => SingularityCreateCharacter,
   factionHero: () => SingularityFactionHero,
   factionBody: () => SingularityFactionBody,
   profileBody: () => SingularityProfileBody,

--- a/frontend/src/pages/characterPaths/__tests__/singularityCreateCharacterGround.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/singularityCreateCharacterGround.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The Singularity create-character archetype's inks, measured on the ground
+ * that is actually behind them (#2353).
+ *
+ * THE SEAM IS THE COMPOSITE, NOT THE DECLARED TOKEN. `factionContrast.test.ts`
+ * already measures every `--faction-singularity-term-*` pairing against the FLAT
+ * chassis, the flat panel, the flat window bar and the flat readout well, and
+ * every one of those rows is green. None of them is what this page's type sits
+ * on. `ComposerSheet` paints the ground layer at `zIndex: 0` and the content
+ * column at `zIndex: 1`, so anything drawn straight on the chassis has TWO more
+ * layers between it and the paint it was measured against:
+ *
+ *   1. the standing raster — `--faction-singularity-term-scan` on one pixel in
+ *      every three, so a line of type can land on a lit row;
+ *   2. the travelling scan band — `--faction-singularity-term-sweep`, whose
+ *      middle stop is the strongest wash on the sheet and which passes under
+ *      every region of the page in turn.
+ *
+ * Measured on that stack, ONE INK THAT PASSES FLAT FAILS: `-term-dim`, the
+ * family's caption tier, reads 5.03 / 5.80 on the bare chassis and 4.12 / 4.20
+ * under the band. That is the archetype's whole colour rule and the reason it is
+ * written as a measurement rather than as prose in a docblock: on this surface
+ * `-term-dim` is a PANEL ink only. Type drawn on the chassis takes `-term-ink`
+ * or `-term-bright`, both of which clear the band with room.
+ *
+ * NOTHING IS TRANSCRIBED. The raster's alpha and the band's peak stop are read
+ * out of `index.css` and composited here, so a repaint of either token re-runs
+ * the measurement instead of leaving these numbers asserting a ground that no
+ * longer exists — which is the failure mode `createCharacterContrast.test.ts`
+ * had to write a stylesheet-parity guard for.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import {
+  AA_NORMAL,
+  compositeOver,
+  contrastRatio,
+  formatRatio,
+  parseColor,
+  type Rgba,
+} from '../../../utils/contrast'
+import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
+
+const CSS_PATH = fileURLToPath(new URL('../../../index.css', import.meta.url))
+const THEMES = readThemes(readFileSync(CSS_PATH, 'utf8'))
+const BOTH_THEMES: Theme[] = ['light', 'dark']
+
+function resolve(token: string, theme: Theme): Rgba {
+  const raw = resolveVar(token, theme, THEMES)
+  expect(raw, `${token} resolves in ${theme}`).not.toBeNull()
+  const parsed = parseColor(raw!)
+  expect(parsed, `${token} is a colour in ${theme}`).not.toBeNull()
+  return parsed!
+}
+
+/**
+ * The band's strongest stop.
+ *
+ * `--faction-singularity-term-sweep` is a three-stop `linear-gradient` that
+ * fades in and out, so the honest worst case is its middle — the peak alpha,
+ * whichever stop carries it. Picked by comparing the stops rather than by index,
+ * so re-ordering the ramp cannot silently pick the transparent end.
+ */
+function sweepPeak(theme: Theme): Rgba {
+  const raw = resolveVar('--faction-singularity-term-sweep', theme, THEMES)
+  expect(raw, `the sweep resolves in ${theme}`).not.toBeNull()
+  const stops = [...raw!.matchAll(/rgba?\([^)]*\)/g)]
+    .map((match) => parseColor(match[0]))
+    .filter((stop): stop is Rgba => stop !== null)
+  expect(stops.length, `the sweep is a ramp in ${theme}`).toBeGreaterThan(1)
+  return stops.reduce((strongest, stop) => (stop.a > strongest.a ? stop : strongest))
+}
+
+/** Chassis → standing raster → travelling band. The worst ground on the sheet. */
+function sweptChassis(theme: Theme): Rgba {
+  const chassis = resolve('--faction-singularity-term-bg', theme)
+  const rastered = compositeOver(resolve('--faction-singularity-term-scan', theme), chassis)
+  return compositeOver(sweepPeak(theme), rastered)
+}
+
+/** Every ink this archetype puts straight on the chassis, and what draws it. */
+const CHASSIS_INKS: Array<{ what: string; token: string }> = [
+  { what: 'the heading and the selected calling', token: '--faction-singularity-term-bright' },
+  {
+    what: 'section labels, the calling hint, the exits and the portrait status',
+    token: '--faction-singularity-term-ink',
+  },
+  // The functional red inside a faction frame takes that faction's card alarm
+  // (#1302) — `--color-danger` is the neutral this page must not draw.
+  { what: 'the error banner and the avatar error', token: '--faction-singularity-card-alarm' },
+]
+
+/** And every ink it puts on the raised panel, which the ground never reaches. */
+const PANEL_INKS: Array<{ what: string; token: string }> = [
+  { what: 'field text', token: '--faction-singularity-term-ink' },
+  { what: 'the @handle and the character counters', token: '--faction-singularity-term-dim' },
+  { what: 'the portrait key and an unpicked calling', token: '--faction-singularity-term-bright' },
+  { what: 'a counter at its cap', token: '--faction-singularity-card-alarm' },
+]
+
+describe('the terminal chassis clears AA under its own two ornament layers', () => {
+  for (const theme of BOTH_THEMES) {
+    for (const { what, token } of CHASSIS_INKS) {
+      it(`${what} — ${theme}`, () => {
+        const ratio = contrastRatio(resolve(token, theme), sweptChassis(theme))
+        expect(
+          ratio,
+          `${token} on the chassis under the raster and the scan band is ${formatRatio(ratio)}`,
+        ).toBeGreaterThanOrEqual(AA_NORMAL)
+      })
+    }
+  }
+})
+
+describe('the raised panel is opaque, so its inks keep their flat measurement', () => {
+  for (const theme of BOTH_THEMES) {
+    for (const { what, token } of PANEL_INKS) {
+      it(`${what} — ${theme}`, () => {
+        const panel = resolve('--faction-singularity-term-panel', theme)
+        const ratio = contrastRatio(resolve(token, theme), panel)
+        expect(
+          ratio,
+          `${token} on --faction-singularity-term-panel is ${formatRatio(ratio)}`,
+        ).toBeGreaterThanOrEqual(AA_NORMAL)
+      })
+    }
+  }
+})
+
+describe('the caption tier is a panel ink on this surface, and that is measured', () => {
+  // The load-bearing half of the archetype's colour rule. `-term-dim` is the
+  // family's caption ink and it is what every other Singularity surface labels
+  // with — including the composer, whose section labels sit on this same
+  // chassis under this same band. Here it is refused, and this row is the
+  // reason: it passes flat and fails composited, which is exactly the mistake
+  // #2353's acceptance criterion was written against.
+  //
+  // If the band or the raster is ever quietened far enough for this to clear,
+  // this row goes red and the label tier can be reconsidered — which is the
+  // outcome worth catching, and why the assertion is `toBeLessThan` rather than
+  // a comment.
+  it.each(BOTH_THEMES)('%s — dim survives the raster and fails the band', (theme) => {
+    const dim = resolve('--faction-singularity-term-dim', theme)
+    const chassis = resolve('--faction-singularity-term-bg', theme)
+    const rastered = compositeOver(resolve('--faction-singularity-term-scan', theme), chassis)
+
+    expect(
+      contrastRatio(dim, chassis),
+      'flat, which is what factionContrast.test.ts measures',
+    ).toBeGreaterThanOrEqual(AA_NORMAL)
+    expect(contrastRatio(dim, rastered), 'the raster alone').toBeGreaterThanOrEqual(AA_NORMAL)
+    expect(
+      contrastRatio(dim, sweptChassis(theme)),
+      `under the band it is ${formatRatio(contrastRatio(dim, sweptChassis(theme)))}`,
+    ).toBeLessThan(AA_NORMAL)
+  })
+})
+
+describe('the error banner keeps its ink under the neutral danger veil', () => {
+  // `ErrorBanner` washes `--color-danger-veil` over whatever it is mounted on
+  // and the veil stays neutral (ADR-0061), so the banner's real ground is a
+  // THIRD layer on the stack above.
+  it.each(BOTH_THEMES)('%s', (theme) => {
+    const ground = compositeOver(resolve('--color-danger-veil', theme), sweptChassis(theme))
+    const ratio = contrastRatio(resolve('--faction-singularity-card-alarm', theme), ground)
+    expect(ratio, `the alarm under the veil is ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    )
+  })
+})
+
+describe('the submit band and the window bar', () => {
+  // Both are opaque paint of their own, drawn ABOVE the ground rather than on
+  // it — the masthead at zIndex 2, the band a filled button. They are here so
+  // the archetype's whole ink set is measured in one place rather than half
+  // here and half by inference.
+  it.each(BOTH_THEMES)('%s — the cast key and the process name', (theme) => {
+    const cast = contrastRatio(
+      resolve('--faction-singularity-term-cta-ink', theme),
+      resolve('--faction-singularity-term-cta-bg', theme),
+    )
+    expect(cast, `the cast key is ${formatRatio(cast)}`).toBeGreaterThanOrEqual(AA_NORMAL)
+
+    const proc = contrastRatio(
+      resolve('--faction-singularity-term-dim', theme),
+      resolve('--faction-singularity-term-chrome', theme),
+    )
+    expect(proc, `the process name is ${formatRatio(proc)}`).toBeGreaterThanOrEqual(AA_NORMAL)
+  })
+})

--- a/frontend/src/pages/characterPaths/__tests__/singularityCreateCharacterRegister.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/singularityCreateCharacterRegister.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * The Singularity create-character archetype wears the terminal, and keeps the
+ * caption tier off the chassis (#2353).
+ *
+ * TWO SEAMS, and the second is the one nothing else in CI can see.
+ *
+ *  1. THE REGISTER. The skin names the `--faction-singularity-term-*` family its
+ *     own task card and composer name, draws the faction's ONE ornament pair
+ *     (`.sg-scan`, `.sg-cursor`) rather than the composer kit's `.ep-*`, and
+ *     speaks in one face. A forked family is invisible to every lint and to
+ *     every contrast sweep, because both halves are real declared tokens —
+ *     `singularityWearsTheTerminalRegister.test.ts` is the same guard one
+ *     surface over.
+ *
+ *  2. THE DIM-INK RULE, MECHANICALLY. `-term-dim` clears AA on the flat chassis
+ *     and FAILS on the composite that is actually behind this page's type — the
+ *     chassis plus the standing raster plus the travelling scan band (4.12:1
+ *     light / 4.20:1 dark; the ratios are in
+ *     `singularityCreateCharacterGround.test.ts`). A ratio test can state that
+ *     and cannot enforce it: nothing stops the next edit from inking a label
+ *     `-term-dim` on the chassis, and it would look perfectly deliberate. So the
+ *     rule is written as a property of the rendered markup — an element inked
+ *     `-term-dim` must declare `-term-panel` (the readout box's opaque fill) or
+ *     `-term-chrome` (the window bar's) as its OWN background, because `color`
+ *     inherits and a background does not.
+ *
+ * `renderToStaticMarkup` only — the frontend harness has no DOM, effects never
+ * run, and nothing asserted here needs either.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CreateCharacterState } from '../useCreateCharacter'
+
+const factor = vi.hoisted(() => ({ value: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useFormFactor')>()),
+  useFormFactor: () => factor.value,
+}))
+
+const SingularityCreateCharacter = (await import('../archetypes/SingularityCreateCharacter'))
+  .default
+
+const WIDTHS = ['desktop', 'mobile'] as const
+
+function state(overrides: Partial<CreateCharacterState> = {}): CreateCharacterState {
+  return {
+    displayName: 'Molly',
+    setDisplayName: () => {},
+    bio: '',
+    setBio: () => {},
+    tagline: '',
+    setTagline: () => {},
+    factionSlug: 'singularity',
+    setFactionSlug: () => {},
+    invited: ['singularity', 'coven'],
+    avatarFile: null,
+    avatarPreview: null,
+    avatarSource: null,
+    setAvatarSource: () => {},
+    avatarError: 'that portrait is too large',
+    setAvatarError: () => {},
+    handleAvatarChange: () => {},
+    handleAvatarConfirm: () => {},
+    error: 'that did not go in',
+    submitting: false,
+    canSubmit: true,
+    handleSubmit: () => {},
+    handle: 'molly',
+    showPicker: true,
+    ...overrides,
+  }
+}
+
+function render(width: (typeof WIDTHS)[number], overrides: Partial<CreateCharacterState> = {}) {
+  factor.value = width
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <SingularityCreateCharacter state={state(overrides)} />
+    </MemoryRouter>,
+  )
+  factor.value = 'desktop'
+  return html
+}
+
+/** Every inline `style` attribute in the markup, one string each. */
+const styleAttributes = (html: string): string[] =>
+  [...html.matchAll(/style="([^"]*)"/g)].map((match) => match[1])
+
+const DIM = '--faction-singularity-term-dim'
+/** The two opaque grounds `-term-dim` was measured against on this surface. */
+const DIM_GROUNDS = ['--faction-singularity-term-panel', '--faction-singularity-term-chrome']
+
+describe('the caption tier never lands on the composited chassis', () => {
+  it.each(WIDTHS)('%s — every dim ink declares its own opaque ground', (width) => {
+    const attributes = styleAttributes(render(width))
+    const inked = attributes.filter((style) => style.includes(DIM))
+
+    // Zero would pass this vacuously — the quiet tier IS drawn, in the readout
+    // boxes' feet and on the window bar.
+    expect(inked.length, 'the caption tier is drawn at all').toBeGreaterThan(0)
+
+    const stranded = inked.filter((style) => !DIM_GROUNDS.some((ground) => style.includes(ground)))
+    expect(
+      stranded,
+      `Each line is an element inked \`${DIM}\` that does not paint its own
+opaque background. Its real ground is therefore the chassis under the standing
+raster and the travelling scan band, where that ink measures 4.12:1 in light and
+4.20:1 in dark — below AA, on a token that passes 5.03 / 5.80 flat.
+Put the element inside a readout box and give it \`background: PANEL\`, or ink it
+\`--faction-singularity-term-ink\` (6.82 / 8.11 on that same composite).`,
+    ).toEqual([])
+  })
+})
+
+describe('the page wears the terminal, and one register only', () => {
+  it.each(WIDTHS)('%s — the chassis, the readout boxes and one face', (width) => {
+    const html = render(width)
+    for (const token of [
+      '--faction-singularity-term-bg',
+      '--faction-singularity-term-chrome',
+      '--faction-singularity-term-panel',
+      '--faction-singularity-term-border',
+      '--faction-singularity-term-bright',
+      '--faction-singularity-term-ink',
+      '--faction-singularity-card-font',
+    ]) {
+      expect(html, `${token} is unpainted`).toContain(token)
+    }
+  })
+
+  it.each(WIDTHS)('%s — the lamps, the raster and the two motions', (width) => {
+    const html = render(width)
+    // The window bar's cluster comes from the kit, so the LED trio is the proof
+    // it is MOUNTED rather than re-declared (#1979).
+    for (const led of ['led-red', 'led-amber', 'led-green']) {
+      expect(html, `the ${led} lamp is missing from the bar`).toContain(
+        `--faction-singularity-${led}`,
+      )
+    }
+    expect(html, 'the standing raster').toContain('--faction-singularity-term-scan')
+    expect(html, 'the travelling band').toContain('--faction-singularity-term-sweep')
+    // The FACTION's own ornament classes, not the composer kit's `.ep-*` — one
+    // primitive per faction (WORLD_ZERO_STYLE §6).
+    expect(html, 'the scan sweep').toContain('class="sg-scan"')
+    expect(html, 'the block cursor').toContain('class="sg-cursor"')
+    expect(html, 'no borrowed composer motion').not.toContain('ep-blink')
+  })
+
+  it.each(WIDTHS)('%s — the alarm is the faction\'s, never the neutral red', (width) => {
+    const html = render(width)
+    // #1302: a shared functional ink inside a faction frame takes that faction's
+    // card family. The VEIL and the EDGE stay neutral — ADR-0061.
+    expect(html).toContain('--faction-singularity-card-alarm')
+    expect(html, 'the error copy must not paint the neutral').not.toContain(
+      'color:var(--color-danger)',
+    )
+    expect(html, 'but the veil is still the platform speaking').toContain('--color-danger-veil')
+  })
+})
+
+describe('the page keeps the contract the archetype is only a dress on', () => {
+  it.each(WIDTHS)('%s — the picker survives, and clearing is reachable', (width) => {
+    const html = render(width)
+    // A player must be able to change their mind, or clear the pick and be born
+    // unaffiliated. The picked row is `aria-pressed`, which is what makes the
+    // second tap read as "unset" rather than as a dead control.
+    expect(html, 'the calling just picked').toContain('Singularity')
+    expect(html, 'and the one not picked').toContain('Cozy Coven')
+    expect(html).toContain('aria-pressed="true"')
+    expect(html).toContain('aria-pressed="false"')
+  })
+
+  it.each(WIDTHS)('%s — every field is named by the label already on screen', (width) => {
+    const html = render(width)
+    const forAttributes = [...html.matchAll(/<label[^>]*\bfor="([^"]+)"/g)].map((m) => m[1])
+    expect(forAttributes.length, 'three labelled fields').toBe(3)
+    for (const id of forAttributes) {
+      expect(html, `nothing carries id="${id}"`).toContain(`id="${id}"`)
+    }
+  })
+
+  it('submits through a real form, so Enter commits from a text field', () => {
+    expect(render('desktop')).toContain('<form')
+  })
+})

--- a/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
@@ -1,0 +1,653 @@
+/**
+ * The Singularity character-creation archetype — A LIFE, COMPILED (#2353, epic
+ * #2346).
+ *
+ * NO DESIGN WAS DRAWN FOR THIS, and none was needed: the owner's ruling is that
+ * the two surfaces this faction already ships carry the whole register between
+ * them. `components/taskCard/SingularityTaskCard` holds the chassis, the window
+ * chrome, the standing raster and the travelling sweep;
+ * `pages/editPraxis/archetypes/SingularityEditPraxis` holds the same terminal
+ * applied to a FORM — labelled fields, counters, a primary commit, a cancel path
+ * — which is structurally what this page is. This file is that dress over this
+ * page's fields, and it draws no new SVG at all: the window bar's lamp cluster
+ * is `components/factionMarks/SingularityLamps` (WORLD_ZERO_STYLE §6, "one
+ * primitive").
+ *
+ * ## The chassis is the composer's, not a second one
+ *
+ * `ComposerPage` / `ComposerSheet` / `ComposerSection` / `ComposerFooter` are
+ * geometry with no praxis in them, so this page mounts the same blocks the
+ * composer does rather than restating a sheet, a window bar and a footer row.
+ * The CONTROLS in `editPraxis/archetypes/controls.tsx` are the half that does
+ * not fit — every one of them takes an `EditPraxisState` — so the fields below
+ * are plain inputs inside this skin's own readout box, which is the same
+ * geometry (`radius 2`, `1px` frame, `-term-panel` fill) that file's fields
+ * wear. Nothing under `pages/editPraxis/` is written to.
+ *
+ * ## One responsive component, no mobile twin
+ *
+ * `useComposerSizes()` reads `useFormFactor()` and picks the size set; there is
+ * one tree at two widths and no second file. Every fixed number here is ornament
+ * geometry, never a layout grid (SPEC-faction-ui-profile §1a).
+ *
+ * ## Copy — none of its own
+ *
+ * Every string is an existing `forms:createCharacter.*` key, unchanged and
+ * un-reordered: chosen name → about → tagline → portrait → answer a calling →
+ * commit / cancel. Two strings are UNTRANSLATED and that is deliberate:
+ * `character.new` on the window bar and the `>` before the heading are ORNAMENT,
+ * in the same class as the three lamps beside them — marks that happen to be
+ * made of glyphs (WORLD_ZERO_STYLE §4, "role vocabulary"). They are module
+ * constants rather than JSX text so they read as identifiers to
+ * `i18next/no-literal-string`, which is the shape `SingularityEditPraxis`'s
+ * `praxis.proc` and `[ok]` already use, and both sit inside `aria-hidden` chrome
+ * so neither is announced.
+ *
+ * ## Colour — and the one rule that is this surface's own
+ *
+ * Every value is a `--faction-singularity-term-*` token, never a ternary and
+ * never a `dark ?` branch. The family is NOT theme-invariant even though both
+ * its halves are near-black (§6): the chassis stays black and the cascade flips
+ * the PHOSPHOR. The one exception is the lamp trio, which is the kit's own
+ * theme-invariant `--faction-singularity-led-*` (#1979) and lives in the mark.
+ *
+ * `-term-dim` — the family's caption tier, and what every other Singularity
+ * surface labels with — IS A PANEL INK HERE AND NEVER A CHASSIS ONE. That is
+ * measured, not stylistic. `ComposerSheet` paints the ground at `zIndex: 0` and
+ * the content column at `zIndex: 1`, so type drawn straight on the chassis has
+ * the standing raster AND the travelling scan band between it and the paint
+ * `factionContrast.test.ts` measured it against. On that composite `-term-dim`
+ * falls from 5.03 / 5.80 to 4.12 / 4.20 — under AA, on a token that passes flat.
+ * So the chassis carries only `-term-ink` (6.82 / 8.11) and `-term-bright`
+ * (8.92 / 10.06), the raised panel carries the quiet tier, and
+ * `__tests__/singularityCreateCharacterGround.test.ts` holds all of it as
+ * measurements rather than as this paragraph. It also pins the invariant
+ * mechanically: an element inked `-term-dim` must declare `-term-panel` (or the
+ * window bar's `-term-chrome`) as its own background, which is why the process
+ * name below repaints the ground it already stands on.
+ *
+ * The error banner and the avatar error take `--faction-singularity-card-alarm`
+ * rather than the neutral `--color-danger`, which is the same deviation
+ * `SingularityEditPraxis` keeps and for the same measured reason (#1302). The
+ * veil and the edge stay neutral — ADR-0061.
+ *
+ * ## Motion — two classes, no inline `animation:`
+ *
+ * `.sg-scan` on the travelling band and `.sg-cursor` on the block cursor after
+ * the cast. Both are the FACTION's own (the task card draws the same pair)
+ * rather than the composer kit's `.ep-*`, per §6's "a faction's ornament is one
+ * primitive, not one per surface"; both live in `motion.ornament.css` behind the
+ * shared `prefers-reduced-motion` guard, and an inline `animation:` would bypass
+ * it (#1003). This file touches no stylesheet.
+ *
+ * ## Not built as the composer draws it, and why
+ *
+ * - **No process light.** `SingularityProcessLight` says a session is UP; there
+ *   is no process here, and no character yet. The bar this page wears is the
+ *   feed frame's and the card band's — lamps plus a name — rather than the
+ *   composer's.
+ * - **The fields keep the browser's focus ring.** `SingularityEditPraxis` and
+ *   the Ephemerists plate both set `outline: none` on their field boxes; this
+ *   one does not, because the ring is the only focus indicator a keyboard
+ *   reaches these six controls with. The frame is on the readout box, so the
+ *   ring has room to draw inside it.
+ * - **The labels are real `<label for>`s.** `ComposerSection` has taken an
+ *   `htmlFor` since #1742 and nothing on this page was using it, so each field
+ *   gets an accessible name from the label already on screen rather than from a
+ *   placeholder.
+ *
+ * ## Presentation only
+ *
+ * `useCreateCharacter` stays the single source of state for every archetype.
+ * Nothing here touches the submit path, the payload, `PortraitPicker` or
+ * `useAvatarPicker`, and THE PICKER STAYS VISIBLE in this skin — a player must
+ * be able to change their mind, or clear the pick and be born unaffiliated,
+ * which returns the page to the Default archetype.
+ */
+import { useId, useRef, type CSSProperties, type ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import CredentialCard from '../../../components/CredentialCard'
+import FactionSigil from '../../../components/sigil/FactionSigil'
+import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
+import SingularityLamps from '../../../components/factionMarks/SingularityLamps'
+import PortraitPicker from '../PortraitPicker'
+import {
+  NAME_MAX,
+  BIO_MAX,
+  TAGLINE_MAX,
+  type CreateCharacterState,
+} from '../useCreateCharacter'
+import {
+  ComposerFooter,
+  ComposerGround,
+  ComposerMasthead,
+  ComposerPage,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ErrorBanner,
+  composerBandStyle,
+  composerLabelStyle,
+  useComposerSizes,
+} from '../../editPraxis/archetypes/shared'
+
+const SLUG = 'singularity'
+
+/* The terminal's two-theme contract (#1023/#1034), named for the ROLE each plays
+   rather than for its colour. Both halves are near-black and the cascade flips
+   the phosphor — see the header. */
+const CHASSIS = 'var(--faction-singularity-term-bg)'
+const CHROME = 'var(--faction-singularity-term-chrome)'
+/** The raised box: every field, the portrait key, an unpicked calling. */
+const PANEL = 'var(--faction-singularity-term-panel)'
+const INK = 'var(--faction-singularity-term-ink)'
+/** Titles and the lit key's edge. */
+const BRIGHT = 'var(--faction-singularity-term-bright)'
+/** The caption tier — PANEL ONLY on this surface. See the header. */
+const DIM = 'var(--faction-singularity-term-dim)'
+const BORDER = 'var(--faction-singularity-term-border)'
+const HAIR = 'var(--faction-singularity-term-hair)'
+const SCAN = 'var(--faction-singularity-term-scan)'
+const SWEEP = 'var(--faction-singularity-term-sweep)'
+const CTA_BG = 'var(--faction-singularity-term-cta-bg)'
+const CTA_INK = 'var(--faction-singularity-term-cta-ink)'
+const CTA_GLOW = 'var(--faction-singularity-term-cta-glow)'
+const HALO_GREEN = 'var(--faction-singularity-term-halo-green)'
+const SHADOW = 'var(--faction-singularity-term-shadow)'
+const ALARM = 'var(--faction-singularity-card-alarm)'
+
+/* Share Tech Mono, for the title, the body AND the label — the whole surface is
+   one face. Reached through the faction's own accessor rather than through
+   --font-faction-terminal directly, which is what §4 asks for when the face IS
+   the faction's. */
+const FACE = 'var(--faction-singularity-card-font)'
+
+/** The design's geometry: radius 2, borderW 1. A terminal has square corners. */
+const RADIUS = 2
+/** The travelling band's depth, and the sweep's overhang. Ornament (§4a). */
+const SWEEP_HEIGHT = 38
+/** The mark each calling wears in the picker — the size every chooser draws (#2223). */
+const PICKER_SIGIL = 18
+
+/* Ornament, not copy — see the header. Module constants so they reach JSX as
+   identifier expressions rather than as literal text. */
+const PROC_NAME = 'character.new'
+const PROMPT = '>'
+
+/** The composer's label tier in the terminal's face, on the chassis's own ink. */
+function chassisLabel(overrides: CSSProperties = {}): CSSProperties {
+  return composerLabelStyle({ fontFamily: FACE, color: INK, ...overrides })
+}
+
+export default function SingularityCreateCharacter({ state }: { state: CreateCharacterState }) {
+  const { t } = useTranslation('forms')
+  const navigate = useNavigate()
+  const sizes = useComposerSizes()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  // Two forms could in principle share a document, so the field ids are
+  // generated rather than written down.
+  const fieldId = useId()
+  const {
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    tagline,
+    setTagline,
+    factionSlug,
+    setFactionSlug,
+    invited,
+    avatarFile,
+    avatarPreview,
+    avatarSource,
+    setAvatarSource,
+    avatarError,
+    setAvatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+    error,
+    submitting,
+    canSubmit,
+    handleSubmit,
+    handle,
+    showPicker,
+  } = state
+
+  /** The readout box: a lit panel inside a hard 1px frame. */
+  const boxStyle: CSSProperties = {
+    background: PANEL,
+    border: `1px solid ${BORDER}`,
+    borderRadius: RADIUS,
+    // So the footer strip's own edge cannot poke past the frame's corners.
+    overflow: 'hidden',
+  }
+
+  /* The field itself is borderless INSIDE that box — the frame belongs to the
+     readout, not to the control. No `outline: none`: see the header. */
+  const inputStyle: CSSProperties = {
+    display: 'block',
+    width: '100%',
+    background: 'transparent',
+    color: INK,
+    border: 'none',
+    padding: 'var(--space-md)',
+    boxSizing: 'border-box',
+    fontFamily: FACE,
+    fontSize: 'var(--text-content)',
+  }
+
+  /**
+   * The readout's foot: the quiet line, INSIDE the panel.
+   *
+   * This is where `-term-dim` lives on this surface and the only place it may —
+   * the strip declares the panel as its own background, which is both the ground
+   * the ink was measured on and what makes the rule machine-checkable (header,
+   * and `singularityCreateCharacterGround.test.ts`).
+   */
+  const foot = (used: number, max: number, lead?: ReactNode) => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        gap: 'var(--space-md)',
+        background: PANEL,
+        color: DIM,
+        borderTop: `1px dashed ${HAIR}`,
+        padding: 'var(--space-xs) var(--space-md)',
+        fontFamily: FACE,
+        fontSize: 'var(--text-lg)',
+      }}
+    >
+      <span>{lead}</span>
+      <span style={used >= max ? { color: ALARM } : undefined}>
+        {t('createCharacter.charsLeft', { count: max - used })}
+      </span>
+    </div>
+  )
+
+  const masthead = (
+    /* The window bar. `ComposerMasthead` is a 3px band by default; the skin
+       gives it its own height and padding through `style`, which is spread
+       last. Its whole content is aria-hidden chrome. */
+    <ComposerMasthead
+      background={CHROME}
+      style={{
+        height: 'auto',
+        padding: 'var(--space-sm) var(--space-lg)',
+        borderBottom: `1px solid ${BORDER}`,
+      }}
+    >
+      <div aria-hidden style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
+        {/* The lamp cluster — the kit's since #1979, drawn once for all six of
+            this faction's window bars. No process light beside it: see the
+            header for why a page with no session does not claim one. */}
+        <SingularityLamps />
+        <span
+          style={composerLabelStyle({
+            fontFamily: FACE,
+            // The bar's own ground, restated on the ink that stands on it —
+            // a no-op paint that makes the dim-ink rule checkable.
+            background: CHROME,
+            color: DIM,
+            letterSpacing: '0.1em',
+            textTransform: 'none',
+            marginLeft: 'var(--space-sm)',
+          })}
+        >
+          {PROC_NAME}
+        </span>
+      </div>
+    </ComposerMasthead>
+  )
+
+  const ground = (
+    /* The standing raster, at inset 0 — a fixed scrim, so unlike a drifting
+       wash it neither travels nor overhangs. The band rides inside it and
+       overhangs horizontally instead, so its soft ends never show against the
+       sheet's edges. */
+    <ComposerGround
+      inset={0}
+      background={`repeating-linear-gradient(0deg, ${SCAN} 0 1px, transparent 1px 3px)`}
+    >
+      <div
+        aria-hidden
+        className="sg-scan"
+        style={{
+          position: 'absolute',
+          left: '-30%',
+          right: '-30%',
+          height: SWEEP_HEIGHT,
+          background: SWEEP,
+        }}
+      />
+    </ComposerGround>
+  )
+
+  const sheetStyle: CSSProperties = {
+    background: CHASSIS,
+    border: `1px solid ${BORDER}`,
+    borderRadius: RADIUS,
+    boxShadow: SHADOW,
+  }
+
+  return (
+    <ComposerPage sizes={sizes} style={{ fontFamily: FACE, color: INK }}>
+      {/* A REAL `<form>`, not a bare button with an onClick. The Default skin
+          submits through one and so must this: it is what makes Enter commit
+          from a text field, and what gives the browser's own required-field
+          behaviour something to attach to. `handleSubmit` calls
+          `preventDefault()` itself. */}
+      <form onSubmit={handleSubmit} data-skin={SLUG}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+          {/* The prompt, and the page's own question — the heading this surface
+              has always asked. */}
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-md)' }}>
+            <span
+              aria-hidden
+              style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}
+            >
+              {PROMPT}
+            </span>
+            <h1
+              style={{
+                fontFamily: FACE,
+                fontWeight: 400,
+                fontSize: sizes.titleSize,
+                color: BRIGHT,
+                textShadow: HALO_GREEN,
+                lineHeight: 1.2,
+                margin: 0,
+              }}
+            >
+              {t('createCharacter.heading')}
+            </h1>
+          </div>
+
+          {/* The life being compiled, live. The card dispatches its own faction
+              dress, so it is already wearing this terminal the moment the
+              calling is picked — the same value this whole page reskins on. */}
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <CredentialCard
+              displayName={displayName || t('createCharacter.previewFallbackName')}
+              handle={handle}
+              factionSlug={factionSlug || null}
+              level={1}
+              score={0}
+              avatarUrl={avatarPreview}
+              onAvatarClick={() => fileInputRef.current?.click()}
+            />
+          </div>
+
+          {/* Chosen name */}
+          <ComposerSection
+            rule={false}
+            htmlFor={`${fieldId}-name`}
+            label={t('createCharacter.nameLabel')}
+            labelStyle={{ fontFamily: FACE, color: INK }}
+          >
+            <div style={boxStyle}>
+              <input
+                id={`${fieldId}-name`}
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={NAME_MAX}
+                placeholder={t('createCharacter.namePlaceholder')}
+                autoFocus
+                style={inputStyle}
+              />
+              {foot(displayName.length, NAME_MAX, `@${handle}`)}
+            </div>
+          </ComposerSection>
+
+          {/* About */}
+          <ComposerSection
+            rule={false}
+            htmlFor={`${fieldId}-about`}
+            label={t('createCharacter.aboutLabel')}
+            labelStyle={{ fontFamily: FACE, color: INK }}
+          >
+            <div style={boxStyle}>
+              <textarea
+                id={`${fieldId}-about`}
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                maxLength={BIO_MAX}
+                placeholder={t('createCharacter.aboutPlaceholder')}
+                rows={3}
+                style={{ ...inputStyle, resize: 'vertical', lineHeight: 1.7 }}
+              />
+              {foot(bio.length, BIO_MAX)}
+            </div>
+          </ComposerSection>
+
+          {/* Tagline — a slogan line, not a short bio (#1628). Its counter turns
+              alarm on the cap the way the name field's does: this is the field
+              the profile header's identity slot is laid out against, so running
+              out of room is worth seeing before the text stops appearing. */}
+          <ComposerSection
+            rule={false}
+            htmlFor={`${fieldId}-tagline`}
+            label={t('createCharacter.taglineLabel')}
+            labelStyle={{ fontFamily: FACE, color: INK }}
+          >
+            <div style={boxStyle}>
+              <textarea
+                id={`${fieldId}-tagline`}
+                value={tagline}
+                onChange={(e) => setTagline(e.target.value)}
+                maxLength={TAGLINE_MAX}
+                placeholder={t('createCharacter.taglinePlaceholder')}
+                rows={2}
+                style={{ ...inputStyle, resize: 'vertical', lineHeight: 1.7 }}
+              />
+              {foot(tagline.length, TAGLINE_MAX)}
+            </div>
+          </ComposerSection>
+
+          {/* Portrait — the shared picker owns the hidden input and the "what's
+              chosen" readout (#1149); the credential card above opens the same
+              input through `fileInputRef`. Its key is dressed as a panel rather
+              than left in `.btn-outline`, which brings a near-white
+              `--color-bg-surface` ground that reads as browser chrome dropped on
+              a black chassis. The error ink is passed for a measured reason —
+              the neutral danger red is 3.42:1 to 3.54:1 on the grounds this
+              control is mounted on (see the prop's own note). */}
+          <ComposerSection
+            rule={false}
+            label={
+              <>
+                {t('createCharacter.portraitLabel')}{' '}
+                <span style={{ textTransform: 'none', letterSpacing: 0 }}>
+                  {t('createCharacter.optional')}
+                </span>
+              </>
+            }
+            labelStyle={{ fontFamily: FACE, color: INK }}
+          >
+            <PortraitPicker
+              inputRef={fileInputRef}
+              onChange={handleAvatarChange}
+              chosenFile={avatarFile}
+              error={avatarError}
+              buttonStyle={chassisLabel({
+                cursor: 'pointer',
+                borderRadius: RADIUS,
+                padding: 'var(--space-sm) var(--space-lg)',
+                background: PANEL,
+                color: BRIGHT,
+                border: `1px solid ${BORDER}`,
+              })}
+              statusStyle={{ fontFamily: FACE, color: INK }}
+              errorStyle={{ color: ALARM }}
+            />
+          </ComposerSection>
+
+          {/* Answer a calling — only when the account holds invitations
+              (ADR-0019). It stays drawn in this skin: tapping the terminal's own
+              faction must not be a one-way door, and clearing the pick returns
+              the page to the Default archetype. */}
+          {showPicker && (
+            <ComposerSection
+              rule={false}
+              label={
+                <>
+                  {t('createCharacter.callingLabel')}{' '}
+                  <span style={{ textTransform: 'none', letterSpacing: 0 }}>
+                    {t('createCharacter.callingOptional')}
+                  </span>
+                </>
+              }
+              labelStyle={{ fontFamily: FACE, color: INK }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
+                {invited.map((slug) => {
+                  const selected = factionSlug === slug
+                  return (
+                    <button
+                      key={slug}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => setFactionSlug(selected ? '' : slug)}
+                      /* NOT the label tier — it forces `uppercase` and its own
+                         tracking, and both would be inherited by the name below.
+                         A calling wears its OWN card face at its own case, which
+                         is what every other chooser draws. The picked row is the
+                         terminal's LIT KEY — the same active state the
+                         composer's mode picker wears. */
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 'var(--space-md)',
+                        width: '100%',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        borderRadius: RADIUS,
+                        padding: 'var(--space-md) var(--space-lg)',
+                        background: selected ? CTA_BG : PANEL,
+                        border: `1px solid ${selected ? CTA_BG : BORDER}`,
+                        boxShadow: selected ? CTA_GLOW : undefined,
+                      }}
+                    >
+                      {/* The faction's own mark, from the dispatcher every other
+                          chooser draws (#2223). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                      <span
+                        style={{
+                          fontFamily: factionCssVar(slug, 'card-font'),
+                          fontSize: 'var(--text-content)',
+                          color: selected ? CTA_INK : INK,
+                        }}
+                      >
+                        {factionName(slug)}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+              <p
+                style={{
+                  fontFamily: FACE,
+                  fontSize: 'var(--text-content)',
+                  color: INK,
+                  margin: 0,
+                  lineHeight: 1.55,
+                }}
+              >
+                {t('createCharacter.callingHint')}
+              </p>
+            </ComposerSection>
+          )}
+
+          <ErrorBanner message={error ?? ''} style={{ color: ALARM }} />
+
+          {/* The footer's own divider — a dashed hair, drawn ONCE above the
+              footer (#1707) rather than at the head of every section; the
+              sheet's gap parts the regions. */}
+          <ComposerRule style={{ height: 0, background: 'none', borderTop: `1px dashed ${HAIR}` }} />
+
+          {/* [Cancel] … [Create] — the global order from #646, with the cast as a
+              full-bleed band flush to the chassis's bottom edge (#1828). */}
+          <ComposerFooter
+            band
+            start={
+              <>
+                <button
+                  type="button"
+                  onClick={() => navigate('/')}
+                  style={chassisLabel({
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                  })}
+                >
+                  {t('createCharacter.cancel')}
+                </button>
+                <span style={{ fontFamily: FACE, fontSize: 'var(--text-content)', color: INK }}>
+                  {t('createCharacter.startsAt')}
+                </span>
+              </>
+            }
+            end={
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                style={{
+                  ...composerBandStyle(sizes, {
+                    /* 13 in the terminal's own band sits between the label rung
+                       (12) and --text-xl (14); the band takes the rung above the
+                       label it has to outrank (§4a). */
+                    fontFamily: FACE,
+                    fontSize: 'var(--text-xl)',
+                    letterSpacing: '0.1em',
+                    frame: BORDER,
+                    color: CTA_INK,
+                    background: CTA_BG,
+                    /* The terminal's own CTA halo — `none` in light, real in
+                       dark, straight off the token. */
+                    boxShadow: CTA_GLOW,
+                  }),
+                  cursor: submitting ? 'wait' : 'pointer',
+                  opacity: canSubmit ? 1 : 0.5,
+                }}
+              >
+                {submitting ? t('createCharacter.submitBusy') : t('createCharacter.submitIdle')}
+                {/* The prompt's block cursor, trailing the word. `.sg-cursor`
+                    carries the reduced-motion-guarded blink; stilled it stays
+                    drawn, because it is punctuation on the prompt and not an
+                    indicator. */}
+                <span
+                  aria-hidden
+                  className="sg-cursor"
+                  style={{
+                    display: 'inline-block',
+                    width: '0.55em',
+                    height: '1em',
+                    marginLeft: 'var(--space-sm)',
+                    verticalAlign: '-0.12em',
+                    background: 'currentColor',
+                  }}
+                />
+              </button>
+            }
+          />
+        </ComposerSheet>
+      </form>
+
+      {/* Portrait crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+          onError={setAvatarError}
+        />
+      )}
+    </ComposerPage>
+  )
+}


### PR DESCRIPTION
Closes #2353

The Singularity archetype of character creation: a terminal session in which a life is compiled. Built from the two surfaces the faction already ships — `SingularityTaskCard` for the chassis, window chrome, standing raster and travelling sweep, `SingularityEditPraxis` for the same terminal applied to a form — per the owner's ruling that no design was needed.

## The seam I tested at

**The composited ground behind this page's type**, and — mechanically — **the rendered markup**, which is the only place the rule can be enforced rather than merely stated.

`ComposerSheet` paints the ground layer at `zIndex: 0` and the content column at `zIndex: 1`. So anything drawn straight on the chassis has two more layers between it and the paint `factionContrast.test.ts` measured it against: the standing raster (`-term-scan`, one pixel in three) and the travelling scan band (`-term-sweep`, the strongest wash on the sheet, which passes under every region in turn).

Measured on that stack, **one ink that passes flat fails**:

| ink | flat chassis | + raster | + scan band |
|---|---|---|---|
| `-term-bright` | 10.88 / 13.87 | 10.05 / 13.01 | **8.92 / 10.06** |
| `-term-ink` | 8.32 / 11.18 | 7.69 / 10.48 | **6.82 / 8.11** |
| `-term-dim` | 5.03 / 5.80 | 4.65 / 5.44 | **4.12 / 4.20** ← fails AA |
| `-card-alarm` | 9.99 / 10.26 | 9.23 / 9.62 | **8.19 / 7.44** |

(light / dark)

So the archetype's colour rule is: **`-term-dim` is a PANEL ink on this surface and never a chassis one.** The chassis carries only `-term-ink` and `-term-bright`; the caption tier lives inside the readout box, whose opaque `-term-panel` fill the ground cannot reach (4.72 / 5.56 there). That is a real register decision made by measurement, not taste — and it is worth flagging that **`SingularityEditPraxis` inks its section labels `-term-dim` on this same chassis under this same band**, so the composer looks likely to carry the same defect. Not fixed here (out of scope, and it is a different file's issue), but recorded.

Two test files hold it:

- `singularityCreateCharacterGround.test.ts` — every pairing on the real composite, in both themes, reading the raster's alpha and the band's peak stop **out of `index.css`** rather than transcribing them, so a repaint re-runs the measurement. It also asserts the `-term-dim` failure explicitly, so if the band is ever quietened enough for it to clear, the row goes red and the label tier can be reconsidered.
- `singularityCreateCharacterRegister.test.tsx` — the enforcement. An element inked `-term-dim` must declare `-term-panel` (or the window bar's `-term-chrome`) as its **own** background, because `color` inherits and a background does not. **Verified red** by inking one section label `-term-dim`, which is exactly the edit that would otherwise look deliberate and ship.

## What else is in it

- Registered on `createCharacter` in `factions/singularity.ts`. `surfaceDispatch.test.ts`'s `createCharacter` row gained `'singularity'` by **appending** to the existing array — the list was not restated or re-sorted.
- `createCharacterDispatch.test.tsx` derives its rows from the surface map, so this archetype is now covered by the live-reskin, clear-to-Default, both-widths and picker-survives rows with nothing to append.
- Character creation is the **sixth** window bar this faction draws, so `singularityLamps.test.tsx`'s roll-call gains a row. It gains **no** process-light row: that mark says a session is *up*, and there is no character yet — the bar this page wears is the feed frame's and the card band's.
- Ornament is the faction's own, not the composer kit's: `.sg-scan` and `.sg-cursor`, both already in `motion.ornament.css` behind the shared reduced-motion guard. No new keyframe, no new CSS, no inline `animation:`.
- No new tokens; `index.css` is untouched.

### Two small improvements over the precedent, deliberately

- **The fields keep the browser's focus ring.** The Ephemerists plate and `SingularityEditPraxis` both set `outline: none` on their field boxes. This one does not — the ring is the only focus indicator a keyboard reaches these six controls with, and the frame is on the readout box, so it has room to draw.
- **The labels are real `<label for>`s.** `ComposerSection` has taken an `htmlFor` since #1742 and no create-character skin was using it, so each field is named by the label already on screen rather than by a placeholder. `DefaultCreateCharacter` and `EphemeristsCreateCharacter` still draw unassociated `<label>`s; worth a follow-up.

## Presentation only — nothing under the dress moved

`useCreateCharacter` is untouched, as are `PortraitPicker` and `useAvatarPicker`. Field order and copy are the Default's, unchanged: chosen name → about → tagline → portrait → answer a calling → commit / cancel. The picker stays visible, the picked row is `aria-pressed` and a second tap clears it, which returns the page to the Default archetype. **The payload is unchanged**: `buildCreatePayload` is still the only thing that builds it and this file never calls it.

Two strings are untranslated and that is deliberate: `character.new` on the window bar and the `>` before the heading are ornament, in the same class as the lamps beside them — module constants inside `aria-hidden` chrome, the shape `SingularityEditPraxis`'s `praxis.proc` and `[ok]` already use.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (398 files / 7089 passed), `npm run build`, `npm run budget`.

`budget` reports a CSS **WARN** at 22.3 KB against a 22.2 KB line. **It is pre-existing and not this PR's**: `git diff origin/main` over `index.css`, `fonts.css`, `fonts.faction.css` and `motion.ornament.css` is empty — this branch adds no CSS at all. `api-schema` is not implicated; no route, `response_model` or Pydantic schema was touched.

## Visual QA is OUTSTANDING

I have no browser and could not produce a single image. The in-app Browser pane cannot screenshot (CDP `captureScreenshot` times out) and real Chrome's `resize_window` reports success without resizing, so the mobile looking in particular is not covered by anything in the toolchain. The human-verifiable checkbox on #2353 is deliberately left unticked.

## What to eyeball

- **Singularity picked.** The whole page as a terminal: black chassis, window bar with the three lamps and `character.new`, the standing raster, the scan band travelling down, `> Who are you becoming?` in phosphor, six framed readout boxes with the quiet counters at their feet, and the lit `Create & step out ▸` band with a blinking block cursor closing the sheet. Check the band's peak passing under a line of type — that is the composite the ratios above are about, and the one thing a number cannot show you.
- **The live transition from Default.** Land on the page unaffiliated (the na watercolour kit), tap **Singularity** in *Answer a calling*, and watch the entire page reskin with no route change; tap it again and watch it fall back to the na kit. Nothing typed should be lost either way, and the credential card should be wearing the terminal the whole time.
- **375px.** One column, no horizontal scroll, the readout boxes and their feet holding together, the picker rows tappable, and the submit band still flush to the sheet's bottom edge.
- **Both themes.** The chassis stays black in light and in dark (§6) — what should move is the phosphor, plus the CTA halo and the title bloom arriving only in dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
