### PR TITLE
The composer register was challenged and held: #2269's reconciliation clause is withdrawn on the record (#2333)

### DIFF
--- a/frontend/src/components/factionMarks/snideAtoms.tsx
+++ b/frontend/src/components/factionMarks/snideAtoms.tsx
@@ -52,6 +52,11 @@ export const WALL_PLAIN =
  * the wall (#2066). The two ends of that rule are measured against all four of
  * this ground's readings (both ramp stops and both washed corners, both themes)
  * in `utils/__tests__/factionContrast.test.ts`.
+ *
+ * THAT RULE WAS CHALLENGED AND HELD (#2333). #2269's option 1 proposed
+ * collapsing the composer's register onto `-card-*`; the clause is withdrawn.
+ * The two families flip differently, and the collapse measures 1.56:1 on
+ * `-composer-alarm`.
  */
 export const WALL = [
   "repeating-linear-gradient(115deg, var(--faction-snide-note-grain) 0 2px, transparent 2px 7px)",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1223,7 +1223,13 @@
      `factionContrast.test.ts`, SNIDE_WALL_PAIRS. The composer is the surface
      that gates this ground, because it is the only one of the three carrying
      form fields and placeholder text, and it is tall enough to put its footer
-     inside the pink corner. */
+     inside the pink corner.
+
+     CHALLENGED AND HELD (#2333). #2269's option 1 read "same surface" as "same
+     tokens" and would have collapsed this 19-token register onto `-card-*`; the
+     clause is withdrawn. Same ground, different tier: `-composer-*` FLIPS with
+     the sheet, `-card-*` is pinned near-black for the slabs pasted ON the wall,
+     and `-composer-alarm` collapsed to `-card-alarm` measures 1.56:1 here. */
   --faction-snide-composer-sheet: #f4f1e8; /* the invite dropdown's stock (FLIPS) */
   --faction-snide-composer-ink: #14110b; /* type on the wall (FLIPS) — 9.87:1 in the pink corner */
   /* The task's prose, the pill, every section label. #5f5c50 read 5.36:1 on the


### PR DESCRIPTION
Closes #2333

**Docs/comment-only diff. Not one token is moved, renamed, added or deleted — no CSS declaration changes at all.** The whole change is two prose notes inside existing comment blocks.

Molly ruled on 2026-08-22 that S.N.I.D.E. keeps its 19-token composer register, Everymen keeps its 2, and option 1's reconciliation clause on #2269 is withdrawn. The builder who declined to force the deletion was right. This records the withdrawal so the next audit finds it rather than re-deriving it and re-filing the issue.

## The seam

The seam is the **written record**, not runtime behaviour: an instruction standing on a closed issue, and two code sites that assert a rule without recording that it was challenged and held. There is no code path to test at — nothing executes differently, so no test is added. (`factionContrast.test.ts` already guards the rule itself, on both ends, against all four readings of the wall; that is untouched and still green.)

## What landed

1. **A comment on #2269** withdrawing the reconciliation clause — [#2269 (comment)](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2269#issuecomment-5383843587). It cites #2177 and #2066 as the two more recent rulings it would reverse, and the three mechanical facts: `-composer-alarm` collapsed to `-card-alarm` measures a recorded 1.56:1; `-composer-sheet` is load-bearing for the invite dropdown; `--faction-everymen-composer-frame` has no `card-*` twin at all.
2. **The register count corrected on the record**, in that same comment, where #2269's survey table lives (its body).
3. **A note at both code sites** recording that a reconciliation was proposed and declined, citing #2333 — `frontend/src/index.css` (the S.N.I.D.E. composer block, beside #2177's note) and `frontend/src/components/factionMarks/snideAtoms.tsx` (the `WALL` doc comment, beside #2066's "never `-card-*`").

## Counts re-verified against the tree, not copied from the issue

Counted with `git grep -c` on `origin/main` at `a1ec5c2a`, in `frontend/src/index.css`:

| register | declarations |
|---|---|
| `--faction-snide-composer-*` | 19 |
| `--faction-everymen-composer-*` | 2 |
| `--faction-default-composer-{field,faint,hair}` | 6 |

Three registers, not the two #2269's survey counted. The issue's line-number citations had rotted (`index.css:1122`, `snideAtoms.tsx:30`) — both sites were located by grepping the phrases instead, and both notes went where the tree actually says.

## Scope respected

- `--faction-default-composer-*` is untouched. Nothing was traced or moved there, and no problem was found that needs filing.
- The roster half of option 1 (PR #2316) is not reopened.
- `.cm-ySelectionInfo`, `roomPresence.ts` and `bodyEditorTheme.ts` are untouched (#2297 is independent and is another agent's work).

## What to eyeball

**Nothing.** No pixel changes and no token changes — CSS comments do not survive minification, and the `.tsx` change is inside a doc comment. **This needs no visual QA**, and that is a statement rather than an omission.

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job was run locally against this branch, and all pass:

- `eslint src .ds-kit e2e` — clean
- `tsc --noEmit` — clean
- `typecheck:design-sync` — clean
- `vitest run` — 402 files, **7181 passed**, 1 skipped
- `vite build` — built
- `npm run budget` — JS 127.1 KB ok; CSS 22.3 KB WARN. **The CSS warning is pre-existing on `main`** (22.3 KB vs the 22.2 KB warn line, unowned and tracked at #2469) and cannot have been caused by this diff, which adds only comments.

The backend `test` and `api-schema` jobs are unaffected — no backend file, route signature or Pydantic schema is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
