### PR TITLE
The Cozy Coven spell slip dresses character creation

### DIFF
--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -106,7 +106,7 @@ const BESPOKE: Record<string, string[]> = {
   // anyway: every Albescent registration is a WRAPPER rather than a skin
   // (ADR-0027), so it renders `DefaultCreateCharacter`, WHICH IS the na kit. The
   // `leaves %s to the surface Default` row below covers it either way.
-  createCharacter: ['ephemerists', 'snide', 'wow', 'ua', 'everymen'],
+  createCharacter: ['ephemerists', 'snide', 'wow', 'ua', 'everymen', 'coven'],
   // Was `mobileFactionPage` with this exact slug list until ADR-0078 collapsed
   // faction detail to one responsive component per faction. Same move the
   // praxis-card row made below: the row follows the surviving surface rather

--- a/frontend/src/factions/coven.ts
+++ b/frontend/src/factions/coven.ts
@@ -14,6 +14,7 @@ import { lazyArchetype } from './lazyArchetype'
 const CovenAvatar = lazyArchetype(() => import('../components/avatar/CovenAvatar'))
 const CovenBackdrop = lazyArchetype(() => import('../components/backdrop/CovenBackdrop'))
 const CovenComment = lazyArchetype(() => import('../components/comments/voices/CovenComment'))
+const CovenCreateCharacter = lazyArchetype(() => import('../pages/characterPaths/archetypes/CovenCreateCharacter'))
 const CovenDuelSealConfirm = lazyArchetype(() => import('../components/duel/CovenDuelSealConfirm'))
 const CovenEditPraxis = lazyArchetype(() => import('../pages/editPraxis/archetypes/CovenEditPraxis'))
 const CovenFactionBody = lazyArchetype(() => import('../pages/factionDetail/archetypes/CovenFactionBody'))
@@ -48,6 +49,10 @@ export const COVEN_MANIFEST: FactionManifest = {
   taskDetail: () => CovenTaskDetail,
   praxisDetail: () => CovenPraxisDetail,
   editPraxis: () => CovenEditPraxis,
+  // The slug this dispatches on is the calling being PICKED, not a loaded
+  // record, so the page reskins to this slip live and returns to the Default
+  // the moment the pick is cleared (#2351).
+  createCharacter: () => CovenCreateCharacter,
   factionHero: () => CovenFactionHero,
   factionBody: () => CovenFactionBody,
   profileBody: () => CovenProfileBody,

--- a/frontend/src/pages/characterPaths/__tests__/covenCreateCharacterContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/covenCreateCharacterContrast.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The Coven create-character slip's inks, measured on the ground that is
+ * actually behind them (#2351).
+ *
+ * WHY THIS FILE EXISTS AT ALL, when `utils/__tests__/factionContrast.test.ts`
+ * already carries `coven ward panel, ink / brief / caption`. Those rows measure
+ * `--faction-coven-ward-card` FLAT, and flat is not what this sheet is. The
+ * archetype mounts a `ComposerGround` over the card and lays the content column
+ * on top of it with no ground of its own, so every string drawn straight on the
+ * sheet lands on **card + bloom**, and in the bottom-right corner on
+ * **card + bloom + the cat**. Measuring the declared token here would be the
+ * exact failure the issue's acceptance criterion names — the na page's own
+ * `-composer-faint` reads 4.49 against the bare token and 3.50 under the wash.
+ *
+ * WHAT THE NUMBERS CAUGHT, which is the reason the archetype does not simply
+ * copy `CovenEditPraxis`'s ground. That file washes its two blooms at a hard
+ * `opacity={0.7}`. On `-ward-card` at that strength the pink bloom drags
+ * `--faction-coven-slip-label` to 2.80:1 in light and 1.95:1 in dark, and
+ * `--faction-coven-slip-ink` to 3.33 / 3.25 — a miss for every tier but nothing.
+ * Coven already mints the strength this wash wants: `--faction-coven-ward-haze`,
+ * 0.22 by day and 0.28 by night, a NUMBER token precisely so the two cascades
+ * can differ without a `dark ? a : b`. The archetype runs the blooms at it, and
+ * the rows below are what that buys.
+ *
+ * THE CAT IS STACKED ON ONE BLOOM AND NOT THE OTHER, deliberately, and this is
+ * geometry rather than leniency. The pink bloom is anchored `at 12% 0%` with a
+ * 48%-tall extent — the top of the sheet. The cat is pinned bottom-right, 240
+ * or 320px tall, on a column that stacks a heading, a credential card, three
+ * fields with counters, a portrait row, the calling picker and a footer. The two
+ * cannot meet. `CovenCat`'s own header measures itself the same way: against
+ * "the two gradient stops the CORNER of the slip actually runs", not against
+ * every stop on the sheet. Stacking it on the lavender bloom, which IS anchored
+ * `at 100% 100%`, is the honest worst case.
+ *
+ * `--faction-coven-slip-soft` is absent from the ink list and present in a
+ * failing-by-design row below, which is the same shape `createCharacterContrast`
+ * uses for the na kit's card tiers: the page does not paint it, and the
+ * measurement is what records why rather than a sentence that can drift.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import {
+  AA_NORMAL,
+  compositeOver,
+  contrastRatio,
+  formatRatio,
+  parseColor,
+  type Rgba,
+} from '../../../utils/contrast'
+import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
+
+const CSS_PATH = fileURLToPath(new URL('../../../index.css', import.meta.url))
+const ARCHETYPE_PATH = fileURLToPath(new URL('../archetypes/CovenCreateCharacter.tsx', import.meta.url))
+const THEMES = readThemes(readFileSync(CSS_PATH, 'utf8'))
+const ARCHETYPE = readFileSync(ARCHETYPE_PATH, 'utf8')
+const BOTH_THEMES: Theme[] = ['light', 'dark']
+
+/** The sheet's own stock — ward paper, laid on the wash rather than in it. */
+const SHEET = '--faction-coven-ward-card'
+/** The watermark's stroke, and the strength every page mount runs it at. */
+const CAT_INK = '--faction-coven-slip-deep'
+const CAT_ALPHA = 0.09
+
+/**
+ * The two blooms the archetype washes over the sheet, and where each is anchored.
+ *
+ * `cat` records whether the watermark can reach this bloom — see the header.
+ */
+const BLOOMS: Array<{ what: string; token: string; cat: boolean }> = [
+  { what: 'the pink glow at the top-left', token: '--faction-coven-slip-pk', cat: false },
+  { what: 'the lavender at the bottom-right', token: '--faction-coven-slip-lav', cat: true },
+]
+
+/** Every ink the archetype puts straight on the sheet, and what draws it. */
+const SHEET_INKS: Array<{ what: string; token: string }> = [
+  {
+    what: 'the wordmark, the heading, the name field and an unpicked calling',
+    token: '--faction-coven-slip-ink',
+  },
+  {
+    what: 'section labels, counters, @handle, the calling hint and the exits',
+    token: '--faction-coven-slip-label',
+  },
+  // NOT `--color-danger`, which misses on every composer sheet in light. The
+  // functional red inside a faction frame takes that faction's card alarm
+  // (#1302 / #1449); it draws the error banner, the portrait error and a
+  // counter that has hit its cap.
+  { what: 'the error banner, the portrait error and a counter at its cap', token: '--faction-coven-card-alarm' },
+]
+
+function resolve(token: string, theme: Theme): Rgba {
+  const raw = resolveVar(token, theme, THEMES)
+  expect(raw, `${token} resolves in ${theme}`).not.toBeNull()
+  const parsed = parseColor(raw!)
+  expect(parsed, `${token} is a colour in ${theme}`).not.toBeNull()
+  return parsed!
+}
+
+/** The haze strength, read from the stylesheet rather than transcribed. */
+function haze(theme: Theme): number {
+  const raw = resolveVar('--faction-coven-ward-haze', theme, THEMES)
+  expect(raw, `--faction-coven-ward-haze resolves in ${theme}`).not.toBeNull()
+  const value = Number(raw)
+  expect(Number.isFinite(value), `--faction-coven-ward-haze is a number in ${theme}`).toBe(true)
+  return value
+}
+
+/** Sheet stock, one bloom at the haze strength, and optionally the cat over it. */
+function ground(theme: Theme, bloom: string, withCat: boolean): Rgba {
+  const washed = compositeOver({ ...resolve(bloom, theme), a: haze(theme) }, resolve(SHEET, theme))
+  return withCat ? compositeOver({ ...resolve(CAT_INK, theme), a: CAT_ALPHA }, washed) : washed
+}
+
+describe('the Coven create-character sheet clears AA on its composited ground', () => {
+  for (const theme of BOTH_THEMES) {
+    for (const bloom of BLOOMS) {
+      for (const ink of SHEET_INKS) {
+        it(`${ink.what} over ${bloom.what} — ${theme}`, () => {
+          const text = resolve(ink.token, theme)
+          const bare = contrastRatio(text, ground(theme, bloom.token, false))
+          expect(
+            bare,
+            `${ink.token} on ${SHEET} under ${bloom.token} is ${formatRatio(bare)}`,
+          ).toBeGreaterThanOrEqual(AA_NORMAL)
+
+          if (!bloom.cat) return
+          const under = contrastRatio(text, ground(theme, bloom.token, true))
+          expect(
+            under,
+            `${ink.token} with the cat over it is ${formatRatio(under)}`,
+          ).toBeGreaterThanOrEqual(AA_NORMAL)
+        })
+      }
+    }
+  }
+})
+
+describe('the ground the archetype refused, measured', () => {
+  // The composer's hard 0.7. Kept as a row rather than a sentence so that a
+  // future reader who reaches for `opacity={0.7}` to match `CovenEditPraxis`
+  // finds the arithmetic instead of a preference.
+  it.each(BOTH_THEMES)('a 0.7 pink wash on the ward card fails the label tier — %s', (theme) => {
+    const at = compositeOver(
+      { ...resolve('--faction-coven-slip-pk', theme), a: 0.7 },
+      resolve(SHEET, theme),
+    )
+    const ratio = contrastRatio(resolve('--faction-coven-slip-label', theme), at)
+    expect(ratio, `slip-label under a 0.7 pink wash is ${formatRatio(ratio)}`).toBeLessThan(AA_NORMAL)
+  })
+
+  // `-slip-soft` is the brief's ink on the slip's own gradient and it is NOT an
+  // ink on this ground: 4.46:1 under the pink bloom in dark. The page has no
+  // brief, so nothing is lost — but the reason is recorded as a number, and if
+  // the token is ever walked far enough to clear, this row goes red and the
+  // archetype's ink list can be reconsidered.
+  it('slip-soft still misses under the pink bloom in dark, so it stays off the sheet', () => {
+    const ratio = contrastRatio(
+      resolve('--faction-coven-slip-soft', 'dark'),
+      ground('dark', '--faction-coven-slip-pk', false),
+    )
+    expect(ratio, `slip-soft is ${formatRatio(ratio)}`).toBeLessThan(AA_NORMAL)
+  })
+})
+
+describe('keeps the measured ground in step with the archetype', () => {
+  // Transcribed constants rot, and this file transcribes three things: which two
+  // pigments the wash uses, that it runs at the haze token, and the cat's alpha.
+  // These rows are what make the numbers above mean something.
+  //
+  // The pink is checked one hop away on purpose. The archetype imports `PINK`
+  // from the kit module rather than spelling the token, which is the whole point
+  // of `covenSlip` existing — so the honest check reads BOTH files rather than
+  // demanding the archetype restate a name it is right not to hold.
+  const KIT = readFileSync(
+    fileURLToPath(new URL('../../../components/factionMarks/covenSlip.tsx', import.meta.url)),
+    'utf8',
+  )
+
+  it('washes the pink the kit module defines', () => {
+    expect(KIT).toContain('export const PINK = "var(--faction-coven-slip-pk)"')
+    expect(ARCHETYPE, 'and reaches for it by that name').toContain('${PINK}')
+  })
+
+  it('washes the lavender measured here', () => {
+    expect(ARCHETYPE).toContain("const LAV = 'var(--faction-coven-slip-lav)'")
+    expect(ARCHETYPE, 'and reaches for it by that name').toContain('${LAV}')
+  })
+
+  it('runs both blooms at the haze token, never at a figure', () => {
+    expect(ARCHETYPE).toContain("const HAZE = 'var(--faction-coven-ward-haze)'")
+    expect(ARCHETYPE).toContain('opacity={HAZE}')
+  })
+
+  it('turns the cat at the alpha measured here', () => {
+    expect(ARCHETYPE).toContain(`const CAT_OPACITY = ${CAT_ALPHA}`)
+  })
+})

--- a/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
@@ -1,0 +1,626 @@
+/**
+ * Cozy Coven — THE SPELL SLIP A LIFE IS WRITTEN ONTO (#2351, epic #2346).
+ *
+ * NO DESIGN WAS DRAWN FOR THIS, and none was needed: the owner's ruling is that
+ * the two surfaces this faction already ships carry the whole register between
+ * them. `components/taskCard/CovenTaskCard` holds the ground, inks, rules and
+ * faces; `pages/editPraxis/archetypes/CovenEditPraxis` holds the same kit
+ * applied to a FORM — labelled fields, counters, a primary commit, a cancel
+ * path — which is structurally what this page is. This file is that dress over
+ * this page's fields.
+ *
+ * IT DRAWS NO NEW SVG AT ALL. Every mark comes out of
+ * `components/factionMarks/covenSlip` — the badge, the braid, the four-point
+ * spark, the cat. That module exists because "thirteen private copies of a
+ * pentagram badge is how a faction acquires a second identity again" (#1209),
+ * and a fourteenth here would be that failure with a new address. Nothing under
+ * `pages/editPraxis/` is written to; it is read as the reference the issue names
+ * it as.
+ *
+ * ## The chassis is the composer's, not a second one
+ *
+ * `ComposerPage` / `ComposerSheet` / `ComposerSection` / `ComposerFooter` are
+ * geometry with no praxis in them, so this page mounts the same blocks the
+ * composer does rather than restating a sheet, a masthead slot and a footer row.
+ * The CONTROLS in `editPraxis/archetypes/controls.tsx` are the half that does
+ * not fit — every one of them takes an `EditPraxisState` — so the fields below
+ * are plain inputs wearing the slip's `fieldBox`, which is the same geometry row
+ * (radius 10, 1.5px in `-slip-border`) that file's fields wear.
+ *
+ * ## One responsive component, no mobile twin
+ *
+ * `useComposerSizes()` reads `useFormFactor()` and picks the size set; there is
+ * one tree at two widths and no second file. Every fixed number here is ornament
+ * geometry, never a layout grid (SPEC-faction-ui-profile §1a).
+ *
+ * ## Copy — none of its own
+ *
+ * Every string is an existing `forms:createCharacter.*` key, unchanged and
+ * un-reordered: chosen name → about → tagline → portrait → answer a calling →
+ * commit / cancel. The masthead's one word is the faction's NAME out of
+ * `factions.json` (ADR-0038); its lower case is the lettering, not the word, so
+ * it is a `textTransform` here rather than a second spelling (#1910).
+ *
+ * ONE FIELD-SET DEVIATION FROM THE DEFAULT, the same one `EphemeristsCreate-
+ * Character` flagged. The na kit's PHONE branch deliberately carries no prose
+ * fields — it is framed as "Step 1 of 2 · Identity" and has never offered `bio`,
+ * with `tagline` following `bio` so the two stay a pair (#1628). This slip
+ * offers all six fields at both widths, because #2351 states the field list once
+ * and unconditionally, and because the two-step framing is the na phone skin's
+ * own chrome rather than something the slip wears.
+ *
+ * ## Where the cat goes, and it is NOT the card's placement
+ *
+ * The mark drifts by MOUNT, so #2041's law is one placement on every surface —
+ * bottom-right, tucked FULLY INSIDE, because "a face can't bleed off the card
+ * the way the pentacle did". What each mount chooses is the SIZE, "by the mark's
+ * weight on the page rather than by pasting that number" (`CovenProfileBody`).
+ * The card mounts hang 190px at -6/-4 and clip a whisker cap; that is a card's
+ * placement and this is not a card, so it is not copied. The page mounts run 240
+ * (profile band, composer) to 400 (the wide detail sheet) at a 16–24px inset.
+ *
+ * This sheet is `ComposerSheet`'s — 720 on desktop, the phone's full width on
+ * mobile — so the figure is sized to the width the sheet actually has. The
+ * composer picked 240 for BOTH and said in its own note that it had "no
+ * form-factor branch to size against, so the figure is the narrow one and the
+ * wide sheet simply carries a quieter mark". This file has that branch, so it
+ * spends it: 240 on the phone, 320 on the 720 sheet — the same ~44% of the
+ * column at either width, fully inside at a 16px inset in both.
+ *
+ * NO ALTERNATION BRANCH, deliberately. `useGroundIsBusy` is the cards' law
+ * (#2396): "a card on an ornamented ground goes plain". The three page mounts —
+ * the profile body, the composer, both detail columns — do not branch, because
+ * the law is explicitly about cards and this is a page body. `covenCat-
+ * Alternates.test.tsx` states that division in as many words.
+ *
+ * ## Colour, and WHICH CANDLE
+ *
+ * Coven has two things a reader will call "the candle" and they are not
+ * interchangeable. `.coven-candle-backdrop` / `.coven-backdrop` is the
+ * candlelight WASH, and its ground is `--faction-coven-ward-page` — the page
+ * stock, whose one live consumer is the mobile field desk. `--faction-coven-
+ * ward-hold-*` is candle GOLD, the "you're on this task" band, minted precisely
+ * so that it "never reads alike" to the pink CTA. Neither is what this page
+ * wants: the sheet is ward CARD (paper laid on the wash) and the commit is the
+ * pink CTA, because committing to a life is not holding a task.
+ *
+ * What this page does borrow from the wash is its STRENGTH.
+ * `--faction-coven-ward-haze` is a number token (0.22 light / 0.28 dark) and the
+ * comment beside it says why it is a token: "the two themes want the same four
+ * blooms at different weights and an opacity picked in TSX is a `dark ? a : b`
+ * in numeric clothing". The composer washes its two blooms at a hard 0.7, which
+ * is a real miss on this ground — measured, `--faction-coven-slip-label` reads
+ * 2.63:1 in light and 1.78:1 in dark under the pink bloom at that strength. So
+ * the ground here runs at the haze token instead, and the readings clear:
+ *
+ *     ink on ward-card under…      pink bloom      lavender bloom (+ the cat)
+ *     --faction-coven-slip-ink     5.98 / 7.72     6.49 / 10.22
+ *     --faction-coven-slip-label   5.04 / 4.63     5.47 / 6.13
+ *     --faction-coven-card-alarm   6.08 / 5.64     6.60 / 7.47
+ *                                  (light / dark)
+ *
+ * `--faction-coven-slip-soft` is the one tier this page does NOT paint on the
+ * sheet: it is 4.46:1 under the pink bloom in dark, a miss, and the page has no
+ * brief for it to be. Chrome takes LABEL and everything else takes INK. Nothing
+ * takes `-slip-deep` or `-slip-pk` as an ink at all — both are ornament here,
+ * for the reason `covenSlip`'s own header gives. Every reading above is in
+ * `__tests__/covenCreateCharacterContrast.test.ts`, measured on the COMPOSITE
+ * rather than the declared token.
+ *
+ * Light and dark flip entirely through the `[data-theme="dark"]` cascade; there
+ * is no `dark ? a : b` anywhere in this file. Motion is reached by CLASS only —
+ * `.ep-spin` on the badge and `.cvn-wheel` inside `CovenCat` — so both stay
+ * behind the shared `prefers-reduced-motion` guard in `index.css` (#1003).
+ *
+ * ## Presentation only
+ *
+ * `useCreateCharacter` stays the single source of state for all eight
+ * archetypes. Nothing here touches the submit path, the payload, `PortraitPicker`
+ * or `useAvatarPicker`, and THE PICKER STAYS VISIBLE in this skin — a player must
+ * be able to change their mind, or clear the pick and be born unaffiliated,
+ * which returns the page to the Default archetype.
+ */
+import { useRef, type CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import CredentialCard from '../../../components/CredentialCard'
+import FactionSigil from '../../../components/sigil/FactionSigil'
+import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
+import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
+import PortraitPicker from '../PortraitPicker'
+import {
+  NAME_MAX,
+  BIO_MAX,
+  TAGLINE_MAX,
+  type CreateCharacterState,
+} from '../useCreateCharacter'
+import {
+  ComposerFooter,
+  ComposerGround,
+  ComposerMasthead,
+  ComposerPage,
+  ComposerSection,
+  ComposerSheet,
+  ErrorBanner,
+  composerBandStyle,
+  composerLabelStyle,
+  useComposerSizes,
+} from '../../editPraxis/archetypes/shared'
+import {
+  BORDER,
+  Braid,
+  CARD,
+  CHROME,
+  CTA_FROM,
+  CTA_INK,
+  CTA_TO,
+  CovenCat,
+  DISPLAY,
+  GOLD,
+  INK,
+  LABEL,
+  PAGE,
+  PINK,
+  SHADOW,
+  SigilMark,
+  Spark,
+} from '../../../components/factionMarks/covenSlip'
+
+const SLUG = 'coven'
+
+/* The three tokens `covenSlip` does not export, because no other surface needs
+   them in this combination: the wash's second pigment, the banner's ink and the
+   haze strength both blooms are laid at. */
+const LAV = 'var(--faction-coven-slip-lav)'
+/* The error ink (#1231/#1449). The banner sits straight on the sheet and the
+   neutral `--color-danger` under its own veil misses AA there in light; the
+   veil and the edge stay neutral, which is ADR-0061's split. */
+const ALARM = 'var(--faction-coven-card-alarm)'
+/* See the WHICH CANDLE note above: the wash's STRENGTH, per theme, as a number
+   token rather than a figure picked here. */
+const HAZE = 'var(--faction-coven-ward-haze)'
+const CTA_BAND = `linear-gradient(180deg, ${CTA_FROM}, ${CTA_TO})`
+
+/** The skin's geometry: radius 14, borders 1.5, and the sheet's edge is gold. */
+const RADIUS = 14
+const FIELD_RADIUS = 10
+const RULE = `1.5px solid ${BORDER}`
+
+/* ── Ornament geometry (WORLD_ZERO_STYLE §4a: not layout spacing) ── */
+/** The turning badge in the masthead — the composer's 30, at the composer's 42s. */
+const BADGE = 30
+/** The sparks flanking the wordmark. */
+const MAST_SPARK = 11
+/** The spark leading the cast. */
+const CAST_SPARK = 12
+/** The mark each calling wears in the picker — the size every chooser draws (#2223). */
+const PICKER_SIGIL = 18
+/** The watermark, sized to the column it turns in. See the cat note above. */
+const CAT = { desktop: 320, mobile: 240 }
+/** Its inset, and its strength — the two figures every page mount already runs. */
+const CAT_INSET = 16
+const CAT_OPACITY = 0.09
+
+export default function CovenCreateCharacter({ state }: { state: CreateCharacterState }) {
+  const { t } = useTranslation('forms')
+  const navigate = useNavigate()
+  const sizes = useComposerSizes()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const factor = sizes.isMobile ? 'mobile' : 'desktop'
+  const {
+    displayName,
+    setDisplayName,
+    bio,
+    setBio,
+    tagline,
+    setTagline,
+    factionSlug,
+    setFactionSlug,
+    invited,
+    avatarFile,
+    avatarPreview,
+    avatarSource,
+    setAvatarSource,
+    avatarError,
+    setAvatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+    error,
+    submitting,
+    canSubmit,
+    handleSubmit,
+    handle,
+    showPicker,
+  } = state
+
+  /** Quicksand, the slip's chrome voice, over the layout's own tracking. */
+  const sectionLabel: CSSProperties = { fontFamily: CHROME, color: LABEL }
+  /** Radius 10, 1.5px in `-slip-border`, on the ward PAGE — the composer's row. */
+  const fieldBox = {
+    width: '100%',
+    background: PAGE,
+    color: INK,
+    border: RULE,
+    borderRadius: FIELD_RADIUS,
+    padding: 'var(--space-md)',
+    outline: 'none',
+    boxSizing: 'border-box',
+    fontFamily: CHROME,
+    fontSize: 'var(--text-content)',
+  } as const
+
+  /** The counter row under a field: quiet, and alarmed on the cap. */
+  const counter = (used: number, max: number) => (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', fontFamily: CHROME, fontSize: 'var(--text-lg)' }}>
+      <span style={{ color: used >= max ? ALARM : LABEL }}>
+        {t('createCharacter.charsLeft', { count: max - used })}
+      </span>
+    </div>
+  )
+
+  const sheetStyle = {
+    background: CARD,
+    border: `1.5px solid ${GOLD}`,
+    borderRadius: RADIUS,
+    boxShadow: SHADOW,
+  }
+
+  const masthead = (
+    /* No `background`: the haze below shows through, which is what makes the
+       band read as the top of one sheet rather than as a strip laid on it. */
+    <ComposerMasthead
+      style={{
+        height: 'auto',
+        padding: 'var(--space-lg) var(--space-lg) var(--space-md)',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 'var(--space-sm)',
+        }}
+      >
+        {/* THE TWINKLES ARE IN THE ROW, NOT BEHIND IT, and that is #1983's
+            lesson taken rather than re-learned. Both shipped twinkle fields are
+            absolutely-positioned `preserveAspectRatio="none"` svgs whose stars
+            are a fixed FRACTION of the band while the wordmark is a centred row
+            at a FIXED size — so narrowing the viewport walks a star UNDER the
+            lettering, which is how one came to sit against the "c" in "cozy" and
+            read as "tozy". The clearance that fixes it is arithmetic that has to
+            be re-derived every time the wordmark changes. Two `Spark`s IN the
+            flex row cannot collide with the lettering at any width, need no
+            exclusion band, and are the kit's own ornament glyph rather than a
+            third private copy of `starPath`. */}
+        <Spark size={MAST_SPARK} color={GOLD} />
+        {/* The badge turns once every 42 seconds. `.ep-spin` owns the motion and
+            its reduced-motion guard; `--ep-spin-dur` re-times it without a
+            second keyframe. The class goes on a wrapper because `SigilMark`
+            takes no `className` — the drawing stays the kit's, unforked. */}
+        <span
+          aria-hidden
+          className="ep-spin"
+          style={{ display: 'block', flex: '0 0 auto', ['--ep-spin-dur' as string]: '42s' } as CSSProperties}
+        >
+          <SigilMark size={BADGE} />
+        </span>
+        <span
+          style={{
+            fontFamily: DISPLAY,
+            fontSize: sizes.titleSize,
+            lineHeight: 1,
+            letterSpacing: '0.02em',
+            color: INK,
+            // The lower case is the lettering, not the word (#1910).
+            textTransform: 'lowercase',
+          }}
+        >
+          {factionName(SLUG)}
+        </span>
+        <Spark size={MAST_SPARK} color={GOLD} />
+      </div>
+      <Braid style={{ marginTop: 'var(--space-sm)' }} />
+    </ComposerMasthead>
+  )
+
+  const ground = (
+    <>
+      {/* The glow and the lavender, at the composer's two anchors — but at the
+          haze token's strength rather than a hard 0.7. See WHICH CANDLE above. */}
+      <ComposerGround
+        inset={0}
+        opacity={HAZE}
+        background={`radial-gradient(62% 48% at 12% 0%, ${PINK}, transparent 70%), radial-gradient(58% 46% at 100% 100%, ${LAV}, transparent 72%)`}
+      />
+      {/* The cat, on its own layer so it keeps its own strength instead of
+          inheriting the wash's. Bottom-right and fully inside — see above. */}
+      <ComposerGround inset={0}>
+        <CovenCat
+          size={CAT[factor]}
+          style={{ right: CAT_INSET, bottom: CAT_INSET, opacity: CAT_OPACITY }}
+        />
+      </ComposerGround>
+    </>
+  )
+
+  return (
+    <ComposerPage sizes={sizes} style={{ fontFamily: CHROME, color: INK }}>
+      {/* A REAL `<form>`, not a bare button with an onClick. The Default skin
+          submits through one and so must this: it is what makes Enter commit
+          from a text field, and what gives the browser's own required-field
+          behaviour something to attach to. `handleSubmit` calls
+          `preventDefault()` itself. */}
+      <form onSubmit={handleSubmit} data-skin={SLUG}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+          {/* NO SECOND MARK BESIDE THE HEADING. #1828 took the composer's
+              status pentacle away for exactly this reason — it was "a second one
+              under the sigil in the masthead directly above". The masthead is
+              this sheet's one faction mark; the cat is a watermark, not a badge. */}
+          <h1
+            style={{
+              fontFamily: DISPLAY,
+              fontWeight: 600,
+              fontSize: sizes.titleSize,
+              lineHeight: 1.1,
+              color: INK,
+              margin: 0,
+            }}
+          >
+            {t('createCharacter.heading')}
+          </h1>
+
+          {/* The life being written, live. The card dispatches its own faction
+              dress, so it is already wearing this slip the moment the calling is
+              picked — the same value this whole page reskins on. */}
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <CredentialCard
+              displayName={displayName || t('createCharacter.previewFallbackName')}
+              handle={handle}
+              factionSlug={factionSlug || null}
+              level={1}
+              score={0}
+              avatarUrl={avatarPreview}
+              onAvatarClick={() => fileInputRef.current?.click()}
+            />
+          </div>
+
+          {/* Chosen name */}
+          <ComposerSection rule={false} label={t('createCharacter.nameLabel')} labelStyle={sectionLabel}>
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              maxLength={NAME_MAX}
+              placeholder={t('createCharacter.namePlaceholder')}
+              autoFocus
+              style={{ ...fieldBox, fontFamily: DISPLAY, fontSize: 'var(--text-title)' }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: CHROME, fontSize: 'var(--text-lg)' }}>
+              <span style={{ color: LABEL }}>@{handle}</span>
+              <span style={{ color: displayName.length >= NAME_MAX ? ALARM : LABEL }}>
+                {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
+              </span>
+            </div>
+          </ComposerSection>
+
+          {/* About */}
+          <ComposerSection rule={false} label={t('createCharacter.aboutLabel')} labelStyle={sectionLabel}>
+            <textarea
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              maxLength={BIO_MAX}
+              placeholder={t('createCharacter.aboutPlaceholder')}
+              rows={3}
+              style={{ ...fieldBox, resize: 'vertical', lineHeight: 1.7 }}
+            />
+            {counter(bio.length, BIO_MAX)}
+          </ComposerSection>
+
+          {/* Tagline — a slogan line, not a short bio (#1628). Its counter turns
+              alarm on the cap the way the name field's does: this is the field the
+              profile header's identity slot is laid out against, so running out of
+              room is worth seeing before the text stops appearing. */}
+          <ComposerSection rule={false} label={t('createCharacter.taglineLabel')} labelStyle={sectionLabel}>
+            <textarea
+              value={tagline}
+              onChange={(e) => setTagline(e.target.value)}
+              maxLength={TAGLINE_MAX}
+              placeholder={t('createCharacter.taglinePlaceholder')}
+              rows={2}
+              style={{ ...fieldBox, resize: 'vertical', lineHeight: 1.7 }}
+            />
+            {counter(tagline.length, TAGLINE_MAX)}
+          </ComposerSection>
+
+          {/* Portrait — the shared picker owns the hidden input and the "what's
+              chosen" readout (#1149); the credential card above opens the same
+              input through `fileInputRef`. */}
+          <ComposerSection
+            rule={false}
+            label={
+              <>
+                {t('createCharacter.portraitLabel')}{' '}
+                <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.optional')}</span>
+              </>
+            }
+            labelStyle={sectionLabel}
+          >
+            {/* Dressed rather than left in site chrome. `.btn-outline` brings its
+                own near-white `--color-bg-surface` ground and neutral ink, which
+                reads as a browser control dropped on the slip; every other
+                control here is the ward page inside a `-slip-border` rule at
+                radius 10. The error ink is passed for a measured reason — see the
+                prop's own note: the neutral danger red does not clear on a
+                faction ground, and each archetype passes its own card alarm. */}
+            <PortraitPicker
+              inputRef={fileInputRef}
+              onChange={handleAvatarChange}
+              chosenFile={avatarFile}
+              error={avatarError}
+              buttonStyle={composerLabelStyle({
+                fontFamily: CHROME,
+                fontWeight: 700,
+                cursor: 'pointer',
+                borderRadius: FIELD_RADIUS,
+                padding: 'var(--space-sm) var(--space-lg)',
+                background: PAGE,
+                color: INK,
+                border: RULE,
+              })}
+              statusStyle={{ fontFamily: CHROME, color: LABEL }}
+              errorStyle={{ color: ALARM }}
+            />
+          </ComposerSection>
+
+          {/* Answer a calling — only when the account holds invitations (ADR-0019).
+              It stays drawn in this skin: tapping the slip's own faction must not
+              be a one-way door, and clearing the pick returns the page to the
+              Default archetype. */}
+          {showPicker && (
+            <ComposerSection
+              rule={false}
+              label={
+                <>
+                  {t('createCharacter.callingLabel')}{' '}
+                  <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.callingOptional')}</span>
+                </>
+              }
+              labelStyle={sectionLabel}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
+                {invited.map((slug) => {
+                  const selected = factionSlug === slug
+                  return (
+                    <button
+                      key={slug}
+                      type="button"
+                      onClick={() => setFactionSlug(selected ? '' : slug)}
+                      /* NOT `composerLabelStyle` — it forces `uppercase` and its
+                         own tracking, and both would be inherited by the name
+                         below. A calling wears its OWN card face at its own case,
+                         which is what every other chooser draws. */
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 'var(--space-md)',
+                        width: '100%',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        borderRadius: FIELD_RADIUS,
+                        padding: 'var(--space-md) var(--space-lg)',
+                        background: selected ? CTA_BAND : PAGE,
+                        border: selected ? `1.5px solid ${CTA_TO}` : RULE,
+                        // The faction's own hue as a RING, never as ink (§3) —
+                        // the row's type stays on the slip's measured pair.
+                        boxShadow: selected ? `0 0 0 2px ${factionCssVar(slug)}` : 'none',
+                      }}
+                    >
+                      {/* The faction's own mark, from the dispatcher every other
+                          chooser draws (#2223). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                      <span
+                        style={{
+                          fontFamily: factionCssVar(slug, 'card-font'),
+                          fontSize: 'var(--text-content)',
+                          color: selected ? CTA_INK : INK,
+                        }}
+                      >
+                        {factionName(slug)}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+              <p style={{ fontFamily: CHROME, fontSize: 'var(--text-content)', color: LABEL, margin: 0, lineHeight: 1.6 }}>
+                {t('createCharacter.callingHint')}
+              </p>
+            </ComposerSection>
+          )}
+
+          <ErrorBanner message={error ?? ''} style={{ color: ALARM }} />
+
+          {/* THE ONE BRAID (#1707). The design calls its rule exactly once,
+              immediately above the footer; every other region is parted by the
+              sheet's own gap. Six braids read as a chain of dividers rather than
+              as the mark that closes the page. */}
+          <Braid />
+
+          {/* [Cancel] … [Create] — the global order from #646, stacked because
+              Coven's cast is a full-bleed band rather than an inline button: the
+              exits read first, the band closes the sheet. */}
+          <ComposerFooter
+            band
+            start={
+              <>
+                <button
+                  type="button"
+                  onClick={() => navigate('/')}
+                  style={composerLabelStyle({
+                    fontFamily: CHROME,
+                    fontWeight: 700,
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    color: LABEL,
+                  })}
+                >
+                  {t('createCharacter.cancel')}
+                </button>
+                <span style={{ fontFamily: CHROME, fontSize: 'var(--text-content)', color: LABEL }}>
+                  {t('createCharacter.startsAt')}
+                </span>
+              </>
+            }
+            end={
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                style={{
+                  ...composerBandStyle(sizes, {
+                    // The one place Coven speaks in the LABEL face rather than
+                    // the title one. Design band: 14 / 700 / 0.12em — 14 is the
+                    // --text-xl rung exactly.
+                    fontFamily: CHROME,
+                    fontSize: 'var(--text-xl)',
+                    fontWeight: 700,
+                    letterSpacing: '0.12em',
+                    // The SHEET's frame, which for Coven is the gilt edge.
+                    frame: GOLD,
+                    color: CTA_INK,
+                    background: CTA_BAND,
+                  }),
+                  cursor: submitting ? 'wait' : 'pointer',
+                  // The dimmed disabled band is the Default's and the plate's,
+                  // kept so one page does not disable in two languages. WCAG
+                  // 1.4.3 exempts an inactive component from the contrast floor,
+                  // which is what this is: `disabled` is set on the same line.
+                  opacity: canSubmit ? 1 : 0.5,
+                }}
+              >
+                {/* The four-point spark leading the cast — the kit's ornament
+                    glyph, in the ink it sits on. */}
+                <Spark size={CAST_SPARK} color={CTA_INK} />
+                {submitting ? t('createCharacter.submitBusy') : t('createCharacter.submitIdle')}
+              </button>
+            }
+          />
+        </ComposerSheet>
+      </form>
+
+      {/* Portrait crop/rotate — locked square (#514). */}
+      {avatarSource && (
+        <ImageEditModal
+          key={`${avatarSource.name}-${avatarSource.lastModified}`}
+          file={avatarSource}
+          aspect={AVATAR_ASPECT}
+          onConfirm={handleAvatarConfirm}
+          onCancel={() => setAvatarSource(null)}
+          onError={setAvatarError}
+        />
+      )}
+    </ComposerPage>
+  )
+}


### PR DESCRIPTION
Closes #2351

Builds `CovenCreateCharacter` and registers it on the `createCharacter` surface, so picking **Cozy Coven** in the calling picker reskins the whole page live and clearing the pick returns it to the Default.

Built from the two surfaces the faction already ships, per the owner's no-design ruling: `CovenTaskCard` for the register, `CovenEditPraxis` for the same kit applied to a form. Nothing under `pages/editPraxis/` is written to — it is read as the reference.

## The seam, and the failing test at it

**The seam is `ward-card` → `ward-card + wash`.** The sheet's content column has no ground of its own, so every string drawn straight on it lands on the composite, not on the declared token. `factionContrast.test.ts`'s `coven ward panel, ink / brief / caption` rows measure the card **flat**, which is not what this sheet is.

Measuring it went red on a real defect straight away. `CovenEditPraxis` washes its two blooms at a hard `opacity={0.7}`, and on `--faction-coven-ward-card` at that strength:

| ink | light | dark |
|---|---|---|
| `--faction-coven-slip-label` | **2.80** | **1.95** |
| `--faction-coven-slip-ink` | **3.33** | **3.25** |
| `--faction-coven-slip-soft` | **2.84** | **1.88** |

So the archetype does not copy that ground. Coven already mints the strength this wash wants — `--faction-coven-ward-haze`, 0.22 light / 0.28 dark, a *number* token declared precisely so the two cascades can differ without a `dark ? a : b`. Run at the haze token, on the composite:

| ink on ward-card under… | pink bloom | lavender bloom + the cat |
|---|---|---|
| `--faction-coven-slip-ink` | 5.98 / 7.72 | 6.49 / 10.22 |
| `--faction-coven-slip-label` | 5.04 / 4.63 | 5.47 / 6.13 |
| `--faction-coven-card-alarm` | 6.08 / 5.64 | 6.60 / 7.47 |

(light / dark; AA normal is 4.50.)

`--faction-coven-slip-soft` is **4.46 under the pink bloom in dark** — a miss — so it is not an ink on this page at all. It has no job here (there is no brief), chrome takes `LABEL` and everything else takes `INK`, and the reason is kept as a failing-by-design row rather than a sentence that can drift. `-slip-deep` and `-slip-pk` stay ornament, per `covenSlip`'s own header.

`__tests__/covenCreateCharacterContrast.test.ts` holds all of it, plus a rot guard: flip `opacity={HAZE}` back to `0.7` and the guard goes red (verified).

The cat is stacked on the **lavender** bloom and not the pink one, and that is geometry rather than leniency: the pink is anchored `at 12% 0%` with a 48%-tall extent and the cat is pinned bottom-right on a very tall column. `CovenCat`'s own header measures itself the same way — against "the two gradient stops the CORNER of the slip actually runs".

## The two Coven traps

**Where the cat goes.** #2041's law is one placement on every surface — bottom-right, tucked fully inside, because "a face can't bleed off the card the way the pentacle did". What each mount picks is the *size*, "by the mark's weight on the page rather than by pasting that number". The card mounts hang 190px at `-6/-4` and clip a whisker cap; that is a **card's** placement and is not transplanted here. `CovenEditPraxis` runs 240 at both widths and says in its own note that it had "no form-factor branch to size against". This file has that branch, so it spends it: **240 on the phone, 320 on the 720 sheet**, 16px inset, opacity 0.09. No `useGroundIsBusy` branch — that is the cards' alternation law, and `covenCatAlternates.test.tsx` says in as many words that the page mounts do not branch.

**Which candle.** `.coven-candle-backdrop` / `.coven-backdrop` is the candlelight **wash**, grounded in `--faction-coven-ward-page`, whose one live consumer is the mobile field desk. `--faction-coven-ward-hold-*` is candle **gold** — the "you're on this task" band, minted so it "never reads alike" to the pink CTA. Neither is what this page wants: the sheet is ward **card** (paper laid on the wash) and the commit is the pink CTA, because committing to a life is not holding a task. What the page borrows from the wash is only its *strength*.

## What it draws

No new SVG. Every mark comes out of `components/factionMarks/covenSlip` — `SigilMark`, `Braid`, `Spark`, `CovenCat` — because "thirteen private copies of a pentagram badge is how a faction acquires a second identity again" (#1209), and a fourteenth here would be that with a new address. The chassis is the composer's shared blocks (`ComposerPage` / `Sheet` / `Section` / `Footer` / `Ground` / `Masthead` / `ErrorBanner` / `composerBandStyle` / `composerLabelStyle` / `useComposerSizes`); `controls.tsx` does **not** fit — every control in it takes an `EditPraxisState` — so the fields are plain inputs wearing the slip's own geometry row (radius 10, 1.5px in `-slip-border`, on the ward page).

**One deliberate departure from the composer's masthead: the twinkles are IN the flex row, not behind it.** Both shipped twinkle fields are absolutely-positioned `preserveAspectRatio="none"` svgs whose stars are a fixed *fraction* of the band while the wordmark is a centred row at a *fixed* size — which is how a star came to sit against the "c" in "cozy" and read as "tozy" (#1983), and why that file carries a hand-derived exclusion band. Two `Spark`s inside the row cannot collide with the lettering at any width, need no arithmetic, and are the kit's own ornament glyph rather than a third private copy of `starPath`.

## Rules honoured

- One responsive component reading `useComposerSizes()` → `useFormFactor()`. No mobile twin, no second file.
- No form logic touched. `useCreateCharacter`, `PortraitPicker` and `useAvatarPicker` are untouched; **the create payload is unchanged** (nothing in the diff reaches the submit path, and `characterPaths.test.tsx` still passes).
- Field order and copy unchanged: chosen name → about → tagline → portrait → answer a calling → commit / cancel, all existing `forms:createCharacter.*` keys.
- The picker stays visible and clearing the pick returns the page to Default — covered by `createCharacterDispatch.test.tsx`, which derives its rows from the map.
- Colour only through tokens; light/dark entirely in the `[data-theme="dark"]` cascade, no ternary. Motion by class only (`.ep-spin`, `.cvn-wheel`), so both stay behind the shared reduced-motion guard.
- Faces are `--font-faction-witch` (Grenze Gotisch) and `--font-faction-rounded` (Quicksand), both already in Coven's loaded set; no new family, so `fontsLoaded.test.ts` / `factionFaceSplit.test.ts` still cover the "resolves to its intended family" criterion.

## Shared-file edits (append-only)

- `surfaceDispatch.test.ts` — appended `'coven'` to the `createCharacter` row only. It conflicted with #2349's `'snide'` on rebase and was resolved as a union: `['ephemerists', 'snide', 'coven']`.
- `.design-sync/config.json` and `frontend/.ds-kit/index.tsx` — **not touched**. Only `DefaultCreateCharacter` has a preview entry; #2347 added none for its archetype either.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (397 files, 7087 passed / 1 skipped) and `npm run build` all green on the rebased tree.

`npm run budget` reports a CSS **WARN** at 22.3 KB against a 22.2 KB line. **It is pre-existing and not this PR's**: the diff contains no CSS, and a build at `origin/main` emits the byte-identical `assets/index-Bd8PVg-T.css`.

## Spotted, not fixed

`CovenEditPraxis`'s `opacity={0.7}` ground is the miss measured in the table above — its masthead wordmark and every label below sit on it. Out of scope here; worth its own issue.

## What to eyeball — outstanding, in light and dark

I cannot produce these images and have not claimed to: the in-app Browser pane cannot screenshot (CDP `captureScreenshot` times out) and real Chrome's `resize_window` reports success without resizing. `docs/agents/design-fidelity.md`: *"a human does the mobile looking. Nothing in the toolchain covers it."* The human-verifiable checkbox on #2351 stays unticked.

- [ ] **Cozy Coven picked** — the whole page in the slip: gold-edged ward sheet, the sigil turning in the masthead between two sparks, the braid under the wordmark, the cat turning in the bottom-right corner, the pink cast band closing the sheet.
- [ ] **The live transition from Default** — tap Cozy Coven in "Answer a calling" and watch the page reskin without a route change; tap it again to clear and confirm it returns to the na kit.
- [ ] **375px** — the sheet at the phone's full width: that the masthead sparks and the wordmark never collide, the cat at 240 stays fully inside its corner, and the full-bleed cast band reaches both edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
