### PR TITLE
Character creation's three new faction plates join the kit

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -86,6 +86,7 @@
     "EphemeristsAvatar": "src/components/avatar/EphemeristsAvatar.tsx",
     "EphemeristsBackdrop": "src/components/backdrop/EphemeristsBackdrop.tsx",
     "EphemeristsComment": "src/components/comments/voices/EphemeristsComment.tsx",
+    "EphemeristsCreateCharacter": "src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx",
     "EphemeristsDuelSealConfirm": "src/components/duel/EphemeristsDuelSealConfirm.tsx",
     "EphemeristsEditPraxis": "src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx",
     "EphemeristsFactionBody": "src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx",
@@ -223,6 +224,7 @@
     "SnideAvatar": "src/components/avatar/SnideAvatar.tsx",
     "SnideBackdrop": "src/components/backdrop/SnideBackdrop.tsx",
     "SnideComment": "src/components/comments/voices/SnideComment.tsx",
+    "SnideCreateCharacter": "src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx",
     "SnideDuelSealConfirm": "src/components/duel/SnideDuelSealConfirm.tsx",
     "SnideEditPraxis": "src/pages/editPraxis/archetypes/SnideEditPraxis.tsx",
     "SnideFactionBody": "src/pages/factionDetail/archetypes/SnideFactionBody.tsx",
@@ -272,6 +274,7 @@
     "WowAvatar": "src/components/avatar/WowAvatar.tsx",
     "WowBackdrop": "src/components/backdrop/WowBackdrop.tsx",
     "WowComment": "src/components/comments/voices/WowComment.tsx",
+    "WowCreateCharacter": "src/pages/characterPaths/archetypes/WowCreateCharacter.tsx",
     "WowDuelSealConfirm": "src/components/duel/WowDuelSealConfirm.tsx",
     "WowEditPraxis": "src/pages/editPraxis/archetypes/WowEditPraxis.tsx",
     "WowFactionBody": "src/pages/factionDetail/archetypes/WowFactionBody.tsx",
@@ -742,6 +745,18 @@
     },
     "MobileStickyBar": {
       "cardMode": "column"
+    },
+    "EphemeristsCreateCharacter": {
+      "cardMode": "single",
+      "viewport": "390x760"
+    },
+    "SnideCreateCharacter": {
+      "cardMode": "single",
+      "viewport": "390x760"
+    },
+    "WowCreateCharacter": {
+      "cardMode": "single",
+      "viewport": "390x760"
     }
   },
   "readmeHeader": ".design-sync/conventions.md",

--- a/.design-sync/previews/EphemeristsCreateCharacter.tsx
+++ b/.design-sync/previews/EphemeristsCreateCharacter.tsx
@@ -1,0 +1,9 @@
+// EphemeristsCreateCharacter — the create-a-life form in the Ephemerists plate (#2473).
+// Character creation became a faction-dispatched surface: one responsive skin
+// per faction, each taking the same CreateCharacterState the Default does.
+import { EphemeristsCreateCharacter } from 'worldzero-frontend'
+import { createCharacterState } from './_state'
+
+export function Create() {
+  return <EphemeristsCreateCharacter state={createCharacterState('ephemerists')} />
+}

--- a/.design-sync/previews/SnideCreateCharacter.tsx
+++ b/.design-sync/previews/SnideCreateCharacter.tsx
@@ -1,0 +1,9 @@
+// SnideCreateCharacter — the create-a-life form in the Snide plate (#2473).
+// Character creation became a faction-dispatched surface: one responsive skin
+// per faction, each taking the same CreateCharacterState the Default does.
+import { SnideCreateCharacter } from 'worldzero-frontend'
+import { createCharacterState } from './_state'
+
+export function Create() {
+  return <SnideCreateCharacter state={createCharacterState('snide')} />
+}

--- a/.design-sync/previews/WowCreateCharacter.tsx
+++ b/.design-sync/previews/WowCreateCharacter.tsx
@@ -1,0 +1,9 @@
+// WowCreateCharacter — the create-a-life form in the Wow plate (#2473).
+// Character creation became a faction-dispatched surface: one responsive skin
+// per faction, each taking the same CreateCharacterState the Default does.
+import { WowCreateCharacter } from 'worldzero-frontend'
+import { createCharacterState } from './_state'
+
+export function Create() {
+  return <WowCreateCharacter state={createCharacterState('wow')} />
+}

--- a/frontend/.ds-kit/index.tsx
+++ b/frontend/.ds-kit/index.tsx
@@ -78,6 +78,7 @@ export { default as EphemerisNet } from "../src/components/factionMarks/Ephemeri
 export { default as EphemeristsAvatar } from "../src/components/avatar/EphemeristsAvatar";
 export { default as EphemeristsBackdrop } from "../src/components/backdrop/EphemeristsBackdrop";
 export { default as EphemeristsComment } from "../src/components/comments/voices/EphemeristsComment";
+export { default as EphemeristsCreateCharacter } from "../src/pages/characterPaths/archetypes/EphemeristsCreateCharacter";
 export { default as EphemeristsDuelSealConfirm } from "../src/components/duel/EphemeristsDuelSealConfirm";
 export { default as EphemeristsEditPraxis } from "../src/pages/editPraxis/archetypes/EphemeristsEditPraxis";
 export { default as EphemeristsFactionBody } from "../src/pages/factionDetail/archetypes/EphemeristsFactionBody";
@@ -215,6 +216,7 @@ export { default as SiteFooter } from "../src/components/layout/SiteFooter";
 export { default as SnideAvatar } from "../src/components/avatar/SnideAvatar";
 export { default as SnideBackdrop } from "../src/components/backdrop/SnideBackdrop";
 export { default as SnideComment } from "../src/components/comments/voices/SnideComment";
+export { default as SnideCreateCharacter } from "../src/pages/characterPaths/archetypes/SnideCreateCharacter";
 export { default as SnideDuelSealConfirm } from "../src/components/duel/SnideDuelSealConfirm";
 export { default as SnideEditPraxis } from "../src/pages/editPraxis/archetypes/SnideEditPraxis";
 export { default as SnideFactionBody } from "../src/pages/factionDetail/archetypes/SnideFactionBody";
@@ -264,6 +266,7 @@ export { default as WatercolorBackground } from "../src/components/layout/Waterc
 export { default as WowAvatar } from "../src/components/avatar/WowAvatar";
 export { default as WowBackdrop } from "../src/components/backdrop/WowBackdrop";
 export { default as WowComment } from "../src/components/comments/voices/WowComment";
+export { default as WowCreateCharacter } from "../src/pages/characterPaths/archetypes/WowCreateCharacter";
 export { default as WowDuelSealConfirm } from "../src/components/duel/WowDuelSealConfirm";
 export { default as WowEditPraxis } from "../src/pages/editPraxis/archetypes/WowEditPraxis";
 export { default as WowFactionBody } from "../src/pages/factionDetail/archetypes/WowFactionBody";


### PR DESCRIPTION
> **Stacked on #2481** — base is `claude/design-sync-437d47`, not `main`. Merge
> #2481 first; this PR's diff is only the 5 files below.

#2473 made character creation a faction-dispatched surface and dressed the
Ephemerists plate first, adding `Ephemerists`, `Snide` and `Wow` skins beside the
`Default` one under `pages/characterPaths/archetypes/`.

That commit already maintained `.design-sync/config.json` itself — it repointed
`DefaultCreateCharacter` at the new `archetypes/` directory, which is why the
map check comes back with **0 dead paths**. What it left behind is the *unmapped*
side: three new siblings in a directory where every other member was already
mapped. That is the "family a sibling short" case, and it is the quiet one —
a dead path is an error, a missing sibling is just silence.

## What this does

- Maps all three, each with the override its siblings already carry —
  `cardMode: single`, `390x760` (they are full phone screens).
- Authors a preview for each. All four skins take the same `CreateCharacterState`,
  so a preview is a slug swap and the content flavors follow from the slug-aware
  fixtures — three lines apiece, cloning the `Default` recipe.
- Regenerates `frontend/.ds-kit/index.tsx`. **278 -> 281.**

## These are sync inputs only

The three components are **not in the uploaded kit yet**. The build that would
render, grade and upload their preview cards did not run, so they land in the
Claude Design project on the next sync. Nothing here changes application code.

## Checks

- `dsKitBarrelGenerated` — 2 passed (config and barrel agree at 281).
- `typecheck:design-sync` — clean.
- Map check — 0 dead paths, 0 case-renames, and the only remaining unmapped
  PascalCase file is `TheArray`, which is excluded on purpose (`return null` is
  its whole render).

Generated with [Claude Code](https://claude.com/claude-code)
