### PR TITLE
ADR-0083: Albescent is one ornament vocabulary over na, not a skin per surface

### DIFF
--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -104,12 +104,16 @@ class PraxisInviteOut(WireModel):
     model_config = {"from_attributes": True}
 
 
+# ``task_level_required``, ``submitted_at`` and ``created_by_faction_slug``
+# below were added for the praxis read page by ADR-0017 §6. That ADR is now
+# marked **Superseded by ADR-0061** — history, not live authority. The fields
+# shipped; this schema is their record.
 class PraxisOut(WireModel):
     id: int
     task_id: int
     task_title: str             # populated by build_praxis_out
     task_point_value: int       # populated by build_praxis_out
-    task_level_required: int = 0  # populated by build_praxis_out; ADR-0017 §6
+    task_level_required: int = 0  # populated by build_praxis_out
     task_faction_slug: Optional[str] = None  # populated by build_praxis_out; drives per-faction vote UI
     type: PraxisType
     status: PraxisStatus
@@ -118,7 +122,7 @@ class PraxisOut(WireModel):
     moderation_status: ModerationStatus
     admin_note: Optional[str]
     flagged_at: Optional[datetime]
-    submitted_at: Optional[datetime] = None  # set on in_progress→submitted; ADR-0017 §6
+    submitted_at: Optional[datetime] = None  # set on in_progress→submitted
     submit_proposed_at: Optional[datetime] = None  # collab pending-publish window opened-at (ADR-0012)
     created_by_id: int
     created_by_display_name: str  # populated by build_praxis_out
@@ -127,7 +131,7 @@ class PraxisOut(WireModel):
     # the byline degrades to each archetype's own monogram, not a placeholder
     # image. Same field, same meaning as ``PraxisCardOut.created_by_avatar_url``.
     created_by_avatar_url: str = ""  # populated by build_praxis_out
-    created_by_faction_slug: Optional[str] = None  # author's member faction; actor-scoped byline; ADR-0017 §6
+    created_by_faction_slug: Optional[str] = None  # author's member faction; actor-scoped byline
     created_at: datetime
     updated_at: datetime
     members: List[PraxisMemberOut]

--- a/docs/adr/0017-praxis-read-page.md
+++ b/docs/adr/0017-praxis-read-page.md
@@ -151,6 +151,13 @@ solo-vs-collab, `body_text`, `media_items`, `moderation_status`, `is_withdrawn`,
 
 ### 7. Albescent is a first-class identity on the read surface (grilling 2026-06-25)
 
+> **Amended by ADR-0083 §8.** The **always-light** clause below is retired: the
+> Albescent reveal register has a dark half, and a dark-mode reader gets a dark
+> letter. Its other half is already dead — the `--faction-albescent-card-*`
+> tokens prescribed here were deleted by #783, and Albescent renders as
+> unaffiliated everywhere. Singularity's always-dark is untouched; the amendment
+> is about the vellum, not about theme-invariant surfaces as a class.
+
 The bundle ships a bespoke **always-light vellum** albescent read page, contradicting the
 global `albescent → ua` alias (`FACTION_ALIASES`). Decision: albescent gets its own
 read-page archetype **now** —

--- a/docs/adr/0017-praxis-read-page.md
+++ b/docs/adr/0017-praxis-read-page.md
@@ -1,5 +1,8 @@
 # The praxis read page is a per-faction archetype surface with an interactive vote caster
 
+**Status:** Superseded by ADR-0061
+**Date:** 2026-06-25
+
 ADR-0005 enriched the praxis **card** (the register-row, list view) and explicitly
 deferred the **Praxis Read** page — `/praxes/:id`, one sealed praxis in full: account
 body, evidence specimens, the **interactive** vote caster, and the full slot set. This
@@ -151,13 +154,6 @@ solo-vs-collab, `body_text`, `media_items`, `moderation_status`, `is_withdrawn`,
 
 ### 7. Albescent is a first-class identity on the read surface (grilling 2026-06-25)
 
-> **Amended by ADR-0083 §8.** The **always-light** clause below is retired: the
-> Albescent reveal register has a dark half, and a dark-mode reader gets a dark
-> letter. Its other half is already dead — the `--faction-albescent-card-*`
-> tokens prescribed here were deleted by #783, and Albescent renders as
-> unaffiliated everywhere. Singularity's always-dark is untouched; the amendment
-> is about the vellum, not about theme-invariant surfaces as a class.
-
 The bundle ships a bespoke **always-light vellum** albescent read page, contradicting the
 global `albescent → ua` alias (`FACTION_ALIASES`). Decision: albescent gets its own
 read-page archetype **now** —
@@ -193,6 +189,44 @@ with #196's metatask-model rework).
 - **Comments** are a separate workstream — reserved slot only (decision 5, #167).
 - **Metatask panel:** omitted (decision 8, #233).
 - **MediaGallery `layout` prop** is added only if the Ephemerists build needs the grid.
+
+## Amendment (2026-08-23) — this record is superseded; what replaced each part
+
+Owner ruling: this ADR is dead. It is **marked, not rewritten** — the decisions
+and the gap tracker above stay as the record of what was decided on 2026-06-25,
+and none of it should be read as live authority. The supersession is spread over
+five records and the status field carries one pointer, so the line at the top
+names the record that re-decided this surface end to end; the rest are here.
+
+- **Decisions 1, 2 and 5 — the staged per-faction seam, the shared slot module,
+  the reserved comments slot.** Superseded by epic #1085: **ADR-0061** (praxis
+  detail is one shared page every faction dresses, and comments become the
+  page's third region rather than a slot this ADR only reserved), **ADR-0063**
+  (one responsive component per faction — the desktop/mobile archetype split
+  this seam grew is retired, `mobilePraxisDetail` with it) and **ADR-0064** (the
+  page owns its chrome). The staging plan finished:
+  `frontend/src/pages/praxisDetail/archetypes/` holds nine archetypes — one per
+  faction plus Default — where this ADR built one (Ephemerists) and pointed
+  every other faction at `DefaultPraxisDetail`. Coven post-dates this record and
+  never appears in the tracker at all.
+- **Decision 3 — the score readout is the point economy, not a distribution.**
+  The rejection held: no `star_distribution` and no `ConcordMeter` exist. The
+  *number* was re-cut after this ADR by **ADR-0053** (a praxis has one number;
+  Merit is retired) and **ADR-0076** (a base-only score reads as a bare total),
+  so read those for what the page shows today.
+- **Decision 6 — the three `PraxisOut` fields.** Shipped.
+  `task_level_required`, `submitted_at` and `created_by_faction_slug` are on
+  `PraxisOut` in `backend/schemas/praxis.py`, which is the record now.
+- **Ruling 7 — Albescent is always-light.** Retired by **ADR-0083 §8**. #2301
+  shipped the reveal register's dark half, so a dark-mode reader gets a dark
+  letter and the always-light clause is contradicted by shipped code. Its other
+  half was already dead: the `--faction-albescent-card-*` tokens this ruling
+  prescribes were deleted by #783 and are absent from
+  `frontend/src/index.css`.
+
+**Singularity's always-dark is untouched.** Theme-invariant surfaces are not
+retired as a class. Ruling 7 died on the vellum's own facts — a register that
+now flips — not on the principle it borrowed to describe itself.
 
 ## Refs
 

--- a/docs/adr/0048-albescent-unfreezes-per-surface-as-designs-land.md
+++ b/docs/adr/0048-albescent-unfreezes-per-surface-as-designs-land.md
@@ -1,8 +1,11 @@
 # ADR-0048 — Albescent unfreezes one surface at a time, as designs land
 
-**Status:** Accepted
+**Status:** Accepted, amended
 **Date:** 2026-07-19
 **Amends:** **ADR-0046** (Albescent is frozen: new surfaces fall through to NA)
+**Amended by:** **ADR-0083** (Albescent is one ornament vocabulary over na) —
+the premise below stands unchanged, but the *per-surface mode* is closed: there
+is now one design, and a surface adopts it rather than commissioning its own.
 **Relates to:** ADR-0027 (Albescent is a secret society), ADR-0039 (the NA/default
 identity is the rainbow), ADR-0047 (the praxis-card score stamp).
 

--- a/docs/adr/0048-albescent-unfreezes-per-surface-as-designs-land.md
+++ b/docs/adr/0048-albescent-unfreezes-per-surface-as-designs-land.md
@@ -1,11 +1,8 @@
 # ADR-0048 — Albescent unfreezes one surface at a time, as designs land
 
-**Status:** Accepted, amended
+**Status:** Amended by ADR-0083
 **Date:** 2026-07-19
 **Amends:** **ADR-0046** (Albescent is frozen: new surfaces fall through to NA)
-**Amended by:** **ADR-0083** (Albescent is one ornament vocabulary over na) —
-the premise below stands unchanged, but the *per-surface mode* is closed: there
-is now one design, and a surface adopts it rather than commissioning its own.
 **Relates to:** ADR-0027 (Albescent is a secret society), ADR-0039 (the NA/default
 identity is the rainbow), ADR-0047 (the praxis-card score stamp).
 
@@ -48,3 +45,12 @@ longer frozen wholesale.
   tell depends on the NA resemblance.
 - Future Albescent surfaces follow this ADR: land a design, unfreeze that one surface,
   keep the rest on NA.
+
+## Amendment (2026-08-23) — the per-surface mode is closed
+
+**ADR-0083** (Albescent is one ornament vocabulary over na, not a skin per
+surface). The premise above stands unchanged — Albescent is still released
+against a design rather than invented — but the *mode* is closed: there is now
+one design for the whole identity, so a surface **adopts** the vocabulary
+instead of commissioning its own. The last bullet above, "future Albescent
+surfaces follow this ADR", is the clause that changes.

--- a/docs/adr/0083-albescent-is-one-ornament-vocabulary-over-na-not-a-skin-per-surface.md
+++ b/docs/adr/0083-albescent-is-one-ornament-vocabulary-over-na-not-a-skin-per-surface.md
@@ -1,0 +1,328 @@
+# ADR-0083 — Albescent is one ornament vocabulary over na, not a skin per surface
+
+**Status:** Accepted
+**Date:** 2026-08-23
+**Amends:** **ADR-0048** (Albescent unfreezes one surface at a time, as designs
+land) — its premise stands and its *mode* is closed; **ADR-0017 ruling 7**, whose
+always-light vellum clause is retired below.
+**Relates to:** ADR-0027 (Albescent is a secret society — the cut voice is
+untouched), ADR-0039 (the na/default identity is the rainbow), ADR-0046 (the
+freeze ADR-0048 reversed), ADR-0066 (one rainbow; the brand palette retired into
+the na spectrum), #2401 (the five undesigned decisions this answers), #2496 (the
+epic and its rulings), #2506 (this decision)
+
+## Context
+
+Every Albescent surface in this repo is a wrapper over `Default`, and the
+wrapping had never been designed as a system. It had been decided per surface, by
+whoever built that surface — differently-named wash classes, `z-index` numbers
+chosen locally, a user-media rule rediscovered once per surface, and a ground
+that was about to move underneath all of it. #2401 catalogued that and asked for
+a design instead of one more instance.
+
+Two failures made the cost concrete rather than theoretical.
+
+**The overlays diverged because nothing held them together.** The praxis card
+wore a rotated repeating linear ramp, multiplied and faint — stripes — and the
+task card wore blurred radials at roughly twice the strength — cloud. Two cards
+meant to be the same paper, two idioms, two strengths. The owner reported it as a
+bug, and it is one: not a value that drifted, but two independent drawings of the
+same idea that had no reason to agree.
+
+**"Too much" was diagnosed as "too visible", and that was the wrong reading.** The
+praxis card stacked *three* spectrum treatments at once — a blurred aurora, a
+turning conic annulus and a drifting striped spectrum, on one small card. The fix
+is **one ground, not a quieter one**. Albescent's ground is a spectrum and is
+meant to read as one in both themes; a result that reads as "is something even
+there?" is a miss in the other direction, and §6 explains why that direction is
+the dangerous one.
+
+What follows is the vocabulary. It is written so the next person to touch an
+Albescent surface inherits these rules rather than rediscovering them.
+
+## Decision
+
+### 1. The shape: the na component plus ornament, never a skin
+
+An Albescent surface is the `Default*` component **rendered whole**, inside a
+wrapper element carrying an `.alb-*` class, plus **one lazy row** in
+`frontend/src/factions/albescent.ts`. Strip the wrapper class and the na surface
+is back byte for byte — that parity is what each wrapper's test asserts, and it
+is the definition of "not a skin".
+
+The ornament mounts one of two ways, and the choice is a clip question:
+
+- **A sibling span inside the wrapper**, when the page is the right thing to clip
+  the light to.
+- **A named slot on the na component** — `ornament`, `identityOrnament`,
+  `worthSlot` — when the light must clip to the *sheet* rather than the page, or
+  must land inside a box only na draws. The slot exists so na is not forked to
+  get an ornament into its own anatomy; na passes nothing and pays nothing.
+
+**The mark is never part of the wrapper.** `FactionSigil` dispatches per slug,
+and the avatar badge stays na's closed ring: a labyrinth on every byline would
+render to every viewer at every size and un-hide the society outright (ADR-0027).
+
+**A repaint is forbidden, and that is the reason the wrapper shape exists at
+all.** `factionCssVar('albescent')` resolves to `--faction-default-*` and stays
+that way. Giving Albescent colours of its own would put it back among the visible
+factions; the delta from unaffiliated is ornament and motion, never livery.
+
+### 2. The ground is a token, not an overlay — and the arity must match
+
+The ground is `--faction-default-card-sheet` with its two siblings `-blend` and
+`-clip`, declared as a **matched triple on a wrapper**. Every na surface inside
+inherits it — plates, cards, panels — without any of them being named. That is
+what makes the ground one override rather than one per surface, and it is why the
+two cards in the Context can no longer diverge: there is one drawing.
+
+**The three properties move together or they do not move**, because a CSS
+background is a list in *three* properties at once — image, blend mode, clip —
+and **CSS cycles short lists rather than padding them**. Albescent's light sheet
+is one image layer and its dark sheet is several; a lone
+`background-blend-mode: multiply` written beside a multi-layer image would be
+handed one value and cycled across all of them — right by accident in one
+cascade, wrong in the other. Any consumer appending its own layer (a spectrum
+border, say) appends to all three lists for the same reason.
+
+`-clip` is `padding-box` for the sheet's own layers, and every consumer writes
+`background-clip: var(--…-sheet-clip), border-box`. That trailing value is
+load-bearing: the background *colour* is clipped by the list's bottom-most value,
+so it still runs out to the border box and shows through a translucent hairline,
+while the sheet's layers stop at the padding box.
+
+**Never selector surgery.** Reaching into descendants to paint a ground is what
+produced the per-surface washes; the token reaches them all, and the wrapper is
+the only thing that names Albescent.
+
+### 3. Everything dispatched moves; nothing site-wide does
+
+There is **no chrome/readout distinction** in this vocabulary. Bands, hairlines
+and dividers move, and so do progression rings, score totals, level bars and
+badge medallions. A readout is not exempt because it carries a number.
+
+The other edge is as firm: **a surface that is not in a manifest does not move
+for Albescent.**
+
+`LevelUpPopup` is the worked example, and it is the example because it looks like
+a candidate and is not one. It paints from `--faction-default-stop-*` — the na
+spectrum's seven stops as indexable scalars — so it *already* carries the
+spectrum, on every player's screen. It is not registered in any faction registry
+and is not resolved through `pickVariant`; it renders identically for a member
+and for a stranger. It stays still. A site-wide celebration that shimmered only
+for members would announce membership to everyone in the room.
+
+The mechanism makes this true by construction rather than by discipline: the
+marker that animates ornament rides **only on a wrapper the manifest dispatches**,
+so "is this Albescent's surface?" and "does it move?" are the same question. A
+surface that stops being dispatched stops moving with no edit anywhere.
+
+### 3a. One marker, not a list of wrappers — and `:empty` is the ornament/frame line
+
+na's spectrum has two named cuts — `.spectrum-rule` (the linear ramp: bands,
+hairlines, dividers, progress fills) and `.spectrum-dial` (the conic wheel: rings
+and annuli) — and Albescent animates them through **one marker class,
+`alb-moves`, worn by every Albescent wrapper**, rather than through a list of
+wrapper scopes. The first dresser named a single surface; a long selector list
+restated in several rule bodies is a place for one entry to be forgotten
+silently, and forgotten here means a surface standing still with no test failing.
+
+**`:empty` separates two different objects wearing one class, and this is the
+part to inherit.** `.spectrum-rule` is worn by two kinds of thing:
+
+- **Ornament** — an `aria-hidden` hairline, band, chip or progress fill with **no
+  children**. This is what "the na spectrum" means on these surfaces, and it
+  moves.
+- **A frame** — a padded ramp with an opaque inner sheet **holding content**. It
+  stays still.
+
+Three reasons a frame stays still, any one of them sufficient: a travelling child
+inside a frame paints over the content the frame frames, and lifting that content
+back into the positioned layer restacks a panel holding live controls; the clip
+such a child needs is `overflow: hidden` on a box whose contents are galleries,
+CTAs and cards rather than an empty band; and where a frame already carries an
+edge of its own, moving the ramp underneath it puts two spectra at two speeds on
+one object — which is exactly what §3b forbids.
+
+The rule is inherited from the selector rather than from a list: **give a ramp
+children and it is a frame.** No frame is ever the only spectrum on its surface,
+because its surface's own carrier travels — so nothing is left standing still by
+this line.
+
+### 3b. One carrier per object
+
+An object that carries the spectrum carries it **once**, as a 3px border at full
+strength — and whatever bar, strip or hairline was previously doing that job
+**comes off**. Two marks on one object is the failure mode, and it is a failure
+of reading rather than of taste: a card with a moving stripe added beside its na
+furniture reads as the na card with a stripe, not as an object the spectrum is
+holding. A carrier is also never dimmed — whatever a shared ring's default
+strength is, a carrier states full.
+
+The mark is a masked ring rather than a real border wherever the box belongs to
+na, for two reasons that land together: growing na's own geometry to a 3px
+transparent border is an edit to na, and a `border-image` does not clip to
+`border-radius`, so the mask idiom is what draws a rounded 3px frame at all.
+
+### 4. Never animate a gradient parameter
+
+An `@property` angle inside a `conic-gradient()` re-rasterises the whole gradient
+every frame. `transform: rotate()` on a **static** conic rasterises once and
+spins on the compositor, and is pixel-identical over a 360° loop. Travel is the
+same shape: translate a pre-painted, wider gradient **child** inside
+`overflow: hidden` rather than walking `background-position`, which is not a
+compositor property.
+
+**This is what makes §3 affordable.** "Everything moves" costs about what "chrome
+moves" would, because the expensive thing was never the number of moving parts —
+it was re-rasterising a gradient per frame. Ruling 3 and this ruling are one
+decision seen from two sides.
+
+A seamless travel needs a ramp **cut to close**: the seven-stop sweep's last stop
+is not its first, so tiling it twice puts a violet-meets-red seam through every
+cycle. That is what the loop-cut token buys, and it is why a turning ring can
+`background-image: inherit` — two tiles of a wheel is a wheel — and a travelling
+band cannot.
+
+Reuse a keyframe rather than minting a byte-identical twin under a new name.
+`spectrumRingCollapse.test.ts` holds this rule over every `alb-` keyframe.
+
+### 5. The light/dark asymmetry is deliberate
+
+**Light washes the hero alone. Dark blooms the hero, the plates and the cards.**
+This is ruled, measured and intended. It is written down here because the next
+person to read the two selectors will otherwise assume one theme is missing a
+rule and "fix" it.
+
+Two reasons it is not symmetric:
+
+- **The blend modes are opposites.** The light sweep *multiplies*, so it can only
+  darken a near-white sheet; the dark bloom *screens*, so it can only lift. The
+  same reach does not produce the same reading, so the same reach is not the
+  goal.
+- **The depth is set by the tighter pairing, and the two themes' tighter pairings
+  are different tiers.** On the dark card the ceiling is the muted prose tier,
+  not the primary ink. Pitching the bloom to land the *ink* where intuition
+  suggests would take a whole prose tier under AA. The dark centres are spread
+  and their falloff kept short for the same reason: stacked hotspots eat the
+  remaining margin.
+
+Both themes were measured composited on the real sheet, and both clear. The
+numbers live beside the declarations; what belongs here is that the asymmetry is
+a design decision with a contrast argument under it.
+
+### 6. The ground is the rest state, and "subtler" has a floor
+
+The ground is **static and visible in both themes**, so it already *is* the rest
+state. There is therefore:
+
+- **no `prefers-reduced-motion` branch on the ground**, and
+- **no separately deepened reduced-motion variant.** An earlier draft had one; it
+  was solving a problem created by the wrong framing of "too much" (see Context)
+  and is withdrawn.
+
+A reduced-motion viewer sees Albescent's spectrum, just not its movement.
+
+**The stranded viewer lands in exactly the same place, and that is a property
+worth stating.** Motion lives on a deferred sheet (`motion.ornament.css`, which
+arrives with the faction chunk) and every animated layer exists **only inside**
+the `prefers-reduced-motion: no-preference` gate. Stranded — reduced motion, or
+that sheet never delivered — there is no animated child at all, and what remains
+is each mount's own background drawn in its final colours at its final size.
+**Both viewers still see Albescent.** Nothing in this vocabulary carries meaning
+through motion alone, and a component may not inject a stylesheet or write an
+inline `animation:` precisely because either would bypass that gate.
+
+**This holds only while the ground reads as a spectrum, so "make it subtler" is a
+change with a floor.** Quieten the ground past legibility and the reduced-motion
+viewer and the never-delivered viewer both see the plain na surface: the tell
+becomes motion-only, and the guarantee in the paragraph above quietly becomes
+false — with nothing in CI able to see it, because every contrast sweep, every
+lint and every census still passes on an invisible ground. The floor is *the
+spectrum being legible as a spectrum*, not a number. Anyone lowering it owes this
+paragraph an answer.
+
+### 7. The avatar is size-gated, and the gate is deliberately high
+
+The avatar ring renders at and above a threshold on the avatar's rendered
+dimension and is **absent** below it. The constant lives in
+`frontend/src/components/avatar/AlbescentAvatar.tsx`; what belongs here is why
+there is one at all.
+
+**Every other tell dresses a surface a viewer is looking *at*. An avatar renders
+*beside other players'*** — comment leaves, praxis bylines, roster rows, duel
+banners. One turning ring in a column of still ones is a **spotlight rather than
+a shimmer**: it announces membership to somebody who was reading a thread, not
+looking for a society. That is the opposite of hiding in plain sight, and it is
+the only Albescent surface whose reasoning is not "reveal it to someone already
+looking".
+
+Two consequences fall out of the same gate. A thin band turning on a small disc
+reads as a **loading spinner** — the browser's own idiom for "waiting" — and is
+below the legibility floor besides. And below the gate the ornament is **never
+rendered** rather than stilled, so a roster never mounts a column of clocks and a
+byline costs exactly what na's costs.
+
+**The threshold is set above every mount that exists today, so the tell ships
+dormant. That is the ruling, not an oversight.** A gate low enough to light the
+single largest disc in a roster column would produce precisely the
+column-of-others case the gate exists to prevent, merely with the biggest disc in
+the column. It lights up on its own the first time a surface shows one player's
+disc large and alone, with no edit here.
+
+The ring is also **chrome outside the portrait**, which settles a separate
+question by construction: it covers the disc's own spectrum band and never the
+picture, so a photo disc and a monogram disc are the same amount of Albescent
+without anything branching on whether a player uploaded a photograph.
+
+### 8. The reveal register flips, and ADR-0017 ruling 7 is amended
+
+ADR-0017 ruling 7 prescribed an **always-light** Albescent register — identical
+values in both cascades, the mechanism singularity uses to stay always-dark. That
+clause is **retired**: a dark-mode reader gets a dark letter.
+
+Its other half was already dead — the `--faction-albescent-card-*` tokens it
+prescribes were deleted, and Albescent has rendered as unaffiliated everywhere
+since. **Singularity's always-dark is untouched**; this amends a ruling about the
+vellum, not about theme-invariant surfaces as a class.
+
+The dark half **mints no colour of its own**, and that is the point: every night
+value is the na card's own pair, or a mix of it. That is this vocabulary's
+pattern rather than an exception to it — an Albescent surface is the na surface
+with light over it, so after dark the letter's stock and ink are simply the na
+card's stock and ink. Nothing to keep in sync, and the society still owns no hue
+anyone could point at.
+
+What is **unchanged**: the reveal register is reached only by the surfaces that
+*are* the reveal. Point an ordinary card, feed row or profile at
+`--albescent-reveal-*` and the society is no longer hidden.
+
+## Consequences
+
+**Building a new Albescent surface** is a lazy manifest row plus a wrapper. The
+ground, the movement, the reduced-motion story and the stranded-sheet story all
+arrive with the vocabulary; none of them is a decision the builder makes again.
+
+**A reviewer has five questions**, and they are five of the sections above with
+teeth: does stripping the wrapper class restore na byte for byte; is the ground a
+token triple with matching arity rather than selector surgery; does the object
+carry exactly one spectrum; does anything animate a gradient parameter; and is
+each `.spectrum-rule` mount on the right side of the ornament/frame line.
+
+**ADR-0048's per-surface mode is closed.** Its premise — Albescent is na plus a
+deliberate tell, never a repaint — is not merely intact; it is what §1
+generalises. What ends is *unfreezing one surface at a time as a design for that
+surface lands*: there is now one design, and a surface adopts it rather than
+commissioning its own.
+
+**What this does not change.** ADR-0027's cut voice: no surface names itself as
+Albescent, and the reveal surfaces stay the only readership of the reveal
+register. `factionCssVar('albescent')` still resolves to `--faction-default-*`.
+The manifest stays override-only, so an undeclared surface still falls through to
+na — which remains the correct and complete statement of Albescent's appearance
+everywhere the vocabulary has not been applied.
+
+**The known sharp edge** is §6's floor. It is the one rule in this document that
+no test can hold, because every check still passes on a ground quietened into
+invisibility. It is written down because writing it down is the only guard
+available.

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -323,7 +323,7 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
   )
 }
 
-// --- letter styles (Albescent vellum tokens; always-light by design) ---------
+// --- letter styles (Albescent vellum tokens; they FLIP since #2301) ----------
 
 const letter: CSSProperties = {
   position: 'relative',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7151,7 +7151,9 @@
      gone. `selectCard/__tests__/snideWearsTheClippingRegister.test.ts` pins it. */
   /* ALBESCENT · vellum correspondence — THE REVEAL SURFACES ONLY (#783).
 
-     IT FLIPS (#2301, epic #2496 ruling 7). This block used to say "always-light,
+     IT FLIPS (#2301, epic #2496 ruling 7, and now ADR-0083 §8, which also
+     amends ADR-0017 ruling 7 — the last place the retired clause was still
+     written down as current). This block used to say "always-light,
      the same mechanism Singularity uses to stay always-dark", and the note under
      it recorded that #1661 deleted the dark half. That instruction is SUPERSEDED
      by owner ruling: a dark-mode reader gets a dark letter. Singularity stays

--- a/frontend/src/pages/AlbescentSecretPlaceholder.tsx
+++ b/frontend/src/pages/AlbescentSecretPlaceholder.tsx
@@ -12,11 +12,10 @@
  * mixed down from `INK`, so the sheet, the rules and the glyph all invert
  * through the cascade with nothing branching on a `dark` boolean.
  *
- * ⚠ ADR-0017's ruling 7 still says Albescent's surfaces are "always-light
+ * ADR-0017's ruling 7 used to say Albescent's surfaces are "always-light
  * (identical values in both the light and dark cascades, exactly as
- * singularity's are always-dark)". That clause is now contradicted here and
- * NEEDS AN AMENDMENT the owner has not yet made — flagged on #2301 rather than
- * rewritten in passing. (Its other half is already dead: the
+ * singularity's are always-dark)". That clause is RETIRED: ADR-0083 §8 makes
+ * the amendment #2301 could only flag. (Its other half was already dead: the
  * `--faction-albescent-card-*` tokens it prescribes were deleted by #783, so
  * Albescent has rendered as unaffiliated everywhere since.) Singularity's
  * always-dark is untouched and stays — this ruling is about the vellum, not

--- a/frontend/src/pages/AlbescentSecretPlaceholder.tsx
+++ b/frontend/src/pages/AlbescentSecretPlaceholder.tsx
@@ -1,8 +1,10 @@
 /**
  * Albescent "sealed" placeholder (#394). What an outsider sees at
  * `/factions/albescent` — deliberately NOT a 404, an in-world dead end.
- * Styled in the Albescent "Register" idiom (ADR-0017 / #231): vellum stock,
- * Cormorant Garamond italic, quiet mono label, faint fleur-de-lis glyph.
+ * Styled in the Albescent "Register" idiom, which arrived with #231 and
+ * ADR-0017 — now marked **Superseded by ADR-0061**, so cite ADR-0083 for
+ * Albescent's vocabulary today: vellum stock, Cormorant Garamond italic,
+ * quiet mono label, faint fleur-de-lis glyph.
  *
  * IT FOLLOWS THE FLIP (#2301, epic #2496 ruling 7), and it does so with no edit
  * below. This docstring used to end "Albescent surfaces never dim in dark mode —
@@ -14,12 +16,17 @@
  *
  * ADR-0017's ruling 7 used to say Albescent's surfaces are "always-light
  * (identical values in both the light and dark cascades, exactly as
- * singularity's are always-dark)". That clause is RETIRED: ADR-0083 §8 makes
- * the amendment #2301 could only flag. (Its other half was already dead: the
- * `--faction-albescent-card-*` tokens it prescribes were deleted by #783, so
- * Albescent has rendered as unaffiliated everywhere since.) Singularity's
- * always-dark is untouched and stays — this ruling is about the vellum, not
- * about retiring theme-invariant surfaces as a class.
+ * singularity's are always-dark)". THAT CLAUSE IS DEAD AND SO IS THE RECORD
+ * CARRYING IT: the owner retired ADR-0017 outright, and it now reads
+ * "**Superseded by ADR-0061**" with an ## Amendment section naming what
+ * replaced each of its decisions; ADR-0083 §8 is what retires ruling 7 in
+ * particular. NOTHING IS OWED HERE ANY MORE — this comment used to say the
+ * amendment was the owner's to make and flag it on #2301. It has been made.
+ * (Ruling 7's other half was already dead: the `--faction-albescent-card-*`
+ * tokens it prescribes were deleted by #783, so Albescent has rendered as
+ * unaffiliated everywhere since.) Singularity's always-dark is untouched and
+ * stays — this was about the vellum, not about retiring theme-invariant
+ * surfaces as a class.
  */
 import { useTranslation } from 'react-i18next'
 // Cormorant Garamond ships in the lazily-fetched faction sheet (#2079), and this

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -111,7 +111,8 @@ describe("FactionProfileBody dispatch", () => {
     // #1626 narrowed it by ONE register, and only that one. The credential
     // footer's faction label became a sigil, and `FactionSigil` now resolves
     // albescent to its own cross-hair — which draws in `--albescent-reveal-*`,
-    // the always-light REVEAL register #783 deliberately kept alive (it is what
+    // the REVEAL register #783 deliberately kept alive (always-light until
+    // #2301 gave it a dark half; it is what
     // the invitation letter, the faction-select tile and the metatask seal are
     // drawn in). The deleted THEME block `--faction-albescent-*` is what "no
     // trace" was written about, and it is still absolutely forbidden here, as is

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -1,5 +1,7 @@
 /**
- * Praxis-read content-slot invariant guard (ADR-0017 §2, ADR-0002).
+ * Praxis-read content-slot invariant guard (ADR-0002, ADR-0061). The guard was
+ * written against ADR-0017 §2, which is now marked **Superseded by ADR-0061**;
+ * the invariant itself is unchanged and ADR-0061 is what records it.
  *
  * Every per-faction praxis-read archetype wears a different skin but must render
  * the same CONTENT slots — an archetype may *arrange* them freely but may not

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -1,5 +1,8 @@
 /**
- * Shared behavior module for praxis-detail archetypes (ADR-0017 §2).
+ * Shared behavior module for praxis-detail archetypes: ADR-0002's content-slot
+ * invariant, re-cut for this surface by ADR-0061 (the layout is the contract)
+ * and ADR-0064 (the page owns its chrome). ADR-0017 §2 set this module up and
+ * is now marked **Superseded by ADR-0061** — do not cite it as live authority.
  *
  * These slots are faction-agnostic and must be rendered identically by
  * every archetype. They are extracted here so no archetype re-implements

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1903,8 +1903,9 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "everymen paper, actor name", surface: "--everymen-paper", text: "--everymen-paper-accent" },
 
   // Albescent's FACTION tokens are gone (#783) — it renders Default's surfaces,
-  // which `default` already covers. What remains is the always-light palette
-  // private to the reveal surfaces (invitation letter, secret placeholder). It
+  // which `default` already covers. What remains is the palette private to the
+  // reveal surfaces (invitation letter, secret placeholder) — always-light until
+  // #2301 gave it a dark half, which is why BOTH_THEMES matters here now. It
   // still carries body text, and it is where #594's 2.78:1 muted ink shipped, so
   // it stays measured. The whole palette is one hue at varying alpha over the
   // sheet, which makes compositing the entire question.


### PR DESCRIPTION
Closes #2506

The last child of epic #2496. A documentation PR: it records decisions and reasons for Albescent's ornament vocabulary so the next person to touch a surface inherits the rules instead of rediscovering them. **No build status, no counts, no checklists** — a count is a state mirror and it rots.

## The seam

There is no runtime seam here — the deliverable is prose, and YAGNI applies to tests too. The seam I actually verified at is **"does the document describe the code on `origin/main`, section by section"**: every claim in the ADR was read out of `frontend/src/index.css`, `frontend/src/motion.ornament.css`, `frontend/src/factions/albescent.ts`, `AlbescentAvatar.tsx` and `LevelUpPopup.tsx` at `8ca5ee11` before it was written down. The guards that hold each rule are named in the ADR by filename (`spectrumRingCollapse.test.ts`, `albescentSpectraMove.test.tsx`) rather than restated.

## ADR-0083

`docs/adr/0083-albescent-is-one-ornament-vocabulary-over-na-not-a-skin-per-surface.md`

0081 was the highest on `main`; **0082 belongs to #2542** (the redaction ADR, still open) so this took 0083. Re-checked `ls docs/adr/` and `git ls-tree origin/main docs/adr/` immediately before the final push — no collision.

All seven the issue asks for, in order: §1 the wrapper shape (sibling span vs. the three named slots, and the clip question that decides which); §2 the ground as a token triple and why the arity must match; §3 everything dispatched moves and nothing site-wide does; §4 never animate a gradient parameter; §5 the light/dark asymmetry is deliberate; §6 the ground is the rest state, with the floor; §7 the avatar's size gate. Plus §8, the reveal register.

## Three things the issue could not know, verified against `origin/main`

**1. `alb-moves` and the `:empty` split (#2541 / issue #2500, merged ~an hour before this branched).** Both are now in the ADR, at §3a. The marker replaced the per-surface dresser scope so the two spectrum classes travel wherever an Albescent wrapper is over them; `:empty` is the genuine vocabulary rule — an empty mount is **ornament** and moves, a mount with children is a **frame** (a padded ramp around content) and stays still, because a travelling child inside a frame paints over the content it frames. Written as a rule inherited from the selector ("give a ramp children and it is a frame"), not as a list of which mounts are which.

**2. One carrier per object (#2527 / issue #2519).** At §3b. A surface gets the 3px spectrum border *or* a bar, never both — with the reason (two marks read as "the na card with a stripe", not as an object the spectrum is holding) and the reason the mark is a masked ring rather than a real border wherever the box belongs to na.

**3. The token triple's real names**, verified at `frontend/src/index.css:921`: `--faction-default-card-sheet` / `-blend` / `-clip`. §2 carries the arity argument (a CSS background is a list in three properties and CSS *cycles* short lists rather than padding them, so a lone `multiply` beside a multi-layer image is right by accident in one cascade and wrong in the other) and the load-bearing trailing `border-box` on the clip.

## Where the code and the brief disagreed — the code won

**The `--albescent-reveal-*` header block in `index.css` no longer forbids theming those tokens.** #2301 (PR #2522, merged 2026-08-23) already rewrote it: it opens `IT FLIPS (#2301, epic #2496 ruling 7)` and spells out that the always-light instruction is superseded. So there was nothing there to correct, and I did not rewrite a block that already says the right thing.

What the retired rule *was* still stated as current, in four places #2301 could not reach:

- **`docs/adr/0017-praxis-read-page.md` ruling 7** — the actual source. `AlbescentSecretPlaceholder.tsx` had a `⚠` block flagging that this clause "NEEDS AN AMENDMENT the owner has not yet made". **That is now ruled — see the next section: ADR-0017 is retired, not amended.**
- **`AlbescentInvitation.tsx:326`** — `// --- letter styles (Albescent vellum tokens; always-light by design) ---`, flatly false since #2301.
- Two test comments (`factionContrast.test.ts`, `factionProfileBody.test.tsx`) describing the reveal register as always-light; both now qualified.

`index.css`'s block gets **three added comment lines only** — the ADR pointer, so the durable citation is an ADR rather than "owner ruling". Kept deliberately surgical so it does not fight #2542's diff.

`ADR-0048` also gets a status change: its premise (Albescent is na plus a deliberate tell, never a repaint) is untouched and is what §1 generalises, but the *per-surface unfreeze mode* is closed.

## ADR-0017 is retired — owner ruling, and the status value I chose

I flagged that I had written ruling 7's amendment myself when the code comment reserved it for the owner. **Molly ruled: "ADR 17 is dead."** That is wider than the clause, so the amendment-in-place is gone and the whole record is marked instead.

**#2536 already specifies the scheme**, and this follows it rather than inventing one or copying ADR-0027's / ADR-0028's shape. A line-2 field, one of exactly `Accepted | Superseded by ADR-NNNN | Reversed | Amended by ADR-NNNN`, with the prose about *which clause* died in the body under `## Amendment`.

### The value: `**Status:** Superseded by ADR-0061`

**No single value in the vocabulary fits cleanly, and I am saying so rather than minting one.** The supersession is spread over five records and the field carries one pointer. Why this value and not the others:

- **Not `Amended by ADR-0083`.** ADR-0083 contradicts *one clause*. That value leaves the record reading live, which is exactly what the ruling says it is not.
- **Not `Reversed`.** ADR-0017 was not decided the other way — it was built, then re-cut. Its headline is still broadly true of the page.
- **`Superseded by ADR-0061`** is the closest true statement: ADR-0061 is the record that re-decided this surface end to end, and its two siblings from the same epic (#1085) finished the job.

### Why it is dead — each claim read off `origin/main`, not off the brief

- **The staging plan finished.** Decision 1 built `EphemeristsPraxisDetail` and pointed everyone else at `DefaultPraxisDetail`. `frontend/src/pages/praxisDetail/archetypes/` now holds **nine** archetypes — Albescent, Coven, Default, Ephemerists, Everymen, Singularity, Snide, Ua, Wow — and `PraxisDetail.tsx`'s own docstring records "ALL EIGHT FACTIONS NOW OVERRIDE `praxisDetail` (epic #1085, closed 2026-07-28)". **Coven post-dates the record and is not in its tracker at all.** ADR-0063 also retired the `mobilePraxisDetail` surface this seam grew.
- **Decision 5's "comments: reserve a marked slot only" is gone**: ADR-0061 made comments the page's third region and ADR-0064 moved the chrome into the layout.
- **Ruling 7 is contradicted by shipped code.** #2301 shipped the reveal register's dark half. Its other half was already dead — `grep -c "faction-albescent-card" frontend/src/index.css` → **0**, deleted by #783.
- **Decision 6 shipped**: `task_level_required`, `submitted_at`, `created_by_faction_slug` are all on `PraxisOut`.
- **Decision 3's rejection held** — `grep` for `ConcordMeter` / `star_distribution` returns nothing — but the number was re-cut afterwards by ADR-0053 and ADR-0076, so the Amendment points there.

**Singularity's always-dark is untouched.** Both the ADR's Amendment section and the code comment say so in as many words: ruling 7 died on the vellum's own facts, not on theme-invariant surfaces as a class.

### What I did *not* do

- **The gap tracker stays byte-for-byte.** #2536: "Do not rewrite ADR bodies… the point is to make its *current standing* legible, not to edit history." I had been told to strip it as a docs-doctrine violation; that instruction was withdrawn and the section is untouched. So are all eight decisions.
- **I did not take on #2536.** One record, not eighty-one. No index, no vocabulary test, no backfill of the other 27 status-less ADRs.
- **One judgement call to check:** ADR-0048's status line. This branch had already set it to the free prose `Accepted, amended` — which is precisely the disease #2536 names — so I normalised *my own* edit to the vocabulary value `Amended by ADR-0083` and moved the prose to an `## Amendment` section. That is a second ADR's status line, which I was told to stop at; I judged that shipping a new non-conforming value was worse than fixing one I had introduced. **Say the word and I will revert 0048 to `Accepted`.**

### The four citations

`grep -rn "ADR-0017" backend frontend` now returns six lines, every one of which marks the record as superseded rather than citing it as authority:

| file | was | now |
|---|---|---|
| `backend/schemas/praxis.py` | three inline `ADR-0017 §6` tags | one block comment above `PraxisOut`: the fields shipped, the schema is their record, the ADR is history |
| `frontend/src/pages/praxisDetail/shared.tsx` | "(ADR-0017 §2)" | ADR-0002's invariant, re-cut by ADR-0061 / ADR-0064 |
| `frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx` | "(ADR-0017 §2, ADR-0002)" | ADR-0002, ADR-0061 |
| `frontend/src/pages/AlbescentSecretPlaceholder.tsx` | ⚠ "NEEDS AN AMENDMENT the owner has not yet made" | "NOTHING IS OWED HERE ANY MORE… It has been made." Register idiom repointed at ADR-0083 |

## Guard rails honoured

- **`LevelUpPopup` re-read before using it as §3's worked example.** Still paints from `--faction-default-stop-*` (lines 45–51), still appears in no faction registry — `grep` over `frontend/src/factions/` and `utils/factions.ts` returns nothing. The ADR uses it precisely because it *looks* like a candidate: it already carries the na spectrum, so the question is live, and the answer is that it renders identically for a member and a stranger.
- **§6's floor is recorded**, and flagged in Consequences as the one rule in the document no test can hold: every contrast sweep, lint and census still passes on a ground quietened into invisibility. "Make it subtler" is a change with a floor, and the floor is the spectrum being legible as a spectrum.
- **No state mirrors.** No surface counts, no "seven surfaces ship it", no status table. The avatar gate's *reasoning* is in §7; the constant stays in `AlbescentAvatar.tsx` and is named as living there.
- **The epic's six stale canvas premises are not restated.** The canvas is referenced only through decisions (the ground as drawn, one carrier per object), never through its status column.
- **`.design-sync/albescent/` does not exist** — nothing to delete.
- **Stayed out of `utils/factions.ts`, `pages/players/playersData.ts`, `backend/routers/factions.py` and `docs/adr/0082-*`** (#2542's files). #2542 also edits `docs/adr/0027-*`; this PR does not touch it.

## Verification

`.github/workflows/test.yml` names three jobs. The `frontend` job was run in full, locally, step by step as files were touched:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean (`tsc --version` → 5.9.3, so this is a real pass, not an absent binary) |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **413 files, 7396 passed, 1 skipped** |
| `npm run build` | built in 5.18s |
| `npm run budget` | JS 127.8 KB ok · CSS 22.3 KB **WARN** (warn>22.2, fail>24.4) |

The CSS warning is **pre-existing on `main`, not this PR**: CSS comments are stripped by the minifier, confirmed by `grep -c "always-light" dist/assets/index-*.css` → 0 and `grep -c "ADR-0083"` → 0 on both emitted sheets. This diff cannot move a byte of shipped CSS.

**The `api-schema` job now matters** — the citation fix touches `backend/schemas/praxis.py`. It is comment-only (`#` comments beside and above fields, no docstring, no `response_model`, no field), so it cannot reach the schema, and that was **verified rather than assumed**: `python scripts/regen_api_client.py` was run from the repo root and `git diff --exit-code backend/openapi.json frontend/src/api/generated/schema.d.ts` returned **0**. Nothing to commit.

`ruff check backend/schemas/praxis.py` run from `backend/`: **11 errors before, 11 after**, none on a line this PR adds — the ratchet only shrinks, and one pre-existing long line got *shorter* (110 → 97) when the inline ADR tag came off. `pytest tests/test_adr_numbers_are_unique.py` passes, which is the existing test that walks `docs/adr/`.

**Visual QA is outstanding** — no browser tools and no dev stack in this session. For a docs PR that is close to a no-op (the only rendered change is three stripped CSS comment lines), but it is stated rather than assumed.

## What to eyeball

1. **Read ADR-0083 against the code it claims to describe.** The document is the deliverable; the fastest read is §2 against `index.css:921` and the `.alb-faction-hero` / `[data-theme="dark"] .alb-faction-body` pair, and §3a against `.spectrum-rule`'s own comment block and the `alb-moves` block below it — the ADR is deliberately the short form of arguments those two sites carry in full.
2. **§6's floor, and whether it is worded strongly enough.** It is the one rule with no mechanical guard, and the paragraph is the whole protection.
3. **§7's decision to name no pixel value** — the gate's reasoning is here, the constant stays in `AlbescentAvatar.tsx`. Confirm that is the right side of the docs-doctrine line.
4. **The `index.css` comment edit** (3 lines, `--albescent-reveal-*` header) — that it reads correctly given the block already stated the flip, and that it will not fight #2542.
5. **The status value on ADR-0017: `Superseded by ADR-0061`.** This is the judgement call of the whole PR. `Amended by ADR-0083` was rejected as too weak for "ADR 17 is dead" and `Reversed` as untrue — but no vocabulary value fits perfectly, so if `Reversed` is what you meant by dead, this is a one-line change.
6. **ADR-0017's `## Amendment` section** — that it accurately says what replaced each decision, and that its closing paragraph protects Singularity's always-dark firmly enough that nobody reads this as retiring theme-invariant surfaces as a class.
7. **ADR-0048's status line**, flagged above: I normalised `Accepted, amended` → `Amended by ADR-0083`, which is a second ADR's status line and therefore adjacent to #2536's territory. Revert on request.
8. **That the gap tracker is untouched.** `git diff origin/main -- docs/adr/0017-*.md` should show only the two-line status header and the appended `## Amendment` section — no deletions from the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

