### PR TITLE
A returning deleted player consents to starting fresh (#2162)

### DIFF
--- a/backend/errors.py
+++ b/backend/errors.py
@@ -224,6 +224,26 @@ class ErrorCode(str, enum.Enum):
     #: player did not choose, and the only one where "try again" is genuine
     #: advice rather than a shrug. Never raised, for the same reason.
     oauth_state_expired = "OAUTH_STATE_EXPIRED"
+    #: #2162. The provider pair resolved to a suspended Account. Until this
+    #: issue the returning-player branch never read ``status`` at all: the
+    #: sign-in succeeded, minted a cookie, and then 401'd from
+    #: ``get_current_account`` on every request afterwards. A moderated account
+    #: is owed a sentence, not a session that does not work.
+    account_suspended = "ACCOUNT_SUSPENDED"
+    #: #2162, and deliberately NOT folded into :attr:`account_suspended`. The
+    #: two statuses reach the same gate but they are not the same answer — one
+    #: is a moderation decision that a human can appeal, the other is a
+    #: tombstone the player made themselves (ADR-0081). Unreachable today by
+    #: construction, because ``delete_account`` destroys the ``OAuthProvider``
+    #: rows in the transaction that sets the status; it exists so that if the
+    #: pairing ever occurs the outcome is a refusal in the right words rather
+    #: than a session.
+    account_deleted = "ACCOUNT_DELETED"
+    #: #2162. The consent gate was asked for, or answered, with no interrupted
+    #: sign-in behind it — walked into by URL, or come back to after the OAuth
+    #: session cookie's ten minutes lapsed. Not a failure of the sign-in: there
+    #: is no sign-in. The player starts one.
+    returning_player_consent_expired = "RETURNING_PLAYER_CONSENT_EXPIRED"
 
 
 #: The keys of a coded ``detail`` body. Named so the frontend contract is

--- a/backend/main.py
+++ b/backend/main.py
@@ -110,9 +110,14 @@ app.add_middleware(
     # 3600` into the stored value and never reads it back, so its hour is
     # decorative; the default this replaces is FOURTEEN DAYS of replayability
     # for an abandoned sign-in. Starlette feeds this to `TimestampSigner.
-    # unsign()`, so it is server-enforced rather than a browser hint. Safe to
-    # cut this short because nothing in `backend/` reads `request.session`
-    # except authlib.
+    # unsign()`, so it is server-enforced rather than a browser hint.
+    #
+    # `routers/auth.py` is the second reader since #2162 — it parks a returning
+    # deleted player's interrupted sign-in here while the consent gate asks its
+    # one question — and it wants this same number for its own reason: an
+    # unanswered gate should lapse, not linger. So the ten minutes now has two
+    # arguments behind it rather than one, and shortening it further would
+    # start refusing people who read the sentence before clicking.
     max_age=600,
     # LOAD-BEARING — never "strict". The callback arrives via a cross-site 302
     # from the provider, so `Lax`'s carve-out for top-level safe-method

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5360,6 +5360,21 @@
         "title": "RelationshipTypeEnum",
         "type": "string"
       },
+      "ReturningPlayerOut": {
+        "description": "What the consent gate is allowed to know (``GET /auth/returning-player``).\n\nOne field, and the reason there is only one is the reason this model exists\nat all. The caller has authenticated as *nobody* — they hold a signed,\nten-minute session cookie stamped by an OAuth handshake they just completed,\nand nothing else. Anything added here is a fact about an account that no\nlonger exists, disclosed on that basis.\n\nA **date, not a timestamp**: the gate's sentence is *\"you deleted your World\nZero account on 3 March\"*, and the hour and minute would be a finer signal\nbought for nothing the sentence needs. The tombstone's ``created_at`` is\ntruncated in ``services.auth.ReturningPlayerConsentRequired``, so the\nprecision is dropped before it ever reaches a response model.",
+        "properties": {
+          "deleted_on": {
+            "format": "date",
+            "title": "Deleted On",
+            "type": "string"
+          }
+        },
+        "required": [
+          "deleted_on"
+        ],
+        "title": "ReturningPlayerOut",
+        "type": "object"
+      },
       "SidebarOut": {
         "description": "Everything the rail's three data panels draw, in one response.\n\nOne field per panel, and nothing else. Identity is deliberately absent: the\ncharacter card reads ``user.character`` from ``/auth/me``, which ~20 call\nsites already refetch, and fattening that payload would make every one of\nthem heavier (#1349). This carries only what the panels need.\n\nRequests are a NUMBER, not a list (#1456). The rail listed them until\n#1423; under ADR-0070 the Requests queue on ``/updates`` is the only\nsurface a request can be answered on, so all that is left here is the\nbadge on the collapsed handle, the mobile bell and the mobile FieldDesk —\nthree consumers of one integer. Shipping up to a hundred hydrated feed\nitems on a page-load path to produce it was the whole of the cost.\n\nThe count is the same one ``counts.requests`` reports, so the badge and\nthe queue's card list cannot disagree — see\n:func:`services.activity_feed.get_sidebar_feed`.",
         "properties": {
@@ -5463,6 +5478,20 @@
           "active_praxes"
         ],
         "title": "SidebarOut",
+        "type": "object"
+      },
+      "StartFreshOut": {
+        "description": "Acknowledgement for ``POST /auth/returning-player``.\n\nSame posture as :class:`LogoutOut`: the work is the ``Set-Cookie`` header,\nand the body exists so the generated client has a declared shape rather than\nan untyped object. The caller learns who it now is from ``/auth/me``, which\nis the one place that answers that question.",
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "StartFreshOut",
         "type": "object"
       },
       "SuspendAction": {
@@ -8127,6 +8156,48 @@
           }
         ],
         "summary": "Auth Me",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/returning-player": {
+      "get": {
+        "description": "What the consent gate says (#2162): a date, and nothing else.\n\nRead from the parked sign-in rather than the tombstone, so this route makes\nno lookup keyed on anything the caller supplied — there is nothing to\nsupply. The identity is in the signed session or the gate does not exist.",
+        "operationId": "returning_player_gate_auth_returning_player_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReturningPlayerOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Returning Player Gate",
+        "tags": [
+          "auth"
+        ]
+      },
+      "post": {
+        "description": "The one button: yes, start fresh (#2162).\n\nExplicitly **not** an offer of any old data, and there is none to offer —\n``delete_account`` blanked it and there is no undo (ADR-0081). All this does\nis finish the sign-in the gate interrupted, as a stranger.\n\nThe tombstone goes FIRST, and that ordering is what does the work: with it\ncleared, ``create_or_get_account`` finds no reason to pause and falls\nthrough to the ordinary stranger path — the same mint, the same email\nbranch, the same rules. There is no second creation path here and no\n\"consent given\" flag threaded through the service to be got wrong.\n\n``email_verified=True`` is a fact this server established, not a claim the\ncaller made: the sign-in that parked this session got past\n``create_or_get_account``'s verified-email gate before it ever reached the\ntombstone (ADR-0075, and ``test_returning_player_gate`` pins the ordering),\nand the parked address rode here inside a cookie signed with ``SECRET_KEY``.",
+        "operationId": "confirm_returning_player_auth_returning_player_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartFreshOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Confirm Returning Player",
         "tags": [
           "auth"
         ]

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional
 
 # `MismatchingStateError` is not re-exported by `starlette_client`, which
@@ -14,9 +15,21 @@ from db import get_db
 from errors import ErrorCode, coded_error, detail_code, raise_coded
 from game_config import CURRENT_ERA
 from models.account import Account, AuthProvider
-from schemas.auth import CurrentUser, DevLoginOut, LogoutOut
+from schemas.auth import (
+    CurrentUser,
+    DevLoginOut,
+    LogoutOut,
+    ReturningPlayerOut,
+    StartFreshOut,
+)
 from schemas.character import CharacterCreate
-from services.auth import create_jwt, create_or_get_account, get_current_account
+from services.account_deletion import resolve_account_tombstone
+from services.auth import (
+    ReturningPlayerConsentRequired,
+    create_jwt,
+    create_or_get_account,
+    get_current_account,
+)
 from services.character import create_character, resolve_active_character
 from services.current_user import build_current_user
 from services.era import get_current_era_row, get_or_create_stats
@@ -66,18 +79,19 @@ _OAUTH.register(
 _COOKIE_MAX_AGE = 7 * 24 * 60 * 60  # 7 days in seconds
 
 
-def _signed_in_redirect(account_id: int) -> Response:
-    """Turn a resolved Account into a session: JWT cookie, then home.
+def _set_session_cookie(response: Response, account_id: int) -> None:
+    """Put the JWT on `response`. The one place the session cookie's flags live.
 
     Extracted when the second provider arrived (#1772) so the cookie flags are
-    stated once. Every kwarg below is a security decision with a reason recorded
-    against it, and a third provider handler that copies the block is a third
-    place for one of them to be quietly dropped — the failure mode being a
-    session cookie that ships without `Secure`, which nothing in the test suite
-    would notice. Not shared with `dev_login`: that seam deliberately sets
-    different flags and returns a body rather than a redirect.
+    stated once, and split from the redirect in #2162 when a second *shape* of
+    successful sign-in appeared — the returning player's confirm answers with a
+    JSON body, not a 302, and must not become a second copy of this block. Every
+    kwarg below is a security decision with a reason recorded against it, and
+    any handler that copies them is another place for one to be quietly dropped
+    — the failure mode being a session cookie that ships without `Secure`, which
+    nothing in the test suite would notice. Not shared with `dev_login`: that
+    seam deliberately sets different flags.
     """
-    response = Response(status_code=302, headers={"location": settings.FRONTEND_URL})
     response.set_cookie(
         key="access_token",
         value=create_jwt(account_id),
@@ -90,6 +104,12 @@ def _signed_in_redirect(account_id: int) -> Response:
         # no value, and "" is not None — Starlette would emit a bare `Domain=`.
         domain=settings.COOKIE_DOMAIN or None,
     )
+
+
+def _signed_in_redirect(account_id: int) -> Response:
+    """Turn a resolved Account into a session: JWT cookie, then home."""
+    response = Response(status_code=302, headers={"location": settings.FRONTEND_URL})
+    _set_session_cookie(response, account_id)
     return response
 
 
@@ -176,6 +196,69 @@ def _sign_in_failed_redirect(exc: Exception) -> Response:
     )
 
 
+#: The frontend route that renders the consent gate (#2162) — a path over
+#: there, not a route in here. Under `/start` because it *is* the onboarding
+#: arc, entered by someone who has walked it before: confirming leads straight
+#: into the rest of it.
+_RETURNING_PLAYER_PATH = "/start/again"
+
+#: Where an interrupted sign-in waits for its answer, in `request.session`.
+#:
+#: THE STARLETTE SESSION, and not a cookie of our own. It already exists (Authlib
+#: needs it for the OAuth `state`), it is already signed with `SECRET_KEY`, it
+#: already carries the flags `main.py` argues for one by one, and its
+#: server-enforced `max_age=600` is exactly the window a consent gate wants —
+#: ten minutes, then the question lapses and the player starts again. A
+#: purpose-built token would have been a second set of cookie flags to get
+#: right and a second expiry to keep honest.
+#:
+#: `main.py` used to justify that ten minutes with "nothing in `backend/` reads
+#: `request.session` except authlib". This is the second reader, and it wants
+#: the same number for its own reasons — see the note there.
+_PENDING_SIGNUP_KEY = "pending_returning_signup"
+
+
+def _returning_player_redirect(
+    request: Request, pending: ReturningPlayerConsentRequired
+) -> Response:
+    """Park the interrupted sign-in and send the browser to the gate (#2162).
+
+    **No session cookie.** That is the whole shape of this: the player is asked
+    before they are signed in, because the question is whether they want to be.
+    The identity rides in the signed session rather than the URL — a deletion
+    date and a provider id in a query string would be written to browser
+    history, and to any referrer the gate page happens to emit.
+    """
+    request.session[_PENDING_SIGNUP_KEY] = {
+        "provider": str(pending.provider),
+        "provider_user_id": pending.provider_user_id,
+        "email": pending.email,
+        "deleted_on": pending.deleted_on.isoformat(),
+    }
+    return Response(
+        status_code=302,
+        headers={"location": f"{settings.FRONTEND_URL}{_RETURNING_PLAYER_PATH}"},
+    )
+
+
+def _pending_signup(request: Request) -> dict:
+    """The interrupted sign-in this request is answering for, or a 404.
+
+    Both gate routes start here, and both refuse the same way: a gate with
+    nothing behind it is not a failed sign-in, it is *no* sign-in — reached by
+    typing the URL, or by coming back to the tab after the ten minutes lapsed.
+    The frontend's move either way is to send them to `/start` to begin one.
+    """
+    pending = request.session.get(_PENDING_SIGNUP_KEY)
+    if not isinstance(pending, dict):
+        raise_coded(
+            404,
+            ErrorCode.returning_player_consent_expired,
+            "That sign-in is no longer waiting on an answer.",
+        )
+    return pending
+
+
 # The two OAuth legs answer with a redirect, not JSON, so they carry
 # `response_class=RedirectResponse` and a 302 instead of a `response_model`
 # (#1400). A model here would be a lie the generated client believes: without
@@ -227,6 +310,10 @@ async def auth_google_callback(
             email_verified=user_info.get("email_verified") is True,
             session=session,
         )
+    except ReturningPlayerConsentRequired as pending:
+        # NOT a failure, so not the arm below: the sign-in is paused for one
+        # question rather than refused (#2162).
+        return _returning_player_redirect(request, pending)
     except (HTTPException, OAuthError) as exc:
         return _sign_in_failed_redirect(exc)
 
@@ -315,10 +402,77 @@ async def auth_discord_callback(
             email_verified=user_info.get("verified") is True,
             session=session,
         )
+    except ReturningPlayerConsentRequired as pending:
+        # NOT a failure, so not the arm below: the sign-in is paused for one
+        # question rather than refused (#2162).
+        return _returning_player_redirect(request, pending)
     except (HTTPException, OAuthError) as exc:
         return _sign_in_failed_redirect(exc)
 
     return _signed_in_redirect(account.id)
+
+
+@router.get("/returning-player", response_model=ReturningPlayerOut)
+async def returning_player_gate(request: Request) -> ReturningPlayerOut:
+    """What the consent gate says (#2162): a date, and nothing else.
+
+    Read from the parked sign-in rather than the tombstone, so this route makes
+    no lookup keyed on anything the caller supplied — there is nothing to
+    supply. The identity is in the signed session or the gate does not exist.
+    """
+    return ReturningPlayerOut(
+        deleted_on=date.fromisoformat(_pending_signup(request)["deleted_on"])
+    )
+
+
+@router.post("/returning-player", response_model=StartFreshOut)
+async def confirm_returning_player(
+    request: Request,
+    response: Response,
+    session: AsyncSession = Depends(get_db),
+) -> StartFreshOut:
+    """The one button: yes, start fresh (#2162).
+
+    Explicitly **not** an offer of any old data, and there is none to offer —
+    ``delete_account`` blanked it and there is no undo (ADR-0081). All this does
+    is finish the sign-in the gate interrupted, as a stranger.
+
+    The tombstone goes FIRST, and that ordering is what does the work: with it
+    cleared, ``create_or_get_account`` finds no reason to pause and falls
+    through to the ordinary stranger path — the same mint, the same email
+    branch, the same rules. There is no second creation path here and no
+    "consent given" flag threaded through the service to be got wrong.
+
+    ``email_verified=True`` is a fact this server established, not a claim the
+    caller made: the sign-in that parked this session got past
+    ``create_or_get_account``'s verified-email gate before it ever reached the
+    tombstone (ADR-0075, and ``test_returning_player_gate`` pins the ordering),
+    and the parked address rode here inside a cookie signed with ``SECRET_KEY``.
+    """
+    pending = _pending_signup(request)
+    provider = AuthProvider(pending["provider"])
+    provider_user_id = pending["provider_user_id"]
+
+    # Consent given, so the digest has done the only job it was kept for. Not
+    # left to expire on its own: it is a thing we store about a person, and the
+    # ninety days are a ceiling, not a target.
+    tombstone = await resolve_account_tombstone(provider, provider_user_id, session)
+    if tombstone is not None:
+        await session.delete(tombstone)
+        await session.flush()
+
+    account = await create_or_get_account(
+        provider=provider,
+        provider_user_id=provider_user_id,
+        email=pending["email"],
+        email_verified=True,
+        session=session,
+    )
+
+    # The question has been answered; a second POST is an ordinary 404.
+    del request.session[_PENDING_SIGNUP_KEY]
+    _set_session_cookie(response, account.id)
+    return StartFreshOut(message="Welcome back. This is a new account.")
 
 
 @router.get("/me", response_model=CurrentUser)

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional
 
 from schemas.base import WireModel
@@ -63,6 +64,37 @@ class LogoutOut(WireModel):
     The work of logging out is the ``Set-Cookie`` header that clears the JWT,
     not the body; this exists so the body is a declared shape in the schema
     rather than an untyped object the generated client cannot check.
+    """
+
+    message: str
+
+
+class ReturningPlayerOut(WireModel):
+    """What the consent gate is allowed to know (``GET /auth/returning-player``).
+
+    One field, and the reason there is only one is the reason this model exists
+    at all. The caller has authenticated as *nobody* — they hold a signed,
+    ten-minute session cookie stamped by an OAuth handshake they just completed,
+    and nothing else. Anything added here is a fact about an account that no
+    longer exists, disclosed on that basis.
+
+    A **date, not a timestamp**: the gate's sentence is *"you deleted your World
+    Zero account on 3 March"*, and the hour and minute would be a finer signal
+    bought for nothing the sentence needs. The tombstone's ``created_at`` is
+    truncated in ``services.auth.ReturningPlayerConsentRequired``, so the
+    precision is dropped before it ever reaches a response model.
+    """
+
+    deleted_on: date
+
+
+class StartFreshOut(WireModel):
+    """Acknowledgement for ``POST /auth/returning-player``.
+
+    Same posture as :class:`LogoutOut`: the work is the ``Set-Cookie`` header,
+    and the body exists so the generated client has a declared shape rather than
+    an untyped object. The caller learns who it now is from ``/auth/me``, which
+    is the one place that answers that question.
     """
 
     message: str

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Optional
 
 from authlib.jose import JoseError, JsonWebToken
@@ -23,6 +23,40 @@ _TOKEN_EXPIRE_DAYS = 7
 _JWT = JsonWebToken([_ALGORITHM])
 
 _BEARER = HTTPBearer(auto_error=False)
+
+
+class ReturningPlayerConsentRequired(Exception):
+    """A departed player signed in again inside the retention window (#2162).
+
+    **Not an** :class:`HTTPException`, on purpose. Every other way
+    :func:`create_or_get_account` stops is a refusal — the provider's claim was
+    no good, the account is suspended — and ``routers.auth`` answers all of them
+    the same way, with a code in ``?login=``. This is not a refusal. The sign-in
+    is *paused* for one question, the player can answer it, and the answer leads
+    somewhere. A distinct type keeps that difference in the type system rather
+    than in a code the failure handler has to remember to special-case, and it
+    means the ``except (HTTPException, OAuthError)`` arm in each callback cannot
+    swallow it by accident.
+
+    Carries everything the confirm step needs to finish the sign-in it
+    interrupted — the identity, and the date its sentence is built from — so the
+    callback does not have to re-read a row it has already read.
+
+    ``deleted_on`` is a **date, not a timestamp**, and that is the whole of what
+    leaves the server. The gate's copy says *"you deleted your account on 3
+    March"*; the hour and minute would be a more precise signal about an account
+    that no longer exists, disclosed to somebody who has authenticated as
+    nobody, in exchange for nothing the sentence needs.
+    """
+
+    def __init__(
+        self, provider: str, provider_user_id: str, email: str, deleted_on: date
+    ) -> None:
+        super().__init__(provider, deleted_on)
+        self.provider = provider
+        self.provider_user_id = provider_user_id
+        self.email = email
+        self.deleted_on = deleted_on
 
 
 def create_jwt(account_id: int) -> str:
@@ -110,7 +144,35 @@ async def create_or_get_account(
         result = await session.execute(
             select(Account).where(Account.id == oauth_row.account_id)
         )
-        return result.scalar_one()
+        account = result.scalar_one()
+        # Status IS consulted, unlike email (#2162). Until this check landed the
+        # branch returned the row unread, so a moderated player got the full
+        # success path — a JWT cookie, a redirect home — and then a 401 from
+        # `get_current_account` (which accepts only `active`) on every request
+        # after it. Signed in and broken, with nothing anywhere saying why.
+        #
+        # Two statuses, two answers, deliberately not one bucket. They differ in
+        # who did it and whether anything can be done about it, and the gate is
+        # the only place a player is ever told either thing.
+        if account.status is AccountStatus.suspended:
+            raise_coded(
+                403,
+                ErrorCode.account_suspended,
+                "That account is suspended.",
+            )
+        if account.status is AccountStatus.deleted:
+            # Unreachable by construction: `delete_account` destroys this very
+            # `OAuthProvider` row in the transaction that sets the status
+            # (ADR-0081), which is what routes a returning player to the gate
+            # below instead of here. Kept because the pairing existing at all
+            # would be a data defect, and the one outcome that must not follow
+            # from a data defect is a working session on a tombstone.
+            raise_coded(
+                403,
+                ErrorCode.account_deleted,
+                "That account was deleted.",
+            )
+        return account
 
     # Everything past here keys off the email claim, so the claim has to be one
     # the provider vouches for. An unseen OAuth identity is attached to any
@@ -127,17 +189,15 @@ async def create_or_get_account(
     # An identity we do not currently know is also the only moment a *deleted*
     # account's retained digest is ever looked at, so this is where the 90-day
     # retention is enforced (ADR-0081, #2160): purge-on-access, because there is
-    # no job runner. The returning tombstone is what #2162's gate will read to
-    # offer "start fresh as a new player"; the call is here today for the purge,
-    # and deliberately changes nothing about what this function returns — a
-    # returning player lands in a NEW account, which is the whole reason the
-    # deleted one released its email and dropped its OAuth rows.
+    # no job runner. A row past its date is deleted by the call itself and
+    # returns None, which is why "expired tombstone" and "never had one" need no
+    # branch here — both are an ordinary new signup.
     #
     # Imported inside the function: ``services.account_deletion`` imports
     # ``services.character``, which imports this module.
     from services.account_deletion import resolve_account_tombstone
 
-    await resolve_account_tombstone(provider, provider_user_id, session)
+    tombstone = await resolve_account_tombstone(provider, provider_user_id, session)
 
     # `is not True` rather than a falsy test: Google has emitted this claim as
     # the *string* "true", and every other non-bool is equally a provider whose
@@ -147,6 +207,29 @@ async def create_or_get_account(
             403,
             ErrorCode.oauth_email_unverified,
             "Your account's email address is not verified.",
+        )
+
+    # A live tombstone means this identity used to be somebody here and ended
+    # it. Minting silently would be the wrong answer twice over: the player is
+    # not told that the account they are signing into is not the one they had,
+    # and nobody asked them whether they wanted a new one (#2162, owner ruling
+    # 2026-08-17). So the sign-in pauses for one question.
+    #
+    # The tombstone is deliberately NOT consumed here. Consent has not been
+    # given yet, and a player who closes the tab must still be recognised the
+    # next time they come back — it is the confirm step
+    # (``routers.auth.confirm_returning_player``) that clears it, which is also
+    # what makes that step's own call to this function fall through to the
+    # ordinary mint below.
+    #
+    # AFTER the verified-email gate above, so a token is never minted for a
+    # sign-in that would be refused at the confirm step anyway.
+    if tombstone is not None:
+        raise ReturningPlayerConsentRequired(
+            provider=provider,
+            provider_user_id=provider_user_id,
+            email=email,
+            deleted_on=tombstone.created_at.date(),
         )
 
     # No existing OAuth link — find or create the Account by email

--- a/backend/tests/integration/test_returning_player_gate.py
+++ b/backend/tests/integration/test_returning_player_gate.py
@@ -1,0 +1,346 @@
+"""A returning deleted player consents to starting fresh (#2162, ADR-0081).
+
+**Seam under test:** ``services.auth.create_or_get_account`` — the one function
+that turns an OAuth identity into an Account — plus the HTTP round trip the
+consent needs, because consent is a second request and a second request is only
+observable through the app.
+
+Two behaviours meet here and they are deliberately *different branches* of that
+function, not one rule with two spellings:
+
+* **A known identity** (a live ``OAuthProvider`` row) whose Account is not
+  ``active``. Before this issue that branch returned the Account without ever
+  reading ``status``: a suspended player was handed a valid JWT cookie and then
+  401'd by ``get_current_account`` on every call afterwards — signed in and
+  broken, with nothing saying why.
+* **An unknown identity** that a tombstone recognises. #2160 already resolves
+  the tombstone here for its purge side effect; what was missing is reading the
+  return value. A hit must not silently mint an account — the player is owed the
+  sentence "nothing carries over" and a button, per the owner ruling of
+  2026-08-17.
+
+The gate carries **no offer of old data**, so nothing in here asserts that any
+of it comes back. There is nothing to come back: ``delete_account`` blanked it.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config import settings
+from errors import ErrorCode, detail_code
+from models.account import (
+    Account,
+    AccountStatus,
+    AccountTombstone,
+    AuthProvider,
+    OAuthProvider,
+)
+from services.account_deletion import (
+    TOMBSTONE_RETENTION_DAYS,
+    delete_account,
+    hash_provider_user_id,
+)
+from services.auth import ReturningPlayerConsentRequired, create_or_get_account
+
+_GOOGLE = AuthProvider.GOOGLE
+
+#: The identity the departed player comes back with. One constant so the
+#: digest, the stub profile and the confirm step cannot drift apart.
+_SUB = "google-sub-came-back"
+_RETURNING_EMAIL = "came-back@example.com"
+
+
+class _StubGoogleClient:
+    """Stands in for ``_OAUTH.google``; the callback calls only this.
+
+    Same shape as ``tests/integration/test_account_linking.py``'s stub — the
+    handler reads ``token["userinfo"]`` when present and never reaches
+    ``userinfo()``.
+    """
+
+    def __init__(self, userinfo: dict) -> None:
+        self._userinfo = userinfo
+
+    async def authorize_access_token(self, request) -> dict:
+        return {"userinfo": self._userinfo}
+
+
+async def _account_count(session: AsyncSession) -> int:
+    return (await session.execute(select(func.count()).select_from(Account))).scalar_one()
+
+
+async def _tombstone(session: AsyncSession) -> AccountTombstone | None:
+    return (
+        await session.execute(
+            select(AccountTombstone).where(
+                AccountTombstone.provider == _GOOGLE,
+                AccountTombstone.provider_user_hash
+                == hash_provider_user_id(_GOOGLE, _SUB),
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def _departed_account(session: AsyncSession, era) -> Account:
+    """An account that signed in with ``_SUB``, then deleted itself.
+
+    Driven through the real ``delete_account`` rather than by writing an
+    ``AccountTombstone`` by hand: the digest, the destroyed OAuth row and the
+    released email are all things that function decides, and a hand-built row
+    would let this file keep passing after that function changed its mind.
+    """
+    account = Account(email="before-the-end@example.com")
+    session.add(account)
+    await session.flush()
+    session.add(
+        OAuthProvider(account_id=account.id, provider=_GOOGLE, provider_user_id=_SUB)
+    )
+    await session.flush()
+    await delete_account(account.id, session, era)
+    await session.flush()
+    return account
+
+
+def _stub_google(monkeypatch: pytest.MonkeyPatch, **overrides) -> None:
+    from routers import auth as auth_router
+
+    profile = {"sub": _SUB, "email": _RETURNING_EMAIL, "email_verified": True}
+    profile.update(overrides)
+    monkeypatch.setattr(auth_router._OAUTH, "google", _StubGoogleClient(profile))
+
+
+# ---------------------------------------------------------------------------
+# The gate — an unknown identity a tombstone recognises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_live_tombstone_stops_the_sign_in_before_anything_is_minted(
+    db_session: AsyncSession, era
+) -> None:
+    """The defect: today this branch mints an account and says nothing."""
+    await _departed_account(db_session, era)
+    accounts_before = await _account_count(db_session)
+
+    with pytest.raises(ReturningPlayerConsentRequired) as excinfo:
+        await create_or_get_account(
+            provider=_GOOGLE,
+            provider_user_id=_SUB,
+            email=_RETURNING_EMAIL,
+            email_verified=True,
+            session=db_session,
+        )
+
+    # The three things the gate needs to finish the job it interrupted, and the
+    # date its sentence is built from.
+    assert excinfo.value.provider == _GOOGLE
+    assert excinfo.value.provider_user_id == _SUB
+    assert excinfo.value.email == _RETURNING_EMAIL
+    assert excinfo.value.deleted_on == datetime.now(timezone.utc).date()
+
+    assert await _account_count(db_session) == accounts_before
+    # Refused, not consumed: the player has not consented yet, so the tombstone
+    # must still recognise them when they come back through the confirm step.
+    assert await _tombstone(db_session) is not None
+
+
+@pytest.mark.asyncio
+async def test_an_expired_tombstone_is_an_ordinary_new_signup(
+    db_session: AsyncSession, era
+) -> None:
+    """Past ninety days there is nobody to recognise — and the row goes."""
+    await _departed_account(db_session, era)
+    tombstone = await _tombstone(db_session)
+    assert tombstone is not None
+    tombstone.created_at = datetime.now(timezone.utc) - timedelta(
+        days=TOMBSTONE_RETENTION_DAYS + 1
+    )
+    await db_session.flush()
+
+    account = await create_or_get_account(
+        provider=_GOOGLE,
+        provider_user_id=_SUB,
+        email=_RETURNING_EMAIL,
+        email_verified=True,
+        session=db_session,
+    )
+
+    assert account.status is AccountStatus.active
+    assert await _tombstone(db_session) is None
+
+
+@pytest.mark.asyncio
+async def test_an_unverified_email_is_still_refused_before_the_gate(
+    db_session: AsyncSession, era
+) -> None:
+    """Consent cannot rescue a claim the provider does not vouch for.
+
+    Ordering, stated as a test because it is invisible in the code: the
+    verified-email gate (ADR-0075) runs FIRST, so a token is never minted for a
+    sign-in that would be refused at the confirm step anyway.
+    """
+    await _departed_account(db_session, era)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_or_get_account(
+            provider=_GOOGLE,
+            provider_user_id=_SUB,
+            email=_RETURNING_EMAIL,
+            email_verified=False,
+            session=db_session,
+        )
+    assert detail_code(excinfo.value.detail) == ErrorCode.oauth_email_unverified.value
+
+
+# ---------------------------------------------------------------------------
+# The adjacent bug — a known identity whose Account is not active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_suspended_account_is_refused_instead_of_signed_in(
+    db_session: AsyncSession, account: Account
+) -> None:
+    """Was: a JWT cookie, then a 401 from every call after it."""
+    account.status = AccountStatus.suspended
+    db_session.add(
+        OAuthProvider(
+            account_id=account.id, provider=_GOOGLE, provider_user_id="google-suspended"
+        )
+    )
+    await db_session.flush()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_or_get_account(
+            provider=_GOOGLE,
+            provider_user_id="google-suspended",
+            email=account.email,
+            email_verified=True,
+            session=db_session,
+        )
+    assert excinfo.value.status_code == 403
+    assert detail_code(excinfo.value.detail) == ErrorCode.account_suspended.value
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_account_is_refused_in_its_own_words(
+    db_session: AsyncSession, account: Account
+) -> None:
+    """Unreachable by construction, and deliberately not the suspended message.
+
+    ``delete_account`` destroys the OAuth rows in the same transaction that sets
+    the status, so this pairing should not exist. If it ever does it is a data
+    defect, and the one outcome that must not follow from it is a session.
+    """
+    account.status = AccountStatus.deleted
+    db_session.add(
+        OAuthProvider(
+            account_id=account.id, provider=_GOOGLE, provider_user_id="google-deleted"
+        )
+    )
+    await db_session.flush()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_or_get_account(
+            provider=_GOOGLE,
+            provider_user_id="google-deleted",
+            email=account.email,
+            email_verified=True,
+            session=db_session,
+        )
+    assert excinfo.value.status_code == 403
+    assert detail_code(excinfo.value.detail) == ErrorCode.account_deleted.value
+
+
+# ---------------------------------------------------------------------------
+# The round trip — callback, gate, confirm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_callback_sends_a_returning_player_to_the_gate_with_no_session(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, era
+) -> None:
+    await _departed_account(db_session, era)
+    await db_session.commit()
+    accounts_before = await _account_count(db_session)
+    _stub_google(monkeypatch)
+
+    resp = await client.get("/auth/google/callback")
+
+    assert resp.status_code == 302
+    assert urlparse(resp.headers["location"]).path == "/start/again"
+    # The whole point: no session until they say yes.
+    assert resp.cookies.get("access_token") is None
+    assert await _account_count(db_session) == accounts_before
+
+
+@pytest.mark.asyncio
+async def test_the_gate_reads_its_date_and_the_confirm_lands_in_a_fresh_account(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch, era
+) -> None:
+    """One button, and what is behind it: a brand-new account, tombstone gone."""
+    departed = await _departed_account(db_session, era)
+    await db_session.commit()
+    accounts_before = await _account_count(db_session)
+    _stub_google(monkeypatch)
+
+    await client.get("/auth/google/callback")
+
+    gate = await client.get("/auth/returning-player")
+    assert gate.status_code == 200
+    assert gate.json()["deleted_on"] == date.today().isoformat()
+
+    confirm = await client.post("/auth/returning-player")
+    assert confirm.status_code == 200
+    assert client.cookies.get("access_token")
+
+    assert await _account_count(db_session) == accounts_before + 1
+    # Fresh, not the corpse.
+    fresh = (
+        await db_session.execute(select(Account).where(Account.email == _RETURNING_EMAIL))
+    ).scalar_one()
+    assert fresh.id != departed.id
+    assert fresh.status is AccountStatus.active
+    # Cleared, so the gate cannot be shown a second time for this identity.
+    assert await _tombstone(db_session) is None
+
+
+@pytest.mark.asyncio
+async def test_the_gate_is_nothing_without_a_sign_in_behind_it(
+    client: AsyncClient,
+) -> None:
+    """Walked into by URL, or come back to after the ten-minute window lapsed."""
+    for response in (
+        await client.get("/auth/returning-player"),
+        await client.post("/auth/returning-player"),
+    ):
+        assert response.status_code == 404
+        assert (
+            detail_code(response.json()["detail"])
+            == ErrorCode.returning_player_consent_expired.value
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_new_signup_sees_none_of_this(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regression guard: a stranger still lands in a session, at home."""
+    accounts_before = await _account_count(db_session)
+    _stub_google(monkeypatch, sub="google-sub-stranger", email="stranger@example.com")
+
+    resp = await client.get("/auth/google/callback")
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == settings.FRONTEND_URL
+    assert resp.cookies.get("access_token")
+    assert await _account_count(db_session) == accounts_before + 1

--- a/backend/tests/integration/test_returning_player_gate.py
+++ b/backend/tests/integration/test_returning_player_gate.py
@@ -74,7 +74,8 @@ class _StubGoogleClient:
 
 
 async def _account_count(session: AsyncSession) -> int:
-    return (await session.execute(select(func.count()).select_from(Account))).scalar_one()
+    result = await session.execute(select(func.count()).select_from(Account))
+    return result.scalar_one()
 
 
 async def _tombstone(session: AsyncSession) -> AccountTombstone | None:
@@ -306,7 +307,9 @@ async def test_the_gate_reads_its_date_and_the_confirm_lands_in_a_fresh_account(
     assert await _account_count(db_session) == accounts_before + 1
     # Fresh, not the corpse.
     fresh = (
-        await db_session.execute(select(Account).where(Account.email == _RETURNING_EMAIL))
+        await db_session.execute(
+            select(Account).where(Account.email == _RETURNING_EMAIL)
+        )
     ).scalar_one()
     assert fresh.id != departed.id
     assert fresh.status is AccountStatus.active

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ const Disclaimer = lazy(() => import('./pages/Disclaimer'))
 const Attributions = lazy(() => import('./pages/Attributions'))
 const Donate = lazy(() => import('./pages/Donate'))
 const Onboarding = lazy(() => import('./pages/Onboarding'))
+const ReturningCard = lazy(() => import('./pages/onboarding/ReturningCard'))
 
 /** The one loading surface: route chunk in flight, or the session still resolving. */
 function PageLoading() {
@@ -123,6 +124,11 @@ export default function App() {
               `ProtectedRoute`: the arc explains the game BEFORE it asks for an
               account, which is the whole point of it (#1861). */}
           <Route path="/start" element={<Onboarding />} />
+          {/* Where `backend/routers/auth.py` sends a returning deleted player
+              (#2162). No `ProtectedRoute` and no session yet — being asked
+              BEFORE an account exists is the entire point of the gate. Under
+              `/start` because confirming continues into that arc. */}
+          <Route path="/start/again" element={<ReturningCard />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/tasks/:id" element={<TaskDetail />} />
           <Route path="/praxis" element={<Praxes />} />

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -86,6 +86,38 @@ export function loginWith(provider: AuthProvider): void {
   window.location.href = `${import.meta.env.VITE_API_URL ?? 'http://localhost:8000'}/auth/${provider}`
 }
 
+/**
+ * The one thing the returning-player consent gate is told (#2162): the date the
+ * account was deleted. A date, not a timestamp — the backend truncates it.
+ */
+export type ReturningPlayerOut = components['schemas']['ReturningPlayerOut']
+
+/**
+ * The interrupted sign-in waiting on an answer, or a rejection if there is none.
+ *
+ * NO ARGUMENTS, and there is nothing the caller could pass: the identity lives
+ * in the signed session cookie the OAuth callback parked it in, never in a URL.
+ * A 404 means the gate has nothing behind it — walked into by typing the
+ * address, or come back to after the ten-minute window lapsed — and the caller's
+ * move either way is to send the visitor to `/start` to begin a sign-in.
+ */
+export async function getReturningPlayer(): Promise<ReturningPlayerOut> {
+  const { data } = await apiGet('/auth/returning-player')
+  return data
+}
+
+/**
+ * Consent to start fresh. Sets the session cookie and clears the tombstone.
+ *
+ * Explicitly NOT a restore, and there is nothing to restore: deletion blanked
+ * the characters, praxis, votes and comments (ADR-0081). What comes back is a
+ * brand-new account on the same provider identity, so the caller must refetch
+ * `/auth/me` afterwards — this returns an acknowledgement, not a session.
+ */
+export async function startFresh(): Promise<void> {
+  await apiPost('/auth/returning-player')
+}
+
 /** Dev-only: log in as a test account without Google OAuth */
 export async function devLogin(): Promise<void> {
   await apiPost('/auth/dev-login')

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -620,6 +620,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/returning-player": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Returning Player Gate
+         * @description What the consent gate says (#2162): a date, and nothing else.
+         *
+         *     Read from the parked sign-in rather than the tombstone, so this route makes
+         *     no lookup keyed on anything the caller supplied — there is nothing to
+         *     supply. The identity is in the signed session or the gate does not exist.
+         */
+        get: operations["returning_player_gate_auth_returning_player_get"];
+        put?: never;
+        /**
+         * Confirm Returning Player
+         * @description The one button: yes, start fresh (#2162).
+         *
+         *     Explicitly **not** an offer of any old data, and there is none to offer —
+         *     ``delete_account`` blanked it and there is no undo (ADR-0081). All this does
+         *     is finish the sign-in the gate interrupted, as a stranger.
+         *
+         *     The tombstone goes FIRST, and that ordering is what does the work: with it
+         *     cleared, ``create_or_get_account`` finds no reason to pause and falls
+         *     through to the ordinary stranger path — the same mint, the same email
+         *     branch, the same rules. There is no second creation path here and no
+         *     "consent given" flag threaded through the service to be got wrong.
+         *
+         *     ``email_verified=True`` is a fact this server established, not a claim the
+         *     caller made: the sign-in that parked this session got past
+         *     ``create_or_get_account``'s verified-email gate before it ever reached the
+         *     tombstone (ADR-0075, and ``test_returning_player_gate`` pins the ordering),
+         *     and the parked address rode here inside a cookie signed with ``SECRET_KEY``.
+         */
+        post: operations["confirm_returning_player_auth_returning_player_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/characters": {
         parameters: {
             query?: never;
@@ -4204,6 +4248,29 @@ export interface components {
          */
         RelationshipTypeEnum: "friend" | "foe";
         /**
+         * ReturningPlayerOut
+         * @description What the consent gate is allowed to know (``GET /auth/returning-player``).
+         *
+         *     One field, and the reason there is only one is the reason this model exists
+         *     at all. The caller has authenticated as *nobody* — they hold a signed,
+         *     ten-minute session cookie stamped by an OAuth handshake they just completed,
+         *     and nothing else. Anything added here is a fact about an account that no
+         *     longer exists, disclosed on that basis.
+         *
+         *     A **date, not a timestamp**: the gate's sentence is *"you deleted your World
+         *     Zero account on 3 March"*, and the hour and minute would be a finer signal
+         *     bought for nothing the sentence needs. The tombstone's ``created_at`` is
+         *     truncated in ``services.auth.ReturningPlayerConsentRequired``, so the
+         *     precision is dropped before it ever reaches a response model.
+         */
+        ReturningPlayerOut: {
+            /**
+             * Deleted On
+             * Format: date
+             */
+            deleted_on: string;
+        };
+        /**
          * SidebarOut
          * @description Everything the rail's three data panels draw, in one response.
          *
@@ -4232,6 +4299,19 @@ export interface components {
             global_activity_count: number;
             /** Pending Requests Count */
             pending_requests_count: number;
+        };
+        /**
+         * StartFreshOut
+         * @description Acknowledgement for ``POST /auth/returning-player``.
+         *
+         *     Same posture as :class:`LogoutOut`: the work is the ``Set-Cookie`` header,
+         *     and the body exists so the generated client has a declared shape rather than
+         *     an untyped object. The caller learns who it now is from ``/auth/me``, which
+         *     is the one place that answers that question.
+         */
+        StartFreshOut: {
+            /** Message */
+            message: string;
         };
         /** SuspendAction */
         SuspendAction: {
@@ -5641,6 +5721,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    returning_player_gate_auth_returning_player_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReturningPlayerOut"];
+                };
+            };
+        };
+    };
+    confirm_returning_player_auth_returning_player_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StartFreshOut"];
                 };
             };
         };

--- a/frontend/src/auth/__tests__/authRefetchLedger.test.ts
+++ b/frontend/src/auth/__tests__/authRefetchLedger.test.ts
@@ -66,6 +66,12 @@ const LEDGER: LedgerEntry[] = [
     why: 'POST /auth/dev-login sets the cookie and returns nothing — /auth/me is the only way to learn who that is.',
   },
   {
+    file: 'pages/onboarding/ReturningCard.tsx',
+    calls: 1,
+    verdict: 'identity-changed',
+    why: 'POST /auth/returning-player mints a brand-new account and sets the cookie; the body is an acknowledgement, so /auth/me is the only way to learn who that is (#2162).',
+  },
+  {
     file: 'pages/characterPaths/useCreateCharacter.ts',
     calls: 1,
     verdict: 'identity-changed',
@@ -144,10 +150,14 @@ describe('the useAuth().refetch() inventory matches the ledger', () => {
 
   it('totals the count this sweep reports', () => {
     // 16 before #1349, in 12 files; 14 in 10 after it; 8 in 5 once #1383 had
-    // the six `response-in-hand` sites consume the response instead.
+    // the six `response-in-hand` sites consume the response instead. 9 in 6
+    // since #2162 — a sign-in that mints an account and answers with an
+    // acknowledgement, which is the dev-login entry's situation exactly and
+    // NOT the response-in-hand class: no CurrentUser is being discarded here,
+    // because the server never built one.
     const total = [...measured.values()].reduce((sum, calls) => sum + calls, 0)
-    expect(total).toBe(8)
-    expect(measured.size).toBe(5)
+    expect(total).toBe(9)
+    expect(measured.size).toBe(6)
   })
 
   it('leaves only identity reloads', () => {

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -91,6 +91,9 @@
     "AVATAR_TOO_LARGE": "Avatar too large (max {{max_megabytes}} MB).",
     "OAUTH_EMAIL_UNVERIFIED": "We can't sign you in: that account has no verified email address. Verify your email where you signed in, then try again.",
     "OAUTH_FAILED": "That sign-in didn't go through. Pick a way in and try again.",
-    "OAUTH_STATE_EXPIRED": "That sign-in took too long, so we let it lapse. Pick a way in and you'll go straight through."
+    "OAUTH_STATE_EXPIRED": "That sign-in took too long, so we let it lapse. Pick a way in and you'll go straight through.",
+    "ACCOUNT_SUSPENDED": "That account is suspended, so we can't sign you in. Get in touch if you think that's wrong.",
+    "ACCOUNT_DELETED": "That account was deleted and can't be signed into.",
+    "RETURNING_PLAYER_CONSENT_EXPIRED": "There's no sign-in waiting on an answer. Pick a way in to start one."
   }
 }

--- a/frontend/src/locales/en/onboarding.json
+++ b/frontend/src/locales/en/onboarding.json
@@ -30,5 +30,12 @@
   },
   "mark": {
     "label": "PLACEHOLDER — START HERE"
+  },
+  "returning": {
+    "title": "Welcome back",
+    "body": "You deleted your World Zero account on {{date}}. Nothing from it carries over — your characters, praxis, votes and comments are gone. Start fresh as a new player?",
+    "note": "PLACEHOLDER — one line, set beside the tick",
+    "confirm": "Start fresh",
+    "error": "That didn't go through. Try again."
   }
 }

--- a/frontend/src/pages/__tests__/returningCard.test.tsx
+++ b/frontend/src/pages/__tests__/returningCard.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The returning-player consent gate (#2162, ADR-0081).
+ *
+ * WHAT THIS CAN TEST. The harness is `renderToStaticMarkup` — no DOM, no
+ * events, effects never run — so the card's two pieces of real logic are
+ * exported and exercised directly, exactly as `TermsCard.runTermsAccept` is.
+ * What is left in the component is a `useState` and a `<p>`.
+ *
+ * Two things here would each be a silent regression:
+ *
+ *   1. **The date is off by one.** An ISO date-only string parses as UTC
+ *      midnight, so every reader west of Greenwich would be told they deleted
+ *      their account the day before they did. The date is the one fact this
+ *      card states and it renders in the reader's timezone, so the guard has to
+ *      hold in whatever timezone the runner happens to be in.
+ *   2. **A failed confirm looks like a success.** `onDone` navigates into the
+ *      onboarding arc; running it when the POST threw would drop the player
+ *      into an arc with no session behind it.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+import '../../i18n'
+import onboarding from '../../locales/en/onboarding.json'
+
+vi.mock('../../api/auth', () => ({
+  getReturningPlayer: () => new Promise(() => {}),
+  startFresh: () => Promise.resolve(),
+}))
+
+import ReturningCard, { formatDeletedOn, runStartFresh } from '../onboarding/ReturningCard'
+
+describe('the deletion date the gate states', () => {
+  /**
+   * The day the sentence names is the day in the string, in every timezone.
+   *
+   * Asserted as "the day number survives" rather than against one expected
+   * string, because that is the actual invariant: a naive `new Date(iso)` gives
+   * the right answer in UTC and the wrong one in New York, and a test that only
+   * held on the CI runner would be a test of the runner.
+   */
+  it.each(['2026-03-03', '2026-01-01', '2025-12-31'])('%s keeps its day', (iso) => {
+    const [dayRendered] = formatDeletedOn(iso, 'en-GB').split(' ')
+    expect(Number(dayRendered)).toBe(Number(iso.split('-')[2]))
+  })
+
+  it('names the month and drops the year', () => {
+    // Ninety days is the whole window, so a year would be noise every time.
+    expect(formatDeletedOn('2026-03-03', 'en-GB')).toBe('3 March')
+  })
+})
+
+describe('consenting to start fresh', () => {
+  it('signs in, then learns who that is, then moves on — in that order', async () => {
+    const calls: string[] = []
+    const done = vi.fn(() => calls.push('done'))
+
+    await runStartFresh(
+      async () => { calls.push('consent') },
+      async () => { calls.push('refetch') },
+      done,
+      () => { throw new Error('should not fail') },
+    )()
+
+    // `refetch` before `onDone`: the cookie is set by the POST, but nothing in
+    // this tab knows whose it is until `/auth/me` answers — navigating first
+    // would land the arc on a session it still believes is absent.
+    expect(calls).toEqual(['consent', 'refetch', 'done'])
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  it('reports a failure instead of walking on', async () => {
+    const done = vi.fn()
+    const failed = vi.fn()
+
+    await runStartFresh(
+      () => Promise.reject(new Error('nope')),
+      async () => {},
+      done,
+      failed,
+    )()
+
+    expect(done).not.toHaveBeenCalled()
+    expect(failed).toHaveBeenCalledOnce()
+    // Falls back to the catalog's own line, never a bare stack or empty string.
+    expect(failed.mock.calls[0][0]).toBeTruthy()
+  })
+})
+
+describe('the card before the gate answers', () => {
+  it('shows nothing of the sentence until it has the date', () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ReturningCard />
+      </MemoryRouter>,
+    )
+
+    // No flash of a sentence with a hole in it — the interpolation is the whole
+    // point of the sentence.
+    expect(markup).not.toContain('data-testid="returning-body"')
+    expect(markup).not.toContain('data-testid="returning-start-fresh"')
+  })
+})
+
+describe('the copy the gate carries', () => {
+  it('interpolates the date rather than hardcoding one', () => {
+    expect(onboarding.returning.body).toContain('{{date}}')
+  })
+
+  it('offers a fresh start and never a restore', () => {
+    // The owner ruling of 2026-08-17: consent to starting fresh, explicitly not
+    // an offer of any old data. There is none — the tombstone blanked it.
+    expect(onboarding.returning.body.toLowerCase()).not.toMatch(/restore|recover|bring back/)
+  })
+})

--- a/frontend/src/pages/onboarding/ReturningCard.tsx
+++ b/frontend/src/pages/onboarding/ReturningCard.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState, type CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../auth/AuthContext'
+import { getReturningPlayer, startFresh } from '../../api/auth'
+import { extractError } from '../../utils/errors'
+import i18n from '../../i18n'
+import OnboardingCard, { primaryControl } from './OnboardingCard'
+
+/**
+ * `/start/again` — the consent gate a returning deleted player meets (#2162).
+ *
+ * NOT A LOCKED DOOR AND NOT A SILENT NEW ACCOUNT. They signed in with the same
+ * Google or Discord identity they deleted, inside the ninety days the tombstone
+ * is kept (ADR-0081), so the backend recognises them and stops *before* minting
+ * anything. This card is the stop.
+ *
+ * ONE BUTTON, AND IT IS NOT AN OFFER OF THE OLD ACCOUNT (owner ruling
+ * 2026-08-17). There is nothing to offer: `delete_account` blanked the
+ * characters, the praxis, the comments, and unlinked the media in place. So the
+ * sentence names what is gone and the control consents to starting over —
+ * naming a restore that cannot happen would be the one genuinely cruel version
+ * of this screen.
+ *
+ * THE ARC CONTINUES FROM HERE. Confirming lands in a fresh account with no
+ * character, and `/start` is what walks that account to one — the same stranger
+ * path everybody else takes, entered at the same door. Nothing about this card
+ * is a second onboarding flow, which is also why it wears `OnboardingCard`'s
+ * sheet rather than a look of its own.
+ *
+ * THE ESCAPE IS THE SHELL'S. Declining is "let me just look around", which
+ * `OnboardingCard` renders on every stop — a returning player who does not want
+ * a new account simply never presses the button, and no account is created.
+ * There is deliberately no "no thanks" control that *does* something: the only
+ * thing it could do is what closing the tab already does.
+ */
+
+const prose: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-content)',
+  lineHeight: 1.55,
+  color: 'var(--faction-default-card-text)',
+  margin: 0,
+}
+
+const failure: CSSProperties = {
+  ...prose,
+  marginTop: 'var(--space-md)',
+  // The app's error INK (index.css §"the danger / warning FILL family"), themed
+  // in both cascades and already measured against the na sheet — the same token
+  // `TermsCard` uses for the same job.
+  color: 'var(--color-danger)',
+}
+
+/**
+ * `2026-03-03` as *3 March*, in the reader's locale.
+ *
+ * Split on the hyphens rather than handed to `new Date(string)`: an ISO
+ * date-only string is parsed as UTC midnight, so `toLocaleDateString` west of
+ * Greenwich renders THE DAY BEFORE. The date is the one fact this card states,
+ * and stating it a day out is worse than not stating it.
+ *
+ * Day and month only, no year — the window is ninety days, so a year would be
+ * noise on every single rendering of this sentence.
+ */
+export function formatDeletedOn(deletedOn: string, locale?: string): string {
+  const [year, month, day] = deletedOn.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'long',
+  })
+}
+
+/**
+ * The confirm wiring, extracted so it is reachable from the DOM-less harness —
+ * the same move `TermsCard.runTermsAccept` makes, and for the same reason:
+ * `renderToStaticMarkup` runs no effects and dispatches no events, so a handler
+ * closed over inside the component can never be exercised.
+ */
+export function runStartFresh(
+  consent: () => Promise<unknown>,
+  refetch: () => Promise<unknown>,
+  onDone: () => void,
+  onFailure: (message: string) => void,
+): () => Promise<void> {
+  return async () => {
+    try {
+      await consent()
+      // The cookie is set, but nothing in this tab knows who it belongs to yet
+      // — `/auth/me` is the only thing that answers that.
+      await refetch()
+      onDone()
+    } catch (err) {
+      onFailure(extractError(err, i18n.t('onboarding:returning.error')))
+    }
+  }
+}
+
+export default function ReturningCard() {
+  const { t } = useTranslation('onboarding')
+  const { t: tCommon } = useTranslation('common')
+  const { refetch } = useAuth()
+  const navigate = useNavigate()
+  const [deletedOn, setDeletedOn] = useState<string | null>(null)
+  const [failed, setFailed] = useState<string | null>(null)
+
+  useEffect(() => {
+    // A gate with no interrupted sign-in behind it is not an error to report,
+    // it is a visitor in the wrong place — so they go to the front of the arc
+    // rather than reading about a 404. `replace` so Back does not bounce them
+    // straight back into a page that will do this again.
+    getReturningPlayer()
+      .then((gate) => setDeletedOn(gate.deleted_on))
+      .catch(() => navigate('/start', { replace: true }))
+  }, [navigate])
+
+  const confirm = runStartFresh(
+    startFresh,
+    refetch,
+    // No character yet, by definition — this account is seconds old. `/start`
+    // picks the arc up from there, exactly as it does for any other session
+    // without a life on it.
+    () => navigate('/start', { replace: true }),
+    setFailed,
+  )
+
+  if (deletedOn === null) {
+    return <div className="page font-body text-muted">{tCommon('loading')}</div>
+  }
+
+  return (
+    <OnboardingCard
+      step={1}
+      title={t('returning.title')}
+      note={t('returning.note')}
+      actions={
+        <button
+          type="button"
+          onClick={confirm}
+          style={primaryControl}
+          data-testid="returning-start-fresh"
+        >
+          {t('returning.confirm')}
+        </button>
+      }
+    >
+      <p style={prose} data-testid="returning-body">
+        {t('returning.body', { date: formatDeletedOn(deletedOn, i18n.language) })}
+      </p>
+
+      {failed && <p style={failure}>{failed}</p>}
+    </OnboardingCard>
+  )
+}


### PR DESCRIPTION
Closes #2162

A player who deleted their account and signs in again with the same Google or
Discord identity, inside the 90 days the tombstone is kept, now meets a consent
gate: the date they deleted it, what does not carry over, and one button. Not a
locked door and not a silent new account. Explicitly **not** an offer of any old
data (owner ruling 2026-08-17) — there is none, `delete_account` blanked it.

## The seam I tested at

`services.auth.create_or_get_account` — the one function that turns an OAuth
identity into an Account, and the place both of this PR's behaviours are
decisions. `backend/tests/integration/test_returning_player_gate.py` goes red on
the real defects first: today a live tombstone mints an account and says
nothing, and the returning-player branch never reads `status`. The HTTP round
trip is tested through the app as well, because consent is a *second* request
and a second request is not observable at the service.

## What #2160 had already built

Steps 2 and 4 of the issue were done: `resolve_account_tombstone` exists, hashes
with the same salt, purges on access, and is already called from the no-OAuth-row
branch. Its **return value was discarded** — the call was there for the purge.
This PR reads it. Verified on disk before writing anything; the wiring was
exactly where the brief said.

## Design decisions worth arguing with

**The interrupted sign-in is parked in the Starlette session, not a token of my
own.** It already exists (authlib needs it for the OAuth `state`), it is already
signed with `SECRET_KEY`, it already carries the cookie flags `main.py` argues
for one at a time, and its server-enforced `max_age=600` is exactly the window a
consent gate wants. A purpose-built token would have been a second set of flags
to get right and a second expiry to keep honest. `main.py`'s comment claiming
authlib is the only session reader is updated — this is the second reader, and
it wants the same ten minutes for its own reason.

**Nothing about the identity goes in the URL.** A provider id and a deletion date
in a query string get written to browser history and to any referrer the gate
page emits. The redirect is to a bare `/start/again`.

**The deletion date is a date, not a timestamp** — `deleted_on`, truncated in the
service before it can reach a response model. The caller has authenticated as
*nobody*: they hold a ten-minute signed cookie stamped by an OAuth handshake they
just completed, and nothing else. The gate's sentence needs "3 March"; the hour
and minute would be a finer signal about an account that no longer exists, bought
for nothing. Flagging it rather than changing it silently, as asked — if you want
it coarser still ("earlier this year") or dropped, say so and it is a one-line
change in `ReturningPlayerConsentRequired`.

**Confirming clears the tombstone first, then calls the ordinary path.** With the
row gone, `create_or_get_account` finds no reason to pause and falls through to
the same mint every stranger gets. There is no second creation path and no
"consent given" flag threaded through the service.

**No migration.** None was needed — #2160 shipped the table.

## The adjacent bug

`services/auth.py`, the `if oauth_row:` branch: confirmed on `origin/main` @
`0c24ac4b`, it returned the Account without reading `status`, so a suspended
account got a valid JWT cookie and then a 401 from `get_current_account` on every
call after it. Signed in and broken, with nothing saying why.

`AccountStatus` now has three members, so the two non-active ones are refused in
their own words rather than as one bucket:

- `suspended` → 403 `ACCOUNT_SUSPENDED`. A moderation decision, appealable.
- `deleted` → 403 `ACCOUNT_DELETED`. Unreachable by construction (deletion
  destroys the OAuth rows in the transaction that sets the status), kept because
  the pairing existing at all would be a data defect, and the one outcome that
  must not follow from a data defect is a working session on a tombstone.

Both codes carry `errors.json` entries, so the `?login=` redirect renders catalog
copy rather than backend prose.

## Deferred, deliberately

**The Privacy-card disclosure is NOT in this PR.** There is no Privacy card —
`frontend/src/pages/settings/` holds only `mobileArchetypes/DefaultSettings.tsx`.
The Cookies/privacy section is #2156 and has not been built, and the exact
disclosure wording is already commented onto that issue so it lands with the
section it belongs to. Inventing a privacy surface to hang one line on would have
been the wrong place for the smallest change.

## Copy note

The issue's example sentence says "praxes". `__tests__/praxisPlural.test.ts`
forbids that string in any catalog value — the plural of praxis is praxis
(CONTEXT.md) — so the shipped line reads "your characters, praxis, votes and
comments are gone." Otherwise the sentence is the issue's own, verbatim. The
card's `note` line is a PLACEHOLDER, matching every other onboarding card.

## Verification

Every step in `.github/workflows/test.yml` run locally, on an isolated
`wz2162_test` database:

- `pytest --cov=. --cov-fail-under=80` — green
- `ruff check` from `backend/` — no new findings (the allowlist ratchet holds)
- `python scripts/regen_api_client.py` — `backend/openapi.json` and
  `frontend/src/api/generated/schema.d.ts` regenerated and committed
- `npm run lint` / `typecheck` / `typecheck:design-sync` / `test` / `build` /
  `budget` — green. The CSS budget WARN is pre-existing (#2469); this branch
  changes no CSS at all.

`authRefetchLedger` caught the new `refetch()` call site and it is written into
the ledger with its reason — same situation as dev-login: the POST sets the
cookie and answers with an acknowledgement, so `/auth/me` is the only way to
learn who that is. No `CurrentUser` is being discarded.

**Visual QA is outstanding.** I have no browser tools and no dev stack, so the
gate has been verified by types and tests only — never rendered.

## What to eyeball

1. **A returning deleted player, inside 90 days.** Delete an account, sign back
   in with the same Google or Discord identity. You should land on
   `/start/again`, with **no session cookie**, reading the deletion date. Press
   the button: fresh account, straight into the onboarding arc, tombstone gone.
   Check the date is the day you actually deleted it — the off-by-one this
   guards against only shows up west of Greenwich.
2. **An ordinary new signup.** Sign in as somebody the site has never seen.
   Nothing should look different: 302 to the frontend root, cookie set, home.
3. **A suspended account.** Flip an account to `suspended` and sign in with its
   provider identity. You should now get a readable refusal on the landing page
   instead of a session that 401s on every request behind it.
