### PR TITLE
E2E-only task fixture: six distinct tasks so C4's premise holds

### DIFF
--- a/frontend/e2e/fixture_tasks.py
+++ b/frontend/e2e/fixture_tasks.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""E2E-only task fixture: the six distinct tasks the collaboration suite needs.
+
+Run by ``run-e2e.sh`` immediately after ``seed.py``, against the e2e database
+only — it reads ``DATABASE_URL``, which that script has already pointed at
+``worldzero_e2e``. ``.github/workflows/e2e.yml`` invokes the same script, so the
+nightly gets this step without a second copy of the fixture living in the
+workflow.
+
+**Why this is here and not in backend/seed.py** (#2483): ``start.sh`` runs
+``seed.py`` on EVERY production deploy, so anything it or the era config names
+is restored the next deploy after an admin deletes it (#1398). ``ERA_1_TASKS``
+is ``()`` for exactly that reason. These six titles are Playwright scaffolding,
+not game content, and must never enter that path — so the fixture lives beside
+the suite that needs it, and ``seed.py`` stays ignorant that a test suite exists.
+
+**What needs them**: ``collaboration.spec.ts`` C4 proves that past FIVE pending
+invites the oldest is still reachable (the requests inbox fetches at most 5), so
+it raises six invites on six different tasks. Its ``pickTasks`` helper dedupes on
+**title** and skips anything above ``level_required`` 8 — so six rows are only
+six usable tasks when all six titles differ. A plain ``seed.py`` run leaves the
+e2e database holding two tasks: the level-0 onboarding task and the duel fixture.
+
+Level 0 stays reserved for the onboarding task (#904 — faction roster content
+lives at levels 1-7), and ``pickOpenTask`` takes the *first* level-0 task, so
+these sit at levels 1-6 and leave that choice untouched.
+
+Idempotent and title-guarded, like every phase of ``seed.py``: the nightly runs
+against a freshly reset database, but a local run may not.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# The fixture lives with the suite; the models it writes live in the backend.
+BACKEND_DIR = Path(__file__).resolve().parents[2] / "backend"
+sys.path.insert(0, str(BACKEND_DIR))
+
+from sqlalchemy import distinct, func, select  # noqa: E402
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from faction_slugs import CROSS_FACTION_SLUG  # noqa: E402
+from models.character import Character  # noqa: E402
+from models.task import Task, TaskStatus, TaskType  # noqa: E402
+
+# Six distinct titles at distinct levels, all <= 8 so the level-8 C4 inviter can
+# attempt every one of them. Cross-faction like the onboarding task: the duel
+# fixture picks on ``primary_faction_slug == 'ua'`` and these must not shadow it.
+FIXTURE_TASKS: tuple[tuple[str, str, int], ...] = (
+    ("E2E fixture: Refill Something", "Fixture task for the e2e suite.", 1),
+    ("E2E fixture: Walk a New Street", "Fixture task for the e2e suite.", 2),
+    ("E2E fixture: Write One Postcard", "Fixture task for the e2e suite.", 3),
+    ("E2E fixture: Mend a Small Thing", "Fixture task for the e2e suite.", 4),
+    ("E2E fixture: Learn a Bird's Name", "Fixture task for the e2e suite.", 5),
+    ("E2E fixture: Cook Without a Recipe", "Fixture task for the e2e suite.", 6),
+)
+
+# What C4's ``pickTasks`` demands of the database before the test can mean
+# anything: this many distinct titles at or below this level.
+REQUIRED_DISTINCT_TASKS = 6
+MAX_LEVEL_REQUIRED = 8
+
+
+async def main() -> None:
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        sys.exit("ERROR: DATABASE_URL is not set — run this via frontend/e2e/run-e2e.sh.")
+
+    engine = create_async_engine(database_url)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            # seed.py's Pixie is the lowest-id character; ``created_by`` is a
+            # non-nullable FK and the fixture has no opinion about the author.
+            created_by_id = (
+                await session.execute(select(Character.id).order_by(Character.id).limit(1))
+            ).scalars().first()
+            if created_by_id is None:
+                sys.exit("ERROR: no character in the e2e database — did seed.py run?")
+
+            existing_titles = set(
+                (await session.execute(select(Task.title))).scalars().all()
+            )
+            added = 0
+            for title, description, level_required in FIXTURE_TASKS:
+                if title in existing_titles:
+                    continue
+                session.add(Task(
+                    title=title,
+                    description=description,
+                    point_value=10,
+                    level_required=level_required,
+                    status=TaskStatus.active,
+                    task_type=TaskType.standard,
+                    created_by=created_by_id,
+                    primary_faction_slug=CROSS_FACTION_SLUG,
+                ))
+                added += 1
+            await session.commit()
+
+            # Fail here, at the fixture step, rather than 400 lines into a serial
+            # spec file: C4's premise is a property of the database, so the
+            # database step is where a missing premise should be reported.
+            usable = (
+                await session.execute(
+                    select(func.count(distinct(Task.title))).where(
+                        Task.status == TaskStatus.active,
+                        Task.task_type == TaskType.standard,
+                        Task.level_required <= MAX_LEVEL_REQUIRED,
+                    )
+                )
+            ).scalar_one()
+            if usable < REQUIRED_DISTINCT_TASKS:
+                sys.exit(
+                    f"ERROR: e2e fixture left {usable} distinct task title(s) at level "
+                    f"<= {MAX_LEVEL_REQUIRED}; collaboration.spec.ts C4 needs "
+                    f"{REQUIRED_DISTINCT_TASKS}."
+                )
+
+            print(f"==> e2e task fixture: +{added} added, {usable} usable distinct titles")
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/e2e/run-e2e.sh
+++ b/frontend/e2e/run-e2e.sh
@@ -11,7 +11,9 @@
 #      to touch anything not ending in _e2e).
 #   3. Runs `alembic upgrade head` — DATABASE_URL is exported because
 #      alembic/env.py reads os.environ, NOT backend/.env. Fails loudly on drift.
-#   4. Seeds via seed.py (env vars override .env, so it seeds the e2e db).
+#   4. Seeds via seed.py (env vars override .env, so it seeds the e2e db), then
+#      adds the suite's own fixtures (fixture_tasks.py) to that database only —
+#      seed.py is production bootstrap and holds no test data.
 #   5. Starts the branch backend on a dedicated port (default 8001) so the
 #      docker-compose backend on :8000 can't shadow the code under test.
 #   6. Runs `npx playwright test` — the playwright config starts the frontend
@@ -75,6 +77,13 @@ echo "==> alembic upgrade head"
 
 echo "==> seed"
 "$PYTHON_BIN" seed.py
+
+# Suite fixtures, not game content. seed.py is production bootstrap (start.sh
+# runs it on every deploy) and must stay ignorant that a test suite exists, so
+# the tasks the specs need are inserted here, into the e2e database only. See
+# the docblock in fixture_tasks.py for why the era config cannot hold them.
+echo "==> e2e task fixture"
+"$PYTHON_BIN" "$SCRIPT_DIR/fixture_tasks.py"
 
 echo "==> start backend on :$E2E_BACKEND_PORT"
 "$PYTHON_BIN" -m uvicorn main:app --port "$E2E_BACKEND_PORT" &


### PR DESCRIPTION
C4 fails on a fixture premise: it needs six distinct-titled tasks at `level_required <= 8` and a seeded e2e database holds two (three locally — `seed_dev_demo` adds one more). This inserts the tasks the suite needs into the **e2e database only**, per the 2026-08-23 ruling, option (a).

Closes #2483

## The seam

**The e2e database's task table, immediately after `run-e2e.sh`'s seed phase.** Not the locator, not `pickTasks`, not C4 itself — all three are correct and stay untouched. The assertion that goes red (`need 6 distinct seeded tasks for the >5-invite test`) is a statement about the database, so the fix is a database step.

## What changed

- **`frontend/e2e/fixture_tasks.py`** (new) — idempotent, title-guarded insert of six distinct tasks at levels 1-6, `primary_faction_slug` cross-faction, `status=active`. Reads `DATABASE_URL`, which `run-e2e.sh` has already pointed at the e2e database.
- **`frontend/e2e/run-e2e.sh`** — one step after the existing `seed.py` line, plus the header docblock.

`ERA_1_TASKS` stays `()`. `backend/seed.py` and `backend/eras/era_1.py` are untouched — `start.sh` re-seeds on every production deploy, so anything named there is restored the deploy after an admin deletes it (#1398). Test scaffolding must never enter that path.

**The nightly gets this for free**: `.github/workflows/e2e.yml` runs `bash frontend/e2e/run-e2e.sh` and nothing else, so there is no second copy of the fixture in the workflow. The workflow file is unmodified — verified, not assumed.

### Three constraints that make this not-a-one-liner

- **Distinct titles.** `pickTasks` dedupes on `title`, so six rows carrying two titles still yields two.
- **Level 0 is not used.** It is reserved for the onboarding task (#904), and `pickOpenTask` takes the *first* level-0 task — which several other tests depend on. Levels 1-6 leave that choice exactly where it was.
- **Not `ua`.** `pickUaDuelTask` selects on `primary_faction_slug === 'ua'`; these are cross-faction so they cannot shadow the duel fixture.

### One extra guard

The fixture asserts its own postcondition and exits non-zero if the database ends up with fewer than six usable distinct titles. A missing premise then fails at the seed step with a one-line reason, rather than 400 lines into a `mode: 'serial'` spec file as an opaque `Expected: 6`.

## Verification — what I actually ran

I have no browser and did not run Playwright (no `node_modules` in this worktree). What I did run, against a dedicated `wz2483_e2e` database on the local Postgres, following `run-e2e.sh`'s own pipeline:

1. `reset_e2e_db.py` → `alembic upgrade head` → `seed.py`. **Red confirmed:** 3 tasks, 3 distinct titles. C4's premise cannot hold.
2. `fixture_tasks.py` → `+6 added, 8 usable distinct titles`.
3. Re-ran it → `+0 added` (idempotent).
4. Started the backend against that database, did the same `POST /auth/dev-login?...&level=8` C4 does, and replayed `pickTasks`' filter verbatim over the real `GET /tasks` response: **6 tasks returned, `expect(...).toBe(6)` passes.** `tasks[0]` is still the onboarding task.

No CI job in `test.yml` covers a `.py` or `.sh` file under `frontend/e2e/`, so there was nothing there to run for this diff.

## The claim, stated narrowly

**C4's premise is satisfied and the serial block no longer dies at C4.** That is all this proves. It does **not** make the nightly green — the nightly has never been green, and 36 of its 39 failures are the S.N.I.D.E. contrast family in #2450, which is still `needs-design`. Expect the count of *reported* failures to go **up** when this lands: P1 and P2 will execute for the first time instead of being suppressed. That is the fixture working.

C4 itself may still fail on its actual subject — the requests inbox caps its fetch at 5 (#960). It will now fail on **that**, which is what it was written to say.

## Blast radius (#1674's standing hazard)

Six new cross-faction task cards appear on `/tasks` and can appear in Home's teaser — in the e2e database only.

- `contrast.spec.ts` is immune by construction, and I checked why rather than assuming: its baseline keys on the **colour pair**, not the DOM node, and its unmeasurable ratchet counts **distinct surfaces** (`unmeasurable.size`), not nodes. Six more cards of a skin already on the page are the same pairs and the same surfaces.
- `pickOpenTask` (level 0 only) and `pickUaDuelTask` (faction `ua`) both select outside this fixture's range, by design — see above.
- `smoke.spec.ts` and `guest.spec.ts` assert headings and routes, not counts.

## What to eyeball

- **The six titles.** They are deliberately prefixed `E2E fixture:` so nobody mistakes scaffolding for game content in a Playwright trace. Say the word if you would rather they read as real tasks.
- **Levels 1-6.** Chosen to dodge level 0 (#904, `pickOpenTask`). Any level `<= 8` works if you want them elsewhere.
- **Cross-faction, not a real faction.** They render the default/na skin. If you want the e2e board to exercise a faction skin instead, that is a one-line change — but it would put them in `pickUaDuelTask`'s path.
- **The postcondition guard.** It is extra code the ruling did not ask for. It exists so the next fixture drift reports itself at the seed step; cut it if you consider it scope creep.
- **Visual QA is outstanding.** No browser in this session, and Playwright was not run.
