### PR TITLE
Albescent's ornament motion leaves the blocking sheet, and its edges slide a pre-painted ramp

### DIFF
--- a/frontend/src/__tests__/motionSplit.test.ts
+++ b/frontend/src/__tests__/motionSplit.test.ts
@@ -225,6 +225,71 @@ reduced-motion gate.`,
     ).toEqual([])
   })
 
+  it('carries every Albescent ornament animation but the spark (#2498)', () => {
+    // The sheet's own "WHAT IS STILL IN index.css AND COULD FOLLOW" list named
+    // "the Albescent drifts" as a candidate on one test: does every consumer
+    // treat the motion as ornament, and is the un-animated frame the one a
+    // reduced-motion reader already gets? Each of these nine says so in its own
+    // words in index.css — "stilled, the page is a static wash and a static
+    // prism ring; nothing carries meaning through motion alone" — and each
+    // leaves its resting `transform` behind in index.css, so nothing jumps.
+    //
+    // `alb-drift`'s KEYFRAME is the one thing that did not travel. #2404 already
+    // reaches it from here across the chunk boundary because index.css is the
+    // always-loaded entry sheet, and railSpectrumFrame.test.ts asserts that.
+    const albescent = (css: string): string[] => [
+      ...new Set(
+        [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+          .filter(([, , body]) => /\banimation(-name)?\s*:/.test(body))
+          .flatMap(([, prelude]) =>
+            prelude.split(',').map((one) => one.trim().replace(/\s+/g, ' ')),
+          )
+          .filter((selector) => selector.startsWith('.alb-')),
+      ),
+    ]
+
+    const here = albescent(SHEET)
+    for (const selector of [
+      '.alb-rainbow',
+      '.alb-task-aurora::before',
+      '.alb-detail-aurora::before',
+      '.alb-detail-foil::before',
+      '.alb-detail-foil::after',
+      '.alb-detail-ring::before',
+      '.alb-praxis-aurora::before',
+      '.alb-praxis-ring::before',
+      '.alb-feed-aurora::before',
+    ]) {
+      expect(here, `${selector} still animates from somewhere else`).toContain(selector)
+    }
+
+    // THE SPARK IS THE ONE THAT MAY NOT FOLLOW, and it is the only one left.
+    expect(
+      albescent(INDEX),
+      `Every Albescent animation index.css still runs. Only .alb-spark may be
+here: its gate does not merely add motion, it drops the glyph to opacity 0 and
+lets the keyframe carry it back up. A paint declaration may never defer, so the
+opacity has to stay — and with the animation deferred and the sheet stranded the
+spark would be an invisible mark rather than a still one, which is the exact
+degradation this sheet is not allowed to cause.`,
+    ).toEqual(['.alb-spark'])
+  })
+
+  it('leaves the spark behind for a reason that is still true', () => {
+    // Asserted, not asserted-in-a-comment: if the gated rule ever stops setting
+    // the paint, the spark becomes a legible still frame and may follow.
+    const gated = GATES.flatMap((body) => declarations(body))
+    expect(gated.some(([selector]) => selector === '.alb-spark')).toBe(false)
+
+    const spark = ruleBodies(INDEX, '.alb-spark').filter((body) =>
+      /\banimation\s*:/.test(body),
+    )
+    expect(spark, '.alb-spark no longer animates from index.css at all').toHaveLength(1)
+    expect(spark[0], 'the spark animates without touching paint — it may follow').toContain(
+      'opacity: 0',
+    )
+  })
+
   it('is reached only through src/factionFaces.ts, so it stays off the entry HTML', () => {
     // Comments stripped, because index.css and the sheet itself both discuss the
     // filename at length and should go on doing so — only an `import` counts.

--- a/frontend/src/__tests__/motionSplit.test.ts
+++ b/frontend/src/__tests__/motionSplit.test.ts
@@ -93,6 +93,18 @@ const MOTION_SCAFFOLDING: Record<string, string> = {
     'pointer-events:none, parked at left:-55% outside its own overflow:hidden ' +
     'track, and declared nowhere but inside the gate — so with the sheet absent ' +
     'there is no band, which is exactly the reduced-motion rendering.',
+  '.alb-task-edge::before, .alb-detail-edge::before, .alb-praxis-edge::before, .alb-feed-edge::before, .alb-profile-edge::before':
+    "the five Albescent spectrum edges' travelling ramp (#2498). Two tiles of " +
+    'the ring\'s own `background-image: inherit`, six mount-widths wide inside ' +
+    "index.css's `overflow: hidden`, slid by transform because " +
+    '`background-position` repaints every frame on the main thread. Declared ' +
+    'nowhere but inside the gate: with the sheet absent there is no child, and ' +
+    "the still ring is the mount's own background in index.css — the exact " +
+    'frame a reduced-motion reader already gets.',
+  '.alb-profile-edge::before':
+    'the same child, two band-widths instead of three, because the profile ' +
+    "band's ring tiles at 200% where the four card edges tile at 300%. A `width` " +
+    'and not a tile, which is the whole reason five keyframes could become one.',
 }
 
 /** Delete every `prefix { … }` block, brace-matched, and return what is left. */
@@ -177,8 +189,12 @@ MOTION_SCAFFOLDING with the reason, the way .wow-balloon-sweep::after is.`,
   })
 
   it('keeps MOTION_SCAFFOLDING honest — every entry still exists', () => {
+    // Whitespace-insensitive, because the keys come from `declarations()`, which
+    // collapses runs of whitespace — so a multi-selector entry's key can never
+    // match the sheet's own one-per-line house style literally.
+    const flat = SHEET.replace(/\s+/g, ' ')
     for (const [selector, reason] of Object.entries(MOTION_SCAFFOLDING)) {
-      expect(SHEET, reason).toContain(selector)
+      expect(flat, reason).toContain(selector)
     }
   })
 

--- a/frontend/src/__tests__/spectrumRingCollapse.test.ts
+++ b/frontend/src/__tests__/spectrumRingCollapse.test.ts
@@ -327,10 +327,18 @@ describe("the travel is a transform on a pre-painted child (#2498)", () => {
   ];
 
   it("runs a transform, and no alb keyframe walks a gradient parameter", () => {
-    const keyframes = [...MOTION.matchAll(/@keyframes (alb-[\w-]+)\s*\{/g)].map(
-      ([, name]) => name,
-    );
-    expect(keyframes, "the five mounts' one keyframe").toEqual(["alb-edge-travel"]);
+    // FIVE KEYFRAMES BECAME ONE — asserted over what the five rules NAME, not
+    // over the sheet's whole inventory of `alb-` keyframes. #2498's second half
+    // moved nine more Albescent ornament motions here off the blocking sheet,
+    // and an inventory assertion would have read that as this collapse coming
+    // undone. What it is really claiming is that no mount needs a keyframe of
+    // its own, and that is a statement about the five rules.
+    const named = [
+      ...new Set(
+        WALK.map(([selector]) => child(selector).get("animation")?.split(/\s+/)[0]),
+      ),
+    ];
+    expect(named, "the five mounts' one keyframe").toEqual(["alb-edge-travel"]);
     const at = MOTION.indexOf("@keyframes alb-edge-travel");
     expect(
       MOTION.slice(at, MOTION.indexOf("}", MOTION.indexOf("}", at) + 1)).replace(
@@ -338,6 +346,21 @@ describe("the travel is a transform on a pre-painted child (#2498)", () => {
         " ",
       ),
     ).toContain("transform: translateX(-50%)");
+
+    // The other half of the title, now that there is a population to say it
+    // about: every `alb-` keyframe on this sheet moves a transform and nothing
+    // else. A gradient parameter — `background-position`, or an `@property`
+    // angle — reappearing in any of them is the expensive idiom coming back.
+    const keyframes = [
+      ...MOTION.matchAll(/@keyframes (alb-[\w-]+)\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g),
+    ];
+    expect(keyframes.length, "no alb keyframes found — the regex has rotted").toBe(8);
+    for (const [, name, body] of keyframes) {
+      expect(
+        [...new Set([...body.matchAll(/([-\w]+)\s*:/g)].map(([, one]) => one))],
+        `@keyframes ${name} animates something a compositor cannot`,
+      ).toEqual(["transform"]);
+    }
   });
 
   for (const [selector, loops, duration] of WALK) {

--- a/frontend/src/__tests__/spectrumRingCollapse.test.ts
+++ b/frontend/src/__tests__/spectrumRingCollapse.test.ts
@@ -221,16 +221,16 @@ describe("the travel moved to the deferred sheet, and only the travel (#2407)", 
     }
   });
 
-  it("four identical keyframes became one, and the fifth is not a duplicate", () => {
+  it("five mounts share one keyframe", () => {
     expect(MOTION).toContain("@keyframes alb-edge-travel");
-    // 200%, not 300%, because the profile band's tile is 200% — the travel and
-    // the tile are one number stated twice. Retiring this one would jump.
-    expect(MOTION).toContain(
-      "@keyframes alb-profile-edge { from { background-position: 0% 50%; } to { background-position: 200% 50%; } }",
+    // #2498 retired the fifth. It existed because a `background-position` walk
+    // states its travel in the TILE's units, so the profile band's 200% tile
+    // needed its own end stop; a transform states travel in the CHILD's units,
+    // and the child carries the difference as a width. One keyframe, two widths.
+    expect(MOTION, "@keyframes alb-profile-edge did not retire").not.toContain(
+      "@keyframes alb-profile-edge",
     );
-    expect(new Map(before(".alb-profile-edge")).get("background-size")).toBe(
-      "200% 100%",
-    );
+    expect(INDEX).not.toContain("@keyframes alb-profile-edge");
   });
 
   it("reduced motion still stops every one of the five", () => {
@@ -243,8 +243,10 @@ describe("the travel moved to the deferred sheet, and only the travel (#2407)", 
     ]) {
       // Either its own rule or a member of the shared list — and no line-ending
       // assumption, which is a real trap on a checkout that normalises to CRLF.
+      // Since #2498 the travel is on a `::before` of each of the five, so the
+      // pseudo-element is optional here rather than assumed either way.
       const at = MOTION.search(
-        new RegExp(`\\${selector}\\s*[,{]`),
+        new RegExp(`\\${selector}(::before)?\\s*[,{]`),
       );
       expect(at, `${selector} has no drift rule at all`).toBeGreaterThan(0);
       const gateAt = MOTION.lastIndexOf("@media", at);
@@ -252,6 +254,120 @@ describe("the travel moved to the deferred sheet, and only the travel (#2407)", 
         MOTION.slice(gateAt, at),
         `${selector} travels outside the reduced-motion gate`,
       ).toContain("prefers-reduced-motion: no-preference");
+    }
+  });
+});
+
+/**
+ * THE TRAVEL STOPS WALKING A GRADIENT PARAMETER (#2498, epic #2496).
+ *
+ * `background-position` is not a compositor property, so a walk repaints the
+ * whole ring every frame on the main thread. The epic's technique ruling names
+ * the replacement exactly: "translate a 300%-wide gradient child inside
+ * `overflow: hidden` rather than walking `background-position`."
+ *
+ * THE CHILD EXISTS ONLY INSIDE THE GATE, which is what keeps this free. Under
+ * reduced motion — or with the deferred sheet not yet delivered — there is no
+ * `::before` at all, and the still ring is the mount's own background painted
+ * from index.css exactly as it was before this change. The child arrives already
+ * registered with it: at `translateX(0)` its first tile starts at the padding
+ * box's left edge, which is where `background-position: 0%` put the image.
+ *
+ * SO THE SEAM IS ARITHMETIC, not a screenshot. Two numbers have to survive the
+ * change of idiom, and both are derived here rather than retyped:
+ *
+ *   the TILE   — `width × background-size-x` must equal the mount's own
+ *                `background-size`, or turning motion on changes the stripe
+ *                width, which is a design change wearing a perf change's clothes.
+ *   the SPEED  — travel per second. The old walk moved `tile × loops` per
+ *                duration; the new one moves half the child's width per
+ *                duration. A wrong width or a wrong duration is invisible to
+ *                every test that only asks whether something animates.
+ *
+ * And the travel must be a whole number of tiles, or the loop seams.
+ */
+describe("the travel is a transform on a pre-painted child (#2498)", () => {
+  /** The travelling child of one mount, resolved over the deferred sheet. */
+  function child(selector: string): Map<string, string> {
+    const out = new Map<string, string>();
+    for (const [, prelude, body] of MOTION.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      if (!prelude.split(",").some((one) => one.trim() === `${selector}::before`)) {
+        continue;
+      }
+      for (const [, property, value] of body.matchAll(/([-\w]+)\s*:\s*([^;]+)/g)) {
+        out.set(property.trim(), value.trim().replace(/\s+/g, " "));
+      }
+    }
+    return out;
+  }
+
+  /** `600%` and `50% 100%` both read as their first number: 600, 50. */
+  const percent = (value: string | undefined): number =>
+    Number((value ?? "").trim().split(/\s+/)[0].replace("%", ""));
+
+  /** The last `<n>s` an `animation` shorthand or an override states. */
+  const seconds = (rule: Map<string, string>): number =>
+    Number(
+      `${rule.get("animation") ?? ""} ${rule.get("animation-duration") ?? ""}`
+        .split(/\s+/)
+        .map((word) => word.match(/^([\d.]+)s$/)?.[1])
+        .filter(Boolean)
+        .at(-1),
+    );
+
+  /** How the walk used to be stated: whole image-widths, and over how long. */
+  const WALK: Array<[string, number, number]> = [
+    // `background-position: 0% 50%` → `300% 50%` over a 300% tile is -6 mount
+    // widths, i.e. TWO image widths; the 200% band's `0%` → `200%` is one.
+    [".alb-task-edge", 2, 16],
+    [".alb-detail-edge", 2, 16],
+    [".alb-praxis-edge", 2, 16],
+    [".alb-feed-edge", 2, 16],
+    [".alb-profile-edge", 1, 9],
+  ];
+
+  it("runs a transform, and no alb keyframe walks a gradient parameter", () => {
+    const keyframes = [...MOTION.matchAll(/@keyframes (alb-[\w-]+)\s*\{/g)].map(
+      ([, name]) => name,
+    );
+    expect(keyframes, "the five mounts' one keyframe").toEqual(["alb-edge-travel"]);
+    const at = MOTION.indexOf("@keyframes alb-edge-travel");
+    expect(
+      MOTION.slice(at, MOTION.indexOf("}", MOTION.indexOf("}", at) + 1)).replace(
+        /\s+/g,
+        " ",
+      ),
+    ).toContain("transform: translateX(-50%)");
+  });
+
+  for (const [selector, loops, duration] of WALK) {
+    it(`${selector} keeps its tile, its speed and its seamless loop`, () => {
+      const rule = child(selector);
+      expect(rule.size, `${selector} has no travelling child`).toBeGreaterThan(0);
+      expect(rule.get("background-image"), "one ramp, declared once").toBe("inherit");
+
+      const mount = percent(new Map(before(selector)).get("background-size"));
+      const span = percent(rule.get("width"));
+      const tile = (span * percent(rule.get("background-size"))) / 100;
+      expect(tile, `${selector} tile, as a % of the mount`).toBe(mount);
+
+      // `translateX(-50%)` of the child, so half its width per cycle.
+      expect(span / 2 / tile, `${selector} loop is not a whole tile`).toBe(1);
+      expect(span / 2 / seconds(rule), `${selector} travels at a new speed`).toBe(
+        (mount * loops) / duration,
+      );
+    });
+  }
+
+  it("declares that child nowhere but inside the gate", () => {
+    // A resting `::before` in index.css would be a second, still ring under the
+    // travelling one — and a byte on the render-blocking sheet, for motion.
+    expect(INDEX).not.toContain("-edge::before");
+  });
+
+  it("clips the overflowing child to the ring's own box", () => {
+    for (const [selector] of BEFORE) {
+      expect(resolve(selector).get("overflow"), `${selector} overflow`).toBe("hidden");
     }
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5933,6 +5933,13 @@
   background-image: var(--spectrum-frame-image, var(--faction-default-rainbow-loop));
   background-size: 300% 100%;
   opacity: 0.6;
+  /* The TRACK for the travelling child (#2498). Five of the six mounts grow a
+     `::before` inside the reduced-motion gate in `motion.ornament.css`, several
+     times this box wide, and slide it by transform instead of walking this
+     background. Border width is 0 here, so `overflow` clips to the same rounded
+     box the mask does — nothing that stands still moves by one pixel, and with
+     the deferred sheet absent there is no child to clip. */
+  overflow: hidden;
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,
     linear-gradient(#000 0 0);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6109,9 +6109,21 @@
   mix-blend-mode: screen;
   opacity: 0.2475;
 }
-@media (prefers-reduced-motion: no-preference) {
-  .alb-rainbow { animation: alb-drift 18s linear infinite; }
-}
+/* THE DRIFT ITSELF IS IN `src/motion.ornament.css` (#2498), with the other eight
+   Albescent ornament motions. Only the keyframe stayed, because `.spectrum-frame
+   ::before` reaches `alb-drift` from that sheet across a chunk boundary and this
+   is the entry sheet the reference resolves against (#2404).
+
+   ponytail: the drift still walks `background-position`, which epic #2496's
+   technique ruling retires everywhere else in this pass. It is left because the
+   conversion cannot pay here: `alb-drift`'s other consumer IS a pseudo-element
+   (`.spectrum-frame::before`), so it cannot grow the pre-painted child the idiom
+   needs without a real span in the rail's markup — the keyframe therefore cannot
+   retire, and converting this half alone adds a second keyframe plus a child
+   while leaving the walk standing on the rail. It is also the cheaper walk of
+   the two: a 220px LENGTH tile under `background-repeat: repeat`, not a gradient
+   re-rasterised at element width. Upgrade path: #2500 is already opening these
+   mounts, so convert both consumers together once the rail's ring is a span. */
 
 /* The other half of the tell (#842). The design draws the drift AND three faint
    gold ✦ sparks scattered over the sheet; #821 shipped only the drift, so the
@@ -6261,10 +6273,6 @@
    a plain card costs no rules and this sheet stays a drawing rather than a
    decision. THE EDGE NEVER BRANCHES: it is chrome, and since #2407 it is the
    shared `.spectrum-frame` ring five other mounts wear. */
-@keyframes alb-task-drift {
-  0%, 100% { transform: translate3d(-6%, -4%, 0) scale(1.12) rotate(0deg); }
-  50% { transform: translate3d(6%, 5%, 0) scale(1.24) rotate(8deg); }
-}
 .alb-task-edge,
 .alb-task-aurora {
   position: absolute;
@@ -6323,10 +6331,6 @@
     radial-gradient(64% 78% at 62% 96%, #f472b6, transparent 100%),
     radial-gradient(60% 74% at 22% 92%, #3aa0a4, transparent 100%);
 }
-@media (prefers-reduced-motion: no-preference) {
-  .alb-task-aurora::before { animation: alb-task-drift 52s ease-in-out infinite; }
-}
-
 /* Albescent — the TASK DETAIL's tell (#1038, ADR-0048). The third surface to
    unfreeze, same rule as the first two: `DefaultTaskDetail` unchanged, with
    light washed over it. The design's own header states the thesis — "Albescent's
@@ -6358,20 +6362,6 @@
      inverted form of the design's `reduce → none`. Stilled, the page is a static
      wash and a static prism ring — the tell is dimmer, but nothing about it
      carries meaning through motion alone. */
-@keyframes alb-detail-drift {
-  0%, 100% { transform: translate3d(-5%, -4%, 0) scale(1.14) rotate(0deg); }
-  50% { transform: translate3d(5%, 4%, 0) scale(1.24) rotate(7deg); }
-}
-@keyframes alb-detail-wheel {
-  from { transform: translate(-50%, -50%) rotate(0deg); }
-  to { transform: translate(-50%, -50%) rotate(360deg); }
-}
-@keyframes alb-detail-sheen {
-  0%, 100% { transform: translateX(-18%); }
-  50% { transform: translateX(18%); }
-}
-@keyframes alb-detail-spin { to { transform: rotate(360deg); } }
-
 .alb-detail {
   position: relative;
   max-width: 1200px;
@@ -6506,13 +6496,6 @@
   text-align: center;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .alb-detail-aurora::before { animation: alb-detail-drift 30s ease-in-out infinite; }
-  .alb-detail-foil::before { animation: alb-detail-wheel 44s linear infinite; }
-  .alb-detail-foil::after { animation: alb-detail-sheen 13s ease-in-out infinite; }
-  .alb-detail-ring::before { animation: alb-detail-spin 46s linear infinite; }
-}
-
 /* Albescent — the PRAXIS DETAIL's tell (#1140, epic #1085, ADR-0048). The fourth
    surface to unfreeze, and the same rule as the three before it: the shared
    `DefaultPraxisDetail` page unchanged, with light washed over it. The design's
@@ -6550,15 +6533,6 @@
 
    The 18px radius tracks `DefaultPraxisDetail`'s own sheet corner. If that
    changes, this follows. */
-@keyframes alb-praxis-drift {
-  0%, 100% { transform: translate3d(-4%, -5%, 0) scale(1.16) rotate(0deg); }
-  50% { transform: translate3d(4%, 5%, 0) scale(1.26) rotate(-6deg); }
-}
-@keyframes alb-praxis-wheel {
-  from { transform: translate(-50%, -50%) rotate(0deg); }
-  to { transform: translate(-50%, -50%) rotate(360deg); }
-}
-
 .alb-praxis {
   isolation: isolate;
 }
@@ -6652,11 +6626,6 @@
   opacity: 0.72;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .alb-praxis-aurora::before { animation: alb-praxis-drift 34s ease-in-out infinite; }
-  .alb-praxis-ring::before { animation: alb-praxis-wheel 58s linear infinite; }
-}
-
 /* Albescent — the FEED CARD's tell (#1203, epic #1192, ADR-0048). The fifth
    surface to unfreeze, and the same rule as the four before it: the shared
    chassis an unaffiliated player sees, with light washed over it. Strip these two
@@ -6700,11 +6669,6 @@
 
    • MOTION IS OPT-IN, gated on `no-preference`. Stilled, the card is a static
      wash and a static edge; nothing carries meaning through motion alone. */
-@keyframes alb-feed-drift {
-  0%, 100% { transform: translate3d(-5%, -4%, 0) scale(1.14) rotate(0deg); }
-  50% { transform: translate3d(5%, 4%, 0) scale(1.22) rotate(-5deg); }
-}
-
 .alb-feed {
   position: relative;
   isolation: isolate;
@@ -6757,10 +6721,6 @@
    `--radius-xl`, so the two now agree — the literal is kept because it is
    measured on the border box the `-1px` above restores, and `inherit` would take
    the padding box's corner instead. */
-
-@media (prefers-reduced-motion: no-preference) {
-  .alb-feed-aurora::before { animation: alb-feed-drift 46s ease-in-out infinite; }
-}
 
 /* UA — the growing mandala's five motions (bloom, twist, spin, ring-grow, halo)
    are in `src/motion.ornament.css` (#2073). Meaning is carried by the mandala's

--- a/frontend/src/motion.ornament.css
+++ b/frontend/src/motion.ornament.css
@@ -641,3 +641,76 @@
     animation-duration: 9s;
   }
 }
+
+/* ── Albescent — the nine ornament motions the five washed surfaces carry
+   (#2498). The sheet's own candidate list above named "the Albescent drifts";
+   this is that list, cashed. Each passes the test the list states: every
+   consumer treats the motion as ornament, and the un-animated frame is the one
+   a reduced-motion reader already gets — index.css says so in words at each
+   mount ("stilled, the page is a static wash and a static prism ring; nothing
+   carries meaning through motion alone").
+
+   ONLY THE ANIMATION TRAVELLED. Every one of these nine has an UNGATED twin in
+   index.css holding its resting form, and the resting form is the animation's
+   own first frame: `.alb-task-aurora::before` rests at
+   `translate3d(-6%, -4%, 0) scale(1.12)`, which is `alb-task-drift`'s 0%, and
+   the three other auroras and the two wheels do the same. So a stranded sheet
+   is not an approximation of the still frame, it IS the still frame, and there
+   is no jump at the moment the sheet lands.
+
+   `.alb-rainbow` RUNS A KEYFRAME THAT STAYED BEHIND, and that is deliberate for
+   the reason stated at `.spectrum-frame::before` above: `alb-drift` is reached
+   from this sheet across the chunk boundary already, keyframe names are
+   document-global, and index.css is the entry sheet the reference always
+   resolves against. Its `ponytail:` note in index.css records why the walk
+   itself is not converted to a transform in this pass.
+
+   `.alb-spark` IS THE ONE THAT MAY NEVER FOLLOW, and it is the only Albescent
+   animation index.css still runs. Its gate does not merely add motion — it
+   drops the glyph to `opacity: 0` and lets the keyframe carry it back up. Paint
+   may not defer, so the opacity has to stay in index.css; with the animation
+   deferred and the sheet stranded the spark would be an invisible mark rather
+   than a still one. `__tests__/motionSplit.test.ts` asserts both halves of that.
+
+   TWO IDENTICAL WHEELS BECAME ONE. `alb-detail-wheel` and `alb-praxis-wheel`
+   were byte-for-byte the same declaration — a centred element turning through
+   360deg — differing only in the duration their consumers pass, which lives on
+   the `animation` shorthand and not in the keyframe. Now that both consumers
+   sit in this one block, one name serves them, the same way `alb-edge-travel`
+   serves five above. ── */
+@keyframes alb-task-drift {
+  0%, 100% { transform: translate3d(-6%, -4%, 0) scale(1.12) rotate(0deg); }
+  50% { transform: translate3d(6%, 5%, 0) scale(1.24) rotate(8deg); }
+}
+@keyframes alb-detail-drift {
+  0%, 100% { transform: translate3d(-5%, -4%, 0) scale(1.14) rotate(0deg); }
+  50% { transform: translate3d(5%, 4%, 0) scale(1.24) rotate(7deg); }
+}
+@keyframes alb-praxis-drift {
+  0%, 100% { transform: translate3d(-4%, -5%, 0) scale(1.16) rotate(0deg); }
+  50% { transform: translate3d(4%, 5%, 0) scale(1.26) rotate(-6deg); }
+}
+@keyframes alb-feed-drift {
+  0%, 100% { transform: translate3d(-5%, -4%, 0) scale(1.14) rotate(0deg); }
+  50% { transform: translate3d(5%, 4%, 0) scale(1.22) rotate(-5deg); }
+}
+@keyframes alb-wheel {
+  from { transform: translate(-50%, -50%) rotate(0deg); }
+  to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+@keyframes alb-detail-sheen {
+  0%, 100% { transform: translateX(-18%); }
+  50% { transform: translateX(18%); }
+}
+@keyframes alb-detail-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: no-preference) {
+  .alb-rainbow { animation: alb-drift 18s linear infinite; }
+  .alb-task-aurora::before { animation: alb-task-drift 52s ease-in-out infinite; }
+  .alb-detail-aurora::before { animation: alb-detail-drift 30s ease-in-out infinite; }
+  .alb-detail-foil::before { animation: alb-wheel 44s linear infinite; }
+  .alb-detail-foil::after { animation: alb-detail-sheen 13s ease-in-out infinite; }
+  .alb-detail-ring::before { animation: alb-detail-spin 46s linear infinite; }
+  .alb-praxis-aurora::before { animation: alb-praxis-drift 34s ease-in-out infinite; }
+  .alb-praxis-ring::before { animation: alb-wheel 58s linear infinite; }
+  .alb-feed-aurora::before { animation: alb-feed-drift 46s ease-in-out infinite; }
+}

--- a/frontend/src/motion.ornament.css
+++ b/frontend/src/motion.ornament.css
@@ -578,33 +578,66 @@
   }
 }
 
-/* ── Albescent — the five card edges' travel (#2407). The rings themselves are
-   `.spectrum-frame::before`'s selector list in index.css, one rule for all six
-   mounts; what arrives here is only the walk, which is the whole of what these
-   five surfaces were carrying in the render-blocking sheet.
+/* ── Albescent — the five card edges' travel (#2407, re-cut by #2498). The rings
+   themselves are `.spectrum-frame::before`'s selector list in index.css, one
+   rule for all six mounts; what arrives here is only the walk, which is the
+   whole of what these five surfaces were carrying in the render-blocking sheet.
 
-   FOUR KEYFRAMES BECAME ONE. `alb-task-edge`, `alb-detail-edge`,
-   `alb-praxis-edge` and `alb-feed-edge` were byte-identical — 0% → 300% at 16s
-   — so the four names retire and the four selectors share one declaration.
+   IT IS NO LONGER A WALK. #2407 shipped this as `background-position`, and
+   epic #2496's technique ruling retires that idiom: `background-position` is not
+   a compositor property, so every frame repainted the whole ring on the main
+   thread — five of them, on lists. What travels now is a PRE-PAINTED CHILD,
+   several ring-widths of ramp slid by `transform`, which rasterises once.
 
-   THE FIFTH IS NOT A DUPLICATE AND DOES NOT RETIRE. `alb-profile-edge` travels
-   200% because the profile band's ring tiles at `background-size: 200% 100%`,
-   two band-widths where the other four are three: the travel and the tile are
-   one number stated twice, and 300% there would overshoot the seam and jump.
-   Its 9s pace is the design's, and differs too.
+   THE CHILD IS DECLARED NOWHERE ELSE, so it belongs whole in this sheet: with
+   the gate closed, or this sheet not yet delivered, there is no `::before` at
+   all and the still ring is the mount's own background in index.css — the exact
+   frame that shipped before, not an approximation of it. It arrives already
+   registered, too: at `translateX(0)` the child's first tile starts at the
+   padding box's left edge, which is where `background-position: 0%` put the
+   image. Border width is 0 on all six, so the child's `inset`-relative box, the
+   background's origin box and index.css's `overflow: hidden` are one box.
 
-   Stranded — this sheet not yet delivered, or reduced motion — each edge is the
-   static spectrum ring an unaffiliated player already sees on the same surface.
-   The frame is drawn, in its final colours, at its final size; it simply is not
-   walking. Nothing here carries meaning through motion alone. ── */
-@keyframes alb-edge-travel { from { background-position: 0% 50%; } to { background-position: 300% 50%; } }
-@keyframes alb-profile-edge { from { background-position: 0% 50%; } to { background-position: 200% 50%; } }
+   FIVE KEYFRAMES BECAME ONE, where #2407 could only get four. A walk states its
+   travel in the TILE's units, so the profile band's 200% tile needed an end stop
+   of its own; a transform states travel in the CHILD's units, so the difference
+   moves into a width and the fifth name retires. Each child is two tiles wide
+   and slides exactly one — `translateX(-50%)` — which is why the loop cannot
+   seam wherever the ramp happens to be cut.
+
+   THE TWO NUMBERS THAT HAD TO SURVIVE, both asserted in
+   `__tests__/spectrumRingCollapse.test.ts` as arithmetic over the old walk:
+
+     tile   600% × 50% = the 300% these four already tiled at;
+            400% × 50% = the 200% the profile band already tiled at.
+     speed  the four moved 6 mount-widths per 16s, so one 300% tile per 8s.
+            The band moved 2 per 9s, which is one 200% tile per 9s — unchanged,
+            because its walk was already exactly one loop.
+
+   `background-image: inherit` rather than a second reference to the ramp: it
+   keeps ONE declaration of the loop cut, and it keeps the rail's suppression
+   working for free — `--spectrum-frame-image: none` on a member reaches the
+   parent, and the child inherits the `none`. ── */
+@keyframes alb-edge-travel { to { transform: translateX(-50%); } }
 @media (prefers-reduced-motion: no-preference) {
-  .alb-task-edge,
-  .alb-detail-edge,
-  .alb-praxis-edge,
-  .alb-feed-edge {
-    animation: alb-edge-travel 16s linear infinite;
+  .alb-task-edge::before,
+  .alb-detail-edge::before,
+  .alb-praxis-edge::before,
+  .alb-feed-edge::before,
+  .alb-profile-edge::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 600%;
+    background-image: inherit;
+    background-size: 50% 100%;
+    animation: alb-edge-travel 8s linear infinite;
   }
-  .alb-profile-edge { animation: alb-profile-edge 9s linear infinite; }
+  /* Two band-widths, not three, and the design's own 9s pace. */
+  .alb-profile-edge::before {
+    width: 400%;
+    animation-duration: 9s;
+  }
 }

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -526,7 +526,11 @@ describe("#1630 motion sits behind the reduced-motion guard", () => {
   it.each(["alb-profile-edge", "cvn-profile-spark"])(
     "%s animates only under no-preference",
     (className) => {
-      const animates = new RegExp(`\\.${className}\\s*\\{[^}]*animation`);
+      // The pseudo-element is optional because #2498 moved `.alb-profile-edge`'s
+      // travel onto a `::before` — a pre-painted ramp slid by transform. The
+      // question is still "is the animation gated", on whichever element runs it,
+      // and an ungated `.alb-profile-edge { animation }` still fails below.
+      const animates = new RegExp(`\\.${className}(::before)?\\s*\\{[^}]*animation`);
       expect(animates.test(GUARDED), `${className} guarded rule`).toBe(true);
       expect(animates.test(UNGUARDED), `${className} UNguarded rule`).toBe(false);
     },


### PR DESCRIPTION
Closes #2498

Part of epic #2496.

## Note on commit 4's subject line

`5a9d9907 WIP (INCOMPLETE, DO NOT MERGE)` is a **WIP-preservation commit made by the orchestrator** after the first agent on this issue stalled with uncommitted work on disk. It removed nine Albescent animation rules from `index.css` without writing the matching additions to `motion.ornament.css`, so the branch was genuinely unmergeable at that point. **This PR completes it.** The "DO NOT MERGE" no longer applies to the branch head.

Rebased onto `origin/main` @ `0c24ac4b` (#2511's na sheet token / `.spectrum-rule` / `.spectrum-dial` / `.faction-plate*` blocks, and #2510's backend tombstone). No conflicts. Those new #2497 blocks carry paint and geometry, not motion, so they stayed on the blocking sheet untouched.

## The seam

**The resolved stylesheet, split across the two sheets** — not a screenshot and not the markup. Two guards read the CSS as text:

- `src/__tests__/motionSplit.test.ts` — which selectors animate from which sheet, and the contract that only motion may defer.
- `src/__tests__/spectrumRingCollapse.test.ts` — the arithmetic that had to survive section 1's change of idiom (tile width, travel per second, whole-tile loop).

Motion itself is invisible to both, which is why the eyeball list at the bottom is the whole of the rest of the verification.

## What is in here

**Section 1 (already on the branch, verified).** `alb-edge-travel` and `alb-profile-edge` stopped walking `background-position` and now slide a pre-painted child by `transform`. Five keyframes became one; the profile band's 200% tile moved into a `width` instead of needing an end stop of its own.

**Section 2 (this PR's work).** The nine ornament animations `index.css` was still blocking first paint with now live in `motion.ornament.css`, each with its keyframe and its `prefers-reduced-motion: no-preference` gate:

`.alb-rainbow`, `.alb-task-aurora::before`, `.alb-detail-aurora::before`, `.alb-detail-foil::before`, `.alb-detail-foil::after`, `.alb-detail-ring::before`, `.alb-praxis-aurora::before`, `.alb-praxis-ring::before`, `.alb-feed-aurora::before`.

Only the animation travelled. Every one of the nine has an **ungated twin in `index.css` holding its resting form, and that resting form is the animation's own first frame** — `.alb-task-aurora::before` rests at `translate3d(-6%, -4%, 0) scale(1.12)`, which is `alb-task-drift`'s 0%. So a sheet arriving late resolves to the frame already on screen; there is nothing to jump.

Two things deliberately did **not** move:

- **`alb-drift`'s keyframe stays in `index.css`.** `.alb-rainbow`'s *rule* moved, but the keyframe is reached from the deferred sheet across a chunk boundary by `.spectrum-frame::before` (#2404). Keyframe names are document-global and `index.css` is the always-loaded entry sheet, so the reference resolves either way.
- **`.alb-spark` may never follow.** Its gate does not merely add motion — it drops the glyph to `opacity: 0` and lets the keyframe carry it back up. Paint may not defer, so a stranded sheet would make the mark *invisible* rather than *still*. That is now asserted rather than only written down, including the condition under which it would become eligible.

**Section 3 is void** per the correction comment on the issue, and nothing was deleted. `index.css` animates `.alb-rainbow` (the card sheet); `motion.ornament.css` animates `.spectrum-frame::before` (the shared ring). Two selectors, two elements, one deliberately shared keyframe name.

## Two judgement calls

**`alb-drift` is not converted to a transform, and there is a `ponytail:` in `index.css` saying why.** Its other consumer *is* a pseudo-element (`.spectrum-frame::before` on the rail), so the pre-painted-child idiom cannot apply there without a real span in the rail's markup. The keyframe therefore cannot retire, and converting one consumer alone would add a second keyframe plus a child while leaving the walk standing on the rail. It is also the cheaper walk of the two — a 220px *length* tile under `background-repeat: repeat`, not a gradient re-rasterised at element width. Upgrade path named: #2500 is already opening these mounts. (This call was the first agent's; I re-checked the reasoning and it holds.)

**`alb-detail-wheel` and `alb-praxis-wheel` were byte-identical** and became one `alb-wheel`. They differed only in the duration their consumers pass, which lives on the `animation` shorthand and not in the keyframe — and both consumers now sit in the same block. Same move `alb-edge-travel` already makes for five mounts above it.

**One test assertion was rewritten, not deleted.** `spectrumRingCollapse`'s "five keyframes became one" asserted the deferred sheet's *whole* `alb-` keyframe inventory, which nine new arrivals read as the collapse coming undone. It now asserts what the five rules **name**, which is the claim it was actually making, and picks up the other half of its own title: every `alb-` keyframe on that sheet moves a `transform` and nothing else, so the expensive idiom cannot creep back unnoticed.

## Measured, not predicted

`npm run budget`, both halves built:

| | `origin/main` @ `0c24ac4b` | this branch | delta |
|---|---|---|---|
| **blocking** `index-*.css` gz | **22,928 B** (22.5 KB) | **22,675 B** (22.3 KB) | **-253 B** |
| blocking `index-*.css` raw | 117,352 B | 115,496 B | -1,856 B |
| deferred `factionFaces-*.css` gz | 3,543 B | 3,805 B | +262 B (off the ledger) |
| JS | 127.1 KB | 127.1 KB | unchanged |

Bytes moved down on the sheet that counts and sideways overall, which is what section 2 exists to do. CSS is still on the WARN side of the 22.2 KB line — it was on `main` before this branch too, and this change moves it toward the line, not away.

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job, run locally: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (**406 files / 7,236 tests green**), `npm run build`, `npm run budget`. No backend, route, `response_model` or Pydantic schema was touched, so `test` and `api-schema` are not engaged.

**Visual QA is outstanding.** I have no browser and no dev stack.

## What to eyeball

Every surface below should look **exactly as it does on `main`** — same motion, same speed, no seam where the loop restarts. The whole change is *where the rule is loaded from*, not what it does.

- **Albescent task card** — the aurora bloom breathing under the sheet (52s, very slow), and the rainbow hairline travelling around the card edge.
- **Albescent praxis card** — the drifting rainbow sheet (`.alb-rainbow`, 18s) and the three gold sparks pulsing out of phase. The sparks are the control: they were deliberately left on the blocking sheet, so they must start moving *immediately*, while everything else in this list may not.
- **Albescent task detail** — four motions at once: the aurora drift (30s), the big blurred colour wheel turning behind the vellum (44s), the diagonal sheen sweeping across it (13s), and the ring around the level medallion spinning (46s).
- **Albescent praxis detail** — the aurora drift (34s) and the masked halo ring turning (58s).
- **Albescent feed card** — the aurora drift (46s) and its travelling edge.
- **Albescent character profile** — the identity band's rainbow edge travelling (9s, the one with its own pace).
- **Rail / sidebar** — the spectrum frame's rainbow drifting. Unchanged by this PR, but it shares the `alb-drift` keyframe with the praxis sheet, so if that keyframe ever failed to resolve across the chunk boundary this is where it would show.

**The one behaviour that is expected and looks like a bug:** a deferred sheet arrives a beat after first paint, so on a cold load the correct sequence is **"still, then moving"** — the ornament is fully drawn, in its final colours and at its final size, and simply begins moving a moment later. That is the design, not a defect.

**What would tell you it actually broke:**

- **"Never moves."** A surface that is still and *stays* still after a few seconds means the deferred sheet is not reaching that route's chunk, or a keyframe name did not resolve.
- **A jump at the moment motion starts.** The resting frame and the animation's first frame are supposed to be identical. A visible pop means a resting `transform` got left behind or mistyped.
- **A seam in a travelling edge** — a hard red-meets-magenta line passing through once per cycle — means the loop is no longer a whole number of tiles.
- **A flash of the wrong colour, or anything shifting position or size on load.** Nothing but animation was supposed to defer; this would mean paint or layout rode along.
- **Motion for a reduced-motion reader.** Set `prefers-reduced-motion: reduce` and every surface above must be completely still — but still fully drawn and legible, including the praxis sparks, which park at a visible resting opacity rather than at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
