### PR TITLE
The returning-player gate test reads the clock the endpoint reads, so the suite stops going red at midnight

### DIFF
--- a/backend/tests/integration/test_returning_player_gate.py
+++ b/backend/tests/integration/test_returning_player_gate.py
@@ -25,7 +25,7 @@ of it comes back. There is nothing to come back: ``delete_account`` blanked it.
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 import pytest
@@ -298,7 +298,7 @@ async def test_the_gate_reads_its_date_and_the_confirm_lands_in_a_fresh_account(
 
     gate = await client.get("/auth/returning-player")
     assert gate.status_code == 200
-    assert gate.json()["deleted_on"] == date.today().isoformat()
+    assert gate.json()["deleted_on"] == datetime.now(timezone.utc).date().isoformat()
 
     confirm = await client.post("/auth/returning-player")
     assert confirm.status_code == 200


### PR DESCRIPTION
## The flake

`backend/tests/integration/test_returning_player_gate.py::test_the_gate_reads_its_date_and_the_confirm_lands_in_a_fresh_account` compares the API's `deleted_on` — computed from a **UTC-aware** server clock — against `date.today()`, the runner's **local** date:

```
AssertionError: assert '2026-08-24' == '2026-08-23'
```

Whenever the two clocks sit on opposite sides of midnight, the test fails on an untouched `main`. That is a red-CI window every single day, as wide as the runner's UTC offset. Found while running the full backend suite for #2409; unrelated to it.

## The fix

Assert against `datetime.now(timezone.utc).date()` — the same form line 148 of this file already uses for the exception's `deleted_on`. The two date assertions in one file now agree on which clock is authoritative. `date` drops out of the imports with its last use.

Deliberately **not** widened to accept either date: the endpoint has exactly one correct answer and the test should keep saying so. Also not frozen — there is no `freezegun` in the deps and one expression does the job; a frozen-clock fixture is worth adding when a test needs to *control* the date rather than just agree with it.

`date.today()` appears nowhere else under `backend/`, so this was the only site.

## Verification

Run on a machine currently **inside** the broken window (local `2026-08-23`, UTC `2026-08-24`):

- pre-fix (stashed): `test_the_gate_reads_its_date_and_the_confirm_lands_in_a_fresh_account` **FAILED** with the exact assertion above
- post-fix: **9 passed** (whole file)
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
