### PR TITLE
One wrap rule in the shared praxis head: a long unbroken title stops running under the score stamp on all nine cards

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/headingRoom.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/headingRoom.test.tsx
@@ -113,3 +113,34 @@ describe('the meta line does not restate the stamp (#2114 supersedes #1833)', ()
     expect(html, 'so what the task is worth stays').toContain('12 pts')
   })
 })
+
+describe('an unbreakable title stays inside its column (#2556)', () => {
+  /*
+   * Same row, the other axis. #2114 gave the column a basis so it could SHRINK;
+   * this is what happens once it has. `min-width: 0` lets the column go below
+   * its content's min-content width, and a title with no space in it — the
+   * keysmash the bug was reported on — has a min-content width of the whole
+   * word, so it painted straight out of the box and under the stamp beside it.
+   *
+   * The declaration sits on the COLUMN, not on the title: `overflow-wrap` is
+   * inherited, so one line reaches the title, the task line and the excerpt,
+   * and all three carry a user-authored string. `anywhere` rather than
+   * `break-word` for the reason `.markdown-preview` gives in index.css — it
+   * also lets min-content shrink, so the token cannot push the stamp either.
+   *
+   * Asserted as a declaration, not a rendered width, for the reason at the top
+   * of this file: there is no layout engine behind `renderToStaticMarkup`.
+   */
+  const column = (html: string) =>
+    styleOf(html, new RegExp(`<div[^>]*style="[^"]*flex:1 1 ${TEXT_MEASURE}px[^"]*"[^>]*>`))
+
+  it('the text column says where an unbroken run may break', () => {
+    expect(column(body({ title: 'a'.repeat(40) }))).toContain('overflow-wrap:anywhere')
+  })
+
+  it('without giving back either half of #2114', () => {
+    const style = column(body())
+    expect(style, 'the column still asks for a measure').toContain(`flex:1 1 ${TEXT_MEASURE}px`)
+    expect(style, 'and still yields rather than push the stamp off').toContain('min-width:0')
+  })
+})

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -225,7 +225,35 @@ export function PraxisBody({
           gap: "var(--space-md)",
         }}
       >
-        <div style={{ flex: `1 1 ${TEXT_MEASURE}px`, minWidth: 0 }}>
+        {/*
+         * `overflowWrap` is the other half of `minWidth: 0` (#2556). The zero
+         * floor is what lets this column shrink past its content so the stamp
+         * is never pushed off the card — but shrinking a box does not tell the
+         * text inside it where it may break, and a title with no space in it
+         * (the keysmash the bug was reported on) has a min-content width of
+         * the whole word. It kept that width, painted out of the column, and
+         * ran UNDER the stamp beside it.
+         *
+         * It sits here rather than on the title because `overflow-wrap` is
+         * INHERITED: one declaration covers all three user-authored strings in
+         * this column — title, task line, excerpt — where patching
+         * `PraxisTitle` would leave a long task title doing the same thing one
+         * line down. Nine archetypes compose this head (Albescent through
+         * `DefaultPraxisCard`), so this is the single slot for all of them.
+         *
+         * `anywhere` rather than `break-word` for the reason `.markdown-preview`
+         * gives in index.css: it also lets min-content shrink, so an unbroken
+         * run cannot inflate this flex item and squeeze its sibling. Truncation
+         * is NOT the alternative — the title is a link, and clipping it hides
+         * where it goes.
+         *
+         * An eyebrow that is a WORDMARK is the one thing that must opt out
+         * (§"A wordmark is a MARK", #2000): a break that invents a new word is
+         * worse than an overflow. No archetype passes one today, and the slot's
+         * own `overflow-wrap: normal` beats this inherited value if one ever
+         * does — the same escape `comments/shared.tsx` already uses.
+         */}
+        <div style={{ flex: `1 1 ${TEXT_MEASURE}px`, minWidth: 0, overflowWrap: "anywhere" }}>
           {eyebrow}
           <PraxisTitle praxis={praxis} style={titleStyle} fonts={fonts} />
           {/*


### PR DESCRIPTION
Closes #2556

A praxis title made of one unbroken run of characters painted out of its column
and under the score stamp. One declaration in the shared head fixes it on all
nine cards.

## The seam

`PraxisBody`'s heading row in `frontend/src/components/praxisCard/desktop/shared.tsx`
— the rendered **declaration** on the text column, asserted in
`praxisCard/__tests__/headingRoom.test.tsx`. That file already pins this row's
flex contract and says why: the suite is `renderToStaticMarkup` with no layout
engine behind it, so the assertable seam is what each side of the row declares,
not a measured width. The new block goes red on the real defect first
(`expected 'flex:1 1 160px;min-width:0' to contain 'overflow-wrap:anywhere'`).

## Cause and fix

`minWidth: 0` lets the column shrink past its content — that is what keeps the
stamp on the card (#2114) — but shrinking a box does not tell the text inside it
where it may break. A title with no space in it has a min-content width of the
whole word, so it kept that width and overflowed.

```tsx
<div style={{ flex: `1 1 ${TEXT_MEASURE}px`, minWidth: 0, overflowWrap: "anywhere" }}>
```

**On the column, not on `PraxisTitle`.** `overflow-wrap` is inherited, so one
declaration reaches all three user-authored strings in that column — title, task
line, excerpt — where patching the title alone would leave a long *task* title
doing the same thing one line down. The issue asked for `PraxisTaskLink` and
`PraxisExcerpt` to be checked for the same exposure; they have it, and this
covers them without touching `praxisCard/shared.tsx` at all (that file is
another agent's in this batch).

`anywhere` rather than `break-word`, for the reason `.markdown-preview` already
gives in `index.css`: it also lets min-content shrink, so an unbroken run cannot
inflate the flex item and squeeze the stamp. No truncation — the title is a link,
and clipping it hides where it goes. `minWidth: 0` and `flex: 1 1 TEXT_MEASURE`
are untouched, and the second new test pins both so this cannot be "fixed" later
by giving back either half of #2114.

`headingRoom.test.tsx`'s existing `flex:1 1 ${TEXT_MEASURE}px` assertion still
holds unchanged — this adds a property, it does not alter that declaration.

## It really is all nine

`grep -c PraxisBody desktop/*PraxisCard.tsx` returns ≥2 for eight of the nine and
**0 for Albescent** — not an exception: `AlbescentPraxisCard` renders
`<DefaultPraxisCard {...props} />` inside its wrapper, so it routes through the
same head transitively. No archetype hand-rolls a head; `PraxisTitle` has no
importer outside `praxisCard/shared.tsx` and `desktop/shared.tsx`. One fix covers
Albescent, Coven, Default, Ephemerists, Everymen, Singularity, Snide, UA and WOW.

## index.css

**Not touched.** No CSS file is in this diff — the head is inline-styled already
and this matches it, which also keeps the change out of the file being serialized
across this batch. Two files changed, both under `frontend/src/components/praxisCard/`.

## One thing deliberately left open

An eyebrow that is a **wordmark** must opt out (§"A wordmark is a MARK", #2000) —
a break that invents a new word is worse than an overflow. No archetype passes an
`eyebrow` today (the slot exists, every caller is prose about it), and a future
one sets its own `overflow-wrap: normal` to beat the inherited value, the same
escape `comments/shared.tsx` already uses. Noted in the code comment.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally: `npm run lint`,
`npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (414 files /
7406 tests green), `npm run build`, `npm run budget`. The budget's CSS **WARN**
(22.4 KB vs. a 22.2 KB warn line) is **pre-existing**: I rebuilt with both files
reverted to `origin/main` and got the byte-identical `index-DFGo8NeQ.css`.
No backend/schema surface touched, so `api-schema` and `test` are unaffected.

**Visual QA is outstanding** — I have no browser and no dev stack, so nothing here
has been looked at. Verified by tests, tsc and eslint only.

## What to eyeball

Post a praxis with a ~40-character title and no spaces (`asdasdfafghsfghddasd…`),
then check:

- **Ephemerists** — where it was reported. The codex plate is the tightest head.
- **Coven** — the stamp with the least give: its arched plate is 150px of ornament
  and yields nothing, so if any card still collides it is this one.
- **Singularity or Snide** — a narrow, hard-edged frame, to confirm the break
  lands inside the column rather than at the frame edge.
- The same title on a **task**, so the *task line* under the title (not the title)
  carries the long run — that is the second slot this declaration covers.
- The praxis card at its **narrow mount** (`.praxis-gallery` on a task detail) and
  on a phone width, where the column is already shrunk furthest.
- An ordinary multi-word title on any card, to confirm nothing about normal
  wrapping moved.
