### PR TITLE
The Albescent vellum stops being always-light: the reveal register gains a dark half

### DIFF
--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -84,8 +84,11 @@ export function barredLives(
   return answerable(lives).filter((life) => life.level >= bar)
 }
 
-// Albescent vellum tokens (index.css). Albescent is always-light by design —
-// these vars are identical in both themes, so the letter never flips dark.
+// Albescent vellum tokens (index.css). THE LETTER FLIPS (#2301): this comment
+// used to say the vars were identical in both themes and the letter never went
+// dark. Since #2301 the reveal block has a `[data-theme="dark"]` half whose
+// values are the na card's own — nothing below changes, because every colour
+// here was already a token and the cascade does the rest.
 const BG = 'var(--albescent-reveal-surface)'
 const INK = 'var(--albescent-reveal-text)'
 const ACCENT = 'var(--albescent-reveal-ink)'
@@ -104,14 +107,15 @@ const MONO = "'Courier Prime', monospace"
 // its own copy of a value the family owns.
 const HAIRLINE = 'var(--albescent-reveal-border)'
 const HAIRLINE_FAINT = 'var(--albescent-reveal-border-faint)'
-// A DECIDED KEEP, and this one really has no rung: 0.07 sits between the two
-// declared alphas and nothing else in the reveal block or outside it draws at
-// it. Minting a third rung for one reader would cost the one blocking
-// stylesheet bytes (§6, #2019) to name a value with a single site. Albescent is
-// always-light by design — these tokens are declared once with no dark half —
-// so a frozen black here is not a dark-mode defect. If #2301 gives the reveal a
-// dark half, this is the line that will not follow, and the two above will.
-const RULE = 'rgba(0,0,0,0.07)'
+// `RULE` — a third hairline, frozen at rgba(0,0,0,0.07) — stood here. The note
+// on it was right about its own terms and right about what would end it: "a
+// frozen black here is not a dark-mode defect … if #2301 gives the reveal a
+// dark half, this is the line that will not follow". #2301 did, so it would
+// have been a black rule on a near-black sheet at 1.02:1 — drawn, and invisible.
+// It did not need the third rung it was refused, either: the canvas draws the
+// letter's `border-top` and its `border-bottom` at the SAME strength after dark,
+// so the terms slip's top rule is `HAIRLINE_FAINT` now like the term rows below
+// it. By day that is 1.17:1 → 1.13:1 at one site.
 
 // i18n key stems under factions:albescent.letter — resolved at render.
 //
@@ -229,7 +233,7 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
       </div>
 
       {/* terms slip */}
-      <div style={{ position: 'relative', margin: '0 var(--space-3xl)', borderTop: `1px solid ${RULE}`, padding: 'var(--space-xl) 0 var(--space-xs)', textAlign: 'left' }}>
+      <div style={{ position: 'relative', margin: '0 var(--space-3xl)', borderTop: `1px solid ${HAIRLINE_FAINT}`, padding: 'var(--space-xl) 0 var(--space-xs)', textAlign: 'left' }}>
         <div style={{
           ...monoCaps, letterSpacing: '0.22em', marginBottom: 'var(--space-md)',
           // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved stationery mono-caps; these draw the letterhead rather than set read copy

--- a/frontend/src/components/metataskSeal/skins/AlbescentSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/AlbescentSeal.tsx
@@ -7,9 +7,15 @@ import type { SealSkinProps } from '../types'
  * Albescent seal — the pale correspondence register (#930). A seal is a foreign
  * sticker that keeps its ISSUER's voice, so this is one of the rare moments the
  * secret society shows its face: near-black ink on a near-white sheet, with a
- * single soft spectrum strip as its only colour. It reads the always-light
+ * single soft spectrum strip as its only colour. It reads the
  * `--albescent-reveal-*` reveal tokens (never a `--faction-albescent-*` theme,
  * which does not exist by design) so it stays restrained and un-tinted.
+ *
+ * IT FOLLOWS THE FLIP (#2301) and needs no edit to do it: every colour above is
+ * a reveal token, and after dark those resolve to the na card's own stock and
+ * ink. So the sticker is a pale sheet by day and an na-dark one by night, on
+ * whatever host card it has been stuck to. Its `-border` is what keeps it a
+ * distinct object when the host card happens to be na's too (2.74:1).
  */
 export default function AlbescentSeal({ metatask, removable, onRemove }: SealSkinProps) {
   const { t } = useTranslation('praxis')

--- a/frontend/src/components/selectCard/AlbescentSelectCard.tsx
+++ b/frontend/src/components/selectCard/AlbescentSelectCard.tsx
@@ -30,25 +30,29 @@ import FactionSigil from "../sigil/FactionSigil";
  * a PURE move: not a byte of the markup below changed, and the six
  * `state` × `members` renders are identical before and after.
  *
- * ── THE REPAINT IS PARKED, DELIBERATELY (#2301) ─────────────────────────────
+ * ── THE PARKED REPAINT, NOW SETTLED (#2301) ─────────────────────────────────
  *
  * The other seven children each gathered their tile's register off its own task
- * card. This one cannot, and the reason is not scheduling — there is no register
- * to gather. `AlbescentTaskCard` is fifty lines that draw nothing of their own:
- * it renders `DefaultTaskCard` and washes two motion overlays over it, because
- * ADR-0048 and that card's own docstring rule that *"a secret society hiding in
- * plain sight is revealed by a shimmer, never by a colour — a repaint in
- * Albescent's own hues would put it back in the spectrum and un-hide it."* Its
- * token families are `--faction-default-*`. Adopting them here would delete this
- * tile's face outright.
+ * card. This one could not, and the reason was not scheduling — there was no
+ * register to gather. `AlbescentTaskCard` is fifty lines that draw nothing of
+ * their own: it renders `DefaultTaskCard` and washes two motion overlays over
+ * it, because ADR-0048 and that card's own docstring rule that *"a secret
+ * society hiding in plain sight is revealed by a shimmer, never by a colour — a
+ * repaint in Albescent's own hues would put it back in the spectrum and un-hide
+ * it."* Its token families are `--faction-default-*`.
  *
  * That tension — a reveal surface painting in `--albescent-reveal-*` while every
- * ordinary surface must not — is real, and it is NOT settled here. The owner has
- * ruled the reveal family gets a dark half (#2301, still `needs-design`) and
- * `index.css` still carries a comment forbidding exactly that. Whatever #2301
- * lands is what decides this tile's ground, so the colour is left untouched and
- * the extraction stands on its own. The light half is therefore still UNMEASURED
- * here, which is the one acceptance line of #2321 this tile does not yet meet.
+ * ordinary surface must not — is real, and #2301 has now dissolved rather than
+ * resolved it. The reveal register gained a dark half whose values ARE the na
+ * card's (`--faction-default-card-bg` / `-text` / `-muted`), so after dark this
+ * tile paints in the very family adopting outright would have handed it, and it
+ * still keeps its own pale face by day. Nothing below changed to get that: every
+ * colour here was already a reveal token, and the cascade did the rest.
+ *
+ * Both halves are measured now, which closes the one acceptance line of #2321
+ * this tile did not meet. Its inks, being the reveal register's, are the three
+ * rows `factionContrast.test.ts` holds under `albescent reveal sheet, …` in
+ * BOTH themes: 17.07 / 6.74 / 4.64 by day, 13.75 / 8.04 / 5.44 by night.
  *
  * The sigil comes from the shared canonical dispatcher — `FactionSigil` resolves
  * `albescent` to `AlbescentSigil` (the labyrinth, which carries no hue of its

--- a/frontend/src/components/sigil/AlbescentSigil.tsx
+++ b/frontend/src/components/sigil/AlbescentSigil.tsx
@@ -8,8 +8,8 @@ import type { CSSProperties } from "react";
  *
  * THIS FILE IS A REINSTATEMENT, and the scope of it is narrow. #1891 / PR #1926
  * deleted `AlbescentSigil` by owner ruling hours before this design was drawn.
- * The mark then was a surveyor's cross-hair inked on the always-light
- * `--albescent-reveal-*` register, and a distinct emblem in a distinct PALETTE,
+ * The mark then was a surveyor's cross-hair inked on the `--albescent-reveal-*`
+ * register (always-light then; it flips since #2301), and a distinct emblem in a distinct PALETTE,
  * worn by an otherwise-hidden faction on surfaces an unrevealed player reads, is
  * a tell. The owner has ruled that this design supersedes that deletion. **Only
  * the mark comes back.** Every other half of #1891/#1926 is untouched and still

--- a/frontend/src/components/sigil/FactionSigil.tsx
+++ b/frontend/src/components/sigil/FactionSigil.tsx
@@ -42,8 +42,8 @@ export function SingularitySigilAdapter({ size, color }: SigilVariantProps) {
  * ruling on Sigil Studies v2).
  *
  * #1891's objection was to the mark it deleted, not to the existence of one: a
- * surveyor's cross-hair, inked on the always-light `--albescent-reveal-*`
- * register, was a distinct emblem in a distinct PALETTE worn by an otherwise-
+ * surveyor's cross-hair, inked on the `--albescent-reveal-*` register (which was
+ * always-light then and flips since #2301), was a distinct emblem in a distinct PALETTE worn by an otherwise-
  * hidden faction. The labyrinth answers that half — it carries no hue of its
  * own, it is filled with the unaffiliated conic, so what a stranger meets is a
  * shape and never a livery. The owner has accepted the remaining consequence

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -242,9 +242,9 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
   /**
    * The seal skin (#930). A seal is a FOREIGN sticker that keeps its ISSUER's
    * voice on someone else's praxis — so an Albescent-issued metatask is a reveal
-   * moment, not a host surface Albescent has to hide on. It reads the always-
-   * light `--albescent-reveal-*` tokens (the same reveal register as the
-   * invitation letter and sigil), never a `--faction-albescent-*` theme, so the
+   * moment, not a host surface Albescent has to hide on. It reads the
+   * `--albescent-reveal-*` tokens (the same reveal register as the invitation
+   * letter and the select tile, and which FLIPS since #2301), never a `--faction-albescent-*` theme, so the
    * society shows its pale face only where it is doing the sealing.
    */
   metataskSeal: () => AlbescentSeal,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7034,19 +7034,62 @@
      the guard that keeps them retired is not a ratio, it is the name being
      gone. `selectCard/__tests__/snideWearsTheClippingRegister.test.ts` pins it. */
   /* ALBESCENT · vellum correspondence — THE REVEAL SURFACES ONLY (#783).
-     Always-light, the same mechanism Singularity uses to stay always-dark.
 
-     This is NOT a faction theme and must never become one. Albescent has no
-     --faction-albescent-* block: it renders as unaffiliated everywhere, because
-     it is a secret society hiding in plain sight, and factionCssVar('albescent')
-     deliberately resolves to --faction-default-*. These tokens are reached only
-     by direct reference, from the two or three components that ARE the reveal
-     (the invitation letter, the secret placeholder, and the sigil they draw) —
-     the one moment the society shows its face. Renamed from --al-* so nobody
-     mistakes it for the theme that was removed.
+     IT FLIPS (#2301, epic #2496 ruling 7). This block used to say "always-light,
+     the same mechanism Singularity uses to stay always-dark", and the note under
+     it recorded that #1661 deleted the dark half. That instruction is SUPERSEDED
+     by owner ruling: a dark-mode reader gets a dark letter. Singularity stays
+     always-dark — that is deliberate and untouched; this is a ruling about the
+     vellum, not about retiring theme-invariant surfaces as a class. Albescent's
+     was the last always-light sheet of its kind, the Ephemerists' vellum having
+     flipped first (#2141).
+
+     This is STILL NOT a faction theme and must never become one. Albescent has
+     no --faction-albescent-* block: it renders as unaffiliated everywhere,
+     because it is a secret society hiding in plain sight, and
+     factionCssVar('albescent') deliberately resolves to --faction-default-*.
+     These tokens are reached only by direct reference, from the surfaces that
+     ARE the reveal — the invitation letter, the secret placeholder, the select
+     tile and the metatask seal. (The header used to say "the two or three
+     components"; that count was stale from the day #2329 split the select cards
+     into one file each. The labyrinth sigil is NOT among them: it paints in
+     --faction-default-rainbow-conic and has carried no reveal hue since #1891.)
 
      Do not point an ordinary Albescent surface at these. If a card, a feed row,
-     or a profile reads --albescent-reveal-*, the society is no longer hidden. */
+     or a profile reads --albescent-reveal-*, the society is no longer hidden.
+
+     ── THE DARK HALF MINTS NO COLOUR OF ITS OWN, WHICH IS THE POINT ──
+
+     Not one literal below. Every night value is the na card's own pair, or a
+     mix of it — `--faction-default-card-bg` / `-card-text` / `-card-muted`,
+     which already flip. That is the drawn design (canvas `Invitation.dc.html`),
+     and it is the epic's pattern rather than an exception to it: an Albescent
+     surface IS the na surface with light over it, so after dark the letter's
+     stock and ink are simply the na card's stock and ink. There is nothing here
+     to keep in sync with anything, the AA question is already answered by the na
+     card's own measured pair, and the society still owns no hue anyone could
+     point at.
+
+     The guard drove it. `factionContrast.test.ts` runs BOTH_THEMES and already
+     held three reveal pairings; the moment the tokens split they became three
+     real dark measurements, and they were let FAIL first — 1.02:1 for the ink
+     and 1.01:1 for the muted tier, which is the day's near-black ink sitting on
+     a near-black sheet, i.e. the letter with its text rubbed out. The values
+     below are what answers that, not what was tuned to fit it afterwards.
+
+     THE HAIRLINES ARE THE TRAP AND THEY ARE MIXED, NOT ALPHA'D. Keeping the day
+     alphas and only swapping the sheet leaves black at 0.10 and 0.055 on a
+     near-black ground: 1.03:1 and 1.02:1, three rules that are simply not there.
+     The design mixes them DOWN FROM THE CARD'S TEXT instead — 34% and 30% — so
+     they land at 2.74:1 and 2.42:1, heavier than their daytime 1.25:1 and
+     1.13:1 because the ground they will sit on is the prism (#2499), not paper.
+
+     Measured, composited, on the real sheet (day → night):
+       -text        17.07 → 13.75    both AAA; the night value is the na ink
+       -ink          6.74 →  8.04    the design's 74% mix
+       -text-muted   4.64 →  5.44    the tier #594 scarred; MORE margin at night
+       -border       1.25 →  2.74
+       -border-faint 1.13 →  2.42 */
   --albescent-reveal-surface: #ffffff;
   --albescent-reveal-text: #1c1c1a; /* near-black ink, no hue */
   /* Muted ink over the #ffffff sheet, at the AA-cleared alpha #594 landed on:
@@ -7059,9 +7102,48 @@
   --albescent-reveal-border-faint: rgba(0, 0, 0, 0.055);
   --albescent-reveal-shadow: 0 2px 18px rgba(0, 0, 0, 0.055), 0 1px 3px rgba(0, 0, 0, 0.04);
 }
-/* The dark half of the block above held nothing but the `--gestalt-*` flips,
-   so it went with them (#1661). snide + albescent are theme-invariant and never
-   had a dark body here. */
+[data-theme="dark"] {
+  /* The stock and the ink are the na card's, aliased — the design's own two
+     lines, and the only two it needed. 13.75:1, and it flips because the na
+     card's pair already does. */
+  --albescent-reveal-surface: var(--faction-default-card-bg);
+  --albescent-reveal-text: var(--faction-default-card-text);
+  /* The quiet tier — the one with a scar on it. #594 shipped it at 0.44α /
+     2.78:1 by mistake and 0.61α / 4.64:1 is what it was fixed to, so the night
+     twin is answered the way that one was: on the composited value, never a raw
+     hex. The design draws only TWO ink levels after dark (74% for the body, full
+     strength for the headline), so the letter's third tier has no counterpart on
+     the board and is ruled here: it takes the na card's OWN quiet tier, which is
+     opaque, already painted on every na card, and already measured at 5.44:1 —
+     more margin than the 4.64 it clears by day, not less. */
+  --albescent-reveal-text-muted: var(--faction-default-card-muted);
+  /* The design's body ink: 74% of the card's text. 8.04:1. A mix rather than an
+     rgba() so nothing here freezes a copy of #f0e6d0 — repaint the na card and
+     the letter follows, which is the whole reason the design aliases instead of
+     minting. */
+  --albescent-reveal-ink: color-mix(in srgb, var(--faction-default-card-text) 74%, transparent);
+  /* THE HAIRLINES ARE THE TRAP, AND MIXING IS WHAT SPRINGS IT. Left as black at
+     the daytime 0.10 and 0.055 they would sit on a near-black sheet at 1.03:1
+     and 1.02:1 — three structural rules that are simply not drawn. The design
+     mixes them down from the card's TEXT instead, 34% and 30%, for 2.74:1 and
+     2.42:1. Heavier than the daytime 1.25:1 / 1.13:1 on purpose: after dark
+     these rules land on the prism (#2499), not on paper.
+     `-border-faint` also absorbs the letter's third hairline. `RULE` — a lone
+     rgba(0,0,0,0.07) module constant in `AlbescentInvitation` — had no rung of
+     its own and was kept raw because minting one for a single reader was not
+     worth the blocking bytes. The design settles it by drawing the letter's
+     `border-top` and its `border-bottom` at the SAME 30%, so the constant folds
+     in here and the one line the old comment predicted "will not follow" now
+     follows. By day that is 1.17:1 → 1.13:1, one site, imperceptible. */
+  --albescent-reveal-border: color-mix(in srgb, var(--faction-default-card-text) 34%, transparent);
+  --albescent-reveal-border-faint: color-mix(in srgb, var(--faction-default-card-text) 30%, transparent);
+  /* The board is silent on the cast, so the file's own unanimous rule decides
+     it: same geometry, deeper black (Ephemerists 0.55 → 0.8, SNIDE 0.55 → 0.85,
+     Everymen 0.5 → 0.8). Albescent's is a paper cast rather than a lift, so it
+     is scaled to the bottom of that band. Left alone it would be black at 0.055
+     on a near-black page — not wrong, just nothing at all. */
+  --albescent-reveal-shadow: 0 2px 18px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.35);
+}
 
 /* ──────────────────────────────────────────────────────────────────────────
    WOW — THE LISTS (#895): the duel seal and the duel rail.

--- a/frontend/src/pages/AlbescentSecretPlaceholder.tsx
+++ b/frontend/src/pages/AlbescentSecretPlaceholder.tsx
@@ -1,10 +1,26 @@
 /**
  * Albescent "sealed" placeholder (#394). What an outsider sees at
  * `/factions/albescent` — deliberately NOT a 404, an in-world dead end.
- * Styled in the Albescent "Register" idiom (ADR-0017 / #231): always-light
- * vellum, near-black ink, Cormorant Garamond italic, quiet mono label, faint
- * fleur-de-lis glyph. Albescent surfaces never dim in dark mode — the
- * `--albescent-reveal-*` tokens carry identical values in both themes.
+ * Styled in the Albescent "Register" idiom (ADR-0017 / #231): vellum stock,
+ * Cormorant Garamond italic, quiet mono label, faint fleur-de-lis glyph.
+ *
+ * IT FOLLOWS THE FLIP (#2301, epic #2496 ruling 7), and it does so with no edit
+ * below. This docstring used to end "Albescent surfaces never dim in dark mode —
+ * the `--albescent-reveal-*` tokens carry identical values in both themes", and
+ * that is no longer true: the reveal register has a dark half whose values are
+ * the na card's own. Every colour on this page is either `BG`/`INK` or `ink()`
+ * mixed down from `INK`, so the sheet, the rules and the glyph all invert
+ * through the cascade with nothing branching on a `dark` boolean.
+ *
+ * ⚠ ADR-0017's ruling 7 still says Albescent's surfaces are "always-light
+ * (identical values in both the light and dark cascades, exactly as
+ * singularity's are always-dark)". That clause is now contradicted here and
+ * NEEDS AN AMENDMENT the owner has not yet made — flagged on #2301 rather than
+ * rewritten in passing. (Its other half is already dead: the
+ * `--faction-albescent-card-*` tokens it prescribes were deleted by #783, so
+ * Albescent has rendered as unaffiliated everywhere since.) Singularity's
+ * always-dark is untouched and stays — this ruling is about the vellum, not
+ * about retiring theme-invariant surfaces as a class.
  */
 import { useTranslation } from 'react-i18next'
 // Cormorant Garamond ships in the lazily-fetched faction sheet (#2079), and this

--- a/frontend/src/utils/__tests__/contrastColorMix.test.ts
+++ b/frontend/src/utils/__tests__/contrastColorMix.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `parseColor` and the one `color-mix()` shape it models (#2301).
+ *
+ * CSS gives a custom property exactly one way to say "that token, at an alpha"
+ * — `color-mix(in srgb, var(--x) N%, transparent)` — and the Albescent letter's
+ * night ink and hairlines are written that way so nothing freezes a copy of the
+ * na card's text colour. The VALUE-level contrast sweep reads `index.css` in
+ * node with no browser to resolve anything, so before this it saw those tokens
+ * as unparseable and failed the row it could not measure.
+ *
+ * Both halves matter and the second is the load-bearing one: `null` is a
+ * FAILURE to every caller, never a skip, so widening the parser can only add
+ * measurements — but only as long as it stays narrow enough that a shape it
+ * does NOT model keeps returning null rather than a plausible wrong answer.
+ */
+import { describe, expect, it } from "vitest";
+
+import { contrastRatio, parseColor } from "../contrast";
+
+describe("parseColor: color-mix fade to transparent", () => {
+  it("reads a fade as the base colour carrying that percentage as alpha", () => {
+    // Premultiplied sRGB mixing with `transparent` leaves the channels alone,
+    // so this is exactly rgba(240, 230, 208, 0.74) — the letter's night ink.
+    expect(parseColor("color-mix(in srgb, #f0e6d0 74%, transparent)")).toEqual({
+      r: 240,
+      g: 230,
+      b: 208,
+      a: 0.74,
+    });
+  });
+
+  it("agrees with the rgba() spelling of the same colour, to the ratio", () => {
+    const sheet = parseColor("#1c1b24")!;
+    const mixed = parseColor("color-mix(in srgb, #f0e6d0 74%, transparent)")!;
+    const rgba = parseColor("rgba(240, 230, 208, 0.74)")!;
+    expect(contrastRatio(mixed, sheet)).toBeCloseTo(contrastRatio(rgba, sheet), 10);
+  });
+
+  it("resolves a nested spelling of the base colour", () => {
+    expect(parseColor("color-mix(in srgb, rgb(255 255 255) 30%, transparent)")).toEqual({
+      r: 255,
+      g: 255,
+      b: 255,
+      a: 0.3,
+    });
+  });
+
+  it.each([
+    // A mix of two REAL colours is not a fade — the channels move, and this
+    // parser does no mixing math.
+    "color-mix(in srgb, #f0e6d0 74%, #1c1b24)",
+    // Another colour space does not interpolate the same way.
+    "color-mix(in oklab, #f0e6d0 74%, transparent)",
+    // A translucent base would need real premultiplied compositing.
+    "color-mix(in srgb, rgba(240, 230, 208, 0.5) 74%, transparent)",
+    // Not a colour at all.
+    "color-mix(in srgb, var(--never-declared) 74%, transparent)",
+  ])("returns null for %s rather than guessing", (value) => {
+    expect(parseColor(value)).toBeNull();
+  });
+});

--- a/frontend/src/utils/contrast.ts
+++ b/frontend/src/utils/contrast.ts
@@ -105,8 +105,35 @@ export function parseColor(input: string): Rgba | null {
     return { r, g, b, a: alpha };
   }
 
+  const faded = COLOR_MIX_FADE.exec(value);
+  if (faded) {
+    const base = parseColor(faded[1].trim());
+    const percent = readAlpha(`${faded[2]}%`);
+    if (base === null || percent === null || base.a !== 1) return null;
+    return { ...base, a: percent };
+  }
+
   return null;
 }
+
+// `color-mix(in srgb, <color> <p>%, transparent)` — fading a colour with
+// `transparent` is the only way CSS lets a custom property carry "that token, at
+// an alpha", and it is what the Albescent letter's night ink is written as
+// (#2301). Because sRGB mixing is premultiplied, mixing an OPAQUE colour with
+// `transparent` leaves the channels alone and lands the alpha at `p` — so this
+// is exactly `rgba(<color>, p/100)` and needs no mixing math.
+//
+// STRICTLY THIS ONE SHAPE. A mix of two real colours, another colour space, or
+// a second percentage still returns null, and null is a FAILURE to every caller
+// (see the note on this function) — never a skip. So this only ever ADDS
+// measurements: nothing that resolves through here could pass before, because
+// before, every `color-mix()` was an unmeasurable hole.
+//
+// The rendered sweeps never needed it — Chromium hands them the resolved
+// `color(srgb …)` above. It is the VALUE-level sweep, reading index.css in node
+// with no browser to resolve anything, that could not see through it.
+const COLOR_MIX_FADE =
+  /^color-mix\(\s*in\s+srgb\s*,\s*(.+?)\s+([\d.]+)%\s*,\s*transparent\s*\)$/i;
 
 function readChannel(token: string): number | null {
   const numeric = Number.parseFloat(token);


### PR DESCRIPTION
Closes #2301

The Albescent vellum stops being always-light. It was the last always-light sheet of its kind — the Ephemerists' flipped first in #2141.

## The seam I tested at

**The token values, measured across `BOTH_THEMES` by `factionContrast.test.ts`.** No harness change, exactly as the issue predicted. The three `albescent reveal sheet, …` rows passed before only because both themes read the same values; the moment the tokens split they became three real dark measurements.

They were let go red first, and the red was the actual defect — the day's near-black ink sitting on a near-black sheet:

```
dark | albescent reveal sheet, ink:   rgba(28, 28, 26, 0.72) on #1e1e1c = 1.02:1, needs 4.5:1
dark | albescent reveal sheet, muted: rgba(28, 28, 26, 0.61) on #1e1e1c = 1.01:1, needs 4.5:1
```

That is the letter with its text rubbed out. The palette below answers it; it was not tuned to fit afterwards.

## The palette is DERIVED FROM THE DESIGN, not invented

The issue body says "mint the dark half — seven tokens — values need the owner's eye." **The canvas artboard `Invitation.dc.html` does not do that, and its way is better.** It repoints the reveal tokens at the na card's own pair, which already flips. So there is no new colour to keep in sync with anything, and the AA question was already answered by the na card's own measured pair.

I first derived a palette of seven literals against the issue's constraints; the vendored design arrived mid-task and I threw it away. Every value below is the design's.

**Not one literal in the dark half.** Every night value is `--faction-default-card-{bg,text,muted}` or a `color-mix()` fade of the card's text.

| token | light (unchanged) | dark | dark resolves to |
|---|---|---|---|
| `-surface` | `#ffffff` | `var(--faction-default-card-bg)` | `#1c1b24` |
| `-text` | `#1c1c1a` | `var(--faction-default-card-text)` | `#f0e6d0` |
| `-text-muted` | `rgba(28,28,26,0.61)` | `var(--faction-default-card-muted)` | `#9b9080` |
| `-ink` | `rgba(28,28,26,0.72)` | `color-mix(in srgb, var(--faction-default-card-text) 74%, transparent)` | `#b9b1a3` |
| `-border` | `rgba(0,0,0,0.1)` | `color-mix(… card-text 34%, transparent)` | `#64605e` |
| `-border-faint` | `rgba(0,0,0,0.055)` | `color-mix(… card-text 30%, transparent)` | `#5c5858` |
| `-shadow` | `0 2px 18px rgba(0,0,0,.055), 0 1px 3px rgba(0,0,0,.04)` | same geometry, `.5` / `.35` | — |

### Composited ratios, both themes

Composited on the real sheet, via `utils/contrast.ts`'s own `compositeOver` — never the raw hex.

| pairing | light | dark |
|---|---|---|
| **sheet / text** (guard row) | **17.07:1** | **13.75:1** |
| **sheet / ink** (guard row) | **6.74:1** | **8.04:1** |
| **sheet / muted** (guard row) | **4.64:1** | **5.44:1** |
| sheet / `-border` | 1.25:1 | 2.74:1 |
| sheet / `-border-faint` | 1.13:1 | 2.42:1 |
| sheet vs `--color-bg-page` | 1.10:1 | 1.09:1 |
| accept button (surface on text) | 17.07:1 | 13.75:1 |

**The muted tier is the one with a scar on it** — #594 shipped it at `0.44α` / 2.78:1 by mistake before landing on `0.61α` / 4.64:1. Its night twin is `--faction-default-card-muted`, opaque, at **5.44:1**: *more* margin than it clears by day, not less. (That 5.44 is the same figure epic ruling 9 already quotes for the na card's quiet tier — measured independently here and it agrees.)

**Three tiers, not two.** The design draws only two ink levels after dark (74% body, full-strength headline), so the letter's third tier has no counterpart on the board. **My ruling, flagged for you:** it takes the na card's own quiet tier rather than being collapsed into the 74%, so the letter keeps the same three-step hierarchy in both themes.

### The hairlines — the trap, and why they do not vanish

Keeping the day alphas and only swapping the sheet leaves black at `0.10` and `0.055` on a near-black ground: **1.03:1 and 1.02:1** — three structural rules that are drawn and invisible. The design mixes them *down from the card's text* instead, at 34% and 30%, landing at 2.74:1 and 2.42:1. Heavier than their daytime 1.25/1.13 on purpose: after dark they sit on the prism (#2499), not on paper.

## §2 of the issue was already two-thirds done

`HAIRLINE` and `HAIRLINE_FAINT` were repointed at the tokens back in #2139 — the issue body's line numbers had rotted. Only **`RULE` (`rgba(0,0,0,0.07)`, one site)** was still frozen, and its own note predicted this exact ending: *"if #2301 gives the reveal a dark half, this is the line that will not follow."* It would have drawn at 1.02:1.

It **folds into `-border-faint`** rather than getting the third rung it was refused, because the design draws the letter's `border-top` and its `border-bottom` at the same 30% after dark. By day: 1.17:1 → 1.13:1, one site, imperceptible. No third token, no extra blocking bytes.

**"Check `AlbescentComment` for the same pattern" — that component does not exist.** There is no `AlbescentComment` anywhere in the tree; Albescent wraps `DefaultComment`. The claim in that code comment is stale.

## Every surface ruled: all follow, none pinned

| surface | ruling | why |
|---|---|---|
| `AlbescentInvitation` (the letter) | **follows** | every colour was already a token; only `RULE` needed the fold |
| `AlbescentSecretPlaceholder` (sealed page) | **follows** | all `BG`/`INK` or `ink()` mixed from `INK` — **zero code change**, cascade carries it |
| `AlbescentSelectCard` | **follows** | reads reveal tokens only; **zero code change** |
| `AlbescentSeal` | **follows** | reads reveal tokens only; **zero code change** |
| `AlbescentSigil` (labyrinth) | **not a reveal surface** | paints in `--faction-default-rainbow-conic`; has carried no reveal hue since #1891. **The issue's table row is stale.** |
| `FactionSigil` (dispatcher) | comment only | historical reference corrected |
| `factions/albescent.ts` | comment only | "always-light" claim corrected |
| `utils/contrast.ts` | doc reference | still accurate — it quotes the *light* value |

Nothing is pinned light, and **nothing was pinned by accident** — that was named as the failure mode and I checked each one by grep, not by assumption. The reason four surfaces needed no colour edit is that all four were already painting in reveal tokens.

The stale in-code comment claiming these tokens are reached by "the two or three components that ARE the reveal" is rewritten; that count had been wrong since #2329 split the select cards.

## ⚠ ADR-0017 needs an amendment — NOT made here

ADR-0017 ruling 7 still says Albescent's surfaces are *"always-light (identical values in both the light and dark cascades, exactly as singularity's are always-dark)"*. `AlbescentSecretPlaceholder` now contradicts that.

**I have not touched the ADR.** The contradiction is flagged in the component's docstring and here, for you to rule on.

Worth knowing before you do: **the ADR's other half is already dead.** It prescribes `--faction-albescent-card-*` tokens, and #783 deleted that whole family — Albescent has rendered as unaffiliated everywhere since. So ruling 7 was already half-superseded before #2301 touched it.

Singularity's always-dark is untouched and stays. This is a ruling about the vellum, not about retiring theme-invariant surfaces as a class.

## One change outside the tokens: `contrast.ts` learns one `color-mix` shape

`parseColor` returned **null** for `color-mix()`, and null is a *failure* to every caller. `color-mix(in srgb, <token> N%, transparent)` is the only way CSS lets a custom property say "that token, at an alpha" — so without this, the design's method is unmeasurable and `-ink`'s guard row fails on a parse rather than a ratio.

Because sRGB mixing is premultiplied, mixing an **opaque** colour with `transparent` leaves the channels alone and lands the alpha at `N` — so it is exactly `rgba(<color>, N/100)` and needs no mixing math.

**This can only add measurements, never loosen one.** Nothing that resolves through it could pass before, because before, every `color-mix()` in a measured slot was a hole. It is deliberately narrow: a mix of two real colours, another colour space, a translucent base and an unresolved var all still return null. Those four negative cases are pinned in `contrastColorMix.test.ts`.

## Scope kept

- `index.css` edits are **confined to the `--albescent-reveal-*` block and its comment**. No `.alb-*` ground rule touched — #2499 owns the prism, including the letter's dark ground.
- The canvas's three-ring `@property --sig-angle` sigil is **not built**: epic #2496's technique ruling retires animating a gradient parameter.
- #2409's secrecy rules and `factionCssVar('albescent') → --faction-default-*` are untouched.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **411 files, 7319 passed**, 1 skipped |
| `npm run build` | clean |
| `npm run budget` | **CSS 22.8 → 22.9 KB gzipped (+0.1 KB)** |

Budget: `main` already WARNs at 22.8 against the 22.2 line; this adds ~100 gzipped bytes and the 24.4 KB fail line is untouched. Aliases are cheap — seven literals would have cost more.

## 🔍 What to eyeball

**I have no browser and no dev stack. Visual QA on all of this is outstanding** — every number above is from the value-level sweep, not from looking at it.

1. **The invitation letter in dark** — the whole point.
   - **its sheet**: now the na card's `#1c1b24`, sitting 1.09:1 off the page. Does it still read as *a sheet of paper*, or has it sunk into the page?
   - **its muted ink**: `#9b9080` at 5.44:1 — the level chips and the "12px" right-aligned level labels are the smallest text on it.
   - **its three hairlines — the thing most likely to disappear.** Please check all three specifically: the **54px divider under the sigil** (`-border`, 2.74:1); the **terms-slip top rule** (now `-border-faint`, 2.42:1 — this is the one that used to be a frozen black and would have been *invisible*); and the **term-row bottom borders** (`-border-faint`). If any of the three is missing, the mix percentage is the dial.
   - **the accept button** inverts to a cream fill with dark text (13.75:1). Check it does not glare.
2. **The sealed placeholder page** (`/factions/albescent` as an outsider) — the fleur-de-lis glyph and its 64px rule are `ink(22)` / `ink(16)` mixes, so they got *fainter relative to nothing* but the ground moved under them. **Also: its "SEALED" eyebrow is `ink(30)` — 1.92:1 in light today and 2.42:1 in dark.** That is a **pre-existing light-mode AA miss** that this change slightly improves; it is not in the guard and I did not touch it. Worth its own issue if you agree it is a defect.
3. **The seal**, stuck on someone else's praxis. In dark its sheet becomes `#1c1b24` — **the same colour as an na card it may be sitting on.** Its `-border` at 2.74:1 is the only thing keeping it a distinct object there. Check it on an **na** praxis card specifically.
4. **The select card** on `/factions` — the pale tile becomes an na-dark one at night, with its inset 12px frame at `-border-faint`. Check the frame survives and that the tile still reads as *the one that is different*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
