### PR TITLE
The twinkle comes out of the Albescent kit: three sparks, their keyframe and both guards built on them

### DIFF
--- a/frontend/src/__tests__/motionSplit.test.ts
+++ b/frontend/src/__tests__/motionSplit.test.ts
@@ -249,7 +249,7 @@ reduced-motion gate.`,
     ).toEqual([])
   })
 
-  it('carries every Albescent ornament animation but the spark (#2498)', () => {
+  it('carries EVERY Albescent ornament animation, with no exception left (#2555)', () => {
     // The sheet's own "WHAT IS STILL IN index.css AND COULD FOLLOW" list named
     // "the Albescent drifts" as a candidate on one test: does every consumer
     // treat the motion as ornament, and is the un-animated frame the one a
@@ -308,31 +308,61 @@ the owner reported — two cards drawing the same light two different ways.`,
       ).not.toContain(`${retired} {`)
     }
 
-    // THE SPARK IS THE ONE THAT MAY NOT FOLLOW, and it is the only one left.
+    // THE ONE EXCEPTION IS GONE, SO THE SET IS EMPTY (#2555).
+    //
+    // This assertion used to read `toEqual(['.alb-spark'])`: the spark was the
+    // single Albescent animation index.css was allowed to keep, and it was stuck
+    // there mechanically rather than by taste — its gate did not merely add
+    // motion, it dropped the glyph to `opacity: 0` and let the keyframe carry it
+    // back up, so deferring it would have stranded an INVISIBLE mark rather than
+    // a still one. The owner ruled the twinkle out of the Albescent kit, the rule
+    // and its keyframe came out of index.css with it, and the exception has
+    // nothing left to except.
+    //
+    // EMPTY IS STRICTER THAN THE ONE-NAME LIST IT REPLACES, which is why it is
+    // the right shape to move the guard to rather than a weakening of it: with
+    // the allow-list at [], ANY Albescent animation appearing in index.css fails
+    // here, including a re-added spark. If a future ornament genuinely has to
+    // animate from the entry sheet, this is the line that makes you say why.
     expect(
       albescent(INDEX),
-      `Every Albescent animation index.css still runs. Only .alb-spark may be
-here: its gate does not merely add motion, it drops the glyph to opacity 0 and
-lets the keyframe carry it back up. A paint declaration may never defer, so the
-opacity has to stay — and with the animation deferred and the sheet stranded the
-spark would be an invisible mark rather than a still one, which is the exact
-degradation this sheet is not allowed to cause.`,
-    ).toEqual(['.alb-spark'])
+      `An Albescent animation is running from src/index.css. Every one of them
+belongs in the deferred sheet: motion may arrive after first paint for free, and
+the still frame is what a reduced-motion reader gets either way. The one historical
+exception (.alb-spark) was retired with the twinkle at #2555, so there is no
+precedent to lean on — if this rule really cannot defer, it is because its gate
+also carries PAINT, and the fix is to split it and leave the paint here.`,
+    ).toEqual([])
   })
 
-  it('leaves the spark behind for a reason that is still true', () => {
-    // Asserted, not asserted-in-a-comment: if the gated rule ever stops setting
-    // the paint, the spark becomes a legible still frame and may follow.
-    const gated = GATES.flatMap((body) => declarations(body))
-    expect(gated.some(([selector]) => selector === '.alb-spark')).toBe(false)
+  it('has no spark left to leave behind (#2555)', () => {
+    // The twinkle is a DELETION, not a re-tune, so what replaces the old
+    // "the exception is still justified" test is a resurrection guard. Three
+    // ways it could come back, all asserted on both sheets at once:
+    //
+    //  1. the rule, under its own name or a dark half;
+    //  2. the keyframe, which had exactly one reference and went with it —
+    //     a @keyframes with no `animation:` referencing it is dead weight in
+    //     the critical sheet and reads as an invitation to re-mount;
+    //  3. an `animation:` naming it from anywhere, which is what would actually
+    //     put a glyph back on screen.
+    //
+    // Both constants are comment-stripped, so the prose in index.css and in
+    // motion.ornament.css may go on discussing the retirement at length.
+    const both = `${SHEET}\n${INDEX}`
+    const why = `The Albescent twinkle is back. #2555 is an owner ruling that it is
+not part of the kit — three ✦ glyphs at hardcoded offsets over the praxis card —
+and the ruling was "it comes out", not "make it subtler". The card's delta over the
+unaffiliated one is the prism ground and the travelling edge (ADR-0083).`
 
-    const spark = ruleBodies(INDEX, '.alb-spark').filter((body) =>
-      /\banimation\s*:/.test(body),
-    )
-    expect(spark, '.alb-spark no longer animates from index.css at all').toHaveLength(1)
-    expect(spark[0], 'the spark animates without touching paint — it may follow').toContain(
-      'opacity: 0',
-    )
+    expect(both, why).not.toContain('.alb-spark {')
+    expect(both, why).not.toContain('@keyframes alb-spark')
+    expect(both, why).not.toMatch(/animation(-name)?\s*:[^;}]*\balb-spark\b/)
+
+    // And the gate list it used to be excluded from is still read by this file,
+    // so the exclusion cannot pass vacuously somewhere else.
+    const gated = GATES.flatMap((body) => declarations(body))
+    expect(gated.some(([selector]) => selector.includes('.alb-spark'))).toBe(false)
   })
 
   it('is reached only through src/factionFaces.ts, so it stays off the entry HTML', () => {

--- a/frontend/src/components/avatar/AlbescentAvatar.tsx
+++ b/frontend/src/components/avatar/AlbescentAvatar.tsx
@@ -77,7 +77,9 @@ import type { FactionAvatarProps } from './FactionAvatar'
  * stylesheet (#911), and an inline `animation:` would bypass the reduced-motion
  * guard (#1003). Stilled, the layer is the spectrum ring it covers, drawn in the
  * same conic at rest: it can park rather than freeze to nothing, the way
- * `.alb-profile-edge` does and `.alb-spark` cannot.
+ * `.alb-profile-edge` does. (The counter-example used to be `.alb-spark`, whose
+ * keyframe start was invisible; #2555 retired the twinkle from the kit, and
+ * Coven's `.cvn-profile-spark` is the surviving mark that must park.)
  */
 /**
  * The disc is "large and alone" at or above this, and one of many below it.

--- a/frontend/src/components/praxisCard/__tests__/albescentDriftStopsAtMedia.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/albescentDriftStopsAtMedia.test.tsx
@@ -155,18 +155,20 @@ describe("the stylesheet lifts user media above the Albescent drift (#1646)", ()
   });
 
   it("clears every Albescent layer that still paints over content", () => {
-    // Derived, not typed twice: the sparks sit at 0 on the praxis card, the
-    // feed's ring at 1, and the `.alb-praxis-*` / `.alb-detail-*` ornaments at
-    // 2. Retune any of them and this fails rather than silently letting light
-    // back over the photo.
+    // Derived, not typed twice: the praxis card's ring and the feed's sit at 1,
+    // and the `.alb-praxis-*` / `.alb-detail-*` ornaments at 2. Retune any of
+    // them and this fails rather than silently letting light back over the photo.
     //
     // #2499 took the four WASHES out of this list by moving them into the card's
     // own background, where a photograph is in front of them by construction.
-    // The sparks replace `.alb-rainbow` as the praxis card's floor — they are
-    // positioned at `z-index: 0`, which paints ABOVE non-positioned in-flow
-    // content, so the lift is still doing work on that surface.
+    // #2555 took the SPARKS: the three glyphs at `z-index: 0` were the praxis
+    // card's entry here, and `.alb-praxis-card-edge` at 1 is what is left over
+    // that surface's content. Substituting it rather than dropping the surface is
+    // the point — `topZ` throws on an empty set, so a deleted ornament cannot
+    // quietly lower the floor and make the lift look like it clears more than it
+    // does.
     const floor = Math.max(
-      topZ(ruleBodies(css, ".alb-spark")),
+      topZ(ruleBodies(css, ".alb-praxis-card-edge")),
       topZ(ruleBodies(css, ".alb-praxis-edge")),
       topZ(ruleBodies(css, ".alb-detail-edge")),
       topZ(ruleBodies(css, ".alb-feed-edge")),

--- a/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
@@ -1,5 +1,4 @@
 import DefaultPraxisCard from "./DefaultPraxisCard";
-import { AlbescentSparks } from "../shared";
 import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { frameBase, type ArchetypeProps } from "./shared";
 
@@ -10,12 +9,16 @@ import { frameBase, type ArchetypeProps } from "./shared";
  * someone already looking. A repaint in Albescent's own colours would put it back
  * in the spectrum and un-hide it, so this stays "na + light".
  *
- * #842 added the other half of the tell: the design pairs the wash with three
- * faint gold sparks ({@link AlbescentSparks}), and only the wash had shipped.
+ * #842 ADDED THREE TWINKLING ✦ AND #2555 TOOK THEM BACK OUT. They were "the
+ * other half of the tell" for two years; the owner ruled the twinkle is not part
+ * of the Albescent kit, and it came out rather than getting quieter. Nothing
+ * replaces it: this card's whole delta over the unaffiliated one is now the prism
+ * ground and the travelling edge below, which is what ADR-0083 says an Albescent
+ * surface is — one ornament vocabulary shared with na, moving.
  *
  * #1646 narrows the light by one element: it stops at the proof photo, which is
  * the one thing here that is not the site's to tint. The class on this wrapper is
- * the scope index.css needs to raise `.user-media` above the sparks for THIS skin
+ * the scope index.css needs to raise `.user-media` above the ring for THIS skin
  * only — the media gallery is shared by all nine archetypes.
  *
  * ── #2499 (epic #2496) — THE OWNER'S LIVE REPORT, AND WHAT IT COST ──
@@ -49,11 +52,11 @@ import { frameBase, type ArchetypeProps } from "./shared";
  * the CLASS instead and the na sheet stands. Strip `alb-prism` and what is left
  * is the unaffiliated card exactly — which is what "plain" has always meant here.
  *
- * WHAT DOES NOT BRANCH, because it is chrome: the travelling ring, the masthead,
- * the score box — and the three `AlbescentSparks`. The sparks are three ✦ glyphs,
- * not a ground texture, and they are what keeps an Albescent card on someone
- * else's patterned profile from reading as a plain unaffiliated card. ADR-0048
- * reveals the society by motion; the alternation takes the ground, never the tell.
+ * WHAT DOES NOT BRANCH, because it is chrome: the travelling ring, the masthead
+ * and the score box. The ring is now the ONLY thing carrying the tell on a
+ * patterned ground — the sparks used to be named here as the second carrier, and
+ * #2555 retired them. ADR-0048 reveals the society by motion and the ring moves,
+ * so the alternation still takes the ground and never the tell.
  *
  * The radius is the token rather than the literal 10 it was typed as. Same
  * number, and now the one place it is written: `--faction-default-card-radius` is
@@ -69,7 +72,6 @@ export function AlbescentPraxisCard(props: ArchetypeProps) {
     >
       <DefaultPraxisCard {...props} />
       <span aria-hidden className="alb-praxis-card-edge" />
-      <AlbescentSparks />
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -1208,39 +1208,3 @@ export function AdminOverlay({
     </>
   );
 }
-
-// ─── Albescent ────────────────────────────────────────────────────────────────
-
-/**
- * The Albescent SPARKS (#842, ADR-0048) — three faint gold ✦ scattered over the
- * sheet, the other half of the secret-society tell.
- *
- * The design pairs `.alb-rainbow`'s slow drift with `.alb-spark`; #821 shipped
- * only the drift, so the card shimmered but never caught the light. Each spark
- * carries its own position, size and delay so the three never pulse together,
- * and all of them sit BEHIND the card content (`z-index: 0`, pointer-events
- * none). Reduced motion parks them at a steady low opacity rather than freezing
- * the keyframes — frozen at 0% they would be invisible, which is not "stilled".
- *
- * Shared by the desktop and mobile Albescent cards: both wrap the exact
- * unaffiliated card and layer the same tell over it. A repaint in Albescent's
- * own colours would put it back in the spectrum and un-hide it (#783).
- */
-export function AlbescentSparks() {
-  return (
-    <>
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ✦ glyph used as a drawn spark, sized as illustration (§4a) */}
-      <span aria-hidden className="alb-spark" style={{ top: 118, left: 24, fontSize: 13, animationDelay: "0s" }}>
-        ✦
-      </span>
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ✦ glyph used as a drawn spark, sized as illustration (§4a) */}
-      <span aria-hidden className="alb-spark" style={{ top: 176, right: 36, fontSize: 9, animationDelay: "1.5s" }}>
-        ✦
-      </span>
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ✦ glyph used as a drawn spark, sized as illustration (§4a) */}
-      <span aria-hidden className="alb-spark" style={{ bottom: 104, left: 64, fontSize: 15, animationDelay: "2.8s" }}>
-        ✦
-      </span>
-    </>
-  );
-}

--- a/frontend/src/components/taskCard/__tests__/albescentPrismAlternates.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/albescentPrismAlternates.test.tsx
@@ -147,10 +147,18 @@ describe.each(CARDS)('the Albescent %s', (_name, card) => {
   })
 })
 
-it('leaves the three sparks on a busy ground — a glyph is not a ground texture', () => {
-  // #842's half of the tell. Three ✦ at 9–15px are the praxis card's, and they
-  // are why a plain Albescent card still does not read as an unaffiliated one.
-  expect(onGround('everymen', praxisCard)).toContain('alb-spark')
+it('draws no spark on any ground — the twinkle is not in the kit (#2555)', () => {
+  // #842 gave this card three twinkling ✦ as "the other half of the tell". The
+  // owner ruled the twinkle out of the kit: a DELETION, not a quieter twinkle,
+  // so what is asserted is that no ground grows one back — the busy one included,
+  // since that is where the glyph used to be the last thing left.
+  //
+  // What a plain Albescent card carries instead is the travelling spectrum edge
+  // asserted above. That is ADR-0083's claim exactly: Albescent's delta over na
+  // is MOTION across one ornament vocabulary, not a mark of its own.
+  for (const ground of [null, 'everymen', 'albescent'] as const) {
+    expect(onGround(ground, praxisCard), 'the spark is back').not.toContain('alb-spark')
+  }
 })
 
 it('draws no ornament SPAN for the ground on either card', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6422,9 +6422,11 @@
    sheet lands in exactly the reduced-motion frame — that equivalence is the
    whole safety argument for deferring it at all. So without a rest frame "the
    motion sheet did not arrive" and "this player is not in Albescent" become the
-   same picture, and nothing in CI can tell them apart. The precedent is
-   `.alb-spark`, which parks at a steady low opacity rather than freezing,
-   because a spark frozen at its keyframe start is invisible.
+   same picture, and nothing in CI can tell them apart. The precedent used to be
+   `.alb-spark`, which parked at a steady low opacity rather than freezing
+   because a spark frozen at its keyframe start is invisible; #2555 retired it,
+   and Coven's `.cvn-profile-spark` further down this file is the same call made
+   for the same reason on a mark that is still drawn.
 
    MEASURED THE SAME WAY, worst pixel, tightest pairing:
      light  muted 4.89:1, ink 14.72:1, ground 78.5% L — a 9.3pp drop, plainly
@@ -6482,29 +6484,24 @@
    ring a span, then it joins `alb-edge-travel` and this keyframe retires too. */
 @keyframes alb-drift { from { background-position: 0 0; } to { background-position: 220px 0; } }
 
-/* The other half of the tell (#842). The design draws the drift AND three faint
-   gold ✦ sparks scattered over the sheet; #821 shipped only the drift, so the
-   sheet shimmered but never caught the light. Each spark carries its own
-   position, size and animation-delay at the call site, so the three never
-   pulse together.
+/* `.alb-spark` RETIRED HERE (#2555). #842 called it "the other half of the tell"
+   — three faint gold ✦ twinkling over the praxis card at their own positions,
+   sizes and delays — and the owner ruled the twinkle is not part of the Albescent
+   kit. A DELETION and not a re-tune: there is no quieter spark, and nothing takes
+   its place on the card.
 
-   Unlike the prism ground, the spark's motion IS the mark: a spark frozen at its
-   own keyframe start would be invisible (opacity 0), so reduced motion parks it
-   at a steady low opacity rather than freezing the animation. The glyph is a
-   typographic ✦, not an emoji (§10), and stays behind the card content. */
-@keyframes alb-spark { 0%, 100% { opacity: 0; transform: scale(0.5) rotate(0); } 50% { opacity: 0.75; transform: scale(1) rotate(28deg); } }
-.alb-spark {
-  position: absolute;
-  z-index: 0;
-  pointer-events: none;
-  line-height: 1;
-  color: #bf7f3a;
-  opacity: 0.4;
-}
-[data-theme="dark"] .alb-spark { color: #f2cc72; }
-@media (prefers-reduced-motion: no-preference) {
-  .alb-spark { opacity: 0; animation: alb-spark 4.5s ease-in-out infinite; }
-}
+   THE KEYFRAME WENT WITH IT, because it had exactly one reference — the gated
+   rule directly under it. That is the only reason it was safe to take: an
+   `@keyframes` NAME being unused-looking is not the test, a grep for the
+   `animation:` that references it is (`alb-drift` two rules up is the shape that
+   survives a retirement on the strength of one remaining consumer).
+
+   WHAT THIS LEAVES. The card's whole delta over the unaffiliated one is now the
+   prism ground and `.alb-praxis-card-edge`'s travelling ring, which is what
+   ADR-0083 says an Albescent surface is: one ornament vocabulary shared with na,
+   moving. It also means NO Albescent animation runs from this sheet any more —
+   they are all in the deferred `motion.ornament.css`, and `motionSplit.test.ts`
+   asserts that set is now empty rather than "the spark, alone". */
 
 /* THE ALBESCENT LIGHT STOPS AT USER MEDIA (#1646). ADR-0048 / #821 wash the
    light over the whole sheet. This narrows it by one element: the proof photo is
@@ -6519,9 +6516,14 @@
    surfaces is under the prism. What is still painted OVER content, and therefore
    still needs excluding, is the ornament that is not a ground:
 
-     `.alb-praxis-card`  the three `.alb-spark` glyphs. Positioned at `z-index: 0`,
-                         which paints ABOVE non-positioned in-flow content — that
-                         is the painting order, not an accident of the number.
+     `.alb-praxis-card`  `.alb-praxis-card-edge` at 1. The three `.alb-spark`
+                         glyphs at 0 were what this entry was written for; #2555
+                         retired them and the ring is what is left. Masked back to
+                         the 3px carrier, so — like the feed's below — it cannot
+                         reach a photo, and it stays listed for the same two
+                         reasons: the surface may gain a wash again, and the four
+                         wrappers share ONE lift rule, so dropping a scope here
+                         would be a second mechanism rather than a smaller one.
      `.alb-praxis`       `.alb-praxis-ring`, a blurred conic annulus at 2.
      `.alb-detail`       `.alb-detail-foil`, a blurred conic wheel at 2.
      `.alb-feed`         `.alb-feed-edge` at 1. Masked back to the hairline, so it
@@ -6712,7 +6714,17 @@
 /* The praxis card's twin of it (#2499). Its own rule states only the two things
    the task card's does not: this span hangs off a wrapper whose corner is the
    token, so the shared `border-radius: inherit` is right and no literal is
-   needed; and `z-index: 1` clears the three `.alb-spark` glyphs at 0.
+   needed; and the `z-index`.
+
+   THE `z-index: 1` STAYS, AND ITS ORIGINAL REASON DOES NOT (#2555). It was
+   written to clear the three `.alb-spark` glyphs at 0, and those are gone. It is
+   kept because it is the FAMILY's number, not this card's workaround:
+   `.alb-task-edge` carries the same `z-index: 1` on a card that never had a
+   spark near it, and both rings have to sit above whatever their wrapped na card
+   positions inside itself while staying under `.user-media`'s 3. Dropping to
+   `auto` would leave the ring beatable by any positioned descendant of
+   `DefaultPraxisCard` that declares a positive one — an invisible-until-it-isn't
+   dependency on a component this rule cannot see into.
 
    IT REPLACED A 1px RING AT 0.6. Until #2499 this card borrowed the RAIL's ring
    through `.spectrum-frame` and the rail's drift hook — the rail's width, walking
@@ -8961,8 +8973,10 @@
    no dark half is declared because none is needed: the token flips on its own.
 
    Stilled, this paints an ordinary static spectrum ring on top of an identical
-   static spectrum frame, i.e. nothing — so it can freeze outright where
-   `.alb-spark` had to park at a resting opacity.
+   static spectrum frame, i.e. nothing — so it can freeze outright. The contrast
+   used to be drawn against `.alb-spark`, which had to PARK at a resting opacity
+   because its keyframe start was invisible; #2555 retired the spark, and Coven's
+   `.cvn-profile-spark` is now this file's example of a mark that must park.
 
    The ring itself is the shared `.spectrum-frame::before` list (#2407), which is
    also where `border-radius: inherit` now comes from: this span mounts straight
@@ -9084,13 +9098,16 @@
 
    The delay is the one thing that differs per instance, so it arrives as a
    custom property set at the call site (`--cvn-spark-delay`) — the shape
-   `.alb-spark` and `--ev-spark-delay` already use, and the reason this is one
-   rule instead of eight.
+   `--ev-spark-delay` already uses, and the reason this is one rule instead of
+   eight. (`.alb-spark` was the third member of that shape and is retired, #2555:
+   the twinkle is not part of the Albescent kit. Coven's candle and Everymen's
+   are unaffected — this is a ruling about one faction's vocabulary, not about
+   the idiom.)
 
    Reduced motion parks the field at a steady low opacity rather than freezing
    it: opacity .12 is the keyframe's own resting value and a spark stopped there
-   reads as dirt on the paper. Same call `.alb-spark` makes for the same
-   reason. */
+   reads as dirt on the paper. This is now the file's own example of that call
+   rather than a restatement of the Albescent one. */
 @keyframes cvn-profile-spark {
   0%, 100% { opacity: 0.12; transform: scale(0.8); }
   50% { opacity: 0.85; transform: scale(1.08); }

--- a/frontend/src/motion.ornament.css
+++ b/frontend/src/motion.ornament.css
@@ -695,12 +695,16 @@
    never defer. index.css deepens it under `prefers-reduced-motion: reduce`
    instead (epic ruling 6).
 
-   `.alb-spark` IS THE ONE THAT MAY NEVER FOLLOW, and it is the only Albescent
-   animation index.css still runs. Its gate does not merely add motion — it drops
-   the glyph to `opacity: 0` and lets the keyframe carry it back up. Paint may not
-   defer, so the opacity has to stay in index.css; with the animation deferred and
-   the sheet stranded the spark would be an invisible mark rather than a still
-   one. `__tests__/motionSplit.test.ts` asserts both halves of that.
+   THE ONE THAT COULD NEVER FOLLOW IS GONE, AND SO IS THE EXCEPTION (#2555).
+   `.alb-spark` was the last Albescent animation index.css still ran, and it was
+   stuck there for a mechanical reason rather than a stylistic one: its gate did
+   not merely add motion, it dropped the glyph to `opacity: 0` and let the
+   keyframe carry it back up, so deferring it would have stranded an INVISIBLE
+   mark rather than a still one. The owner ruled the twinkle out of the Albescent
+   kit, the rule and its keyframe came out of index.css with it, and this sheet is
+   now the sole home of every Albescent animation. `__tests__/motionSplit.test.ts`
+   asserts that set is EMPTY — a stricter shape than the one-name exception it
+   replaced, so a new Albescent animation landing in index.css fails there.
 
    TWO IDENTICAL WHEELS BECAME ONE. `alb-detail-wheel` and `alb-praxis-wheel`
    were byte-for-byte the same declaration — a centred element turning through
@@ -853,8 +857,11 @@
    like, and a per-diameter table would be tuning nobody asked for.
 
    Stilled or stranded, the ring is the spectrum ring na already wears, parked at
-   rotation 0 over an identical static one — so this one freezes outright where
-   `.alb-spark` has to park at a resting opacity. Nothing about membership is
+   rotation 0 over an identical static one — so this one freezes outright rather
+   than having to park at a resting opacity the way a mark whose keyframe start
+   is invisible does (`.alb-spark` was that mark until #2555 retired it; Coven's
+   `.cvn-profile-spark` in index.css is the surviving example). Nothing about
+   membership is
    carried by the motion that is not also carried by the ring standing still;
    what is carried by the motion is that a viewer LOOKING at the disc notices it.
    ── */

--- a/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx
@@ -26,7 +26,8 @@
  * (#911), and an inline `animation:` would bypass the guard (#1003). Stilled,
  * the layer paints nothing at all: the frame it dresses is Default's own and is
  * still there, which is why this one can freeze rather than park at a resting
- * opacity the way `.alb-spark` has to.
+ * opacity. (`.alb-spark` was the contrast here until #2555 took the twinkle out
+ * of the kit; Coven's `.cvn-profile-spark` is the surviving mark that parks.)
  *
  * Both form factors, one row: the ornament mounts inside the identity band in
  * each of `DefaultProfileBody`'s two branches, so the phone stack drifts too.


### PR DESCRIPTION
The Albescent praxis card drew three twinkling gold ✦ at hardcoded offsets with
staggered delays. Owner ruling: the twinkle is not part of the Albescent kit.
This is a **deletion**, not a redesign — nothing subtler takes its place.

Closes #2555

## The seam I tested at

**The Albescent praxis card's rendered markup**, in
`components/taskCard/__tests__/albescentPrismAlternates.test.tsx`. That file
already owned the "what does this card draw on which ground" question, and it
already held the assertion that the sparks were *present* (#842). The loop went
red on the real defect first — `expected '<div class="alb-praxis-card…' not to
contain 'alb-spark'` — then green on the deletion. Commits are red-then-green in
that order.

## What came out

| File | What |
|---|---|
| `praxisCard/shared.tsx` | `AlbescentSparks()` and the `// ─── Albescent ───` section it was the only member of |
| `praxisCard/desktop/AlbescentPraxisCard.tsx` | the `<AlbescentSparks />` mount and its import |
| `index.css` | `@keyframes alb-spark`, `.alb-spark`, its dark half, its `prefers-reduced-motion` gate |

`@keyframes alb-spark` had **exactly one** reference — the gated rule directly
beneath it — checked by grepping for the `animation:` that names it, not by the
rule looking unused. (`alb-drift` two rules up is the counter-example that
survives its own retirement on the strength of one remaining consumer, and it is
untouched.) No keyframe in `motion.ornament.css` was touched at all.

## What stayed, and why

**`.alb-praxis-card-edge { z-index: 1 }` is KEPT.** Its comment said the number
existed "to clear the three `.alb-spark` glyphs at 0", and that reason is gone —
but the number is the *family's*, not this card's workaround: `.alb-task-edge`
carries the same `z-index: 1` on a card that never had a spark near it. Dropping
to `auto` would leave the ring beatable by any positioned descendant of
`DefaultPraxisCard` declaring a positive one. The rule is unchanged; the comment
is rewritten to say the real reason.

## ⚠️ Does this leave the card with no ornament?

**No — but it does leave it with exactly one, and you should see that stated.**
What the card keeps is the `.alb-prism` ground (dropped on a patterned page per
the alternation law) and `.alb-praxis-card-edge`'s travelling 3px spectrum ring,
which is chrome and never branches. On a busy ground the ring is now the *only*
thing distinguishing an Albescent praxis card from an unaffiliated one — the
sparks used to be the second carrier, and `AlbescentPraxisCard`'s docstring said
so in those words.

That reads as correct under ADR-0083 (Albescent is one ornament vocabulary over
na, and the delta is **motion**), and it is consistent with the one-ornament-per-
faction rule rather than in tension with it. Flagging it because it is a real
reduction in the tell on that one ground, not because I think it is wrong.

## The guards moved with the change — neither was weakened

**`__tests__/motionSplit.test.ts`** asserted `.alb-spark` was *the one* Albescent
animation index.css was still allowed to run. It was stuck there mechanically
rather than by taste: its gate did not merely add motion, it dropped the glyph to
`opacity: 0` and let the keyframe carry it back up, so deferring it would have
stranded an **invisible** mark rather than a still one.

- `toEqual(['.alb-spark'])` → `toEqual([])`. **This is stricter, not weaker**:
  with the allow-list empty, *any* Albescent animation appearing in index.css now
  fails, a re-added spark included.
- The companion test ("leaves the spark behind for a reason that is still true")
  had its entire subject deleted. It is **replaced, not removed**, by a
  resurrection guard on all three shapes the twinkle could come back in — the
  rule, the keyframe, and an `animation:` naming it — asserted across both
  sheets. Verified non-vacuous: all three exist in `HEAD~1`.

**`praxisCard/__tests__/albescentDriftStopsAtMedia.test.tsx`** derives its
z-order floor from the ornaments' own declared values. `.alb-spark` (0) is
**substituted** with `.alb-praxis-card-edge` (1) rather than dropped from the
`Math.max` — `topZ` throws on an empty set precisely so a deleted ornament cannot
quietly lower the floor and make the lift look like it clears more than it does.

## Comments that pointed at a rule that no longer exists

Five citations of `.alb-spark` as precedent — "parks at a resting opacity rather
than freezing, because a spark frozen at its keyframe start is invisible" — are
rewritten to point at Coven's `.cvn-profile-spark`, the surviving mark that makes
the same call for the same reason. Sites: `index.css` ×4 (the prism rest frame,
the `.user-media` lift list, `.alb-profile-edge`, the Coven spark),
`motion.ornament.css` ×2, `AlbescentAvatar.tsx`, `AlbescentProfileBody.tsx`.
Every surviving mention of the string now says in the same breath that it is
retired.

**Not edited:** `docs/adr/0050` line 106 names "Albescent's sparks" in a
parenthetical list of places `✦` appears as generic ornament. ADR bodies are
historical records and #2536 forbids rewriting them, so the stale example stands.

## Verified locally — every step in `.github/workflows/test.yml`'s `frontend` job

- `npm run lint` — clean (the three `local/no-raw-style-values` disables went out
  with the glyphs they excused)
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **414 files / 7404 passed**, 1 skipped
- `npm run build` — clean; `alb-spark` appears in zero built CSS assets
- `npm run budget` — **CSS 22.3 KB, WARN**. Pre-existing: I built `origin/main`'s
  `frontend/src` in this worktree and it reports **22.4 KB, same WARN**. This
  change *shrinks* the critical sheet by 0.1 KB. No backend or schema surface
  touched, so `test` and `api-schema` are untouched.

## Visual QA is OUTSTANDING

I have no browser and no dev stack. Nothing here proves a pixel — the tests prove
the wiring (no `alb-spark` in the markup, no rule in either sheet, the z-order
floor still derived from a live ornament) and nothing more.

## What to eyeball

1. **An Albescent praxis card, light theme** — no ✦ anywhere on the sheet,
   moving or stilled. Three used to sit near the top-left, upper-right and
   lower-left.
2. **The same card, dark theme** — the sparks had their own dark ink
   (`#f2cc72`), so a leftover would be brightest here.
3. **With `prefers-reduced-motion: reduce`** — confirm no glyph is parked at a
   resting opacity where the animation used to be.
4. **The card's 3px spectrum ring still travels**, and still sits *above* the
   card content — that is the `z-index: 1` this PR kept on a rewritten reason.
5. **A proof photo on an Albescent praxis card** is still untinted (#1646's
   lift), and its gallery thumbnails still sit above the ring.
6. **An Albescent praxis card on someone else's patterned profile** (e.g. an
   Everymen page) — the ground goes plain, and the travelling ring is now the
   only tell left. This is the one to judge: is the card still legibly
   Albescent?
7. **The Albescent task card, the profile identity band and the avatar ring** —
   all should be byte-identical to before; only comments changed near them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
