### PR TITLE
Nothing dispatched to Albescent holds a still spectrum: one marker moves the na spectra on nine surfaces

### DIFF
--- a/frontend/src/__tests__/albescentSpectraMove.test.tsx
+++ b/frontend/src/__tests__/albescentSpectraMove.test.tsx
@@ -120,9 +120,11 @@ describe('the census: every Albescent surface with a classed spectrum wears the 
    * and this is the line that says so.
    */
   it('the field desk drops its bar rather than moving it', () => {
-    const bodies = ruleBodies(INDEX, '.alb-desk .spectrum-rule')
-    expect(bodies.length).toBeGreaterThan(0)
-    expect(bodies.join('\n')).toContain('display: none')
+    // The mount shares a rule with the composer's retired band, so the prelude
+    // is a list and `ruleBodies` (whole-prelude matching) cannot reach it.
+    const at = INDEX.indexOf('.alb-desk .spectrum-rule')
+    expect(at).toBeGreaterThan(-1)
+    expect(INDEX.slice(at, INDEX.indexOf('}', at))).toContain('display: none')
   })
 })
 

--- a/frontend/src/__tests__/albescentSpectraMove.test.tsx
+++ b/frontend/src/__tests__/albescentSpectraMove.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * NOTHING DISPATCHED TO ALBESCENT HOLDS A STILL SPECTRUM (#2500, epic #2496).
+ *
+ * #2497 minted `.spectrum-rule` and `.spectrum-dial` for the seventeen unclassed
+ * inline spectra scattered through the ten `Default*` files Albescent wears, and
+ * its own note says why: *"#2500 is what will animate them."* This is that,
+ * and the seam is the one the census exposed — a MOUNT WITH NO DRESSER OVER IT.
+ *
+ * ## The defect this goes red on
+ *
+ * Before this issue only two of those mounts moved, and both by a selector
+ * naming one surface (`.alb-stamp .spectrum-rule`, #2501). Every other classed
+ * spectrum on an Albescent surface — the task card's two hairlines and its
+ * points ring, the task detail's four rules, the praxis detail's dial and two
+ * bands, the faction body's five plate rules, the whole profile — stood still,
+ * and nothing could see it: each one renders, paints and passes every existing
+ * test whether or not a `::before` is walking across it.
+ *
+ * So the guard is a CENSUS, pinned. `alb-moves` is the marker that says "this
+ * surface is dispatched to Albescent, so the na spectra inside it move"; the
+ * list below is every wrapper that carries it and the reason. A wrapper dropped
+ * from the list, or a new Albescent surface that forgets the class, is the exact
+ * shape of the defect and turns this red.
+ *
+ * ## Why `:empty` is in the selector and not an oversight
+ *
+ * `.spectrum-rule` is worn by two different objects. Most mounts are ORNAMENT —
+ * an `aria-hidden` hairline, band, chip or progress fill with no children — and
+ * those travel. Four are FRAMES: a padded ramp wrapped around an opaque inner
+ * sheet (the ×mult badge, the task-detail action panel, the praxis proof panel,
+ * the profile identity band). A travelling child inside a frame has to be
+ * clipped and its content lifted back over the rim, and the identity band would
+ * then carry two ramps at two speeds, since `.alb-profile-edge` already travels
+ * on it — the "one carrier per object" #2519 spent a PR establishing. `:empty`
+ * is the difference between the two objects, stated once.
+ *
+ * ## Harness
+ *
+ * The stylesheet read as source text, plus `renderToStaticMarkup` — no DOM and
+ * no compositor in CI (SPEC-testing.md), so nothing here proves a pixel. The
+ * pixels are visual QA and stated outstanding on the PR.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import '../i18n'
+import { stripComments, ruleBodies } from '../utils/__tests__/cssVars'
+import AlbescentSeal from '../components/metataskSeal/skins/AlbescentSeal'
+import type { TaskOut } from '../api/tasks'
+
+const read = (path: string) =>
+  readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8')
+
+const INDEX = stripComments(read('../index.css'))
+const MOTION = stripComments(read('../motion.ornament.css'))
+
+/**
+ * THE CENSUS. Every row of `ALBESCENT_MANIFEST` whose na component declares a
+ * `.spectrum-rule` or a `.spectrum-dial`, and therefore had a still spectrum on
+ * it until this issue.
+ */
+const WEARS_THE_MARKER: Record<string, string> = {
+  // two hairlines (the in-progress chip, the CTA rule) + DefaultPointsRing's dial
+  '../components/taskCard/AlbescentTaskCard.tsx': 'task card',
+  // the vote divider
+  '../components/praxisCard/desktop/AlbescentPraxisCard.tsx': 'praxis card',
+  // the band and the working-out rule — #2501's two, generalised
+  '../components/praxisCard/scoreStamp/AlbescentScoreStamp.tsx': 'score stamp',
+  // two section heads, the eyebrow chip, the breakdown hairline
+  '../pages/taskDetail/archetypes/AlbescentTaskDetail.tsx': 'task detail',
+  // the member dial, a section head, the sheet-head band
+  '../pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx': 'praxis detail',
+  // the section heads, the badge and laurel dials, the progression fill
+  '../pages/characterProfile/archetypes/AlbescentProfileBody.tsx': 'profile',
+  // the five plates' hairlines
+  '../pages/factionDetail/archetypes/AlbescentFactionBody.tsx': 'faction body',
+  // the pale sheet's one strip — classed here, since the seal is Albescent's own
+  '../components/metataskSeal/skins/AlbescentSeal.tsx': 'metatask seal',
+}
+
+/**
+ * The rows deliberately WITHOUT it, each because its na component declares
+ * neither class — so there is no still spectrum for a marker to reach. The
+ * assertion is computed rather than asserted by hand: a `Default*` that grows
+ * one turns this red and sends the reader back to the census.
+ */
+const NO_CLASSED_SPECTRUM: Record<string, string> = {
+  '../components/feed/FactionFeedFrame.tsx': 'feed frame',
+  '../pages/editPraxis/archetypes/DefaultEditPraxis.tsx': 'composer',
+  '../components/factionHero/DefaultFactionHero.tsx': 'faction hero',
+  '../components/avatar/FactionAvatar.tsx': 'avatar',
+  '../components/vote/AlbescentVote.tsx': 'vote',
+  '../components/selectCard/AlbescentSelectCard.tsx': 'select card',
+}
+
+describe('the census: every Albescent surface with a classed spectrum wears the marker', () => {
+  for (const [path, surface] of Object.entries(WEARS_THE_MARKER)) {
+    it(`${surface} carries alb-moves`, () => {
+      expect(read(path)).toContain('alb-moves')
+    })
+  }
+
+  for (const [path, surface] of Object.entries(NO_CLASSED_SPECTRUM)) {
+    it(`${surface} has no classed spectrum to move`, () => {
+      const source = read(path)
+      expect(source).not.toContain('className="spectrum-rule')
+      expect(source).not.toContain("className='spectrum-rule")
+      expect(source).not.toContain('className="spectrum-dial')
+      expect(source).not.toContain("className='spectrum-dial")
+    })
+  }
+
+  /**
+   * The mobile field desk is the one exception and it is a REPLACEMENT, not an
+   * omission: `DefaultFieldDesk` does draw a `.spectrum-rule`, and #2519 took it
+   * off the Albescent desk when the identity card grew a travelling border. One
+   * carrier per object — so the desk needs no marker because the bar is gone,
+   * and this is the line that says so.
+   */
+  it('the field desk drops its bar rather than moving it', () => {
+    const bodies = ruleBodies(INDEX, '.alb-desk .spectrum-rule')
+    expect(bodies.length).toBeGreaterThan(0)
+    expect(bodies.join('\n')).toContain('display: none')
+  })
+})
+
+describe('the track lives on the blocking sheet', () => {
+  it('an ornament rule is a clip with a containing block', () => {
+    const body = ruleBodies(INDEX, '.alb-moves .spectrum-rule:empty').join('\n')
+    expect(body).toContain('overflow: hidden')
+    expect(body).toContain('position: relative')
+  })
+
+  it('a dial and its face are both in the positioned layer', () => {
+    expect(ruleBodies(INDEX, '.alb-moves .spectrum-dial').join('\n')).toContain(
+      'position: relative',
+    )
+    expect(ruleBodies(INDEX, '.alb-moves .spectrum-dial > *').join('\n')).toContain(
+      'position: relative',
+    )
+  })
+
+  /** Paint may not defer, and motion may not block. Neither may cross. */
+  it('index.css declares no animation for the marker', () => {
+    const marker = INDEX.split('\n').filter((line) => line.includes('.alb-moves'))
+    expect(marker.join('\n')).not.toContain('animation')
+  })
+
+  /**
+   * The generalisation REPLACES #2501's two selectors rather than standing
+   * beside them. Two rules doing the same job to the same mounts is how a
+   * duration silently forks.
+   */
+  it('the score stamp no longer names itself', () => {
+    expect(INDEX).not.toContain('.alb-stamp .spectrum-rule {')
+    expect(MOTION).not.toContain('.alb-stamp .spectrum-rule::before')
+    expect(MOTION).not.toContain('.alb-stamp .spectrum-dial::before')
+  })
+})
+
+describe('the motion is a transform on a pre-painted gradient', () => {
+  const gate = '@media (prefers-reduced-motion: no-preference)'
+
+  it('both children exist only inside the reduced-motion gate', () => {
+    for (const selector of [
+      '.alb-moves .spectrum-rule:empty::before',
+      '.alb-moves .spectrum-dial::before',
+    ]) {
+      const at = MOTION.indexOf(selector)
+      expect(at, selector).toBeGreaterThan(-1)
+      expect(MOTION.lastIndexOf(gate, at), selector).toBeGreaterThan(-1)
+      expect(INDEX, selector).not.toContain(selector)
+    }
+  })
+
+  it('the band states the loop cut and the rim inherits its wheel', () => {
+    const band = ruleBodies(MOTION, '.alb-moves .spectrum-rule:empty::before').join('\n')
+    // A two-tile child slid by exactly one tile — the only cut that cannot seam.
+    expect(band).toContain('width: 200%')
+    expect(band).toContain('background-size: 50% 100%')
+    expect(band).toContain('var(--faction-default-rainbow-loop)')
+    expect(band).toContain('alb-edge-travel')
+
+    const rim = ruleBodies(MOTION, '.alb-moves .spectrum-dial::before').join('\n')
+    expect(rim).toContain('background-image: inherit')
+    expect(rim).toContain('alb-spin')
+  })
+
+  /**
+   * Epic ruling: never animate a gradient parameter. `@property` inside a
+   * `conic-gradient` re-rasterises every frame; so does walking
+   * `background-position`. Both keyframes named above are bare transforms and
+   * are declared elsewhere on this sheet — nothing new is minted here.
+   */
+  it('neither child walks a gradient parameter', () => {
+    const bodies = [
+      ...ruleBodies(MOTION, '.alb-moves .spectrum-rule:empty::before'),
+      ...ruleBodies(MOTION, '.alb-moves .spectrum-dial::before'),
+    ].join('\n')
+    expect(bodies).not.toContain('background-position')
+    expect(bodies).not.toContain('@property')
+  })
+})
+
+describe('the seal, whose only spectrum was unclassed', () => {
+  const METATASK = {
+    id: 12,
+    title: 'File it before the tide turns',
+    point_value: 15,
+    metatask_faction_slug: 'albescent',
+  } as unknown as TaskOut
+
+  it('wears the marker over a classed strip', () => {
+    const html = renderToStaticMarkup(<AlbescentSeal metatask={METATASK} />)
+    expect(html).toContain('alb-moves')
+    expect(html).toContain('spectrum-rule')
+    // The ramp is the class's now — an inline copy would be a second declaration
+    // of the same paint, and the one the stylesheet cannot reach.
+    expect(html).not.toContain('--faction-default-rainbow)')
+  })
+})

--- a/frontend/src/__tests__/motionSplit.test.ts
+++ b/frontend/src/__tests__/motionSplit.test.ts
@@ -111,8 +111,9 @@ const MOTION_SCAFFOLDING: Record<string, string> = {
     'the same child, two band-widths instead of three, because the profile ' +
     "band's ring tiles at 200% where the four card edges tile at 300%. A `width` " +
     'and not a tile, which is the whole reason five keyframes could become one.',
-  '.alb-stamp .spectrum-rule::before':
-    "the Albescent score stamp's travelling band (#2501). Two tiles of " +
+  '.alb-moves .spectrum-rule:empty::before':
+    "every ornament spectrum on a dispatched Albescent surface (#2501, widened " +
+    'by #2500). Two tiles of ' +
     '`--faction-default-rainbow-loop` across a 200%-wide child, slid one tile by ' +
     'transform inside the `overflow: hidden` index.css puts on the band. The loop ' +
     'cut is NAMED rather than inherited, unlike the five edges above: the band ' +
@@ -120,8 +121,9 @@ const MOTION_SCAFFOLDING: Record<string, string> = {
     'tiling that would seam. Declared nowhere but inside the gate — with the sheet ' +
     "absent there is no child and the still band is `.spectrum-rule`'s own " +
     'background, which is the na band exactly.',
-  '.alb-stamp .spectrum-dial::before':
-    "the same stamp's turning rim (#2501). `background-image: inherit` takes the " +
+  '.alb-moves .spectrum-dial::before':
+    'every points ring, medallion and annulus on one (#2501, widened by ' +
+    '#2500). `background-image: inherit` takes the ' +
     "annulus's own conic, so the rim registers exactly over the ring it replaces " +
     'and the sheet arriving late changes no pixel. It is a pseudo-element and not ' +
     'the mount so that the TOTAL inside the ring does not turn with it — the call ' +

--- a/frontend/src/components/__tests__/spectrumClasses.test.tsx
+++ b/frontend/src/components/__tests__/spectrumClasses.test.tsx
@@ -56,8 +56,8 @@ const RETIRED = [
 /**
  * The BASE rule for a class — the one whose prelude is EXACTLY the selector.
  *
- * `ruleBodies` matches by substring, so a dresser scope like `.alb-stamp
- * .spectrum-rule` (#2501) or `.alb-desk .spectrum-rule` (#2505) counts as a
+ * `ruleBodies` matches by substring, so a dresser scope like `.alb-moves
+ * .spectrum-rule` (#2501, #2500) or `.alb-desk .spectrum-rule` (#2505) counts as a
  * `.spectrum-rule` rule to it. That is right for the cascade questions it
  * usually answers and wrong for this one: a dresser scope is the DESIGNED use
  * of these names — #2497's own docblock says so ("a dresser reaches them with

--- a/frontend/src/components/metataskSeal/skins/AlbescentSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/AlbescentSeal.tsx
@@ -16,6 +16,20 @@ import type { SealSkinProps } from '../types'
  * ink. So the sticker is a pale sheet by day and an na-dark one by night, on
  * whatever host card it has been stuck to. Its `-border` is what keeps it a
  * distinct object when the host card happens to be na's too (2.74:1).
+ *
+ * ITS ONE COLOUR MOVES (#2500, epic #2496 ruling 3). The strip was the last
+ * still spectrum on any Albescent-dispatched surface, and it was still for a
+ * mechanical reason rather than a designed one: it named
+ * `--faction-default-rainbow` inline, so no stylesheet could reach it. It wears
+ * `.spectrum-rule` now — the class #2497 minted for exactly these seventeen
+ * inline ramps, and which carries that same token and nothing else, so the
+ * resting sheet is the one that shipped yesterday — and the root wears
+ * `alb-moves`, the marker every other Albescent wrapper carries. The `opacity`
+ * stays at the call site with the height and the radius: those are this mount's
+ * geometry, not the ramp.
+ *
+ * A seal is a reveal moment, so this is the one place the tell may be looked at
+ * directly rather than noticed sideways.
  */
 export default function AlbescentSeal({ metatask, removable, onRemove }: SealSkinProps) {
   const { t } = useTranslation('praxis')
@@ -23,7 +37,7 @@ export default function AlbescentSeal({ metatask, removable, onRemove }: SealSki
 
   return (
     <div
-      className="relative"
+      className="relative alb-moves"
       style={{
         background: 'var(--albescent-reveal-surface)',
         color: 'var(--albescent-reveal-text)',
@@ -63,14 +77,14 @@ export default function AlbescentSeal({ metatask, removable, onRemove }: SealSki
         {t('detail.seal.label', { faction })}
       </span>
 
-      {/* the soft spectrum strip — the one colour on the sheet, kept pale */}
+      {/* the soft spectrum strip — the one colour on the sheet, kept pale, and
+          travelling under `alb-moves` above (#2500) */}
       <span
         aria-hidden="true"
-        className="block"
+        className="block spectrum-rule"
         style={{
           height: 2,
           borderRadius: 2,
-          background: 'var(--faction-default-rainbow)',
           opacity: 0.35,
           margin: 'var(--space-xs) 0 var(--space-sm)',
         }}

--- a/frontend/src/components/praxisCard/__tests__/albescentDriftStopsAtMedia.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/albescentDriftStopsAtMedia.test.tsx
@@ -291,7 +291,7 @@ describe("both Albescent surfaces emit the hook the rule scopes on (#1646)", () 
 
   it("praxis detail mounts the gallery inside .alb-praxis", () => {
     const html = render(<AlbescentPraxisDetail state={detailState()} />);
-    expect(html, "the detail's Albescent scope").toContain('class="alb-praxis alb-prism"');
+    expect(html, "the detail's Albescent scope").toContain('class="alb-praxis alb-moves alb-prism"');
     expect(html, "the media region").toContain("user-media");
     expect(html, "the ornaments still mount").toContain("alb-praxis-ring");
   });

--- a/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
@@ -64,7 +64,7 @@ export function AlbescentPraxisCard(props: ArchetypeProps) {
   const groundIsBusy = useGroundIsBusy();
   return (
     <div
-      className={groundIsBusy ? "alb-praxis-card" : "alb-praxis-card alb-prism"}
+      className={groundIsBusy ? "alb-praxis-card alb-moves" : "alb-praxis-card alb-moves alb-prism"}
       style={{ ...frameBase, borderRadius: "var(--faction-default-card-radius)", /* inherits the Default sheet */ position: "relative", overflow: "hidden" }}
     >
       <DefaultPraxisCard {...props} />

--- a/frontend/src/components/praxisCard/scoreStamp/AlbescentScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/AlbescentScoreStamp.tsx
@@ -57,7 +57,7 @@ import type { ScoreStampProps } from "./ScoreStamp";
  */
 export default function AlbescentScoreStamp(props: ScoreStampProps) {
   return (
-    <div className="alb-stamp">
+    <div className="alb-stamp alb-moves">
       <DefaultScoreStamp {...props} />
     </div>
   );

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -223,7 +223,7 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
           this line, so it always parts something from something.
 
           `position: relative` is the mount Albescent's travelling child needs.
-          `.alb-stamp .spectrum-rule::before` is absolutely positioned, so
+          `.alb-moves .spectrum-rule:empty::before` is absolutely positioned, so
           without a containing block here it would resolve against the plate and
           paint the ramp straight over the working out. That the class reaches
           both this rule and the band above is the point of #2520: the two stamps

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -304,12 +304,12 @@ describe('scoreStamp surface dispatch (ADR-0049)', () => {
     const props = { praxis: scored } as unknown as ScoreStampProps
     const dressed = renderToStaticMarkup(<AlbescentScoreStamp {...props} />)
     expect(dressed).toBe(
-      `<div class="alb-stamp">${renderToStaticMarkup(<DefaultScoreStamp {...props} />)}</div>`,
+      `<div class="alb-stamp alb-moves">${renderToStaticMarkup(<DefaultScoreStamp {...props} />)}</div>`,
     )
     // And the two mounts the cascade dresses are UNDER that hook. The equality
     // above cannot see this: it would still hold the day `DefaultScoreStamp`
-    // re-inlines its ramps, at which point `.alb-stamp .spectrum-rule` and
-    // `.alb-stamp .spectrum-dial` match nothing and the whole tell goes quiet
+    // re-inlines its ramps, at which point `.alb-moves .spectrum-rule` and
+    // `.alb-moves .spectrum-dial` match nothing and the whole tell goes quiet
     // with every test in the repo green. `spectrumClasses.test.tsx` and
     // `pointsMarkUnification.test.tsx` hold the na side of each; this is the
     // pairing with the dresser.
@@ -1167,8 +1167,8 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
  * all (#1131 / ADR-0076), so it draws no rule either: the band is the whole
  * spectrum on it.
  *
- * `position: relative` on the rule is not decoration. `.alb-stamp
- * .spectrum-rule::before` is absolutely positioned, so a rule that is not itself
+ * `position: relative` on the rule is not decoration. `.alb-moves
+ * .spectrum-rule:empty::before` is absolutely positioned, so a rule that is not itself
  * a containing block hands Albescent's travelling child the stamp PLATE, and the
  * ramp paints over the working out.
  */

--- a/frontend/src/components/taskCard/AlbescentTaskCard.tsx
+++ b/frontend/src/components/taskCard/AlbescentTaskCard.tsx
@@ -56,7 +56,7 @@ export default function AlbescentTaskCard(props: CardProps) {
          the light, since the difference is a shimmer and never a colour. It is
          unconditional: it is not a ground texture.
          `alb-prism` is the ground, and it is the one the alternation takes. */
-      className={groundIsBusy ? "alb-task" : "alb-task alb-prism"}
+      className={groundIsBusy ? "alb-task alb-moves" : "alb-task alb-moves alb-prism"}
       style={{ position: "relative", width: "fit-content", maxWidth: "100%" }}
     >
       <DefaultTaskCard {...props} />

--- a/frontend/src/components/taskCard/__tests__/taskCardsV3.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/taskCardsV3.test.tsx
@@ -272,9 +272,10 @@ describe('albescent draws the same rule, fainter (#2030)', () => {
     const albescent = render(SKINS.find((s) => s.slug === 'albescent')!)
     const unaffiliated = render(SKINS.find((s) => s.slug === 'na')!)
     expect(albescent.html).toContain(unaffiliated.html)
-    // Two classes since #2499 — `alb-task` is the cascade this test is about and
-    // `alb-prism` is the ground, which the alternation may drop independently.
-    expect(albescent.html).toContain('class="alb-task alb-prism"')
+    // Three classes since #2500 — `alb-task` is the cascade this test is about,
+    // `alb-moves` sets the card's own na spectra travelling, and `alb-prism` is
+    // the ground, which the alternation may drop independently.
+    expect(albescent.html).toContain('class="alb-task alb-moves alb-prism"')
     expect(unaffiliated.html).toContain('opacity:var(--faction-default-cta-rule-opacity, 0.6)')
   })
 })

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6020,6 +6020,67 @@
   background-image: var(--faction-default-rainbow-conic);
 }
 
+/* ── `alb-moves` — THE DRESSER THE TWO CLASSES ABOVE WERE MINTED FOR (#2500,
+   epic #2496 ruling 3). The block above says it in as many words: "a dresser
+   reaches them with `.alb-x .spectrum-rule` … and #2500 is what will animate
+   them." This is that class, and it is the whole of it.
+
+   ONE MARKER, NOT A LIST OF WRAPPERS. `.alb-stamp .spectrum-rule` (#2501) was
+   the first dresser and named one surface; eight more surfaces each carry na
+   spectra of their own, and a nine-selector list restated in four rule bodies is
+   a place for one of them to be forgotten silently. The marker rides on the
+   wrapper each Albescent archetype already draws — the manifest row IS the
+   claim, so a surface that stops being dispatched stops moving by construction.
+   `__tests__/albescentSpectraMove.test.tsx` holds the census.
+
+   `:empty` SEPARATES TWO DIFFERENT OBJECTS WEARING ONE CLASS, and it is the one
+   decision in this block. Most `.spectrum-rule` mounts are ORNAMENT — an
+   `aria-hidden` hairline, band, chip or progress fill with no children — and
+   those are what "the na spectrum" means on these surfaces. Four are FRAMES: a
+   padded ramp with an opaque inner sheet sitting in it (the ×mult badge and the
+   action panel on the task detail, the proof panel on the praxis detail, the
+   profile's identity band). Three reasons they stay still, and any one is
+   enough:
+
+     • a travelling child inside a frame paints over the frame's CONTENT, so it
+       needs the content lifted back into the positioned layer — which changes
+       the stacking of a panel holding live controls;
+     • the clip that child needs is `overflow: hidden` on a box whose contents
+       are a gallery, a CTA and a credential card, not an empty 2px band;
+     • the identity band already carries `.alb-profile-edge`, a ring travelling
+       on its own clock. Moving the ramp underneath it would put two spectra at
+       two speeds on one object — the doubling #2519 spent a PR undoing.
+
+   Every one of those four sits on a surface whose own carrier already travels,
+   so no Albescent surface is left standing still by this line.
+
+   WHAT LIVES HERE IS ONLY WHAT A DEFERRED CHILD CANNOT BRING WITH IT, the shape
+   #2498 and #2501 established: the clip, and the containing block the child's
+   `inset` resolves against. The travel and the turn are in
+   `src/motion.ornament.css` behind the reduced-motion gate. Stranded — reduced
+   motion, or that sheet not yet delivered — there is no child at all and the
+   still frame is each mount's own background right above, which is the na
+   surface exactly. Nothing here carries meaning through motion alone.
+
+   A mount that declares its own `position` inline keeps it: an inline style beats
+   a stylesheet, and `absolute` is a containing block too (the score stamp's band
+   is exactly that). Decorative on every mount, so no contrast is owed, and both
+   cascades come from the tokens, so no dark half is written here. */
+.alb-moves .spectrum-rule:empty {
+  position: relative;
+  overflow: hidden;
+}
+.alb-moves .spectrum-dial {
+  position: relative;
+}
+/* The dial's face — the disc holding the numeral, the monogram or the portrait.
+   The rim is a pseudo-element precisely so the face does not turn with it, and an
+   absolutely positioned `::before` paints over a STATIC sibling however late it
+   sits in the DOM. No offsets, so this moves nothing while the rim is absent. */
+.alb-moves .spectrum-dial > * {
+  position: relative;
+}
+
 /* ── THE na PLATE (#2497, epic #2496) ──
    A kicker, a sheet and a hairline: the three-part block every other faction
    body already draws for itself (`WowFactionBody`'s `PLATE_FRAME`, the Coven's
@@ -6975,9 +7036,10 @@
    measured on the border box the `-1px` above restores, and `inherit` would take
    the padding box's corner instead. */
 
-/* ── Albescent — the SCORE STAMP's tell (#2501, epic #2496). The last faction
-   with a roster to claim a `scoreStamp` row, and the shortest wrapper in the kit:
-   `AlbescentScoreStamp` renders `DefaultScoreStamp` whole and adds `.alb-stamp`.
+/* ── Albescent — the SCORE STAMP's tell (#2501, epic #2496, generalised by
+   #2500). The last faction with a roster to claim a `scoreStamp` row, and the
+   shortest wrapper in the kit: `AlbescentScoreStamp` renders `DefaultScoreStamp`
+   whole and adds a class.
 
    NOT ONE ORNAMENT SPAN, AND NOT ONE NEW COLOUR. The five blocks above each hang
    an aurora, a ring or an edge off their surface, because na drew nothing there
@@ -6989,34 +7051,17 @@
      `.spectrum-dial`  the 96px points ring's annulus           → TURNS
 
    That is the epic's ruling 3 ("everything moves") read literally, and ruling 4
-   ("upgrade, never replace") kept honestly: strip `.alb-stamp` and every pixel is
+   ("upgrade, never replace") kept honestly: strip the class and every pixel is
    the one an unaffiliated player sees.
 
-   THREE DECLARATIONS IS THE WHOLE COST ON THIS SHEET, because the moving parts
-   are #2498's shape: each spectrum grows a travelling/turning `::before` that is
-   declared NOWHERE BUT INSIDE the reduced-motion gate in
-   `src/motion.ornament.css`. Stranded — reduced motion, or the deferred sheet not
-   yet delivered — there is no child at all and the still frame is the mount's own
-   background right here, which is the na stamp exactly. What has to live on the
-   blocking sheet is only what a child cannot bring with it:
-
-   • `overflow: hidden` on the band, the clip the pre-painted ramp slides inside.
-     It changes nothing on its own — the band has no overflowing content — and it
-     inherits the band's inline `10px 10px 0 0` corner for free.
-   • `position: relative` on the dial, so the rim's `inset: 0` resolves against
-     the 96px ring rather than against the stamp plate two levels up.
-   • `position: relative` on the dial's ONE CHILD — `DefaultPointsRing`'s inner
-     disc, which holds the total. The rim is a pseudo-element precisely so the
-     numeral does not turn with it (the call `.alb-detail-ring` already makes),
-     and an absolutely positioned `::before` paints over a STATIC sibling however
-     late it sits in the DOM. Lifting the disc into the positioned layer puts it
-     back on top. No offsets, so it moves nothing while the rim is absent.
-
-   Both cascades come from the tokens, so no dark half is written here. Decorative:
-   both spans are `aria-hidden` chrome and no contrast is owed. ── */
-.alb-stamp .spectrum-rule { overflow: hidden; }
-.alb-stamp .spectrum-dial { position: relative; }
-.alb-stamp .spectrum-dial > * { position: relative; }
+   THE THREE DECLARATIONS THAT STOOD HERE ARE GONE, and nothing about this stamp
+   changed. They were `.alb-stamp .spectrum-rule`/`-dial`/`-dial > *`, and #2500
+   found eight more Albescent surfaces carrying the same two classes and standing
+   still. The stamp's wrapper wears `alb-moves` beside `alb-stamp` now, and the
+   rules it used to own are that marker's, near `.spectrum-rule`'s own
+   declaration further up this sheet — same properties, same durations, nine
+   surfaces instead of one. `.alb-stamp` survives because
+   `DefaultScoreStamp`'s own note points at it; it declares nothing. ── */
 
 /* UA — the growing mandala's five motions (bloom, twist, spin, ring-grow, halo)
    are in `src/motion.ornament.css` (#2073). Meaning is carried by the mandala's

--- a/frontend/src/motion.ornament.css
+++ b/frontend/src/motion.ornament.css
@@ -733,9 +733,33 @@
   .alb-faction-hero .faction-hero-sigil { animation: alb-spin 48s linear infinite; }
 }
 
-/* ── Albescent — the SCORE STAMP's two spectra (#2501, epic #2496). The whole
-   delta between a member's stamp and an unaffiliated player's: the 2px band
-   across its top edge travels, and the 96px points ring's annulus turns.
+/* ── Albescent — EVERY na SPECTRUM ON A DISPATCHED SURFACE (#2501, widened by
+   #2500; epic #2496 ruling 3). "Nothing dispatched to Albescent holds a still
+   spectrum", read literally: the two classes #2497 minted for the seventeen
+   inline ramps scattered through the `Default*` files get up and walk wherever
+   an Albescent wrapper is over them.
+
+     `.spectrum-rule`  every band, hairline, chip and progress fill → TRAVELS
+     `.spectrum-dial`  every points ring, medallion and annulus     → TURNS
+
+   READOUTS TOO, WHICH IS THE RULING AND NOT AN OVERSHOOT. There is no
+   chrome/readout distinction in this epic: the task card's points ring, the
+   stamp's total, the profile's level bar and its badge medallions are all in
+   this list. Ruling 10 draws the other edge — a surface not in a manifest
+   (`LevelUpPopup` and its `--faction-default-stop-*`) is untouched, because
+   `alb-moves` only ever rides on a wrapper the manifest dispatches.
+
+   TWO SELECTORS FOR NINE SURFACES. #2501 shipped this as `.alb-stamp
+   .spectrum-rule`/`-dial`, which is the same two rules scoped to one wrapper;
+   the census in `__tests__/albescentSpectraMove.test.tsx` found eight more
+   surfaces wearing the same classes and standing still. The marker replaces the
+   scope and the declarations below are #2501's own, byte for byte — the stamp's
+   two spectra move at exactly the pace and phase they moved at yesterday.
+
+   `:empty` IS THE ORNAMENT/FRAME LINE and index.css carries the whole argument
+   for it beside `.spectrum-rule`'s declaration. Short form: four mounts wear
+   this class as a padded ramp AROUND content rather than as an ornament, and a
+   travelling child inside one paints over the content it frames.
 
    NO KEYFRAME IS DECLARED HERE, and both reuses were checked rather than
    assumed. `alb-edge-travel` above is "slide a two-tile child by one tile" and
@@ -749,30 +773,40 @@
    this sheet. Each moves a STATIC pre-painted gradient with `transform`, so the
    ramp rasterises once and the frames are the compositor's.
 
-   BOTH CHILDREN EXIST ONLY INSIDE THIS GATE, the shape #2498 gave the five card
+   BOTH CHILDREN EXIST ONLY INSIDE THIS GATE, the shape #2498 gave the nine card
    edges. Stranded — reduced motion, or this sheet never delivered — there is no
-   `::before` on either mount and the still stamp is `.spectrum-rule` and
+   `::before` on either mount and the still surface is `.spectrum-rule` and
    `.spectrum-dial` painting their own backgrounds from index.css: the exact
-   spectrum stamp every unaffiliated player already sees, drawn in its final
-   colours at its final size. Nothing here carries meaning through motion alone.
+   spectrum an unaffiliated player already sees, drawn in its final colours at
+   its final size. Nothing here carries meaning through motion alone.
 
    THE BAND STATES ITS RAMP; THE RING INHERITS ITS OWN. That asymmetry is the one
    decision in this block. The ring's resting paint is
    `--faction-default-rainbow-conic` and two tiles of a wheel is a wheel, so
    `background-image: inherit` registers the rim exactly over the annulus it
-   replaces — the same trick the five edges use. The band cannot: `.spectrum-rule`
+   replaces — the same trick the nine edges use. The band cannot: `.spectrum-rule`
    is `--faction-default-rainbow`, the seven-stop sweep whose last stop is NOT its
    first, so tiling it twice would put a violet-meets-red seam through every
    cycle. `--faction-default-rainbow-loop` is the same spectrum cut to close, and
    naming it is what buys the seamless loop.
 
+   ONE CLOCK EACH, NOT ONE PER MOUNT, and the issue's "give each mount its own
+   duration so they drift apart rather than pulsing together" is already answered
+   two ways. Nothing here PULSES: both keyframes are linear and endless, so there
+   is no crest for two mounts to reach at once — the canvas's 12-42s randomiser
+   and its negative `animation-delay` were desyncing a preview of blooms, which
+   #2499 retired. And the tile is the MOUNT's own width, so a 7px chip and a
+   400px band on one clock travel at wildly different apparent speeds and never
+   read as one machine. What a shared clock does buy is the thing #2501 measured:
+   two rainbows at two speeds on one page are "two rainbows arguing". Across the
+   kit the family is already spread — 8s and 9s for the masked edges, 16s here,
+   24s the avatar, 44/46/48/58s the wheels.
+
    THE PACES ARE THE SIBLING SURFACES', not new numbers: 46s for a turn is
    `.alb-detail-ring`'s, and 16s across the band is the four card edges' old
-   mount-width pace. A stamp sits on the same page as both, and two rainbows
-   moving at different speeds beside each other is the "two rainbows arguing" the
-   feed block warns about. ── */
+   mount-width pace. ── */
 @media (prefers-reduced-motion: no-preference) {
-  .alb-stamp .spectrum-rule::before {
+  .alb-moves .spectrum-rule:empty::before {
     content: "";
     position: absolute;
     top: 0;
@@ -783,7 +817,7 @@
     background-size: 50% 100%;
     animation: alb-edge-travel 16s linear infinite;
   }
-  .alb-stamp .spectrum-dial::before {
+  .alb-moves .spectrum-dial::before {
     content: "";
     position: absolute;
     inset: 0;

--- a/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
@@ -30,15 +30,35 @@
  *
  * Both form factors, one row: the ornament mounts inside the identity band in
  * each of `DefaultProfileBody`'s two branches, so the phone stack drifts too.
+ *
+ * ── THE REST OF THE PAGE'S SPECTRA (#2500, epic ruling 3) ───────────────────
+ *
+ * The band was the only thing moving here, and this is the surface where that
+ * showed most: the na profile draws the spectrum SIX more times — three section
+ * heads, the FDL laurel's ring, a medallion behind every badge, and the level
+ * bar's fill — and every one of them stood still under a member's own name.
+ * Ruling 3 is explicit that readouts are not exempt, and a progression bar is
+ * the readout the ruling names.
+ *
+ * The wrapper is what those six needed. This is the one row in the manifest that
+ * hands `Default` a slot and nothing else, so there was no element in the tree
+ * for `.alb-x .spectrum-rule` to descend from; the div below is that element and
+ * declares nothing of its own — `alb-moves` is a marker, and index.css carries
+ * the rules. The identity band is deliberately NOT among the six: it is a frame
+ * with the page inside it rather than an ornament, and it already carries a
+ * travelling ring, so moving its ramp too would put two spectra at two speeds on
+ * one object. `:empty` in the selector is what draws that line.
  */
 import type { ProfileBodyProps } from '../FactionProfileBody'
 import DefaultProfileBody from './DefaultProfileBody'
 
 export default function AlbescentProfileBody(props: ProfileBodyProps) {
   return (
-    <DefaultProfileBody
-      {...props}
-      identityOrnament={<span aria-hidden="true" className="alb-profile-edge" />}
-    />
+    <div className="alb-moves">
+      <DefaultProfileBody
+        {...props}
+        identityOrnament={<span aria-hidden="true" className="alb-profile-edge" />}
+      />
+    </div>
   )
 }

--- a/frontend/src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx
@@ -40,7 +40,7 @@ import DefaultFactionBody from "./DefaultFactionBody";
  */
 export default function AlbescentFactionBody({ state }: { state: FactionDetailState }) {
   return (
-    <div className="alb-faction-body">
+    <div className="alb-faction-body alb-moves">
       <DefaultFactionBody
         state={state}
         plateOrnament={<span aria-hidden="true" className="alb-plate-edge" />}

--- a/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
@@ -202,7 +202,7 @@ function render(
 function undress(html: string): string {
   return html
     .replace(/<span[^>]*class="alb-praxis-[a-z]+"[^>]*><\/span>/g, "")
-    .replace(/^<div class="alb-praxis alb-prism">/, "")
+    .replace(/^<div class="alb-praxis alb-moves alb-prism">/, "")
     .replace(/<\/div>$/, "");
 }
 
@@ -287,13 +287,17 @@ describe("Albescent praxis detail — where the light sits", () => {
       [...new Set(html.match(/alb-[\w-]+/g))].sort(),
       "wrapper + prism + two layers + the dispatched stamp, nothing else",
     ).toEqual([
+      "alb-moves",
       "alb-praxis",
       "alb-praxis-edge",
       "alb-praxis-ring",
       "alb-prism",
       "alb-stamp",
     ]);
-    expect(html.match(/alb-/g)?.length, "each of the five drawn once").toBe(5);
+    // `alb-moves` is drawn TWICE — once on this wrapper and once on the score
+    // stamp the sidebar dispatches, which is its own manifest row (#2501) and
+    // carries its own marker.
+    expect(html.match(/alb-/g)?.length, "the six drawn once each, the marker twice").toBe(7);
     expect(html, "the report card is mounted bare").toContain("sidebar-card");
   });
 

--- a/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx
@@ -83,7 +83,7 @@ import type { PraxisDetailState } from '../usePraxisDetail'
  */
 export default function AlbescentPraxisDetail({ state }: { state: PraxisDetailState }) {
   return (
-    <div className="alb-praxis alb-prism">
+    <div className="alb-praxis alb-moves alb-prism">
       <DefaultPraxisDetail
         state={state}
         ornament={

--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -168,7 +168,7 @@ export default function AlbescentTaskDetail({
   );
 
   return (
-    <div className="alb-detail alb-prism">
+    <div className="alb-detail alb-moves alb-prism">
       <DefaultTaskDetail state={state} worthSlot={worth} />
       <span aria-hidden="true" className="alb-detail-foil" />
       <span aria-hidden="true" className="alb-detail-edge" />


### PR DESCRIPTION
Closes #2500

Part of #2496.

## The seam

**The na spectrum classes and the wrapper over them.** #2497 minted
`.spectrum-rule` and `.spectrum-dial` for the seventeen unclassed inline ramps
scattered through the ten `Default*` files Albescent wears, and its own docblock
says why — *"a dresser reaches them with `.alb-x .spectrum-rule` … and #2500 is
what will animate them."* This is that dresser.

The defect a test can see is a **mount with nothing over it**: a `.spectrum-rule`
renders, paints and passes every existing test whether or not a `::before` is
walking across it. So the guard is a census, pinned in
`frontend/src/__tests__/albescentSpectraMove.test.tsx` — it went red on 15 of 23
assertions before the change.

## The census — all fifteen manifest rows

You asked for this before a diff. Two of the four suspicions are refuted.
Verified against `origin/main` @ `122836fa` and `frontend/src/factions/albescent.ts`.

| # | manifest row | wrapper | classed spectrum mounts | before | after |
|---|---|---|---|---|---|
| 1 | `factionSelectCard` | bespoke | **none** — the reveal-register vellum tile paints no spectrum at all | n/a | n/a |
| 2 | `praxisCard` | `.alb-praxis-card` | edge ring; 1 rule (the vote divider) | ring 8s, rule **STILL** | rule travels 16s |
| 3 | `scoreStamp` | `.alb-stamp` | band, working rule, 96px points dial | all MOVE (#2501) | unchanged; selector generalised |
| 4 | `taskCard` | `.alb-task` | edge ring; 2 rules (7px chip, CTA hairline); 1 dial (92px points ring) | edge 8s, rest **STILL** | rules 16s, dial 46s |
| 5 | `taskDetail` | `.alb-detail` | edge 8s, foil 44s, worth ring 46s; **6 rules** | 3 move, 6 rules **STILL** | 4 ornament rules travel 16s; 2 framed panels stay (below) |
| 6 | `praxisDetail` | `.alb-praxis` | edge 8s, prism ring 58s; 1 dial, 3 rules | 2 move, rest **STILL** | dial 46s, 2 ornament rules 16s; 1 framed panel stays |
| 7 | `feedFrame` | `.alb-feed` | edge only — no classed spectrum inside | MOVES | unchanged |
| 8 | `profileBody` | **none existed** | `.alb-profile-edge` 9s; 3 section rules, 2 dials, the progression fill | edge only, rest **STILL** | rules + progression fill 16s, laurel + badge dials 46s |
| 9 | `avatar` | `.alb-avatar-ring` | the ring | 24s, gated at ≥48px | unchanged |
| 10 | `factionHero` | `.alb-faction-hero` | sigil 48s; the 3px spectrum border is a **sheet layer**, not a rule | MOVES | unchanged — grounds are static by ruling 6 |
| 11 | `factionBody` | `.alb-faction-body` | 5 plate edges 8s; **5 plate hairlines** | edges move, hairlines **STILL** | hairlines 16s |
| 12 | `vote` | bespoke | 5 windowed rainbow dots | **MOVE** — the clip-path morph + `.spectrum-dot--reached` bob | unchanged |
| 13 | `metataskSeal` | bespoke | 1 inline rainbow strip | **STILL** | classed `.spectrum-rule`, travels 16s |
| 14 | `editPraxis` | `.alb-composer` | edge 8s; `RingMark … spin` is na's own `.ep-spin` | MOVES | unchanged |
| 15 | `mobileFieldDesk` | `.alb-desk` | edge 8s; the identity bar is `display: none` since #2519 | MOVES | unchanged |

**Refuted:** `factionSelectCard` holds no spectrum to still — it is the pale
reveal tile and ruling 8 keeps it flat, so there is nothing to wire. `vote`
already moves: the ferrofluid clip-path morph and the shared bob are its motion,
and its rainbow is a *continuous* window across the whole row, which is the one
spectrum here that must not be slid per-dot.

**Confirmed:** `metataskSeal` was genuinely still, and so was the progression
ring — but the ring's real home is the **task card** and the **profile**, not
only the stamp, and eight more surfaces were still along with it. The motion half
was **not** already complete: the batch that landed moved the *ornament Albescent
adds*, and left every na spectrum it *wraps* standing.

## What changed

**`frontend/src/index.css`** — one marker class beside the two it dresses:

- `.alb-moves .spectrum-rule:empty` → `position: relative; overflow: hidden` (the clip and the containing block the deferred child needs)
- `.alb-moves .spectrum-dial` and `… > *` → `position: relative`
- **deleted** `.alb-stamp .spectrum-rule` / `-dial` / `-dial > *` — #2501's three lines, which are these three scoped to one surface.

**`frontend/src/motion.ornament.css`** — the same two `::before` rules #2501
wrote, byte for byte, re-scoped from `.alb-stamp` to `.alb-moves`. **No keyframe
is minted or renamed**: `alb-edge-travel` (a two-tile child slid one tile) and
`alb-spin` (a bare 360deg turn) already exist and already have nine and four
consumers. `motionSplit.test.ts` and `spectrumRingCollapse.test.ts` stay green.

**Eight wrappers gained `alb-moves`** (class-only, no logic touched):
`AlbescentTaskCard`, `AlbescentPraxisCard`, `AlbescentScoreStamp`,
`AlbescentTaskDetail`, `AlbescentPraxisDetail`, `AlbescentFactionBody`,
`AlbescentProfileBody`, `AlbescentSeal`.

Two of them needed slightly more than a class:

- **`AlbescentProfileBody`** is the one manifest row that hands `Default` a slot and nothing else, so there was no element for a descendant selector to start from. It now wraps in `<div className="alb-moves">` — the same shape `.alb-detail`, `.alb-praxis` and `.alb-feed` already use. The parent is a fragment in normal block flow (`CharacterProfile.tsx:422`), so the div changes no layout.
- **`AlbescentSeal`**'s strip named `--faction-default-rainbow` inline, so no stylesheet could reach it. It wears `.spectrum-rule` now — the class that carries that exact token and nothing else, so the resting sheet is unchanged — and the `opacity: 0.35` stays at the call site with the height and the radius.

**I did not touch `AlbescentSelectCard.tsx` at all**, so #2409 rebases onto this
cleanly.

## Two design decisions

**1. `:empty` separates ornament from frame.** `.spectrum-rule` is worn by two
different objects. Most mounts are ornament — an `aria-hidden` hairline, band,
chip or progress fill with no children — and those travel. Four are *frames*: a
padded ramp around an opaque inner sheet (the ×mult badge and the action panel on
the task detail, the proof panel on the praxis detail, the profile identity
band). Those stay still, for three independent reasons:

- a travelling child inside a frame paints **over the content it frames**, so it needs the content lifted back into the positioned layer — inside panels holding a CTA and a media gallery;
- the clip it needs is `overflow: hidden` on those same panels;
- the profile identity band already carries `.alb-profile-edge`, a ring travelling on its own 9s clock. Moving the ramp underneath it would put **two spectra at two speeds on one object** — the doubling #2519 spent a PR undoing.

Each of those four sits on a surface whose own carrier already travels, so no
Albescent surface is left standing still by this line.

**2. One clock each, not one per mount.** The issue asks for per-mount durations
"so they drift apart rather than pulsing together". I checked before adding
anything, as asked, and the requirement is already met two ways:

- **Nothing pulses.** Both keyframes are linear and endless — there is no crest for two mounts to reach at once. The canvas's 12–42s randomiser with its negative `animation-delay` was desyncing a preview of *blooms*, which #2499 retired.
- **The tile is the mount's own width**, so a 7px chip and a 400px band on one clock travel at wildly different apparent speeds and never read as one machine.

What a shared clock buys is the thing #2501 measured and pinned: two rainbows at
two speeds on one page are *"two rainbows arguing"*. Across the kit the family is
already spread — 8s/9s masked edges, 16s rules, 24s avatar, 44/46/48/58s wheels —
and this PR adds no new number.

## The `content-visibility` half — BLOCKED, not dropped

I did not ship it, and this is a report rather than a call I made lightly: **two
blockers turned up that no measurement can fix, and neither is the scroll-jump
the issue anticipates.** Both are code-verified.

**(a) `Tasks.tsx` and `Praxes.tsx` are not lists of rows.** Both are
**flex-wrap grids of ragged-width cards** (`Tasks.tsx:101` `.task-card-row`,
`Praxes.tsx:76` `flex flex-wrap`). `content-visibility: auto` applies **size
containment in both axes** to a skipped element, so each off-screen card would
take `contain-intrinsic-size`'s *width* instead of its own — and index.css says
in as many words why that cannot happen:

> NEVER `.task-card-row > *` itself: the row's own item grows along the ROW's main axis … a `flex-grow` there would stretch cards to fill the line — the exact width-regularizing §6 forbids. — `index.css:4549`

Uniform off-screen widths mean the wrap re-flows as you scroll and cards jump
between lines. `contain-intrinsic-size: auto <length>` does not save it: the
remembered size only exists after a first render, and the whole point is that
these never render. The same containment also breaks the equal-height chain #1945
built (`.task-card-row [data-form-factor] > article`, `flex: 1 1 auto`), because
a size-contained flex item stops contributing its content height to the line's
cross size.

**(b) The feed is the right shape, but paint containment clips the cards.**
`Updates.tsx:104` *is* a single-column flex column with full-width rows, so the
inline axis is safe there. But `content-visibility: auto` applies **layout, style
and paint containment unconditionally** — not only while skipped — and paint
containment clips descendants to the padding box. Six feed frames paint a
`box-shadow` outside their own box (`CovenFeedFrame.tsx:196`,
`EphemeristsFeedFrame.tsx:169`, `EverymenFeedFrame.tsx:86`,
`SingularityFeedFrame.tsx:191`, `SnideFeedFrame.tsx:98`, `WowFeedFrame.tsx:136`),
so putting it on the column's children clips every one of them, in every theme,
for every player. That is a visible na-and-everyone regression, and it is not the
failure mode the issue guards against.

**(c) I cannot make the measurement the issue requires.** No browser and no dev
stack here, so "measure the per-row height; do not estimate it" is not something
I can honestly do — shipping a number would be exactly the guess the issue
forbids.

**Proposal, for a follow-up that would be your call:** mount it on the **card
frame itself** rather than on a list wrapper. An element's own `box-shadow` is
not clipped by its own paint containment, so a frame-level mount solves (b), and
on the feed the frame is already the full-width row so (a) never arises. That
needs a shared hook on the nine feed frames — a `frontend-feature` change — plus
a real browser to measure. I would rather file that than ship a regression behind
a green build.

## Findings for later — still spectra this PR does not reach

All are **unclassed inline ramps in na files**, i.e. #2497's unfinished half
rather than Albescent motion. Classing them is a paint edit to na components and
does not belong in a motion PR:

- `components/feed/FeedRowContent.tsx:149` — 28px conic avatar ring, inside `.alb-feed`
- `pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx:205` — 56px conic avatar ring, inside `.alb-desk`
- `pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx:282` — the level-track fill, inside `.alb-desk`
- `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx:126,549` — the voters' rung dots (conditional `backgroundImage`, so a class means a conditional `className`)
- `pages/praxisDetail/DuelCard.tsx:177` — the duel side's ring (same conditional shape)
- `components/metataskSeal/MetataskPicker.tsx:129` — the picker's 3px head band
- `components/avatar/FactionAvatar.tsx:143` — the disc's own conic; `.alb-avatar-ring` turns an identical one over it at ≥48px, so this is only still at the byline steps, which is the dormant gate #2502 ruled

Also for `frontend-feature`, spotted while reading: `AlbescentSelectCard.tsx` and
`AlbescentSeal.tsx` are entirely inline-styled (the select card carries an
`eslint-disable local/no-raw-style-values` for a raw `fontSize: 40`), and
`DefaultProfileBody.tsx:104` launders a raw colour past the ratchet on a `filter`
property, by its own admission.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **413 files, 7396 passed, 1 skipped** |
| `npm run build` | ok |
| `npm run budget` | below |

**Byte budget — no measurable growth.** Built `origin/main` @ `122836fa` and this
branch in the same worktree:

```
main         22.3 KB css   (warn>22.2  fail>24.4)
this branch  22.3 KB css
```

Still on the wrong side of the 22.2 KB warn line, exactly as `main` already is;
nothing here moved it. The new rules are ~8 declarations and the deleted
`.alb-stamp` trio pays for three of them. All the motion is in
`motion.ornament.css`, which is deferred and outside the ledger by construction.

**Eight tests needed updating**, all because a wrapper's class list grew:
`motionSplit.test.ts` (the `MOTION_SCAFFOLDING` keys), `taskCardsV3.test.tsx`,
`albescentDriftStopsAtMedia.test.tsx`, `albescentPraxisDetail.test.tsx` (the
`undress()` regex and the `alb-*` inventory), `scoreStamp.test.tsx` (the exact
wrapper markup), plus three doc comments naming the retired selector.

## What to eyeball

Visual QA is **outstanding on all of it** — no browser, no dev stack, no
compositor in CI, so nothing above proves a pixel.

**Both themes, and once more with `prefers-reduced-motion: reduce`** (everything
below must then be a legible still frame, identical to the na surface):

1. **`/tasks`, an Albescent card** — the 7px in-progress chip and the hairline above SIGN UP now travel, and the 92px points ring turns. Watch the ring's **numeral**: it must stay upright while the annulus turns.
2. **`/tasks/<id>` (Albescent)** — four section-head hairlines travel. The **×mult badge** and the **score+action panel** must stay still and un-clipped: they are the `:empty` exclusion, and a wrong exclusion shows up as the ramp painting over the multiplier or the CTA.
3. **`/praxes/<id>` (Albescent)** — the member avatar's 44px ring turns; the sheet-head band and the section head travel; the **proof panel** around the gallery stays still.
4. **A praxis card with a score stamp** — must be *pixel-identical to yesterday*; #2501's mounts changed selector, not clock.
5. **`/characters/<id>` for an Albescent member** — the biggest change. Section heads, the FDL laurel ring, **every badge medallion** and the **level progression bar's fill** all move. The identity band at the top must keep exactly ONE moving ring (`.alb-profile-edge`), not two. Check the phone stack too — the wrapper covers both branches.
6. **`/factions/albescent`** (needs a revealed account) — the five plate hairlines travel under the plate edges that already do.
7. **A praxis carrying an Albescent metatask seal** — the pale strip travels now. This is the one surface where the tell is looked at directly; if it reads loud, that is the one to dial back.
8. **Site-wide things must NOT move** (ruling 10): `LevelUpPopup`, the sidebar rail's spectrum, `CredentialCard`, and any na surface with no Albescent wrapper over it.
9. **The tiny mounts** — the 7px chips on the task card and the task detail. The tile is the mount's own width, so the whole ramp is always in frame and they should shimmer rather than cycle hue. If either reads as a *colour change*, that breaks ADR-0048 ("a shimmer, never a colour") and I would take those two out of the selector.

**And the three list pages, scrolled** — `/tasks`, `/praxes`, `/updates`. This PR
ships **no** `content-visibility`, so what to look for is the opposite of a
scroll jump: whether long lists of Albescent cards, each now carrying two or
three more animated pseudo-elements, feel heavy while scrolling. If they do, that
is the argument for the frame-level follow-up above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
