### PR TITLE
The calling a qualified account earned is finally named at creation (#2518)

### DIFF
--- a/backend/services/albescent_reveal.py
+++ b/backend/services/albescent_reveal.py
@@ -4,14 +4,14 @@ Every surface that behaves differently for a member of the secret society —
 whether the word is printed (``GET /factions``), whether the unlock rung is
 announced (``services.progression``), and now whether a faction filter answers
 the roster question or the anti-oracle one (``faction_slugs``, #2422) — asks
-this function rather than reading the column.
+this function rather than reading the columns.
 
-It is one line today. It is a function because #2409 §6 holds an open owner
-question about widening the predicate to ``albescent_revealed ||
-can_start_as_albescent``: when that is answered the answer lands here, once,
-instead of in however many places had inlined the attribute read. Two
-independently-drifting definitions of "revealed" is the parallel-registry
-failure this repo keeps stamping out.
+It is a function because #2409 §6 held an open owner question about widening the
+predicate to ``albescent_revealed || can_start_as_albescent``. That question is
+answered — **reveal on QUALIFY, not on join** (#2518) — and the widening landed
+here, once, instead of in however many places had inlined an attribute read. Two
+independently-drifting definitions of "revealed" is the parallel-registry failure
+this repo keeps stamping out; this is the shape that paid for itself.
 
 Anonymous callers are unrevealed by definition — fail closed.
 """
@@ -22,33 +22,67 @@ from models.account import Account
 def is_albescent_revealed(account: Account | None, *, is_admin: bool = False) -> bool:
     """True when this account may be told the society exists.
 
-    ``Account.albescent_revealed`` is sticky: it flips the first time any
-    character on the account joins Albescent (``services.faction_service``) and
-    is never unset, so it survives age-out and character switches.
+    A union of three, and a union is the whole point — none of them replaces
+    another, and each is sticky in its own right:
 
-    ``is_admin`` short-circuits it (#2400). Moderation has to be able to read
-    the surfaces it moderates, and the only other way in was for an admin to
-    inflate their own progress until they qualified — cheating, to do the job.
-    It is a **read-side** bypass and deliberately nothing else: no caller writes
-    ``albescent_revealed`` for an admin, so an admin who later loses the role
-    loses the reveal with it, and the column keeps meaning "earned".
+    * ``Account.albescent_revealed`` flips the first time any character on the
+      account joins Albescent (``services.faction_service``) and is never unset,
+      so it survives age-out, character switches, and the #2399 eviction that
+      moved ``faction_slug`` and touched neither flag.
+    * ``Account.albescent_unlocked`` is the earned door (#2399, ADR-0080). Before
+      #2518 it opened character creation without opening the word, so a qualified
+      account was offered the calling on a tile labelled "Unaffiliated" — the
+      join gate open, the reveal gate shut. Reveal is now **derived** from it
+      rather than a second sticky write, which is what stops the two from
+      drifting apart again.
+    * ``is_admin`` short-circuits both (#2400). Moderation has to be able to read
+      the surfaces it moderates, and the only other way in was for an admin to
+      inflate their own progress until they qualified — cheating, to do the job.
+
+    **Nothing here writes.** The admin bypass never wrote ``albescent_revealed``,
+    and neither does the unlock read: an admin who loses the role loses the
+    reveal with it, and both columns keep meaning what they say. Deriving rather
+    than stamping is why ``albescent_unlocked`` remains the single record of
+    "earned".
 
     **Seeing is not joining, and that split is what keeps this safe.**
-    ``can_start_as_albescent`` and ``defect_to_faction``'s Albescent guard never
-    consult admin status: an admin joins by qualifying like anyone else. Compare
+    ``can_start_as_albescent`` is an *input* to this predicate now, never a peer:
+    the widening runs one way only. ``defect_to_faction``'s Albescent guard is
+    untouched and still consults admin status not at all, so an admin joins by
+    qualifying like anyone else. Compare
     ``services.character_capabilities.can_apply_metatask``, which pointedly does
     *not* short-circuit on ``is_admin`` because ``apply_metatask`` has no admin
     escape hatch — a capability flag saying yes where enforcement says no is
-    drift. Here there is no such claim to drift from: this predicate governs
-    only what is *shown*, the join gate is a separate flag on the same payload
-    (``CurrentUser.can_start_as_albescent``), and no caller on either side of
-    the wire derives one from the other. Keep it that way.
+    drift. Here there is no such claim to drift from: this predicate governs only
+    what is *shown*, the join gate is a separate flag on the same payload
+    (``CurrentUser.can_start_as_albescent``), and no caller on either side of the
+    wire derives one from the other. Keep it that way.
+
+    **The New Game+ ceiling must never appear here.** ``defect_to_faction``
+    refuses a character at ``era.albescent_level_required`` — the game's one
+    maximum-level gate — and that is a fact about the *joining character*. An
+    account that qualifies is by definition a level-8 account, so a ceiling test
+    in this account-scoped predicate would darken the society for exactly the
+    people who earned it, and the level-0 sibling that is the only way in is
+    created from the screen it would blank. This function has no character in
+    hand and must never grow one.
 
     Caller-supplied rather than resolved here: admin status is an
     ``account_role`` row (``dependencies.account_has_admin_role``), so looking
     it up would make this async and force a session on every reader — including
     ``services.progression``, which is otherwise pure config filtering. Every
     call site already resolves or receives the flag. It defaults to ``False``,
-    so a reader that does not pass it gets the unprivileged answer.
+    so a reader that does not pass it gets the unprivileged answer. The unlock
+    column needs no such care: it is on the ``Account`` already in hand, which is
+    what let #2518 stay a one-line widening.
+
+    ``bool()`` rather than a bare ``or`` chain: both columns are ``default=False``
+    at *flush*, so an ``Account`` that has not been flushed yet still holds
+    ``None``, and ``False or None`` is ``None`` — falsy, so no caller misbehaves,
+    but the annotation would be a lie and an ``is False`` assertion would fail on
+    a value that is not False.
     """
-    return account is not None and (is_admin or account.albescent_revealed)
+    return bool(
+        account is not None
+        and (is_admin or account.albescent_revealed or account.albescent_unlocked)
+    )

--- a/backend/tests/integration/test_albescent_reveal_on_qualify.py
+++ b/backend/tests/integration/test_albescent_reveal_on_qualify.py
@@ -1,0 +1,269 @@
+"""#2518: reveal on QUALIFY, not on join — the last gap between earning and being told.
+
+#2409 §6 held this open; it is now ruled. An account that has **earned** the
+Albescent door but never **joined** used to be offered the calling at character
+creation while the tile read "Unaffiliated": ``can_start_as_albescent`` opened
+off the stamped ``account.albescent_unlocked`` column, and
+``is_albescent_revealed`` stayed shut because ``account.albescent_revealed``
+only flips on a join. Two flags, one door, and only one of them opened.
+
+The seam is :func:`services.albescent_reveal.is_albescent_revealed` — the one
+predicate every "may this account be told the society exists" surface asks. The
+wire field these tests read, ``/auth/me``'s ``albescent_revealed``, is that
+predicate's only route to the frontend mask (``utils/factions.factionName``),
+so pinning it here pins the tile's label without a browser.
+
+Post-#2399 that is every future member: the reveal column is sticky and only a
+join ever wrote it, so an account qualifying under the new rule has never had it
+set. See #2518's repro note — the owner account joined *before* #2399 re-cut the
+gate, which is why it is the one account on the system that cannot reproduce it.
+
+**What must NOT widen with it.** Two things, and both have a test below:
+
+* The **join** side. ``can_start_as_albescent`` is an *input* to reveal now, not
+  a peer, and ``defect_to_faction``'s guard is untouched. The reverse asymmetry
+  — ``is_admin`` reveals without granting (#2400) — is pinned in
+  ``test_albescent_admin_reveal.py`` and is unaffected by this widening.
+* The **ceiling**. ``defect_to_faction``'s maximum-level gate is a fact about the
+  joining *character*; a qualified account is by definition a level-8 account,
+  and a fix that read "the account is at the ceiling, so hide it" would shut the
+  only path into the faction (#2399's New Game+ shape). The reveal predicate has
+  no character in hand and must never grow one.
+
+The ceiling's own behaviour — earner refused, level-0 sibling admitted — is
+already pinned in ``test_albescent_unlock.py`` and is not restated here; what is
+tested below is only that the *reveal* did not learn about it.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from errors import ErrorCode
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character, CharacterStatus
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction, FactionStatus
+
+
+async def _seed_faction(session: AsyncSession, slug: str) -> None:
+    existing = await session.scalar(select(Faction).where(Faction.slug == slug))
+    if existing is None:
+        session.add(Faction(slug=slug, status=FactionStatus.visible))
+        await session.flush()
+
+
+async def _set_level(
+    session: AsyncSession, character: Character, era_row: Era, level: int
+) -> None:
+    stats = await session.scalar(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era_row.id,
+        )
+    )
+    stats.level = level
+    await session.commit()
+
+
+async def _qualify(session: AsyncSession, account: Account) -> None:
+    """Stamp the unlock and nothing else — never joined, so reveal stays unwritten.
+
+    Deliberately does not go through ``character_earns_albescent``: how the door
+    was earned has its own tests in ``test_albescent_unlock.py``, and stamping
+    directly is what keeps *this* file about the reveal.
+    """
+    account.albescent_unlocked = True
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_qualified_but_never_joined_account_is_revealed(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """The bug, at the wire field the creation tile reads.
+
+    Both flags now open together, and the column stays unwritten — reveal is
+    *derived* from the unlock, not a second sticky write that could drift from
+    it.
+    """
+    await _seed_faction(db_session, "albescent")
+    await _qualify(db_session, account)
+
+    me = (await client.get("/auth/me", headers=auth_headers)).json()
+    assert me["can_start_as_albescent"] is True
+    assert me["albescent_revealed"] is True
+
+    invited = (await client.get("/me/invited-factions", headers=auth_headers)).json()
+    assert "albescent" in invited
+    # One row per slug: two "Unaffiliated" tiles was the louder half of the bug.
+    assert len(invited) == len(set(invited))
+
+    # Derived, not written. A second sticky write is a second definition.
+    await db_session.refresh(account)
+    assert account.albescent_revealed is False
+
+
+@pytest.mark.asyncio
+async def test_unqualified_account_still_gets_the_mask(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """Widening reveal must not leak the society to someone who has not earned it.
+
+    ADR-0027's secrecy rule is unamended for this account: no reveal flag, no
+    word in ``/factions``, and no tile to mislabel at creation.
+    """
+    await _seed_faction(db_session, "albescent")
+
+    me = (await client.get("/auth/me", headers=auth_headers)).json()
+    assert me["can_start_as_albescent"] is False
+    assert me["albescent_revealed"] is False
+
+    listed = (await client.get("/factions", headers=auth_headers)).json()
+    assert "albescent" not in [f["slug"] for f in listed]
+
+    invited = (await client.get("/me/invited-factions", headers=auth_headers)).json()
+    assert "albescent" not in invited
+
+
+@pytest.mark.asyncio
+async def test_the_ceiling_does_not_reach_the_reveal(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """The earner sees the name it can no longer take — and the door still refuses it.
+
+    This is the #2399 regression guard. The account that earned the door is by
+    definition at ``era.albescent_level_required``; if the widened predicate ever
+    grows a character-level test, this account goes dark and the faction becomes
+    unreachable, because the level-0 sibling that *can* join is created from this
+    very screen.
+
+    Reveal is account-scoped and says yes. The ceiling is character-scoped and
+    still says no. Both, at once, is the correct state.
+    """
+    await _seed_faction(db_session, "albescent")
+    await _qualify(db_session, account)
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+
+    me = (await client.get("/auth/me", headers=auth_headers)).json()
+    assert me["albescent_revealed"] is True
+    invited = (await client.get("/me/invited-factions", headers=auth_headers)).json()
+    assert "albescent" in invited
+
+    # ...and the door is still shut to *this* life.
+    resp = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "albescent"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403
+    assert (
+        resp.json()["detail"]["code"]
+        == ErrorCode.faction_albescent_new_game_plus_only.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_reveal_survives_the_eviction_that_unset_no_column(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """The owner-account shape: joined long ago, evicted by #2399, still revealed.
+
+    Widening is a union, never a replacement. An account whose sticky column was
+    written by an old join keeps the reveal even though it no longer qualifies —
+    #2399 moved ``faction_slug`` and touched neither flag. Guards against
+    "reveal = unlocked" being written as an assignment rather than an ``or``.
+    """
+    await _seed_faction(db_session, "albescent")
+    account.albescent_revealed = True
+    account.albescent_unlocked = False
+    await db_session.commit()
+
+    me = (await client.get("/auth/me", headers=auth_headers)).json()
+    assert me["albescent_revealed"] is True
+    assert me["can_start_as_albescent"] is False
+
+    listed = (await client.get("/factions", headers=auth_headers)).json()
+    assert "albescent" in [f["slug"] for f in listed]
+
+
+@pytest.mark.asyncio
+async def test_qualifying_does_not_open_the_join_gate_for_a_stranger(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+):
+    """Seeing is not joining, from the other side: reveal alone grants nothing.
+
+    An account that is revealed-but-not-unlocked is refused at the door with the
+    *eligibility* code, not the ceiling code — proof the two gates read different
+    columns and that the widening ran one way only.
+    """
+    from services.faction_service import defect_to_faction
+
+    await _seed_faction(db_session, "albescent")
+    account.albescent_revealed = True
+    await db_session.commit()
+
+    with pytest.raises(Exception) as excinfo:
+        await defect_to_faction(character, "albescent", db_session)
+    assert (
+        excinfo.value.detail["code"] == ErrorCode.faction_albescent_not_eligible.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_level_zero_sibling_on_a_qualified_account_still_joins(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+):
+    """The only path into the faction, asserted alongside the reveal that names it.
+
+    ``test_albescent_unlock.py`` owns the ceiling's full matrix; this restates the
+    one branch #2518 names as the thing a careless fix would break.
+    """
+    from services.faction_service import defect_to_faction
+
+    await _seed_faction(db_session, "albescent")
+    await _qualify(db_session, account)
+    await _set_level(db_session, character, era, CURRENT_ERA.albescent_level_required)
+
+    sibling = Character(
+        account_id=account.id,
+        username="newgameplus",
+        display_name="New Game Plus",
+        faction_slug="na",
+        status=CharacterStatus.active,
+    )
+    await _seed_faction(db_session, "na")
+    db_session.add(sibling)
+    await db_session.commit()
+    await db_session.refresh(sibling)
+
+    joined = await defect_to_faction(sibling, "albescent", db_session)
+    assert joined.faction_slug == "albescent"

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -3,6 +3,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode
 from models.account import Account
 from models.character import Character
 from models.era import Era
@@ -407,14 +408,28 @@ async def test_albescent_join_reveals_and_lists(
     era: Era,
     db_session: AsyncSession,
 ):
-    """A successful Albescent defect flips albescent_revealed and unlocks the
-    faction in GET /factions for that account."""
+    """A successful Albescent defect flips albescent_revealed and keeps the
+    faction listed in GET /factions for that account.
+
+    Since #2518 the listing is already open before the join — reveal follows
+    QUALIFY, and this account is qualified by construction, so there is no
+    pre-join hidden state left to assert here. The masked case moved to
+    ``test_list_factions_hides_albescent_when_unrevealed`` (no unlock, no
+    listing) and to ``test_albescent_reveal_on_qualify.py``.
+
+    What is still this test's own: the *column write*. ``albescent_revealed``
+    stays load-bearing rather than subsumed by the unlock, because an account
+    that joined before #2399 existed carries the reveal without ever having been
+    stamped — the owner account's shape. The join is what writes it.
+    """
     await _seed_faction(db_session, "albescent")
     await _make_account_albescent_eligible(db_session, character, era)
 
-    # Pre-join: hidden.
+    # Pre-join: already listed, because qualifying is now what reveals (#2518).
     before = await client.get("/factions", headers=auth_headers)
-    assert "albescent" not in [f["slug"] for f in before.json()]
+    assert "albescent" in [f["slug"] for f in before.json()]
+    await db_session.refresh(account)
+    assert account.albescent_revealed is False
 
     resp = await client.post(
         "/factions/choose",
@@ -433,7 +448,7 @@ async def test_albescent_join_reveals_and_lists(
 
 
 @pytest.mark.asyncio
-async def test_hidden_ladder_rung_still_fires_the_ability(
+async def test_the_ladder_rung_is_display_only_never_the_gate(
     client: AsyncClient,
     character: Character,
     account: Account,
@@ -441,44 +456,54 @@ async def test_hidden_ladder_rung_still_fires_the_ability(
     era: Era,
     db_session: AsyncSession,
 ):
-    """Hiding the ``join_albescent`` rung must not withhold the ability (#1891).
+    """The ``join_albescent`` rung is announcement copy, never the gate (#1891).
 
-    The ladder filter is announcement copy only. Eligibility is decided by the
-    stamped ``account.albescent_unlocked`` column in ``services.character``
-    (ADR-0080) plus the ceiling in ``services.faction_service``, neither of
-    which ever consults ``level_profiles`` — this is the tripwire for anyone who
-    later routes the gate through the ladder and turns a display filter into an
-    enforcement gate.
+    Eligibility is decided by the stamped ``account.albescent_unlocked`` column
+    in ``services.character`` (ADR-0080) plus the ceiling in
+    ``services.faction_service``, neither of which ever consults
+    ``level_profiles`` — this is the tripwire for anyone who later routes the
+    gate through the ladder and turns a display filter into an enforcement gate.
 
-    An unrevealed account that reaches the level is therefore never told the
-    order's name, and can still walk through the door the moment something
-    tells it the door is there.
+    #2518 flipped which direction demonstrates it. This test used to show a
+    *hidden* rung over a working ability: an account could qualify without being
+    revealed, so the ladder stayed dark while the door stood open. That state is
+    exactly the defect #2518 closed and is now unreachable — qualifying reveals.
+
+    The gap survives the other way round, and that is what runs below: an
+    account revealed by an old join but never stamped (the owner account's shape
+    after #2399's eviction) is *shown* the rung and still refused at the door.
+    Display says yes, enforcement says no, and the two are read off different
+    columns — which is the same tripwire, from the side that still exists.
     """
     await _seed_faction(db_session, "albescent")
-    await _make_account_albescent_eligible(db_session, character, era)
-    assert account.albescent_revealed is False
+    account.albescent_revealed = True
+    await db_session.commit()
 
-    # The rung is not on this account's ladder...
+    # The rung IS on this account's ladder — it is revealed...
     config = (await client.get("/game-config", headers=auth_headers)).json()
     keys = {
         unlock["key"]
         for profile in config["level_profiles"]
         for unlock in profile["unlocks"]
     }
-    assert "join_albescent" not in keys
+    assert "join_albescent" in keys
 
-    # ...but the ability it describes has fired.
+    # ...but the ability it describes has NOT fired: nothing stamped the door.
     me = (await client.get("/auth/me", headers=auth_headers)).json()
-    assert me["can_start_as_albescent"] is True
-    assert me["albescent_revealed"] is False
+    assert me["albescent_revealed"] is True
+    assert me["can_start_as_albescent"] is False
 
-    # And the join it gates still succeeds.
+    # And the join it advertises is refused, on the eligibility code — proof the
+    # gate read the unlock column and not the ladder that just showed the rung.
     resp = await client.post(
         "/factions/choose",
         json={"faction_slug": "albescent"},
         headers=auth_headers,
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 403
+    assert (
+        resp.json()["detail"]["code"] == ErrorCode.faction_albescent_not_eligible.value
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_albescent_reveal.py
+++ b/backend/tests/unit/test_albescent_reveal.py
@@ -16,8 +16,12 @@ from models.account import Account
 from services.albescent_reveal import is_albescent_revealed
 
 
-def _account(*, revealed: bool) -> Account:
-    return Account(email="a@example.com", albescent_revealed=revealed)
+def _account(*, revealed: bool, unlocked: bool = False) -> Account:
+    return Account(
+        email="a@example.com",
+        albescent_revealed=revealed,
+        albescent_unlocked=unlocked,
+    )
 
 
 def test_unrevealed_non_admin_is_not_revealed():
@@ -49,3 +53,56 @@ def test_admin_bypass_does_not_write_the_sticky_column():
     account = _account(revealed=False)
     is_albescent_revealed(account, is_admin=True)
     assert account.albescent_revealed is False
+
+
+# ---------------------------------------------------------------------------
+# #2518 — reveal on QUALIFY, not on join
+# ---------------------------------------------------------------------------
+
+
+def test_a_qualified_account_that_never_joined_is_revealed():
+    """The #2518 defect at its seam: the earned door now opens the word too.
+
+    ``albescent_unlocked`` without ``albescent_revealed`` is exactly the state
+    every account reaches under #2399's rule, because only a join ever wrote the
+    reveal column.
+    """
+    assert is_albescent_revealed(_account(revealed=False, unlocked=True)) is True
+
+
+def test_the_widening_is_a_union_not_a_replacement():
+    """An old join keeps the reveal after #2399 evicted it from the faction.
+
+    This is the owner account's shape, and the reason the predicate is ``or``
+    rather than an assignment: eviction moved ``faction_slug`` and unset neither
+    column, so revealed-but-no-longer-unlocked is a real, reachable state.
+    """
+    assert is_albescent_revealed(_account(revealed=True, unlocked=False)) is True
+
+
+def test_neither_flag_is_still_the_mask():
+    """Widening reveal must not leak the society to someone who has not earned it.
+
+    ADR-0027 is unamended for this account.
+    """
+    assert is_albescent_revealed(_account(revealed=False, unlocked=False)) is False
+
+
+def test_reading_the_unlock_does_not_write_the_reveal():
+    """Derived, never stamped — one record of "earned", not two that can drift."""
+    account = _account(revealed=False, unlocked=True)
+    assert is_albescent_revealed(account) is True
+    assert account.albescent_revealed is False
+
+
+def test_an_unflushed_account_answers_False_and_not_None():
+    """Both columns default at *flush*, so an unflushed ``Account`` holds ``None``.
+
+    A bare ``or`` chain returns that ``None`` — falsy, so nothing misbehaves, but
+    the ``-> bool`` annotation would be a lie and every ``is False`` assertion in
+    this file would fail against a value that is not ``False``. The ``bool()``
+    wrapper is load-bearing; this is its tripwire.
+    """
+    account = Account(email="unflushed@example.com")
+    assert account.albescent_unlocked is None
+    assert is_albescent_revealed(account) is False

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterCalling.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterCalling.test.tsx
@@ -26,10 +26,11 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import '../../../i18n'
 import type { CreateCharacterState } from '../useCreateCharacter'
 import FactionSigil from '../../../components/sigil/FactionSigil'
+import { factionName, setAlbescentRevealed } from '../../../utils/factions'
 
 const hoisted = vi.hoisted(() => ({
   state: null as CreateCharacterState | null,
@@ -141,5 +142,72 @@ describe('the calling copy asserts no precondition (#2223)', () => {
     const { text } = renderMobile(createState({}))
     expect(text).not.toContain('Some of these already know you.')
     expect(text, 'the born-unaffiliated explainer survives').toContain('Unaffiliated')
+  })
+})
+
+/**
+ * #2518 — the calling that was offered without being named.
+ *
+ * A qualified account has been offered `albescent` in `invited` since #2399, but
+ * the tile read "Unaffiliated" wearing the labyrinth: the join gate opened off
+ * `can_start_as_albescent` while the mask stayed shut on `albescentRevealed`,
+ * which only a join ever set. The fix is one widened backend predicate
+ * (`services/albescent_reveal.py`) — reveal on QUALIFY, not on join.
+ *
+ * The seam these cases sit at is the LINK between that predicate and this
+ * screen: the tile takes its label from `factionName`, so it reads whatever
+ * `/auth/me`'s `albescent_revealed` last pushed into the module flag via
+ * `AuthContext`. Pinning that the picker routes through the mask — rather than
+ * naming the slug itself — is what makes the backend fix reach the tile, and is
+ * the half a browser would otherwise have to prove.
+ *
+ * The flag is module-level and mutable (#1891), so every case resets it: a
+ * leaked `true` outlives its test and makes a later assertion pass for the wrong
+ * reason.
+ */
+describe('the Albescent tile is named once the account qualifies (#2518)', () => {
+  const WITH_ALBESCENT = [...INVITED, 'albescent']
+
+  afterEach(() => setAlbescentRevealed(false))
+
+  function pickerWithAlbescent(): CreateCharacterState {
+    return createState({ invited: WITH_ALBESCENT, showPicker: true })
+  }
+
+  for (const [mount, renderAt] of [['mobile', renderMobile], ['desktop', renderDesktop]] as const) {
+    it(`prints the real name for a revealed account — ${mount}`, () => {
+      setAlbescentRevealed(true)
+      expect(renderAt(pickerWithAlbescent()).text).toContain('Albescent')
+    })
+
+    it(`still masks the name for an unrevealed viewer — ${mount}`, () => {
+      // Unreachable from the server since #2518 (the tile only ships to accounts
+      // that qualify, and qualifying now reveals), but this is the assertion that
+      // proves the label goes THROUGH the mask instead of being written here. A
+      // tile that hardcoded the slug's name would pass the case above and leak.
+      setAlbescentRevealed(false)
+      expect(renderAt(pickerWithAlbescent()).text).not.toContain('Albescent')
+    })
+  }
+
+  it('gives every offered calling its own label — no two "Unaffiliated" rows', () => {
+    // The louder half of the bug: a masked Albescent beside any `na` row renders
+    // the same word twice, which ADR-0027's masking exists to avoid ("a blank
+    // advertises the omission" — two identical labels advertise it louder).
+    setAlbescentRevealed(true)
+    const labels = [...WITH_ALBESCENT, 'na'].map(factionName)
+    expect(new Set(labels).size, labels.join(' / ')).toBe(labels.length)
+  })
+
+  it('the mark and the name agree — labyrinth beside the real word', () => {
+    // `FactionSigil` resolves `albescent` unconditionally and always has. That
+    // was the inconsistency #2518 names: the mark un-hid while the name hid.
+    // Once the name is real the pair agrees, so the sigil needs no gate of its
+    // own — this pins that conclusion rather than a change.
+    setAlbescentRevealed(true)
+    const { html, text } = renderMobile(pickerWithAlbescent())
+    const mark = renderToStaticMarkup(<FactionSigil slug="albescent" size={PICKER_SIGIL} />)
+    expect(html, 'the labyrinth is drawn').toContain(mark)
+    expect(text, 'and the word beside it is the real one').toContain('Albescent')
   })
 })


### PR DESCRIPTION
Closes #2518

An account that had **earned** Albescent but never **joined** it was offered the calling at character creation while the tile read **"Unaffiliated"** wearing the labyrinth. The join gate opened off `can_start_as_albescent`; the reveal gate stayed shut because `account.albescent_revealed` only ever flipped on a join. Two flags, one door, one of them open.

#2409 §6 held the widening as an open owner question. It is ruled — **reveal on QUALIFY, not on join** — so this lands it.

## The seam

`services/albescent_reveal.is_albescent_revealed` — the one predicate every "may this account be told the society exists" surface asks, and a function *specifically* so this widening lands in one place. Its docstring said so, and that stale "open question" paragraph goes with the change.

The failing test went in first at that seam and at the wire field it dresses, `/auth/me`'s `albescent_revealed`, which is the predicate's only route to the frontend mask.

```python
return bool(
    account is not None
    and (is_admin or account.albescent_revealed or account.albescent_unlocked)
)
```

A union, not a replacement, and **derived, never stamped** — nothing writes `albescent_revealed` for a qualified account, so `albescent_unlocked` stays the single record of "earned" and the two cannot drift apart again.

**No frontend change.** The tile already takes its label from `factionName`, so the widened predicate reaches it through `/auth/me` → `AuthContext` → the module flag. Tests pin that link rather than a diff.

**No migration** (both columns exist), **no schema drift** (`regen_api_client.py` re-run, `git diff` clean — no route signature or Pydantic schema touched).

## One thing the loop caught

The obvious one-liner was a bare `or` chain, and it returned `None`, not `False`. Both columns are `default=False` at *flush*, so an unflushed `Account` holds `None` and `False or None is None`. Falsy, so nothing misbehaved — but the `-> bool` annotation was a lie, and the **existing** unit test's `is False` went red on it. Hence `bool()`, with its own tripwire test.

## The four things #2518 said were not optional

1. **The asymmetry survives.** `can_start_as_albescent` is an *input* here now, never a peer; the widening runs one way only. `defect_to_faction`'s guard is untouched. The reverse asymmetry (`is_admin` reveals without granting, #2400) is unaffected — `test_albescent_admin_reveal.py` is green unchanged.
2. **The sigil.** `FactionSigil` resolves `albescent` unconditionally and always has. Once the name is real the mark and the word agree, so the right behaviour is *no gate on the sigil* — and the tile only ever ships to accounts that qualify, so an unqualified account never sees the labyrinth at creation either. Pinned as a conclusion, not changed.
3. **The ceiling does not leak.** No character-level test entered this account-scoped predicate; the docstring now says why it never may. A qualified account is by definition level 8, so a ceiling test here would darken the society for exactly the people who earned it — and the level-0 sibling that is the only way in is created from the screen it would blank.
4. **No leak to the unqualified.** Neither flag set is still the mask: no reveal, no word in `/factions`, no tile.

**ADR-0027 is unamended and still stands for unqualified accounts.** It does not need amending: it governs who may be told, and this changes only *when* an earner qualifies as one of them. ADR-0080 already made the unlock the record of "earned". Flagging rather than touching either.

## Tests

Seam-first, then green. New `backend/tests/integration/test_albescent_reveal_on_qualify.py` (6) plus 5 new unit cases cover the issue's suggested list; suggested test 4 (the ceiling matrix) **already had thorough coverage** in `test_albescent_unlock.py` and is not duplicated — only the "reveal did not learn about the ceiling" half is new.

Two existing tests encoded the reversed premise. Neither is deleted; both keep their real tripwire:

- `test_albescent_join_reveals_and_lists` loses only its "pre-join: hidden" step. What it is actually for survives and is now stated: the join still **writes** the column, and that column stays load-bearing rather than subsumed — an account that joined before #2399 existed carries the reveal without ever having been stamped.
- `test_hidden_ladder_rung_still_fires_the_ability` asserted a hidden rung over a working ability, which *is* the defect being fixed, so that state is now unreachable and it could not be repaired in place. The display-is-not-enforcement tripwire survives in the other direction and now runs there: an account revealed by an old join but never stamped is **shown** the rung and still refused at the door on the eligibility code. Renamed to `test_the_ladder_rung_is_display_only_never_the_gate`.

Every CI step from `.github/workflows/test.yml` run locally: backend `pytest --cov --cov-fail-under=80` **1582 passed, 94.39%**; `ruff check` from `backend/` (ratchet green, new files clean); `regen_api_client.py` + `git diff` clean; frontend `lint`, `typecheck`, `typecheck:design-sync`, `test` (**410 files / 7318 passed**), `build`, `budget`.

The budget's **CSS WARN is pre-existing** (#2469), not from this change: rebuilding without my test file produced a byte-identical CSS bundle, same hash. Backend ran against a dedicated `wz2518_test`.

## Visual QA is outstanding

I have no browser and no dev stack — everything above is tests, tsc and lint. Nobody has *looked* at this.

## What to eyeball

**The owner account cannot reproduce this**, and that is not a counter-example — it is the one account on the system that can't. It joined Albescent before #2399 re-cut the gate, `albescent_revealed` is sticky, and #2399's eviction moved `faction_slug` without touching the flag. It has been revealed the whole time.

**You need a reproducing account: `albescent_unlocked = true`, `albescent_revealed = false`** — never joined. Post-#2399 that is every future member.

Three outcomes:

1. **Qualified, never joined** → character creation offers the calling **named "Albescent"**, labyrinth beside the real word, one tile per calling and no second "Unaffiliated" row. `/factions` lists it and the `join_albescent` ladder rung appears. This is the fix.
2. **Unqualified** → unchanged and still masked: no Albescent tile at creation, no Albescent in `/factions`, no rung, and the word appears nowhere.
3. **A level-0 sibling on a qualified account can still actually join.** Create the new life from that picker and take Albescent — it must go through. The level-8 life that earned the door is still refused with "Available only for New Game+". Both at once is the correct state; if the *first* one broke, the faction would have no path in at all.

Worth a glance while you are there: how the Albescent tile's ground reads in the `na` creation kit (that is #2401's open design question, untouched here), and #2499 is rewriting Albescent's ground in `index.css` / `motion.ornament.css` concurrently — no overlap with this PR, which touches no CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
