### PR TITLE
Character creation's three new faction plates join the kit (replaces #2482)

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -86,6 +86,7 @@
     "EphemeristsAvatar": "src/components/avatar/EphemeristsAvatar.tsx",
     "EphemeristsBackdrop": "src/components/backdrop/EphemeristsBackdrop.tsx",
     "EphemeristsComment": "src/components/comments/voices/EphemeristsComment.tsx",
+    "EphemeristsCreateCharacter": "src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx",
     "EphemeristsDuelSealConfirm": "src/components/duel/EphemeristsDuelSealConfirm.tsx",
     "EphemeristsEditPraxis": "src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx",
     "EphemeristsFactionBody": "src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx",
@@ -223,6 +224,7 @@
     "SnideAvatar": "src/components/avatar/SnideAvatar.tsx",
     "SnideBackdrop": "src/components/backdrop/SnideBackdrop.tsx",
     "SnideComment": "src/components/comments/voices/SnideComment.tsx",
+    "SnideCreateCharacter": "src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx",
     "SnideDuelSealConfirm": "src/components/duel/SnideDuelSealConfirm.tsx",
     "SnideEditPraxis": "src/pages/editPraxis/archetypes/SnideEditPraxis.tsx",
     "SnideFactionBody": "src/pages/factionDetail/archetypes/SnideFactionBody.tsx",
@@ -272,6 +274,7 @@
     "WowAvatar": "src/components/avatar/WowAvatar.tsx",
     "WowBackdrop": "src/components/backdrop/WowBackdrop.tsx",
     "WowComment": "src/components/comments/voices/WowComment.tsx",
+    "WowCreateCharacter": "src/pages/characterPaths/archetypes/WowCreateCharacter.tsx",
     "WowDuelSealConfirm": "src/components/duel/WowDuelSealConfirm.tsx",
     "WowEditPraxis": "src/pages/editPraxis/archetypes/WowEditPraxis.tsx",
     "WowFactionBody": "src/pages/factionDetail/archetypes/WowFactionBody.tsx",
@@ -742,6 +745,18 @@
     },
     "MobileStickyBar": {
       "cardMode": "column"
+    },
+    "EphemeristsCreateCharacter": {
+      "cardMode": "single",
+      "viewport": "390x760"
+    },
+    "SnideCreateCharacter": {
+      "cardMode": "single",
+      "viewport": "390x760"
+    },
+    "WowCreateCharacter": {
+      "cardMode": "single",
+      "viewport": "390x760"
     }
   },
   "readmeHeader": ".design-sync/conventions.md",

--- a/.design-sync/previews/EphemeristsCreateCharacter.tsx
+++ b/.design-sync/previews/EphemeristsCreateCharacter.tsx
@@ -1,0 +1,9 @@
+// EphemeristsCreateCharacter — the create-a-life form in the Ephemerists plate (#2473).
+// Character creation became a faction-dispatched surface: one responsive skin
+// per faction, each taking the same CreateCharacterState the Default does.
+import { EphemeristsCreateCharacter } from 'worldzero-frontend'
+import { createCharacterState } from './_state'
+
+export function Create() {
+  return <EphemeristsCreateCharacter state={createCharacterState('ephemerists')} />
+}

--- a/.design-sync/previews/SnideCreateCharacter.tsx
+++ b/.design-sync/previews/SnideCreateCharacter.tsx
@@ -1,0 +1,9 @@
+// SnideCreateCharacter — the create-a-life form in the Snide plate (#2473).
+// Character creation became a faction-dispatched surface: one responsive skin
+// per faction, each taking the same CreateCharacterState the Default does.
+import { SnideCreateCharacter } from 'worldzero-frontend'
+import { createCharacterState } from './_state'
+
+export function Create() {
+  return <SnideCreateCharacter state={createCharacterState('snide')} />
+}

--- a/.design-sync/previews/WowCreateCharacter.tsx
+++ b/.design-sync/previews/WowCreateCharacter.tsx
@@ -1,0 +1,9 @@
+// WowCreateCharacter — the create-a-life form in the Wow plate (#2473).
+// Character creation became a faction-dispatched surface: one responsive skin
+// per faction, each taking the same CreateCharacterState the Default does.
+import { WowCreateCharacter } from 'worldzero-frontend'
+import { createCharacterState } from './_state'
+
+export function Create() {
+  return <WowCreateCharacter state={createCharacterState('wow')} />
+}

--- a/frontend/.ds-kit/index.tsx
+++ b/frontend/.ds-kit/index.tsx
@@ -78,6 +78,7 @@ export { default as EphemerisNet } from "../src/components/factionMarks/Ephemeri
 export { default as EphemeristsAvatar } from "../src/components/avatar/EphemeristsAvatar";
 export { default as EphemeristsBackdrop } from "../src/components/backdrop/EphemeristsBackdrop";
 export { default as EphemeristsComment } from "../src/components/comments/voices/EphemeristsComment";
+export { default as EphemeristsCreateCharacter } from "../src/pages/characterPaths/archetypes/EphemeristsCreateCharacter";
 export { default as EphemeristsDuelSealConfirm } from "../src/components/duel/EphemeristsDuelSealConfirm";
 export { default as EphemeristsEditPraxis } from "../src/pages/editPraxis/archetypes/EphemeristsEditPraxis";
 export { default as EphemeristsFactionBody } from "../src/pages/factionDetail/archetypes/EphemeristsFactionBody";
@@ -215,6 +216,7 @@ export { default as SiteFooter } from "../src/components/layout/SiteFooter";
 export { default as SnideAvatar } from "../src/components/avatar/SnideAvatar";
 export { default as SnideBackdrop } from "../src/components/backdrop/SnideBackdrop";
 export { default as SnideComment } from "../src/components/comments/voices/SnideComment";
+export { default as SnideCreateCharacter } from "../src/pages/characterPaths/archetypes/SnideCreateCharacter";
 export { default as SnideDuelSealConfirm } from "../src/components/duel/SnideDuelSealConfirm";
 export { default as SnideEditPraxis } from "../src/pages/editPraxis/archetypes/SnideEditPraxis";
 export { default as SnideFactionBody } from "../src/pages/factionDetail/archetypes/SnideFactionBody";
@@ -264,6 +266,7 @@ export { default as WatercolorBackground } from "../src/components/layout/Waterc
 export { default as WowAvatar } from "../src/components/avatar/WowAvatar";
 export { default as WowBackdrop } from "../src/components/backdrop/WowBackdrop";
 export { default as WowComment } from "../src/components/comments/voices/WowComment";
+export { default as WowCreateCharacter } from "../src/pages/characterPaths/archetypes/WowCreateCharacter";
 export { default as WowDuelSealConfirm } from "../src/components/duel/WowDuelSealConfirm";
 export { default as WowEditPraxis } from "../src/pages/editPraxis/archetypes/WowEditPraxis";
 export { default as WowFactionBody } from "../src/pages/factionDetail/archetypes/WowFactionBody";


### PR DESCRIPTION
Replaces **#2482**, which GitHub auto-closed: it was stacked on `claude/design-sync-437d47` (PR #2481) rather than on `main`, so merging #2481 and deleting its branch closed this one and left its three previews unlanded. Same branch, same commit content, rebased onto `main`.

## What this adds

The character-creation plates that shipped with the `createCharacter` chassis (#2346/#2347) and its first two faction archetypes:

- `EphemeristsCreateCharacter`
- `SnideCreateCharacter`
- `WowCreateCharacter`

plus their `.design-sync/config.json` entries and the regenerated barrel.

## It is PARTIAL, deliberately, and here is exactly how much

Four more `createCharacter` archetypes merged **after** this branch was cut — **UA (#2348), Everymen (#2352), Coven (#2351) and Singularity (#2353)**. They are not in this PR. After this lands the kit carries **4 of 8** create-character archetypes (the three above plus `DefaultCreateCharacter`, which came in with the chassis).

The remaining four want a fresh `/design-sync` run rather than hand-authored preview files.

## Barrel

`frontend/.ds-kit/index.tsx` was regenerated with `node .design-sync/gen-barrel.mjs` after the rebase, and `git status` is clean against it — so it satisfies the ratchet that landed today in #2182/PR #2465, which is what would otherwise catch a stale barrel here.

## What to eyeball

The three new plates in the kit, in light and dark. Nothing in the running app changes — this PR touches only `.design-sync/` and the generated barrel.
