### PR TITLE
na's kit carries the spectrum the design draws, so Albescent's delta is motion alone (#2520)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -353,6 +353,36 @@ component compose image, blend and clip together. Custom properties inherit as a
 or gets `normal`. **The component owns its ground. A page may hand it a value; it may never paint
 half of one onto it.**
 
+### The na kit carries the SPECTRUM; a dresser's delta is MOTION (#2520, epic #2496)
+
+The Albescent kit's whole claim is "the na component plus ornament, never a skin", and its
+canvas states the corollary the built surfaces missed: **na's own kit gains the spectrum
+treatment, and Albescent's delta is motion alone.** Four surfaces shipped from issue prose
+without the drawing and all four got this the same way round — the society ANIMATED a rule the
+unaffiliated player did not have, so the two kits differed *structurally* where the design says
+they differ only by whether the rainbow moves. Three consequences, each of which was a live
+inconsistency on the site:
+
+- **A flat 1px grey line on an na surface is a spectrum rule waiting to happen.** The score
+  stamp ruled its working in grey (a hairline per row, plus a divider over the tally); it now
+  draws ONE 2px spectrum rule wherever its working ends, and the grey goes. One rule per object,
+  in every state it has — where there is no divider to upgrade, the same rule prints under the
+  rows instead, so the geometry does not change shape between states.
+- **The spectrum arrives as a BORDER, not as a bar pinned to an edge.** `border: 3px solid
+  transparent` with the ramp appended to all three of the sheet's background lists
+  (`factionSpectrumSheet()`), `background-origin: border-box`. The task card, the praxis card
+  (#2499), the metatask seal and the composer sheet now all say it that way. A 3px strip across
+  a top edge is the same rainbow said in a second dialect, and a kit that says one thing four
+  ways cannot read as one material.
+- **na must not be moving already.** The composer's masthead band was walked by `.ep-edge` for
+  every player, so the society's travelling sheet edge was not a tell at all — it was a second
+  moving rainbow beside na's own. The band is off, and na's spectrum on that page is a static
+  frame. **Before giving a dresser a motion, check the na surface is still.**
+
+The board's own comment on the seal says 2px and its CSS says 3px. Build the CSS, flag the
+discrepancy, and do not average the two — 3px is also what the two cards already wear, which is
+the tiebreak the prose could not give.
+
 ### When AA forces a colour CODE onto one hue's lightness, the axis left is chroma (#2019)
 
 A design can hand you a set of inks whose whole job is to be told apart. Coven's rebuilt score stamp colour-codes its working — base pink, multiplier gold, votes blue, and the blue is deliberate because votes are the one term that comes from other people — and all three of the design's own values failed AA on the light plate: **3.27 / 1.89 / 3.18** on the plate's darker stop. Walking each down its own hue line is the routine half, and it is §"a spine hue is a FILL" arriving one issue later: the gold has no yellow that clears near-white paper, so light lands on an olive, exactly where `--faction-wow-accent-deep` had to.

--- a/frontend/src/components/__tests__/spectrumClasses.test.tsx
+++ b/frontend/src/components/__tests__/spectrumClasses.test.tsx
@@ -134,26 +134,14 @@ describe("the na mounts wear the class, not the declaration (#2497)", () => {
           }
         />,
       ),
-    "the seal's accent strip": () =>
-      renderToStaticMarkup(
-        <DefaultSeal
-          metatask={{
-            id: 1,
-            title: "A small kindness",
-            condition: "Do it twice",
-            bonus_points: 3,
-            metatask_faction_slug: "na",
-          } as never}
-        />,
-      ),
   };
 
   for (const [name, render] of Object.entries(surfaces)) {
     it(`${name} is classed`, () => {
       const markup = render().replace(/\s*([:;,])\s*/g, "$1");
-      // All three draw at least one LINEAR cut, so the rule class is the one
-      // every surface here must show. The conic sibling is held from the other
-      // side by `pointsMarkUnification.test.tsx`, which probes for it by name.
+      // Both draw at least one LINEAR cut, so the rule class is the one every
+      // surface here must show. The conic sibling is held from the other side
+      // by `pointsMarkUnification.test.tsx`, which probes for it by name.
       expect(markup).toContain("spectrum-rule");
       for (const declaration of RETIRED) {
         expect(
@@ -163,4 +151,54 @@ describe("the na mounts wear the class, not the declaration (#2497)", () => {
       }
     });
   }
+});
+
+/**
+ * THE SEAL'S SPECTRUM IS ITS BORDER NOW (#2520, epic #2496).
+ *
+ * It was the third mount in the block above — a `.spectrum-rule` strip pinned
+ * across the top edge. `Score-Stamp.dc.html` drops the bar and paints the
+ * spectrum into the border box itself, which is the idiom `DefaultTaskCard` and
+ * (since #2499) `DefaultPraxisCard` already wear, so the na kit reads as one
+ * material rather than as three different ways of saying "rainbow".
+ *
+ * The seam is the same one the block above uses — the rendered markup — and the
+ * claim has two halves, because either alone passes against the wrong thing: the
+ * strip is GONE, and the ramp arrives through `factionSpectrumSheet()`, appended
+ * to all three of the sheet's background lists so Albescent's five-layer dark
+ * prism cannot be handed the wrong blend mode (see the helper's own note).
+ */
+describe("the seal wears the spectrum as a border, not a bar (#2520)", () => {
+  const markup = () =>
+    renderToStaticMarkup(
+      <DefaultSeal
+        metatask={{
+          id: 1,
+          title: "A small kindness",
+          condition: "Do it twice",
+          bonus_points: 3,
+          metatask_faction_slug: "na",
+        } as never}
+      />,
+    ).replace(/\s*([:;,])\s*/g, "$1");
+
+  it("draws no accent strip at all", () => {
+    expect(markup()).not.toContain("spectrum-rule");
+  });
+
+  it("paints the ramp into a transparent 3px frame", () => {
+    const html = markup();
+    // The design board's comment says 2px and its CSS says 3px; the CSS is what
+    // is drawn, and 3px is the width the task card and the praxis card already
+    // use — flagged on the PR rather than averaged.
+    expect(html).toContain("border:3px solid transparent");
+    expect(html).toContain(
+      "background-image:var(--faction-default-card-sheet),var(--faction-default-rainbow)",
+    );
+    // `background-origin: border-box` is what makes the ramp start at the frame
+    // instead of at the padding box, and the padding-box clip is what keeps the
+    // sheet off it. Without either the border is a flat sheet colour.
+    expect(html).toContain("background-origin:border-box");
+    expect(html).toContain("border-box");
+  });
 });

--- a/frontend/src/components/metataskSeal/skins/DefaultSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/DefaultSeal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { factionName, factionSheet } from '../../../utils/factions'
+import { factionName, factionSpectrumSheet } from '../../../utils/factions'
 import type { SealSkinProps } from '../types'
 
 /**
@@ -10,9 +10,16 @@ import type { SealSkinProps } from '../types'
  * whose issuing faction has no bespoke skin registered falls through to it via
  * {@link MetataskSeal}'s dispatch table (e.g. `wow` until #931), so integrations
  * render end to end before the per-faction skins land. It stays a tasteful
- * neutral card — a full-spectrum rainbow accent strip and an uppercase register
- * are its only signature — showing the "<FACTION> METATASK" label, the condition
- * and the "+N PTS" bonus, plus the `×` peel control when `removable`.
+ * neutral card — a full-spectrum rainbow FRAME and an uppercase register are its
+ * only signature — showing the "<FACTION> METATASK" label, the condition and the
+ * "+N PTS" bonus, plus the `×` peel control when `removable`.
+ *
+ * THE SPECTRUM IS THE BORDER, NOT A BAR (#2520, epic #2496). A 3px strip was
+ * pinned across the top edge until `Score-Stamp.dc.html` ruled otherwise: "drop
+ * the bar and paint the spectrum into the border box itself". That is the idiom
+ * `DefaultTaskCard` and `DefaultPraxisCard` already wear, so the na kit reads as
+ * one material — which is the precondition for "Albescent = na + motion" being
+ * true rather than aspirational.
  */
 export default function DefaultSeal({ metatask, removable, onRemove }: SealSkinProps) {
   const { t } = useTranslation('praxis')
@@ -22,26 +29,19 @@ export default function DefaultSeal({ metatask, removable, onRemove }: SealSkinP
     <div
       className="relative"
       style={{
-        ...factionSheet(),
+        // The 3px spectrum frame, not a 3px bar across the top edge (#2520).
+        // Only the geometry is stated here; the composition — the ramp appended
+        // to all THREE of the sheet's lists — belongs to the helper, because a
+        // background list is a list in three properties at once and CSS cycles
+        // the short ones rather than padding them.
+        border: '3px solid transparent',
+        ...factionSpectrumSheet(),
         color: 'var(--faction-default-card-text)',
-        border: '2px solid var(--faction-default-border)',
         borderRadius: 12,
         padding: 'var(--space-md) var(--space-lg)',
         overflow: 'hidden',
       }}
     >
-      {/* the whole rainbow, no allegiance — a full-spectrum accent, top edge */}
-      <span
-        aria-hidden="true"
-        className="absolute spectrum-rule"
-        style={{
-          top: 0,
-          left: 0,
-          right: 0,
-          height: 3,
-        }}
-      />
-
       {removable && (
         <button
           type="button"

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -13,9 +13,16 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * Rebuilt to the Unaffiliated praxis-detail design (#1091, epic #1085). That
  * skin IS the unaffiliated one, so "restyle the default stamp" and "build the
  * design's score rail" are the same object: a total mark carrying the total
- * over a `POINTS` caption, then the working out as RULED LEADER-LINE ROWS —
- * `LABEL … hairline … value` — and, under a rule of its own, the votes tally.
- * A 2px spectrum bar is pinned across the top edge.
+ * over a `POINTS` caption, then the working out as `LABEL … value` rows, then
+ * ONE 2px spectrum rule, then the votes tally. A 2px spectrum bar is pinned
+ * across the top edge.
+ *
+ * THE GREY LINES ARE GONE (#2520, epic #2496). `Score-Stamp.dc.html` gives the
+ * na stamp the spectrum treatment so that Albescent's delta can be MOTION alone
+ * — the society was animating a rule the unaffiliated stamp did not have. The
+ * rows' grey leader hairlines go (the figures keep their column on
+ * `margin-left: auto`), the tally's grey `border-top` divider goes, and one
+ * spectrum rule stands in for both wherever the working ends.
  *
  * THE MARK IS NO LONGER THIS DESIGN'S STRUCK DISC. #2042 found `na` drawing its
  * points mark twice and the owner ruled that the point card takes the task card's,
@@ -159,9 +166,9 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
           rainbow, and the owner's ruling on #2042 is that the point card reflects
           the card's total look. {@link DefaultPointsRing} is the one drawing now.
 
-          THE RAINBOW IS STILL ON THIS OBJECT TWICE, and both appearances are
-          structural rather than clipped to type: the 2px spectrum bar across the
-          top edge, and the ring's annulus. What goes is the four-stop
+          THE RAINBOW IS STRUCTURAL ON THIS OBJECT, never clipped to type: the
+          2px bar across the top edge, the ring's annulus, and — since #2520 —
+          the one rule over the working. What goes is the four-stop
           `-total-rainbow` fill on the figure and the gold caption under it — the
           ring letters its unit in `-card-muted`, which measures 6.15:1 light and
           4.82:1 dark on this plate against the gold's 5.00:1 / 8.23:1. Both clear
@@ -219,16 +226,8 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
             {row.label}
           </span>
           <span
-            aria-hidden
             style={{
-              flex: "1 1 auto",
-              minWidth: 6,
-              height: 1,
-              background: "var(--faction-default-card-line)",
-            }}
-          />
-          <span
-            style={{
+              marginLeft: "auto",
               fontFamily: "var(--faction-default-card-font)",
               fontSize: "var(--text-lg)",
               whiteSpace: "nowrap",
@@ -239,26 +238,56 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
         </div>
       ))}
 
-      {/* The flat terms, under a rule of their own — the rule is the multiplier's
-          edge: everything over it is inside `(base + meta) × mult` and everything
-          under it is flat (#1617). Both leave at 0: the habit bonus always did,
-          and the tally does since ADR-0076. With neither, the block goes rather
-          than hanging an empty rule under the disc.
+      {/* THE STAMP'S ONE RULE (#2520, epic #2496) — a 2px spectrum, inset from
+          the plate's edges by the plate's own padding, run to the width of the
+          breakdown column.
 
-          `rows.length > 0` whenever this block is drawn — votes or habit both
-          un-suppress the base row — so the rule is only ever conditional in the
-          direction the compiler cannot see.
+          It replaces the 1px grey line the flat-terms block used to hang off its
+          own `border-top`, and it is anchored HERE rather than on that block so
+          the geometry holds in every state: with a tally it parts the working
+          from the flat terms exactly where the grey divider sat; with a sealed
+          metatask and no votes it prints under the working instead. `Score-
+          Stamp.dc.html` draws all four states to make that the point — one
+          spectrum rule per stamp, wherever the stamp ends.
 
-          The guard is `hasFlatTerms`, NOT `hasWorking`: the implication runs one
-          way only. A sealed metatask nobody has voted on has rows and no flat
-          terms, and widening this to `hasWorking` would draw the block's rule
-          under it with nothing beneath — the orphan ADR-0076 exists to stop. */}
+          `hasWorking`, not `hasFlatTerms`: base-only draws no breakdown at all
+          (#1131 / ADR-0076), and a rule under a bare disc would be the orphan
+          that ruling exists to stop.
+
+          `position: relative` is the mount Albescent's travelling child needs.
+          `.alb-stamp .spectrum-rule::before` is absolutely positioned, so
+          without a containing block here it would resolve against the plate and
+          paint the ramp straight over the working out. That the class reaches
+          both this rule and the band above is the point of #2520: the two stamps
+          are one stamp, and the society's delta is that these SAME spectra move
+          (index.css owns the resting paint, motion.ornament.css the travel). */}
+      {hasWorking && (
+        <span
+          aria-hidden
+          className="spectrum-rule"
+          style={{
+            display: "block",
+            position: "relative",
+            height: 2,
+            borderRadius: 2,
+            marginTop: "var(--space-xs)",
+          }}
+        />
+      )}
+
+      {/* The flat terms, under the rule above — everything over it is inside
+          `(base + meta) × mult` and everything under it is flat (#1617). Both
+          leave at 0: the habit bonus always did, and the tally does since
+          ADR-0076, and with neither the block goes.
+
+          THE RULE IS NO LONGER THIS BLOCK'S `border-top`. It was, which is why
+          it had to be conditional on `rows.length` from in here; it is now the
+          stamp's own rule above, drawn once for the whole sheet, so this block
+          carries nothing but its ink and the space under that rule. */}
       {hasFlatTerms && (
         <div
           style={{
-            borderTop: rows.length > 0 ? "1px solid var(--faction-default-card-line)" : undefined,
-            marginTop: "var(--space-xs)",
-            paddingTop: rows.length > 0 ? "var(--space-sm)" : undefined,
+            marginTop: "var(--space-sm)",
             fontFamily: "var(--font-body)",
             fontSize: "var(--text-base)",
             letterSpacing: "0.06em",

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -201,6 +201,48 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
         />
       </div>
 
+      {/* THE STAMP'S ONE RULE (#2520, epic #2496) — a 2px spectrum, inset from
+          the plate's edges by the plate's own padding, run to the width of the
+          breakdown column. It replaces the 1px grey line the flat-terms block
+          used to hang off its own `border-top`.
+
+          IT SITS UNDER THE TOTAL, ABOVE THE WORKING, and that position is a
+          ruling rather than a layout preference (owner, 2026-08-23). The board
+          says the rule "prints under BASE — the row directly after the total —
+          so the geometry matches the votes case", and anchoring it here is what
+          makes "one spectrum rule per stamp, in every state" true WITHOUT ever
+          leaving it orphaned. Anchored below the working instead, a sealed
+          metatask nobody has voted on has rows and no flat terms, so the rule
+          would be the last thing on the sheet with nothing beneath it — the
+          orphan ADR-0076 exists to stop, and the exact reversal the old comment
+          on this file warned against by name.
+
+          `hasWorking`, not `hasFlatTerms`: base-only draws no breakdown at all
+          (#1131 / ADR-0076) and so prints no rule, which is the one state the
+          board also leaves bare. Every other state has rows or a tally beneath
+          this line, so it always parts something from something.
+
+          `position: relative` is the mount Albescent's travelling child needs.
+          `.alb-stamp .spectrum-rule::before` is absolutely positioned, so
+          without a containing block here it would resolve against the plate and
+          paint the ramp straight over the working out. That the class reaches
+          both this rule and the band above is the point of #2520: the two stamps
+          are one stamp, and the society's delta is that these SAME spectra move
+          (index.css owns the resting paint, motion.ornament.css the travel). */}
+      {hasWorking && (
+        <span
+          aria-hidden
+          className="spectrum-rule"
+          style={{
+            display: "block",
+            position: "relative",
+            height: 2,
+            borderRadius: 2,
+            marginBottom: "var(--space-xs)",
+          }}
+        />
+      )}
+
       {/* Ruled leader-line rows — label, a hairline running out to fill the gap,
           then the figure. */}
       {rows.map((row) => (
@@ -238,52 +280,15 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
         </div>
       ))}
 
-      {/* THE STAMP'S ONE RULE (#2520, epic #2496) — a 2px spectrum, inset from
-          the plate's edges by the plate's own padding, run to the width of the
-          breakdown column.
-
-          It replaces the 1px grey line the flat-terms block used to hang off its
-          own `border-top`, and it is anchored HERE rather than on that block so
-          the geometry holds in every state: with a tally it parts the working
-          from the flat terms exactly where the grey divider sat; with a sealed
-          metatask and no votes it prints under the working instead. `Score-
-          Stamp.dc.html` draws all four states to make that the point — one
-          spectrum rule per stamp, wherever the stamp ends.
-
-          `hasWorking`, not `hasFlatTerms`: base-only draws no breakdown at all
-          (#1131 / ADR-0076), and a rule under a bare disc would be the orphan
-          that ruling exists to stop.
-
-          `position: relative` is the mount Albescent's travelling child needs.
-          `.alb-stamp .spectrum-rule::before` is absolutely positioned, so
-          without a containing block here it would resolve against the plate and
-          paint the ramp straight over the working out. That the class reaches
-          both this rule and the band above is the point of #2520: the two stamps
-          are one stamp, and the society's delta is that these SAME spectra move
-          (index.css owns the resting paint, motion.ornament.css the travel). */}
-      {hasWorking && (
-        <span
-          aria-hidden
-          className="spectrum-rule"
-          style={{
-            display: "block",
-            position: "relative",
-            height: 2,
-            borderRadius: 2,
-            marginTop: "var(--space-xs)",
-          }}
-        />
-      )}
-
-      {/* The flat terms, under the rule above — everything over it is inside
+      {/* The flat terms — everything over the rule is inside
           `(base + meta) × mult` and everything under it is flat (#1617). Both
           leave at 0: the habit bonus always did, and the tally does since
           ADR-0076, and with neither the block goes.
 
           THE RULE IS NO LONGER THIS BLOCK'S `border-top`. It was, which is why
           it had to be conditional on `rows.length` from in here; it is now the
-          stamp's own rule above, drawn once for the whole sheet, so this block
-          carries nothing but its ink and the space under that rule. */}
+          stamp's own element under the total, drawn once for the whole sheet,
+          so this block carries nothing but its ink and its own space. */}
       {hasFlatTerms && (
         <div
           style={{

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -654,19 +654,21 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
       const html = text(markup)
       expectBaseRow(html, showsBase)
       expectVotesRow(html, showsVotes)
-      // The LEADER HAIRLINE is what only a working row draws — the rule that
-      // runs out from a label to fill the gap before its figure. In the
-      // base-only state the mark is alone and no row survives (ADR-0076), and a
-      // tally block implies rows (votes un-suppress the base row), so the
-      // hairline is present exactly when there is working to show.
+      // THE SPECTRUM RULE is what only a sheet with working draws — the stamp's
+      // one rule, under the rows or between them and the tally. In the base-only
+      // state the mark is alone and no row survives (ADR-0076), and a tally
+      // block implies rows (votes un-suppress the base row), so the rule is
+      // present exactly when there is working to show.
       //
       // This used to read `--faction-default-card-muted`, on the stated grounds
       // that the ink dressed the rows and the tally "and nothing else on the
       // sheet". #2042 made that false: the total mark is
       // `DefaultPointsRing` now and it letters its unit in the same ink, so the
-      // proxy stopped distinguishing a sheet with working from one without.
-      if (showsBase) expect(markup).toContain('min-width:6px')
-      else expect(markup).not.toContain('min-width:6px')
+      // proxy stopped distinguishing a sheet with working from one without. It
+      // then read `min-width:6px`, the grey leader hairline, until #2520 traded
+      // both grey lines on this sheet for the one spectrum rule.
+      if (showsBase) expect(markup).toContain('position:relative;height:2px')
+      else expect(markup).not.toContain('position:relative;height:2px')
       expect(html).toContain(formatPoints(fields.score))
       expect(html).toContain('points')
       expect(html).not.toMatch(HEX)
@@ -700,10 +702,10 @@ describe('a base-only score reads as a bare total on every stamp (ADR-0076)', ()
    * have nothing to check here.
    */
   const STAMPS = [
-    // `min-width:6px` is the leader hairline a working row runs out to its
-    // figure — see the note in the conditional-states block above for why this
-    // is no longer `--faction-default-card-muted`.
-    ['the unaffiliated sheet', DefaultScoreStamp, 'base', /votes/, 'min-width:6px'],
+    // `position:relative;height:2px` is the na sheet's one spectrum rule, drawn
+    // wherever its working ends (#2520) — see the note in the conditional-states
+    // block above for the two proxies that came before it.
+    ['the unaffiliated sheet', DefaultScoreStamp, 'base', /votes/, 'position:relative;height:2px'],
     ['Everymen', EverymenScoreStamp, 'base', /votes/, 'TALLY'],
     ['the Ephemerists', EphemeristsScoreStamp, EPHEMERISTS_LABEL.base, /票/, null],
     ['S.N.I.D.E.', SnideScoreStamp, 'base', /votes/, '2px dashed'],
@@ -877,14 +879,20 @@ describe('the unaffiliated disc shrink-wraps when nothing follows it (#1894)', (
     }
   })
 
-  it('still hangs no flat-terms rule on a metatask praxis nobody has voted on', () => {
-    // `padding-top` is the flat-terms block's alone on this sheet — the rows
-    // carry `padding:var(--space-xs) 0` and nothing else pads one edge.
+  it('draws no tally block on a metatask praxis nobody has voted on', () => {
+    // The flat-terms block is `margin-top:var(--space-sm)` and this sheet's only
+    // reader of `card.stamp.fromVotes`, so the tally's absence is countable off
+    // the copy. Until #2520 this case ALSO asserted that no rule was drawn —
+    // the rule was that block's own `border-top` and could not exist without
+    // it. The stamp's rule is its own element now and prints here too, which is
+    // the design's "one spectrum rule per stamp, in every state"; what must
+    // still not appear is the empty tally.
     const markup = renderToStaticMarkup(
       <DefaultScoreStamp praxis={praxis({ ...bareFields, metatask_points: 3, score: 13 })} />,
     )
     expect(markup).toContain('meta')
-    expect(markup).not.toContain('padding-top')
+    expect(text(markup)).not.toContain('from votes')
+    expect(markup).not.toContain('margin-top:var(--space-sm)')
   })
 })
 
@@ -1136,5 +1144,79 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
     expect(text(markup)).toContain('habit')
     expect(markup).not.toContain('習')
     expect(markup).not.toContain('title="habit"')
+  })
+})
+
+/**
+ * ONE SPECTRUM RULE PER STAMP, in every state (#2520, epic #2496).
+ *
+ * `Score-Stamp.dc.html` draws three columns — shipped (a flat 1px grey line),
+ * na (a 2px STATIC spectrum rule) and Albescent (that same stamp with the rule
+ * travelling and the ring turning). #2501 built the third column and skipped the
+ * second, so the society's stamp animated a rule the unaffiliated stamp did not
+ * have and the two differed STRUCTURALLY, when the design says they differ only
+ * by motion. This is the second column.
+ *
+ * The seam is the rendered markup of `DefaultScoreStamp`, and the claim is
+ * COUNTABLE: the stamp carries the band across its top edge plus AT MOST ONE
+ * rule over its working. A presence check would pass against a rule per row,
+ * which is the shape the board's own comment rejects — "one spectrum rule per
+ * stamp is enough".
+ *
+ * The four cases are the board's four fixtures. Base-only draws no breakdown at
+ * all (#1131 / ADR-0076), so it draws no rule either: the band is the whole
+ * spectrum on it.
+ *
+ * `position: relative` on the rule is not decoration. `.alb-stamp
+ * .spectrum-rule::before` is absolutely positioned, so a rule that is not itself
+ * a containing block hands Albescent's travelling child the stamp PLATE, and the
+ * ramp paints over the working out.
+ */
+describe('the na stamp rules its working in the spectrum (#2520)', () => {
+  const fields = {
+    task_point_value: 12,
+    display_multiplier: 1,
+    metatask_points: 0,
+    points_from_votes: 0,
+    habit_bonus_points: 0,
+  }
+  /** The band's mount plus the working's, counted by the shared class. */
+  const spectra = (markup: string) => markup.split('spectrum-rule').length - 1
+  const RULE = 'position:relative;height:2px'
+
+  const STATES = {
+    'base only': { ...fields, score: 12 },
+    '+ metatask': { ...fields, metatask_points: 20, score: 32 },
+    '+ votes': { ...fields, points_from_votes: 4, score: 16 },
+    both: { ...fields, metatask_points: 20, points_from_votes: 4, score: 36 },
+  }
+
+  for (const [name, p] of Object.entries(STATES)) {
+    const bare = name === 'base only'
+    it(`draws the band and ${bare ? 'no' : 'exactly one'} rule — ${name}`, () => {
+      const markup = renderToStaticMarkup(<DefaultScoreStamp praxis={praxis(p)} />)
+      expect(spectra(markup)).toBe(bare ? 1 : 2)
+      if (bare) expect(markup).not.toContain(RULE)
+      else expect(markup).toContain(RULE)
+    })
+  }
+
+  it('drops the grey divider, and the grey leader hairlines with it', () => {
+    const markup = renderToStaticMarkup(<DefaultScoreStamp praxis={praxis(STATES.both)} />)
+    // The votes divider the spectrum rule replaces.
+    expect(markup).not.toContain('border-top:1px solid var(--faction-default-card-line)')
+    // The leader line each row ran out to its figure. The figures keep their
+    // column — `margin-left:auto` on the value does what the spacer did.
+    expect(markup).not.toContain('min-width:6px')
+    expect(markup).toContain('margin-left:auto')
+  })
+
+  it('prints the rule under the working when there is no tally to divide', () => {
+    // The board's own words: where there is no votes divider the same single
+    // rule prints under BASE instead, so the geometry matches across states.
+    const markup = renderToStaticMarkup(
+      <DefaultScoreStamp praxis={praxis(STATES['+ metatask'])} />,
+    )
+    expect(markup.indexOf(RULE)).toBeGreaterThan(markup.lastIndexOf('meta'))
   })
 })

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -1211,12 +1211,43 @@ describe('the na stamp rules its working in the spectrum (#2520)', () => {
     expect(markup).toContain('margin-left:auto')
   })
 
-  it('prints the rule under the working when there is no tally to divide', () => {
+  it('prints the rule under the TOTAL, above the working', () => {
     // The board's own words: where there is no votes divider the same single
-    // rule prints under BASE instead, so the geometry matches across states.
+    // rule prints "under BASE — the row directly after the total — so the
+    // geometry matches the votes case". Under the total, above the working.
     const markup = renderToStaticMarkup(
       <DefaultScoreStamp praxis={praxis(STATES['+ metatask'])} />,
     )
-    expect(markup.indexOf(RULE)).toBeGreaterThan(markup.lastIndexOf('meta'))
+    expect(markup.indexOf(RULE)).toBeLessThan(markup.lastIndexOf('meta'))
   })
+
+  // THE ORPHAN GUARD (owner ruling 2026-08-23, ADR-0076).
+  //
+  // This is the assertion the position exists for, and it is why the rule is
+  // anchored under the total rather than under the working. Anchored below, a
+  // sealed metatask nobody has voted on has rows and NO flat terms, so the rule
+  // became the last thing on the sheet with nothing beneath it — the orphan
+  // ADR-0076 was written to stop, and the reversal the old comment on
+  // `DefaultScoreStamp` warned against by name before #2520 removed it.
+  //
+  // Stated as "something always follows the rule" rather than as an index
+  // comparison against one row label, so it keeps holding if the breakdown
+  // grows a row this suite does not know about.
+  for (const [name, p] of Object.entries(STATES)) {
+    if (name === 'base only') continue
+    it(`never leaves the rule orphaned — ${name}`, () => {
+      const markup = renderToStaticMarkup(<DefaultScoreStamp praxis={praxis(p)} />)
+      const at = markup.indexOf(RULE)
+      expect(at, 'the rule is drawn at all').toBeGreaterThan(-1)
+      // Everything after the rule's own closing tag must still carry ink, not
+      // just the plate's closing markup. `</span>` and not `/>`: React does not
+      // self-close a void-less element, so a `/>` search runs straight past the
+      // rule and makes this assertion vacuous — which it was, until the probe
+      // that was supposed to fail did not.
+      const close = markup.indexOf('</span>', at)
+      expect(close, "the rule's closing tag").toBeGreaterThan(-1)
+      const after = markup.slice(close + '</span>'.length)
+      expect(text(after).trim(), 'nothing follows the rule').not.toBe('')
+    })
+  }
 })

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -19,7 +19,7 @@
  *
  * ## The layout, in order
  *
- * masthead → status row (`Draft` · `Saved just now`) → the task slip (title,
+ * status row (`Draft` · `Saved just now`) → the task slip (title,
  * level pill, description, points mark) → `Title` → `How it was done` → the mode
  * block (the collaborator roster, or the duel pair) → `Write-up` (Write /
  * Preview) → `Proof` → footer (`Save draft` … `Submit`).
@@ -59,12 +59,17 @@
  * branch anywhere in the file. Every hex in `edit-praxis.jsx` is a design-side
  * literal; none of them appear here.
  *
- * ## The two motions
+ * ## The one motion
  *
- * `ep-edge` walks the masthead's spectrum band, `ep-drift` wanders the aurora.
- * Both are CLASSES: the keyframes live in `index.css` behind the shared
- * `prefers-reduced-motion` guard, and an inline `animation:` would bypass that
- * guard (#1003). The other five `ep*` keyframes ship unused, for the skins.
+ * `ep-drift` wanders the aurora. It is a CLASS: the keyframes live in
+ * `index.css` behind the shared `prefers-reduced-motion` guard, and an inline
+ * `animation:` would bypass that guard (#1003).
+ *
+ * `ep-edge` walked the masthead's spectrum band until #2520 took the band off —
+ * na's spectrum is the sheet's STATIC 3px frame now, which is what lets the
+ * epic's "Albescent = na + motion" be true on this page rather than aspirational
+ * (the society's travelling edge had been a second moving rainbow beside na's
+ * own). It joins the other five `ep*` keyframes that ship unused, for the skins.
  *
  * ## Reused, not rebuilt
  *
@@ -85,13 +90,13 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { mediaUrl } from "../../../utils/media";
+import { factionSpectrumSheet } from "../../../utils/factions";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
 import { pickArtKey } from "../blocks/useMediaArt";
 import {
   ComposerFooter,
   ComposerGround,
-  ComposerMasthead,
   ComposerPage,
   ComposerRule,
   ComposerSection,
@@ -169,12 +174,14 @@ const HAIR = "var(--faction-default-composer-hair)";
 const ON_ACCENT = "var(--faction-default-on-accent)";
 /* The seven wedges, for both marks. */
 const RING = "var(--faction-default-rainbow-conic)";
-/* The masthead band is the LOOP cut, not the seven-stop bar ramp the design
- * literal shows. `ep-edge` walks background-position across a 300%-wide band, so
- * the paint has to tile: the bar ramp's red-at-0% meets magenta-at-100% and
- * shows a hard seam every cycle, which is the exact failure the `-loop` token's
- * own docstring exists to describe. Same spectrum, cut for this geometry. */
-const BAND = "var(--faction-default-rainbow-loop)";
+/* THE MASTHEAD BAND IS GONE (#2520). It was the `-loop` cut of the spectrum,
+ * walked by `.ep-edge` for every player — so na's composer carried a MOVING
+ * rainbow, and Albescent's travelling sheet edge (#2505) was not a delta on it
+ * but a second one. The spectrum is the sheet's 3px frame now, static, which is
+ * the idiom the task card, the praxis card and the seal all wear. `.ep-edge`
+ * and `@keyframes epEdge` stay declared in index.css beside the five other
+ * composer motions no skin reads yet; that block says outright that an unread
+ * motion there is the point of it. */
 
 /* The design's title + body face is Lora (--font-display); its label face is
  * Courier Prime (--font-body), which is what composerLabelStyle already
@@ -199,10 +206,9 @@ const primaryStyle = composerLabelStyle({
 });
 
 /* The chrome, named once and mounted twice: the composer below, and the
-   waiting surface once your part is in (#1189). These are the same ELEMENTS
-   both times, not two constructions of the same idea, so na's spectrum band
-   and drifting aurora cannot drift apart between the two stages. */
-const masthead = <ComposerMasthead background={BAND} animated />;
+   waiting surface once your part is in (#1189). The same ELEMENT both times,
+   not two constructions of the same idea, so na's drifting aurora cannot drift
+   apart between the two stages. */
 const ground = (
   <ComposerGround
     background="var(--faction-default-aurora)"
@@ -212,9 +218,20 @@ const ground = (
     animated
   />
 );
+/* THE SHEET'S FRAME IS THE SPECTRUM (#2520) — a 3px transparent border with the
+   ramp painted into the border box under it, which is the same `border-box`
+   idiom `DefaultTaskCard`, `DefaultPraxisCard` and `DefaultSeal` wear. Only the
+   width is stated here; the composition belongs to the helper, because the ramp
+   has to be appended to all three of the sheet's background lists and saying
+   that at a fourth call site is how one of them gets the arity wrong.
+
+   `ComposerSheet`'s own `overflow: hidden` clips at the PADDING box, so the
+   aurora at `inset: -30%` cannot paint over the frame — the ring stays spectrum
+   all the way round, and Albescent's travelling `.alb-composer-edge` still sits
+   a pixel inside it. */
 const sheetStyle = {
-  background: SHEET,
-  border: `1px solid ${BORDER}`,
+  border: "3px solid transparent",
+  ...factionSpectrumSheet(),
   boxShadow: "0 16px 40px -24px var(--color-cast-shadow)",
 };
 const statusMark = (
@@ -223,10 +240,11 @@ const statusMark = (
 const slip = {
   style: {
     background: FIELD,
+    /* The 2px left ink bar #1706 put here came off with the masthead band
+       (#2520): the design's na column rules this page ONCE, at the sheet's own
+       spectrum frame. The seven dressed skins keep theirs — `composerRule`
+       asserts that from the other side. */
     border: `1px solid ${BORDER}`,
-    /* The design left-rules the slip in the accent (#1706). It sits AFTER the
-       border shorthand on purpose: a shorthand spread last would erase it. */
-    borderLeft: `2px solid ${INK}`,
     borderRadius: 10,
     padding: "var(--space-lg)",
   },
@@ -247,7 +265,8 @@ export const DEFAULT_COMPOSER_DRESS: ComposerDress = {
   alarm: ALARM,
   pageStyle: { fontFamily: TITLE_FACE, color: INK },
   sheetStyle,
-  masthead,
+  /* No `masthead` since #2520 — the slot is optional, and na's band is the
+     sheet's own spectrum frame now. */
   ground,
   rule: () => <ComposerRule style={{ background: HAIR }} />,
   mark: statusMark,
@@ -307,7 +326,6 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
       <ComposerSheet
         sizes={sizes}
         style={sheetStyle}
-        masthead={masthead}
         ground={
           ornament ? (
             <>

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -359,13 +359,18 @@ describe("every skin swaps in the waiting surface (#1189)", () => {
     expect(markup).not.toContain("repeating-linear-gradient");
   });
 
-  it("na falls through to the spectrum kit's own band (ADR-0065 §4)", () => {
+  it("na falls through to the spectrum kit's own frame (ADR-0065 §4)", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>
         <DefaultEditPraxis state={waitingState(null)} />
       </MemoryRouter>,
     );
-    expect(markup).toContain("--faction-default-rainbow-loop");
+    // The spectrum was a walked masthead band (`--faction-default-rainbow-loop`)
+    // until #2520 made it the sheet's static 3px frame — so the dress still
+    // carries na's spectrum onto this stage, in the kit's own border idiom.
+    expect(markup).toContain("border:3px solid transparent");
+    expect(markup).toContain("var(--faction-default-rainbow)");
+    expect(markup).not.toContain("--faction-default-rainbow-loop");
   });
 
   it.each(

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
@@ -230,9 +230,72 @@ describe("the last two archetype seams of #1706", () => {
     expect(markup).toContain(i18n.t("forms:editPraxis.composer.proofHelper"));
   });
 
-  it.each(SLUGS)("%s left-rules the task slip in its accent", (slug) => {
-    const markup = render(slug === "na" ? null : slug);
-    expect(markup).toMatch(/border-left:2px solid var\(--[a-z-]+\)/);
+  // na is not in this list since #2520: its slip's 2px left ink bar came off
+  // with the masthead band, so the sheet's own spectrum frame is the only rule
+  // around the page's chrome. The seven dressed skins keep theirs — the design
+  // took the bar off the UNAFFILIATED kit, not out of the shared contract.
+  it.each(SLUGS.filter((slug) => slug !== "na"))(
+    "%s left-rules the task slip in its accent",
+    (slug) => {
+      const markup = render(slug);
+      expect(markup).toMatch(/border-left:2px solid var\(--[a-z-]+\)/);
+    },
+  );
+});
+
+/**
+ * THE na COMPOSER IS THE SPECTRUM SHEET (#2520, epic #2496).
+ *
+ * The design canvas gives the na kit the spectrum treatment so that Albescent's
+ * delta can be MOTION alone. On this page na was carrying the louder half of
+ * that already: a full-bleed rainbow band across the masthead which `.ep-edge`
+ * WALKS for every player, unaffiliated ones included — so the society's
+ * travelling sheet edge (#2505) was not a delta at all, it was a second moving
+ * rainbow on the same page.
+ *
+ * So the strip comes off, the masthead's own 3px rule goes with it, the slip's
+ * 2px left ink bar goes, and the sheet wears the kit's 3px spectrum frame — the
+ * one the task card, the praxis card and (since earlier in this issue) the seal
+ * all wear. Stilled, Albescent's edge is now a hairline just inside a spectrum
+ * border rather than a second band.
+ *
+ * The seam is the rendered markup of `DefaultEditPraxis` at both stages: the
+ * composer, and the waiting surface it hands `DEFAULT_COMPOSER_DRESS` to — the
+ * masthead is carried ON the dress, so dropping it in one place and not the
+ * other is exactly the drift the dress exists to prevent.
+ */
+describe("na's composer sheet wears the spectrum, and no band (#2520)", () => {
+  const SHEET = [
+    "border:3px solid transparent",
+    "background-image:var(--faction-default-card-sheet),var(--faction-default-rainbow)",
+    "background-origin:border-box",
+  ];
+  /** A background LIST renders with a space after each comma; close it up. */
+  const stages = () => ({
+    composing: render(null).replace(/\s*([:;,])\s*/g, "$1"),
+    waiting: render(null, "desktop", { phase: "waiting" }).replace(
+      /\s*([:;,])\s*/g,
+      "$1",
+    ),
+  });
+
+  it("draws no masthead band at either stage", () => {
+    for (const [stage, markup] of Object.entries(stages())) {
+      // The band's paint was the LOOP cut, which nothing else on this page
+      // names, and `.ep-edge` is the class that walked it.
+      expect(markup, stage).not.toContain("--faction-default-rainbow-loop");
+      expect(markup, stage).not.toContain("ep-edge");
+    }
+  });
+
+  it("frames the sheet in the kit's own 3px spectrum instead", () => {
+    for (const [stage, markup] of Object.entries(stages())) {
+      for (const declaration of SHEET) expect(markup, stage).toContain(declaration);
+    }
+  });
+
+  it("takes the ink bar off the task slip", () => {
+    expect(render(null)).not.toMatch(/border-left:2px solid var\(--[a-z-]+\)/);
   });
 });
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
@@ -174,11 +174,16 @@ describe("WOW claims the composer surface", () => {
     expect(na, "which the na page has no notion of").not.toContain(
       "--faction-wow-quest-ribbon",
     );
-    expect(na, "na's masthead is the spectrum").toContain(
+    // na's spectrum is its sheet's 3px frame since #2520 — the walked masthead
+    // band it used to be is off, on both skins.
+    expect(na, "na's frame is the spectrum").toContain(
+      "border:3px solid transparent",
+    );
+    expect(na, "and it no longer walks a band").not.toContain(
       "--faction-default-rainbow-loop",
     );
-    expect(wow, "and WOW's is not").not.toContain(
-      "--faction-default-rainbow-loop",
+    expect(wow, "WOW's sheet is its own").not.toContain(
+      "border:3px solid transparent",
     );
   });
 });


### PR DESCRIPTION
Closes #2520

`Score-Stamp.dc.html` draws three columns — **shipped** (a flat 1px grey line), **na** (a 2px
*static* spectrum rule) and **Albescent** (that same stamp, rule travelling + ring turning).
#2501 built the third column and skipped the second, so the society's stamp animated a rule the
unaffiliated stamp did not have and the two kits differed **structurally**, where the design
says they differ only by whether the rainbow moves. This is the second column, on all three
surfaces the board applies it to.

**Item 2 of the issue body was already built.** `DefaultPraxisCard` calls
`factionSpectrumSheet()` with `border: 3px solid transparent` on `main` (#2499 / PR #2525) —
verified on disk, not redone. It is the idiom the other two surfaces are copied from.

## The seam

The rendered markup of the three `Default*` components (`renderToStaticMarkup`, no DOM —
SPEC-testing.md), plus `index.css` read as text where a class's paint is the claim. Every case
below went red on the real defect first.

## 1. `DefaultScoreStamp` — one spectrum rule, in every state

- The rows' grey leader hairlines and the tally's grey `border-top` divider both go.
- One `.spectrum-rule` span, 2px, `border-radius: 2px`, run to the breakdown column's width
  (so inset from the plate's edges by the plate's own padding), drawn on `hasWorking`:
  between the rows and the tally where the divider sat, and **under the rows** where there is
  no tally to divide. Base-only draws no breakdown at all (#1131 / ADR-0076) and so draws no
  rule — the band across the top edge is the whole spectrum on it.
- It carries `position: relative`, which is load-bearing: `.alb-stamp .spectrum-rule::before`
  is absolutely positioned, so without a containing block here Albescent's travelling child
  would resolve against the stamp PLATE and paint the ramp over the working out.

New cases in `scoreStamp.test.tsx` count the spectra per state (1 bare, 2 otherwise); three
existing cases that used the grey hairline as their "this sheet has working" proxy now use the
rule.

## 2. `DefaultSeal` — the spectrum is the border, not a bar

The 3px strip pinned across the top edge is gone; the sheet is `factionSpectrumSheet()` inside
`border: 3px solid transparent`. `spectrumClasses.test.tsx`'s third mount moves out of the
"wears the class" loop into its own describe: the strip is gone AND the ramp arrives appended
to all three of the sheet's background lists.

## 3. `DefaultEditPraxis` — the band comes off, the frame goes on

The masthead band, the `.ep-edge` walk that carried it, and the task slip's 2px left ink bar
are off; the sheet takes the kit's 3px spectrum frame. **This one fixed a live inconsistency
the issue only implies:** `.ep-edge` walked na's masthead for *every* player, so Albescent's
travelling sheet edge (#2505) was not a delta on this page — it was a second moving rainbow
beside na's own.

`.ep-edge` and `@keyframes epEdge` stay declared in `index.css`, now unread. That block says in
its own header that five of its seven motions ship unused on purpose, as the library the skins
draw from; deleting one would contradict a written decision for ~60 bytes.

## Three things to rule on, none of them averaged

1. **The board says 2px in its comment and 3px in its CSS** for the seal. Built at **3px**, per
   the issue's instruction — and 3px is what the task card and the praxis card already wear,
   which is the tiebreak the prose could not give.
2. **One deviation from the board's CSS, deliberate.** The board hides the leader hairline with
   `display: none`, which also removes the flex spacer that pushes each figure right — its own
   render collapses `BASE … 12` to `BASE 12`, ragged left. A design canvas cannot edit the DOM,
   so that is the bluntest tool available rather than a drawn intent. The hairline is deleted
   here and the figure column is kept by `margin-left: auto` on the value. **Say so if the
   collapse was wanted; it is a one-line change.**
3. **The metatask-with-no-votes state now draws a rule with nothing beneath it.** That is the
   board's explicit "where there is no votes divider the same single rule prints under BASE
   instead, so the geometry matches", and it sits close to ADR-0076 / #1894's orphan-rule
   ruling. Read as: the ADR forbids an empty *divider* (a rule hung over a block that did not
   render); this is a terminating ornament at the foot of the working. The #1894 case is
   re-pointed at the tally's absence rather than at the rule's, with the reversal written down
   at the assertion.

## For #2519 / the Albescent carrier pass — no `.alb-*` was touched

- `.alb-stamp .spectrum-rule` now matches **two** mounts (the band and the new rule), so both
  travel. That is ruling 3 read literally and it needed no edit, but it should be eyeballed
  once: two rainbows moving at the same 16s pace on one small object.
- `.alb-composer-edge` now sits inside a 3px border instead of a 1px one. Its `inset: 1px` and
  `border-radius: inherit` are unchanged, so the ring's corner is now slightly rounder than the
  padding box it rides in. Cosmetic; flagging rather than editing.
- `AlbescentSeal` is a bespoke reveal-register skin, not a `DefaultSeal` wrapper, so it does not
  follow this change. Possibly a gap for the epic; not this issue.

## Verification

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` · `npm test`
(412 files, 7358 passed) · `npm run build` · `npm run budget` — all green, run locally against
this branch.

Budget: **CSS 22.3 KB → 22.3 KB** (byte-identical: the emitted stylesheet hash is unchanged, no
CSS was added or removed). **JS 127.8 KB → 127.9 KB.** Both sides of the line are exactly where
`main` left them; CSS is still on the wrong side of the 22.2 warn, which #2499 got most of the
way back.

**Visual QA is outstanding.** No browser and no dev stack here — everything above is asserted
from markup and stylesheet text.

## What to eyeball

1. **An na score stamp and an Albescent score stamp side by side** — a praxis card of each, on
   a task with a metatask and some votes. They should now be the SAME stamp: one 2px spectrum
   rule over the working, no grey lines, and the only difference is that Albescent's rule
   travels and its ring turns. Then the same pair with `prefers-reduced-motion: reduce`, where
   they should be indistinguishable.
2. The stamp through its four states — base only (no rule at all), metatask, votes, both — and
   that the figures still sit in a column now the leader lines are gone.
3. **The metatask seal on an na praxis card** (and in the composer's seal stack): a 3px spectrum
   frame all the way round, no bar across the top, in both themes.
4. **The na composer**: no band at the top of the sheet, a 3px spectrum frame instead, and the
   task slip with no left ink bar. Then the Albescent composer over it — its travelling edge
   should read as the tell rather than as a second rainbow.
5. Both themes on all of the above; the dark card's hairline shows the sheet through it, which
   is what the trailing `border-box` clip in `factionSpectrumSheet()` protects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
