### PR TITLE
The Field Desk's dot field comes off

### DIFF
--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -157,7 +157,7 @@ export default function FieldDesk() {
   }
 
   return (
-    <div className="page" style={pageStyle}>
+    <div className="page">
       {/* ── The roster (#1560: only when it has a choice to offer) ─────────── */}
       {/* Top-bar pill: the ACTIVE life's @handle + avatar + lives-in-play. No
           account handle. Inside the gate — a count is an invitation to make
@@ -595,15 +595,6 @@ function BrowseSection({ onSignup }: { onSignup: (taskId: number) => void }) {
 
 // --- token-driven styles (no hardcoded hex) ---------------------------------
 
-const pageStyle: CSSProperties = {
-  // The dot field is the page's own ink at 3.5%, not a fixed black (#1609):
-  // black dots on #13121a are invisible, so the texture simply vanished in dark
-  // mode. `color-mix` on a themed token is how the Everymen and S.N.I.D.E. wall
-  // grounds already draw theirs in index.css — one value, both themes.
-  backgroundImage:
-    'radial-gradient(color-mix(in srgb, var(--color-text-primary) 3.5%, transparent) 1px, transparent 1px)',
-  backgroundSize: '5px 5px',
-}
 const pillStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDesktopHome.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDesktopHome.test.tsx
@@ -172,3 +172,16 @@ describe('both browse tabs ask for already-narrowed data', () => {
     expect(BROWSE_PRAXIS_FILTERS.voted).toBe('no')
   })
 })
+
+describe('the page ground is bare (#2551)', () => {
+  it('paints no dot field behind the desktop FieldDesk', () => {
+    mocks.activePraxes = []
+    // The seam is the root element's own inline style: `pageStyle` was the only
+    // thing that ever put a background on `.page`, and the mobile skins return
+    // before this element exists. An opening tag with no background in it is
+    // the whole ruling.
+    const root = render().match(/^<div class="page"[^>]*>/)
+    expect(root).not.toBeNull()
+    expect(root![0]).not.toContain('background')
+  })
+})


### PR DESCRIPTION
The signed-in home page painted a 5px dot grid behind everything — "Whose shoes
today?", the character cards, "Continue where you left off", the task row. Owner
ruling: it comes off. This is a deletion, not a reskin; nothing replaces it.

`pageStyle` held nothing but the dot field, so the constant goes with it, and
with it the `color-mix` expression, the `style` prop on `<div className="page">`,
and the comment block that narrated the light/dark reasoning for a texture that
no longer exists. `CSSProperties` stays imported — fourteen other style constants
in the file still use it.

Closes #2551

## The seam

The root element's own inline style. `pageStyle` had exactly one call site and
was the only thing that ever put a background on `.page`, so the SSR opening tag
for that element is the whole ruling in one string. The red test asserted
`<div class="page" …>` contains no `background`; on `main` it failed with the
literal `background-image:radial-gradient(color-mix(…))`, and it is green now.
The check lives in `frontend/src/pages/fieldDesk/__tests__/fieldDeskDesktopHome.test.tsx`,
which already SSR-renders this page.

## The siblings — checked, and all three stay

The deleted comment claimed kinship with two other dot fields. Neither is this
page's ground, and the ruling reaches neither:

- **The Everymen / S.N.I.D.E. wall grounds in `index.css`** — different surfaces,
  out of scope by the ruling. **No `index.css` edit in this PR at all**, so this
  does not collide with the `.alb-*` work in flight.
- **`.ht-dots`** — S.N.I.D.E.'s halftone screen, a decided keep (#2139 ②).

I also grepped all nine `pages/fieldDesk/mobileArchetypes/*FieldDesk.tsx`. Two
paint dots, and neither is a page ground:

- `EverymenFieldDesk.tsx:120` — inside the `Plate` component: newsprint tooth on
  a *card*, drawn from `--everymen-ink` at 6%, not `--color-text-primary` at 3.5%.
- `SnideFieldDesk.tsx:85,190` — the `HALFTONE` constant, an absolutely-positioned
  screen inside a flyposter card. Same family as the `.ht-dots` keep.

The structural point that settles it: `FieldDesk.tsx:157` returns the mobile skin
*before* `<div className="page">` is ever constructed, so the mobile archetypes
never wore this dot field. Removing it changes nothing on a phone, and the two
faction textures above are archetype identity rather than page ground. Nothing
touched under `mobileArchetypes/`.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(414 files / 7405 tests), and `npm run build` all pass. `npm run budget` reports
its usual CSS WARN at 22.4 KB — pre-existing and untouched by this PR, which
changes no CSS and only removes JS bytes. Backend and the API schema are
unaffected.

**Visual QA is outstanding** — I have no browser and no dev stack, so nothing
here confirms how the bare page actually looks.

## What to eyeball

- `/` signed in, **desktop, light** — the ground behind "Whose shoes today?" and
  the character cards is flat, with no grain left over.
- `/` signed in, **desktop, dark** — same, and confirm the cards still read as
  raised off the page now that no texture separates them from it.
- `/` signed in, **mobile, light** — unchanged is the expected result; the
  faction skin's own textures (Everymen's newsprint plate, S.N.I.D.E.'s halftone)
  must still be there.
- `/` signed in, **mobile, dark** — same check.
- Console spot-check on desktop:
  `getComputedStyle(document.querySelector('.page')).backgroundImage` → `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
