### PR TITLE
Albescent's sigil becomes a manifest row, and no dispatcher may spread a surface map again

### DIFF
--- a/frontend/src/components/sigil/FactionSigil.tsx
+++ b/frontend/src/components/sigil/FactionSigil.tsx
@@ -83,7 +83,14 @@ export function factionSigilRing(slug: string | null | undefined): string | unde
   return slug === "albescent" ? "var(--faction-default-stop-6)" : undefined;
 }
 
-function DefaultSigilAdapter({ size }: SigilVariantProps) {
+/**
+ * The na ring — a `Default*` archetype co-located with its dispatcher, which
+ * `manifest.ts` names as the normal shape for three surfaces already. Exported
+ * so a test can resolve the surface the way this component does (`pickVariant`
+ * over `surfaceMap('sigil')`, with the na fallback named) rather than
+ * re-deriving the fallback and proving its own copy instead.
+ */
+export function DefaultSigilAdapter({ size }: SigilVariantProps) {
   // The default ring has no color prop — it draws
   // --faction-default-rainbow-conic.
   return <DefaultSigil size={size} />;

--- a/frontend/src/components/sigil/FactionSigil.tsx
+++ b/frontend/src/components/sigil/FactionSigil.tsx
@@ -52,15 +52,25 @@ export function SingularitySigilAdapter({ size, color }: SigilVariantProps) {
  * and the sidebar's activity rail. Everything about the NAME stays masked —
  * that is #1891/#1926's other half and it is untouched.
  *
- * WHY THE ADAPTER AND NOT THE MANIFEST. `albescent.ts`'s contract is explicit:
- * anything added there must be "a flourish LAYERED OVER Default's structure",
- * because a surface that repaints Albescent in its own colours un-hides the
- * society (#783). A bespoke emblem is not Default-plus-a-flourish, so it is not
- * a manifest row. It resolves here, where the mark→slug question already lives —
- * and it sits BEFORE the spread, so the day albescent does declare a `sigil` the
- * manifest wins and this line quietly stops mattering.
+ * IT IS A MANIFEST ROW NOW (#2529), and the note this replaces named its own
+ * retirement: the adapter used to be spread into the map at the call site,
+ * *ahead* of `surfaceMap('sigil')`, "so the day albescent does declare a `sigil`
+ * the manifest wins and this line quietly stops mattering." That day is #2529.
+ * The old reasoning was that `albescent.ts` takes only "a flourish LAYERED OVER
+ * Default's structure" and a bespoke emblem is not one — true of the SHAPE and
+ * not of the risk it was guarding, which is livery (#783): the labyrinth is
+ * painted from `--faction-default-rainbow-conic`, the same spectrum na wears,
+ * so registering it repaints nothing. What the bypass did cost was real. It made
+ * every census of who skins what report `sigil: 7/8, albescent absent`, and it
+ * put the mark outside the one map a refactor of this surface would carry — the
+ * way it was already dropped once (`Sidebar.tsx:40`).
+ *
+ * Exported, not local, for the reason `UaSigilAdapter` and
+ * `SingularitySigilAdapter` above are: a manifest names it through
+ * `lazyArchetype`, which defers the read past module evaluation and keeps the
+ * dispatcher↔archetype cycle harmless. See the thunk note in `factions/manifest.ts`.
  */
-function AlbescentSigilAdapter({ size, color }: SigilVariantProps) {
+export function AlbescentSigilAdapter({ size, color }: SigilVariantProps) {
   return <AlbescentSigil size={size ?? 22} color={color} />;
 }
 
@@ -97,10 +107,6 @@ export function DefaultSigilAdapter({ size }: SigilVariantProps) {
 }
 
 export default function FactionSigil({ slug, size, color }: FactionSigilProps) {
-  const Variant = pickVariant(
-    { albescent: AlbescentSigilAdapter, ...surfaceMap("sigil") },
-    slug,
-    DefaultSigilAdapter,
-  );
+  const Variant = pickVariant(surfaceMap("sigil"), slug, DefaultSigilAdapter);
   return <Variant size={size} color={color} />;
 }

--- a/frontend/src/components/sigil/__tests__/factionSigil.test.tsx
+++ b/frontend/src/components/sigil/__tests__/factionSigil.test.tsx
@@ -7,7 +7,9 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 import "../../../i18n";
-import FactionSigil from "../FactionSigil";
+import FactionSigil, { DefaultSigilAdapter } from "../FactionSigil";
+import { pickVariant } from "../../../utils/factionDispatch";
+import { surfaceMap } from "../../../factions";
 import UaMandala from "../../factionMarks/UaMandala";
 
 describe("FactionSigil dispatcher (#659)", () => {
@@ -180,6 +182,88 @@ describe("Albescent's labyrinth (Sigil Studies v2)", () => {
       expect(html, `${size}px`).toContain(`width:${size}px`);
       expect(html, `${size}px`).toContain(`height:${size}px`);
     }
+  });
+});
+
+/**
+ * THE MANIFEST IS THE WHOLE MAP (#2529).
+ *
+ * The seam is `pickVariant(surfaceMap('sigil'), slug)` — the map on its own,
+ * with nothing added at the call site. `FactionSigil` used to spread
+ * `{ albescent: AlbescentSigilAdapter, ...surfaceMap('sigil') }`, so the
+ * labyrinth reached the screen without ever appearing in `ALBESCENT_MANIFEST`:
+ * a bypass `SURFACE_KEYS_ARE_EXHAUSTIVE` cannot see, because it is not a new
+ * surface key but a slug injected into an existing map.
+ *
+ * Two things go red here if it comes back, and both matter:
+ *
+ *   1. the census lie — `surfaceMap('sigil')` must ANSWER for albescent rather
+ *      than report a hole the dispatcher quietly patches;
+ *   2. the deletion hazard — the mark must render the SAME through the map
+ *      alone as through the dispatcher. `Sidebar.tsx` records that a refactor
+ *      already dropped this mark once with nothing going red.
+ *
+ * Byte-identity is asserted rather than "contains the asset" on purpose: #2529
+ * is a migration, not a redesign, so a pixel that moves means the move was
+ * wrong. Every size the app mounts is walked because the comparison is over
+ * inline style, where the size is the only thing that varies.
+ */
+describe("every sigil the dispatcher draws comes out of the manifest (#2529)", () => {
+  // Every game slug, plus the two fall-through cases. `na` is a state rather
+  // than a faction and deliberately has no manifest, so it must resolve exactly
+  // the way an unknown slug does.
+  const SLUGS = [
+    "coven",
+    "snide",
+    "ephemerists",
+    "singularity",
+    "everymen",
+    "ua",
+    "wow",
+    "albescent",
+    "na",
+    "not_a_faction",
+    null,
+  ] as const;
+
+  // The mounts in the tree, plus the 64px step the avatar's ring gates on.
+  const SIZES = [15, 18, 22, 26, 34, 40, 42, 44, 64, 84];
+
+  it.each(SLUGS.map((slug) => [String(slug), slug] as const))(
+    "%s renders identically through surfaceMap('sigil') alone",
+    (_label, slug) => {
+      const Variant = pickVariant(surfaceMap("sigil"), slug, DefaultSigilAdapter);
+      for (const size of SIZES) {
+        expect(
+          renderToStaticMarkup(<FactionSigil slug={slug} size={size} />),
+          `${slug} at ${size}px`,
+        ).toBe(renderToStaticMarkup(<Variant size={size} />));
+      }
+    },
+  );
+
+  it("keeps the caller's paint on the same path", () => {
+    // The sidebar's neutral rows hand the mark a position-sampled window of the
+    // ramp, so `color` has to survive the map lookup as well as the size does.
+    const sampled = "var(--faction-default-rainbow) 40% 0 / 600% 100%";
+    for (const slug of SLUGS) {
+      const Variant = pickVariant(surfaceMap("sigil"), slug, DefaultSigilAdapter);
+      expect(
+        renderToStaticMarkup(<FactionSigil slug={slug} color={sampled} />),
+        String(slug),
+      ).toBe(renderToStaticMarkup(<Variant color={sampled} />));
+    }
+  });
+
+  it("answers for albescent out of the map, not out of the call site", () => {
+    // The census assertion. Without it the two above stay green if someone
+    // re-adds the spread AND the manifest row — a slower version of the same
+    // bug, since the call site would win again.
+    const map = surfaceMap("sigil");
+    expect(map["albescent"]).toBeDefined();
+    expect(renderToStaticMarkup(<FactionSigil slug="albescent" size={40} />)).toContain(
+      "/factionMarks/labyrinth.svg",
+    );
   });
 });
 

--- a/frontend/src/components/sigil/__tests__/factionSigil.test.tsx
+++ b/frontend/src/components/sigil/__tests__/factionSigil.test.tsx
@@ -77,10 +77,10 @@ describe("FactionSigil dispatcher (#659)", () => {
 
   // #1626 gave albescent its own adapter row here, holding the surveyor's
   // cross-hair; #1891 deleted it; Sigil Studies v2 reinstates it holding the
-  // labyrinth, by owner ruling. `factions/albescent.ts` still registers no
-  // `sigil` row and still must not (its manifest takes only
-  // Default-plus-a-flourish surfaces, #783), so the row lives in the dispatcher.
-  // Asserted in full further down.
+  // labyrinth, by owner ruling. Since #2529 `factions/albescent.ts` REGISTERS
+  // that row like every other faction/surface pair — it used to be spread into
+  // the map at the call site, which is the bypass the block at the bottom of
+  // this file now pins. Asserted in full further down.
   it("renders the labyrinth for the albescent slug", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="albescent" />);
     expect(html).toContain("/factionMarks/labyrinth.svg");

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -19,8 +19,27 @@
  * markup — a mis-wire surfaces there, not as a bare identity check here.
  */
 import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
 import { surfaceMap, SURFACE_KEYS } from '..'
 import type { FactionSurface } from '..'
+
+/** Every non-test source module under `src`, as [path relative to src, text]. */
+function walkSource(root: string): Array<[string, string]> {
+  const files = (dir: string): string[] =>
+    readdirSync(dir).flatMap((entry) => {
+      const full = join(dir, entry)
+      return statSync(full).isDirectory() ? files(full) : [full]
+    })
+  return files(root)
+    .filter(
+      (path) =>
+        /\.tsx?$/.test(path) &&
+        !/\.test\.tsx?$/.test(path) &&
+        !path.includes(`${sep}__tests__${sep}`),
+    )
+    .map((path) => [relative(root, path), readFileSync(path, 'utf8')])
+}
 
 // The table asserts each surface's registry CONTENTS: a bespoke slug has an
 // entry, a non-bespoke faction does not (and so falls through to the surface
@@ -197,5 +216,58 @@ describe('Coven is bespoke on every core surface, never the Default', () => {
 describe('WOW is bespoke on every core surface, never the Default', () => {
   it.each(REQUIRED)('wow skins %s', (surface) => {
     expect(surfaceMap(surface)['wow']).toBeDefined()
+  })
+})
+
+/* -------------------------------------------------------------------------- */
+/* No dispatcher may add a slug the manifest does not have (#2529)            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Everything above derives its bar from `surfaceMap()`, which is exactly why
+ * nothing above could see #2529: `FactionSigil` dispatched on
+ * `{ albescent: AlbescentSigilAdapter, ...surfaceMap('sigil') }`, so the one
+ * surface reached outside the map was the one surface this file had no opinion
+ * about. `SURFACE_KEYS_ARE_EXHAUSTIVE` could not see it either — that guard
+ * catches a new surface KEY, and this was a slug injected at a call site.
+ *
+ * THE RULE IS "NEVER SPREAD IT", and the narrowness is the point. A map can
+ * only gain a sibling key by being opened up, so a spread is the whole surface
+ * area of the bypass — `{ x: A, ...surfaceMap(k) }` and
+ * `{ ...surfaceMap(k), x: A }` are both spreads and both caught, in either
+ * order and however the object is formatted. A dispatcher that hands the map
+ * straight to `pickVariant`, or parks it in a local first the way
+ * `FactionSelectCard` does, never trips this.
+ *
+ * A source scan, like `archetypeReachability`'s two: the thing being asserted is
+ * a property of what people WRITE at a call site, and a graph walk cannot see it
+ * — by the time `pickVariant` has an object, the injected key is
+ * indistinguishable from a registered one.
+ */
+const CALL_SITES = walkSource(join(process.cwd(), 'src'))
+const READS_SURFACE_MAP = CALL_SITES.filter(([, text]) => text.includes('surfaceMap('))
+
+describe('every dispatcher reads surfaceMap() whole (#2529)', () => {
+  it('has dispatchers to check at all', () => {
+    // Guards the guard: a walk that matched nothing would be vacuously green
+    // forever, which is the failure mode this whole block exists to end.
+    expect(READS_SURFACE_MAP.length).toBeGreaterThan(10)
+  })
+
+  it('never spreads a surface map, so nothing can be added beside it', () => {
+    const offenders = READS_SURFACE_MAP.filter(([, text]) =>
+      /\.\.\.\s*surfaceMap\s*\(/.test(text),
+    ).map(([path]) => path)
+
+    expect(
+      offenders,
+      `A dispatcher spreads surfaceMap() into an object literal.\n` +
+        `That is how a slug reaches the screen without a manifest row (#2529):\n\n` +
+        `    pickVariant({ albescent: Adapter, ...surfaceMap('sigil') }, slug, Default)\n\n` +
+        `Register the component in factions/<slug>.ts instead and pass the map\n` +
+        `whole. A surface reached outside surfaceMap() is invisible to every\n` +
+        `assertion in this file and gets dropped by the next refactor of its\n` +
+        `dispatcher.`,
+    ).toEqual([])
   })
 })

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -25,9 +25,15 @@
  * deliberately not in this issue. Until it exists, the empty manifest is the
  * correct and complete statement of Albescent's appearance.
  *
- * Anything added here must be a flourish LAYERED OVER Default's structure
- * reading `--faction-default-*`. A surface that repaints Albescent in its own
- * colours puts it back in the spectrum and un-hides it.
+ * Anything added here must read `--faction-default-*`. A surface that repaints
+ * Albescent in its own colours puts it back in the spectrum and un-hides it, and
+ * that is the edge — livery, not novelty. Every row below but one is also a
+ * flourish LAYERED OVER Default's structure, which is the usual way of staying
+ * on the safe side of it. `sigil` (#2529) is the exception and stays inside the
+ * rule: the labyrinth is a shape of its own, painted with na's spectrum and
+ * nothing else. It is registered rather than special-cased in its dispatcher
+ * because a mark reached outside `surfaceMap()` is a mark a refactor of that
+ * surface drops — which already happened once.
  */
 import type { FactionManifest } from './manifest'
 import { lazyArchetype } from './lazyArchetype'
@@ -62,6 +68,11 @@ const AlbescentEditPraxis = lazyArchetype(() => import('../pages/editPraxis/arch
 const AlbescentFieldDesk = lazyArchetype(() => import('../pages/fieldDesk/mobileArchetypes/AlbescentFieldDesk'))
 // #2502 — the avatar unfreeze, lazy for the same reason as every wrapper above.
 const AlbescentAvatar = lazyArchetype(() => import('../components/avatar/AlbescentAvatar'))
+// #2529 — the mark. Named out of the DISPATCHER, exactly as `ua` and
+// `singularity` name theirs: the three sigil adapters are defined inside
+// `FactionSigil.tsx`, and `lazyArchetype` is what makes reading one from here
+// safe (the thunk note in `./manifest.ts`).
+const AlbescentSigilAdapter = lazyArchetype(() => import('../components/sigil/FactionSigil').then((m) => ({ default: m.AlbescentSigilAdapter })))
 
 export const ALBESCENT_MANIFEST: FactionManifest = {
   slug: 'albescent',
@@ -210,6 +221,30 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * Albescent.
    */
   avatar: () => AlbescentAvatar,
+
+  /**
+   * THE MARK (#2529) — and the one row here that is not a wrapper over an na
+   * surface. It is a MIGRATION, not a new surface: the labyrinth has rendered
+   * for this slug since Sigil Studies v2, but it reached the screen through a
+   * slug spread into the map at `FactionSigil`'s call site, so it was the one
+   * dispatched surface `surfaceMap()` could not see. Registering it changes no
+   * pixel; it makes the registry the whole answer.
+   *
+   * WHY IT DOES NOT BREAK THE MODULE'S CONTRACT above. That contract's edge is
+   * LIVERY — "a surface that repaints Albescent in its own colours puts it back
+   * in the spectrum and un-hides it". The labyrinth carries no hue of its own:
+   * it is an alpha stencil under `public/`, painted with
+   * `--faction-default-rainbow-conic`, the exact spectrum an unaffiliated player
+   * wears. So it is a SHAPE and never a livery, which is the property the owner
+   * ruled on when reinstating it and the property this row inherits.
+   *
+   * IT ADDS NO MOTION, and ADR-0083 §3 is why that has to be said out loud.
+   * `alb-moves` is a class each wrapper writes on itself, not something derived
+   * from manifest membership, and nothing here wears it — the mark is still
+   * "never part of the wrapper" (ADR-0083 §1). One more row in the registry is
+   * not one more surface that moves.
+   */
+  sigil: () => AlbescentSigilAdapter,
 
   /**
    * The ferrofluid vote widget (#843, the eighth of #821's eight). Same rule as


### PR DESCRIPTION
Closes #2529

Albescent's labyrinth was spread into the map at the dispatcher's call site,
ahead of `surfaceMap("sigil")`, so it rendered for the slug without ever
appearing in `ALBESCENT_MANIFEST`. It now registers like every other
faction/surface pair and the call site is a bare `surfaceMap("sigil")`.

## The seam

`pickVariant(surfaceMap('sigil'), slug)` — the map on its own, with nothing
added at the call site.

The failing test went first, in `components/sigil/__tests__/factionSigil.test.tsx`:
for every slug, `renderToStaticMarkup(<FactionSigil slug={s} size={n} />)` must
be **byte-identical** to rendering what the map alone resolves to. That went red
on `albescent` and on `albescent` only, at every mount size and with a caller's
paint — which is also the issue's "this is the only bypass" claim made
executable, since the other ten slugs already matched.

## Verifying the claim before relying on it

Grepped every `pickVariant(` call site on `origin/main` (21 of them, plus the
multi-line ones read individually). **`FactionSigil.tsx:94` was the only one
that injected a slug.** Every other dispatcher passes `surfaceMap()` straight
through; `FactionSelectCard` parks it in a local first and is still clean.
No second offender to report.

## The shape, which is prior art rather than invented

`ua` and `singularity` already register sigil adapters that live *inside*
`FactionSigil.tsx`, through `lazyArchetype`:

```ts
const UaSigilAdapter = lazyArchetype(() => import('../components/sigil/FactionSigil').then((m) => ({ default: m.UaSigilAdapter })))
```

`albescent.ts` now does exactly that and adds `sigil: () => AlbescentSigilAdapter`.
The issue's step 2 (move the adapter to its own module) turned out to be
unnecessary: `manifest.ts`'s thunk discipline exists precisely for the
three-adapters-in-the-dispatcher case, and `manifestsStayLazy.test.ts` *requires*
`lazyArchetype`, so a plain static import from the manifest was never an option.

## Output-neutral

- The 31 assertions already in `factionSigil.test.tsx` were written against the
  pre-change markup (exact asset URL, exact `width:Npx`, "no `#`", "never puts
  the word in the markup") and are untouched and green. That is the before/after
  proof.
- The new byte-identity block walks 11 slugs × 10 sizes plus a sampled `color`.
- No CSS, no token, no copy, no motion. `alb-moves` is a class each wrapper
  writes on itself, not something derived from manifest membership — nothing
  here wears it, so one more registry row is **not** one more surface that moves
  (ADR-0083 §3 says that has to be true, and it is).
- One real behavioural delta, and it is the one every other faction's sigil
  already has: the mark now renders `null` for the frame before its chunk lands,
  exactly as `ua`'s and `singularity`'s do. `lazyArchetype`'s docblock calls this
  the sanctioned substitute for `<Suspense fallback={null}>`.

## The regression guard

`surfaceDispatch.test.ts` gains a source-scan repo rule: **a dispatcher may never
spread a surface map.** A map can only gain a sibling key by being opened up, so
the spread is the bypass's whole surface area — caught in either key order and
however the object is formatted. Verified non-vacuous by reintroducing the old
call site: it goes red and names `components/sigil/FactionSigil.tsx`.

This is the shape the issue asked for and the narrowest rule that covers the
defect class. Everything else in that file derives its bar from `surfaceMap()`,
which is exactly why none of it could see #2529.

## Two things the owner needs to decide on, not me

1. **There was an in-tree comment saying the bypass was deliberate.**
   `FactionSigil.tsx`'s old "WHY THE ADAPTER AND NOT THE MANIFEST" docblock
   argued `albescent.ts` takes only "a flourish LAYERED OVER Default's
   structure". I built it anyway because **that same comment named its own
   retirement condition**: *"it sits BEFORE the spread, so the day albescent does
   declare a `sigil` the manifest wins and this line quietly stops mattering."*
   The contract's actual edge is **livery**, and the labyrinth carries no hue of
   its own — it is an alpha stencil painted with `--faction-default-rainbow-conic`,
   the spectrum na already wears. So registering it repaints nothing. The
   reasoning is carried forward into the manifest row rather than deleted, and
   `albescent.ts`'s module docstring is amended so its blanket claim is not left
   false.
2. **#2532's ADR note goes stale if this lands first.** The sibling agent was
   told to describe this bypass as a known live one. It is not live any more.

## Not done

- **Visual QA is outstanding.** No browser tools and no dev stack here; verified
  by tsc, eslint, vitest, build and budget only.

## CI, run locally

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` ·
`npm test` (414 files, 7419 passed) · `npm run build` · `npm run budget` (exit 0).
The CSS budget WARN is pre-existing on `main` — this branch changes zero CSS.
`api-schema` and the backend `test` job are untouched: no route, schema or
`response_model` in the diff.

## What to eyeball

- **Albescent's sigil** — the labyrinth, not the na ring, and not a blank space.
  Sidebar activity rail, players roster, filter facet, requests tray, credential
  card footer.
- **Two other factions' sigils** — say **UA** (the ensō, already lazy, the control
  for "does lazy registration look the same") and **Coven** (the witch hat).
- **The na / unaffiliated ring**, since the fallback path is the line that
  changed.
- **Both themes**, light and dark. Nothing here should differ between them, which
  is the point.
- **Every mount size**: 15, 18, 22, 26, 34, 40, 42, 44, 64, 84 px — the sigil has
  a known gate at 64px, so check either side of it.
- **A hard reload**, specifically. The mark is code-split now, so the frame
  before its chunk lands is the one new thing to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
