### PR TITLE
tsconfig declares the ES2022 lib the source already uses

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
`frontend/tsconfig.json` declared `"lib": ["ES2020", "DOM", "DOM.Iterable"]` while the source calls `Array.prototype.at()` — an **ES2022** method — in twelve files. This raises `lib` to `ES2022`.

## Why now

#2447 bumps `@types/node` 20 → 26 and its `frontend` job fails with twelve of these:

```
src/__tests__/albescentPrismSheet.test.ts(167,20): error TS2550:
  Property 'at' does not exist on type 'string[]'.
  Try changing the 'lib' compiler option to 'es2022' or later.
```

Across `albescentPrismSheet`, `spectrumRingCollapse`, `avatarUpload`, `layoutShell`, `FlagControl`, `OwnerControls`, `ephemeristsGravity` and `imageEditFailure`.

**The bump did not break this — it removed a prop.** `@types/node@20` was transitively widening the lib; v26 stops, and the real state of the config surfaces. The declaration has been wrong for as long as those calls have existed.

Pinning `@types/node` at 20 was the alternative and is the wrong move: it keeps a dependency propping up a `lib` line that does not describe the code.

## Nothing changes at runtime

The app already ships `.at()` to browsers. Vite builds it today, and every target browser has had it since 2022. This makes the type declaration match what is already deployed.

## Scope

- **`target` stays `ES2020`, deliberately.** `.at()` is a library built-in, not syntax, so `lib` is the entire fix. `noEmit` is `true` here and Vite owns the real transpile target regardless, so moving `target` would change nothing but would widen the blast radius.
- **`tsconfig.e2e.json` extends this file**, so the second typecheck in `npm run typecheck` inherits the change. It uses `.at()` zero times today, so nothing there depends on it.
- **`tsconfig.node.json` is a separate root and is untouched** — it covers `vite.config.ts` / `tailwind.config.ts` / `postcss.config.js`.

## Verification

Raising a `lib` only *adds* declarations, so this cannot remove a type that something depended on. The two CI runs that matter:

1. **This PR** proves no regression against the dependency set currently on `main`.
2. **#2447 after a rebase** proves it actually clears the twelve errors.

I have not run `tsc` locally — this worktree has no `node_modules` and CI is the authority on the typecheck either way.

## What to eyeball

Nothing visual. This is a compiler declaration; there is no rendered surface and no runtime behaviour attached to it.

Owner ruled to raise the lib rather than pin the dependency (2026-08-24).

Unblocks #2447.

> *This was generated by AI during /builder-bot.*
