### PR TITLE
The composer's primary is dead until the praxis has a title, and says so

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -317,7 +317,8 @@
       "proofButtonMobile": "Browse photos / files",
       "proofHelper": "Photos, clips or receipts — max 50 MB each.",
       "submit": "Submit",
-      "submitBusy": "Submitting…"
+      "submitBusy": "Submitting…",
+      "publishNeedsTitle": "Add a title before you submit — the Title box is at the top of this sheet."
     }
   },
   "proposeTask": {

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -756,6 +756,16 @@ export default function SingularityEditPraxis({ state }: Props) {
             <PublishButton
               state={state}
               skin={{
+                /* The one surface that re-points the house disabled pair
+                   (#2573). `controls.tsx` adds `.control-off` itself when the
+                   title gate holds the band (#2484); the house neutral is a
+                   warm off-white, which on this theme-invariant black chassis
+                   would make the dead control the loudest thing on the page. So
+                   this hands it the terminal's own panel and dim ink instead —
+                   a token override, not a second rule about what disabled looks
+                   like. Inert while the band is live: it declares two custom
+                   properties and nothing reads them until `:disabled`. */
+                className: "sg-control-off",
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),
                 // The prompt's block cursor, trailing the word. `.ep-blink` is

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
@@ -17,7 +17,7 @@
 import type { ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect, vi } from "vitest";
-import "../../../../i18n";
+import i18n from "../../../../i18n";
 import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
 import type { DuelDetailOut, DuelStatus } from "../../../../api/duel";
 import type { EditPraxisState } from "../../useEditPraxis";
@@ -58,6 +58,7 @@ function collabState(
     moderationStatus?: string;
     publish?: () => Promise<void>;
     pullBack?: () => Promise<void>;
+    title?: string;
   } = {},
 ): EditPraxisState {
   const praxis = {
@@ -76,6 +77,10 @@ function collabState(
   return {
     praxis,
     duel: null,
+    // Titled unless a case says otherwise: the title is a precondition of the
+    // primary since #2484, so a fixture that omits it is describing the gated
+    // composer rather than the ordinary one.
+    title: overrides.title ?? "A title",
     submitting: false,
     switchingMode: null,
     isPublished: false,
@@ -126,6 +131,7 @@ function duelState(
     publish?: () => Promise<void>;
     pullBack?: () => Promise<void>;
     requestDuelSeal?: () => void;
+    title?: string;
   } = {},
 ): EditPraxisState {
   const published = overrides.isPublished ?? true;
@@ -156,6 +162,7 @@ function duelState(
     praxis,
     duel,
     duelMode: true,
+    title: overrides.title ?? "A title",
     submitting: false,
     switchingMode: null,
     isPublished: published,
@@ -197,6 +204,7 @@ describe("PublishButton — a multi-member collab hands over to CollabSignals (#
   it("keeps the archetype's own idle label for a solo praxis", () => {
     const state = {
       praxis: { id: 1, type: "solo", members: [] },
+      title: "A title",
       submitting: false,
       switchingMode: null,
       isPublished: false,
@@ -298,6 +306,7 @@ describe("PublishButton — duel pull-back on the moderated composer (#1077, #11
       praxis: { id: 1, type: "solo", members: [] },
       duel: null,
       duelMode: false,
+      title: "A title",
       submitting: false,
       switchingMode: null,
       isPublished: true,
@@ -326,5 +335,124 @@ describe("PublishButton — duel pull-back on the moderated composer (#1077, #11
     expect(requestDuelSeal).toHaveBeenCalledTimes(1);
     expect(pullBack).not.toHaveBeenCalled();
     expect(publish).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The title precondition (#2484).
+ *
+ * The seam is `PublishButton` invoked as a plain function, for the reason this
+ * file's header gives: it takes no hooks, so the returned element can be
+ * inspected without a DOM. The owner asked for "the control is disabled on an
+ * untitled composer and enabled once a title is typed" — a rendered fact about a
+ * button, which is why it cannot live in `useEditPraxis.test.ts` (pure-function
+ * only, and the hook is deliberately untouched by this change).
+ *
+ * Untitled is the NORMAL entry state for the two flows that mint a praxis:
+ * `handleSignup` posts a task id and a type, `accept_duel` mints the opponent's
+ * side with neither. So these cases are the main path for duels and collabs,
+ * not an edge.
+ */
+describe("PublishButton — the primary is dead until the praxis has a title (#2484)", () => {
+  /** The opening `<button …>` tag, whether or not it came wrapped in a notice. */
+  function tag(el: ReactElement | null): string {
+    const markup = renderToStaticMarkup(el);
+    const opening = /<button[^>]*>/.exec(markup)?.[0];
+    expect(opening, "a primary is drawn either way").toBeTruthy();
+    return opening ?? "";
+  }
+
+  function untitledSolo(title: string): EditPraxisState {
+    return {
+      praxis: { id: 1, type: "solo", members: [] },
+      title,
+      submitting: false,
+      switchingMode: null,
+      isPublished: false,
+      currentCharacterId: 1,
+      publish: async () => {},
+      pullBack: async () => {},
+    } as unknown as EditPraxisState;
+  }
+
+  it("disables the cast while the title box is empty", () => {
+    expect(tag(renderButton(untitledSolo("")))).toContain("disabled");
+  });
+
+  it("counts whitespace as empty — the same trim the server refuses on", () => {
+    expect(tag(renderButton(untitledSolo("   ")))).toContain("disabled");
+  });
+
+  it("comes back to life the moment a title is typed", () => {
+    expect(tag(renderButton(untitledSolo("I caught the papers")))).not.toContain(
+      "disabled",
+    );
+  });
+
+  // The whole point of the ruling: the sheet is never reachable from a state
+  // that would have to be refused, so `publish()`'s dismiss-then-validate
+  // ordering (#718) is left exactly as it was.
+  it("keeps the duel seal sheet unreachable from an untitled composer", () => {
+    const requestDuelSeal = vi.fn();
+    const state = duelState("active", {
+      isPublished: false,
+      title: "",
+      requestDuelSeal,
+    });
+    expectComposerMounts(state);
+    expect(tag(renderButton(state))).toContain("disabled");
+    expect(requestDuelSeal).not.toHaveBeenCalled();
+  });
+
+  it("lets the opponent seal once they have named their side", () => {
+    const state = duelState("active", {
+      isPublished: false,
+      title: "My answer",
+    });
+    expect(tag(renderButton(state))).not.toContain("disabled");
+  });
+
+  // The one branch of this button that does not publish. A moderator failed the
+  // entry and this is the author's way back into the text — gating it on a title
+  // would strand them (#1177).
+  it("leaves the duel pull-back live whatever the title says", () => {
+    const state = duelState("active", {
+      moderationStatus: "failed",
+      title: "",
+    });
+    expectComposerMounts(state);
+    expect(tag(renderButton(state))).not.toContain("disabled");
+  });
+
+  it("wears the house disabled dress and adds no second dimming (#2486/#2573)", () => {
+    const el = renderButton(untitledSolo(""));
+    expect(tag(el)).toContain("control-off");
+    expect(renderToStaticMarkup(el), "no opacity anywhere").not.toMatch(
+      /opacity/,
+    );
+  });
+
+  // A dead control with no explanation is worse than the silent failure it
+  // replaces — and for a duel or a collab this is the entry state, so it is the
+  // first thing the player meets.
+  it("says why, in a live region the button points at", () => {
+    const markup = renderToStaticMarkup(renderButton(untitledSolo("")));
+    const describedBy = /aria-describedby="([^"]+)"/.exec(markup)?.[1];
+    expect(describedBy, "the button names its description").toBeTruthy();
+    expect(markup).toContain(`id="${describedBy}"`);
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain(
+      i18n.t("forms:editPraxis.composer.publishNeedsTitle"),
+    );
+    // And the reason points at the field, by the name the field wears.
+    expect(markup).toMatch(/[Tt]itle/);
+  });
+
+  it("draws no notice, and no description, once there is a title", () => {
+    const markup = renderToStaticMarkup(
+      renderButton(duelState("active", { isPublished: false })),
+    );
+    expect(markup).not.toContain("aria-describedby");
+    expect(markup).not.toContain('role="status"');
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx
@@ -27,7 +27,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
-import "../../../../i18n";
+import i18n from "../../../../i18n";
 import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
 import type { TaskOut } from "../../../../api/tasks";
 import type { EditPraxisState } from "../../useEditPraxis";
@@ -99,6 +99,8 @@ interface Scenario {
   iApproved?: boolean;
   /** I have ticked "my part is finished". */
   iAmDone?: boolean;
+  /** The composer's title box. Empty is the entry state a signup mints (#2484). */
+  title?: string;
   markDone?: (isDone: boolean) => Promise<void>;
   propose?: () => Promise<void>;
   publish?: () => Promise<void>;
@@ -149,7 +151,7 @@ function state(scenario: Scenario = {}): EditPraxisState {
     task: task(slug),
     error: "",
     setError: () => {},
-    title: praxis.title,
+    title: scenario.title ?? praxis.title,
     setTitle: () => {},
     body: "## What I did\n\nCaught the papers.",
     setBody: () => {},
@@ -378,5 +380,73 @@ describe("what each signal does", () => {
     expect(labels).not.toContain(collabCopy(null, "approveFinalAction"));
     expect(labels).toContain(collabCopy(null, "withdrawAction"));
     expect(labels).toContain(collabCopy(null, "doneAction"));
+  });
+});
+
+/**
+ * The title precondition, on the one signal of the three that publishes (#2484).
+ *
+ * This is where "hidden, never disabled" bends, and deliberately. That rule is
+ * about Propose / Approve / Withdraw being mutually exclusive *by construction*
+ * — a window is open or it is not — and not about preconditions. Hiding is not
+ * available here anyway: a collab composer with no primary at all is worse than
+ * the dead end this replaces, and a crew signup is exactly where an untitled
+ * praxis comes from (`handleSignup` posts a task id and a type, nothing else).
+ */
+describe("the crew's primary waits for a title (#2484)", () => {
+  function signal(scenario: Scenario, words: string): TestButton {
+    const button = signals(scenario).find((child) => label(child) === words);
+    expect(button, `a button labelled "${words}" renders`).toBeTruthy();
+    return button!;
+  }
+
+  it("disables Propose while the write-up is unnamed", () => {
+    const button = signal({ title: "" }, collabCopy(null, "proposeAction"));
+    expect(button.props.disabled).toBe(true);
+    expect(button.props.className).toContain("control-off");
+  });
+
+  it("disables Approve too — it is the same endpoint by another name", () => {
+    const button = signal(
+      { title: "  ", proposalLive: true },
+      collabCopy(null, "approveFinalAction"),
+    );
+    expect(button.props.disabled).toBe(true);
+  });
+
+  it("enables it again once the crew names the praxis", () => {
+    const button = signal({}, collabCopy(null, "proposeAction"));
+    expect(button.props.disabled).toBe(false);
+    expect(button.props.className ?? "").not.toContain("control-off");
+  });
+
+  // Neither of the other two publishes, so neither goes dead. Done is a social
+  // toggle; Withdraw takes a proposal back.
+  it("leaves Done live on an untitled draft", () => {
+    expect(signal({ title: "" }, collabCopy(null, "doneAction")).props.disabled).toBe(
+      false,
+    );
+  });
+
+  it("leaves Withdraw live on an untitled draft", () => {
+    const button = signal(
+      { title: "", proposalLive: true },
+      collabCopy(null, "withdrawAction"),
+    );
+    expect(button.props.disabled).toBe(false);
+  });
+
+  it("says why, beside the control it disables", () => {
+    const markup = renderSkin({ title: "" });
+    expect(markup).toContain(
+      i18n.t("forms:editPraxis.composer.publishNeedsTitle"),
+    );
+    expect(markup).toContain('role="status"');
+  });
+
+  it("says nothing at all once there is a title", () => {
+    expect(renderSkin({})).not.toContain(
+      i18n.t("forms:editPraxis.composer.publishNeedsTitle"),
+    );
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -1587,6 +1587,85 @@ export function ModePicker<O extends { key: PraxisType }>({
 }
 
 /* -------------------------------------------------------------------------- */
+/* The title precondition, shared by the composer's two primaries (#2484).      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A praxis cannot be published without a title, and the composer only ever said
+ * so after the fact. `publish()` dismisses the seal dialog on its first line and
+ * refuses on its second (#718), so the refusal rendered in `ErrorBanner` at the
+ * foot of a long sheet — announced, but off-screen from where the player just
+ * pressed. Owner ruling on #2484: remove the dead end rather than report it
+ * better. The primary is dead while there is nothing to publish, so the seal
+ * sheet is never reachable in a state that must be refused.
+ *
+ * The hook is deliberately untouched. `setDuelSealOpen(false)`-then-validate
+ * stays exactly as #718 wrote it — its reasoning is not reversed, the branch it
+ * was written for simply stops being reachable — and the server's own
+ * `title.trim()` refusal stays too. This is an affordance, not a validation
+ * move, and it is derived here rather than added to `EditPraxisState` because
+ * `state.title` is already on it and nothing else needs to know.
+ *
+ * Untitled is the NORMAL entry state, not a slip: `handleSignup` posts a task id
+ * and a type, and `accept_duel` mints the opponent's side with no title at all.
+ * So for a duel or a collab this is a required step added to the main path,
+ * which is why the reason is drawn (below) rather than implied — a dead control
+ * with no explanation is worse than the silent failure it replaces.
+ */
+function publishNeedsTitle(state: EditPraxisState): boolean {
+  return !state.title.trim();
+}
+
+/**
+ * A fixed id, not `useId`. Both primaries are invoked as plain functions by
+ * their tests — the harness has no DOM and runs no effects — so neither may take
+ * a hook. One id is enough for the same reason one `data-testid` is: exactly one
+ * composer primary is on screen at a time.
+ */
+const PUBLISH_NEEDS_TITLE_ID = "composer-publish-needs-title";
+
+/**
+ * The reason, drawn beside the control it disables and pointed at from it.
+ *
+ * `role="status"` because the line appears and disappears as the title box is
+ * filled and cleared, and a disabled button is out of the tab order — so
+ * `aria-describedby` alone would reach only a reader browsing the page, never
+ * one tabbing through it.
+ *
+ * `width: 100%` gives it its own line in the footer's wrapping row and in
+ * `CollabSignals`' signal row, and costs nothing in the column seven skins lay
+ * their band out in. Same move `HoldoutPublishNotice` makes with `flex 1 1 100%`.
+ * The ink is `label-caption`'s and only the class's (#1819): an inline `color`
+ * beats `--label-ink`, and three of the nine sheets are near-black.
+ */
+function PublishNeedsTitleNotice() {
+  return (
+    <p
+      id={PUBLISH_NEEDS_TITLE_ID}
+      role="status"
+      className="label-caption"
+      style={{ width: "100%", margin: 0 }}
+    >
+      {i18n.t("forms:editPraxis.composer.publishNeedsTitle")}
+    </p>
+  );
+}
+
+/**
+ * The house disabled dress (#2486/#2573), reached by adding the class and
+ * nothing else — no opacity, no second token family.
+ *
+ * Only while the TITLE gate is what holds the control. The busy and
+ * mode-switching disables predate this and dress themselves (several skins set
+ * `cursor: wait` on the submitting button); folding them in would repaint a
+ * state this issue was not asked about.
+ */
+function offClassName(skinClassName: string | undefined, off: boolean): string | undefined {
+  if (!off) return skinClassName;
+  return skinClassName ? `${skinClassName} control-off` : "control-off";
+}
+
+/* -------------------------------------------------------------------------- */
 /* PublishButton — renders nothing once published (with one duel exception,     */
 /* below) and is disabled while saving / submitting / switching mode. The       */
 /* archetype arranges it inside its bespoke file bar and supplies faction-voiced */
@@ -1687,7 +1766,15 @@ export function PublishButton({
     : sealsADuel
       ? async () => state.requestDuelSeal()
       : state.publish;
-  return (
+  // Every branch of this button but ONE publishes: the solo cast calls
+  // `publish()` outright, and the duel's `requestDuelSeal()` opens the sheet
+  // whose confirm is that same `publish()` — so the gate belongs on both, or the
+  // seal sheet stays reachable from an untitled composer. `duelPullBack` is the
+  // exception and stays live: reopening a side that is already cast has nothing
+  // to do with the title, and it is the moderated composer's only way back into
+  // the text a moderator just asked the author to fix (#1177).
+  const needsTitle = !duelPullBack && publishNeedsTitle(state);
+  const button = (
     <button
       type="button"
       // The composer's one primary action, whatever it currently says (#2453).
@@ -1696,15 +1783,28 @@ export function PublishButton({
       // spec presses the SLOT. `CollabSignals` carries the same id for the same
       // reason; between them exactly one is on screen at a time.
       data-testid="composer-primary"
+      // The notice below is this control's description while there is one, so
+      // the reason is reachable without hunting the sheet for a caption.
+      aria-describedby={needsTitle ? PUBLISH_NEEDS_TITLE_ID : undefined}
       onClick={() => void onClick()}
-      disabled={state.submitting || state.switchingMode !== null}
-      className={skin.className}
+      disabled={needsTitle || state.submitting || state.switchingMode !== null}
+      className={offClassName(skin.className, needsTitle)}
       style={skin.style}
     >
       {skin.ornament}
       {state.submitting ? skin.busyLabel : idleLabel}
       {skin.trailingOrnament}
     </button>
+  );
+  // The bare button when there is nothing to explain, so a titled composer's
+  // footer is byte-identical to what every archetype already lays out (and the
+  // hookless test seam keeps reading `onClick` straight off the return).
+  if (!needsTitle) return button;
+  return (
+    <>
+      <PublishNeedsTitleNotice />
+      {button}
+    </>
   );
 }
 
@@ -1778,6 +1878,12 @@ export function CollabSignals({
   const primaryLabel = proposalLive
     ? collabCopy(slug, finalApproval ? "approveFinalAction" : "approveAction")
     : collabCopy(slug, "proposeAction");
+  // The publishing one of the three, and only that one (#2484). Propose asks
+  // first and then calls `publish()`; Approve calls it outright — one endpoint
+  // the server tells apart by state — so both need a title to send. **Done** is
+  // a social toggle and **Withdraw proposal** takes one back; neither publishes,
+  // and neither goes dead because the write-up has not been named yet.
+  const needsTitle = publishNeedsTitle(state);
   return (
     <div className="flex flex-wrap items-center gap-2">
       <button
@@ -1800,13 +1906,21 @@ export function CollabSignals({
           // only by wording, and wording is what the nightly must stop reading.
           data-testid="composer-primary"
           data-collab-signal={proposalLive ? "approve" : "propose"}
-          title={collabCopy(
-            slug,
-            proposalLive ? "approveDescription" : "proposeDescription",
-          )}
+          // What pressing it would do, until there is a reason it cannot be
+          // pressed — a description of a live act on a dead control is worse
+          // than none.
+          title={
+            needsTitle
+              ? i18n.t("forms:editPraxis.composer.publishNeedsTitle")
+              : collabCopy(
+                  slug,
+                  proposalLive ? "approveDescription" : "proposeDescription",
+                )
+          }
+          aria-describedby={needsTitle ? PUBLISH_NEEDS_TITLE_ID : undefined}
           onClick={() => void (proposalLive ? state.publish() : state.propose())}
-          disabled={busy}
-          className={skin.className}
+          disabled={needsTitle || busy}
+          className={offClassName(skin.className, needsTitle)}
           style={skin.style}
         >
           {skin.ornament}
@@ -1826,6 +1940,10 @@ export function CollabSignals({
           {collabCopy(slug, "withdrawAction")}
         </button>
       )}
+      {/* Under the row rather than over it: two of these three signals are still
+          live, so the line explains the one that is not instead of heading the
+          group. It only exists while the button it describes does. */}
+      {needsTitle && (!proposalLive || !gate.iCast) && <PublishNeedsTitleNotice />}
     </div>
   );
 }

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -1667,7 +1667,8 @@ function offClassName(skinClassName: string | undefined, off: boolean): string |
 
 /* -------------------------------------------------------------------------- */
 /* PublishButton — renders nothing once published (with one duel exception,     */
-/* below) and is disabled while saving / submitting / switching mode. The       */
+/* below) and is disabled while saving / submitting / switching mode, and while  */
+/* the praxis has no title (#2484 — see `publishNeedsTitle` above). The          */
 /* archetype arranges it inside its bespoke file bar and supplies faction-voiced */
 /* labels via skin. (The old Save Draft button was removed in #297 — autosave    */
 /* persists title/body and media uploads on pick, so no manual draft-save        */
@@ -1846,9 +1847,19 @@ const SECONDARY_SIGNAL_STYLE: CSSProperties = {
  *  - **Withdraw proposal** — for the member who has read the draft and has no
  *    edit to make. Any member, not just the proposer (ADR-0013).
  *
- * **Hidden, never disabled.** Propose and Approve are mutually exclusive by
- * construction — a window is open or it is not — and Withdraw has nothing to
- * withdraw while the crew is drafting.
+ * **Hidden, never disabled — for MUTUAL EXCLUSION.** Propose and Approve cannot
+ * both apply — a window is open or it is not — and Withdraw has nothing to
+ * withdraw while the crew is drafting. A signal that does not apply is not
+ * drawn, and that is what this rule is about.
+ *
+ * A PRECONDITION is the other thing, and #2484 rules it disabled: Propose and
+ * Approve are dead until the praxis has a title. Hiding was not available —
+ * untitled is the state a crew signup mints, so hiding would leave the ordinary
+ * collab composer with no primary action at all, which is worse than the dead
+ * end it replaces. The reason is drawn beside the control (see
+ * `publishNeedsTitle`), which is what makes a disabled control honest. This is a
+ * deliberate exception to `frontend/CLAUDE.md`'s "hide unusable controls", not a
+ * drift back from it — do not "fix" it in a sweep.
  *
  * The WORDS are shared across all nine factions (ADR-0079's exception to
  * ADR-0065): they are a mechanical fact a player must read correctly in order

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
The composer's primary is dead until the praxis has a title, and says so.

Closes #2484

## The ruling this builds

Option **(c)** from the owner's 2026-08-23 comment, not the issue body's (a)/(b):
**remove the dead end rather than report it better.** The publish control is
disabled while the title is empty, so the seal sheet is never reachable in a
state that must be refused.

What is deliberately **not** touched:

- `useEditPraxis.ts` — **zero lines changed.** `setDuelSealOpen(false)`-then-validate
  stays exactly as #718 wrote it. #718's reasoning is not reversed; the branch it
  was written for simply stops being reachable.
- The server's `title.trim()` refusal. This is a UI affordance, not a validation
  move.
- No `publishBlockedReason` flag on the hook. `state.title` is already on
  `EditPraxisState`, so the predicate is derived where it is drawn.

## The seam

`PublishButton({ state, skin })` and `CollabSignals({ state, skin })` in
`frontend/src/pages/editPraxis/archetypes/controls.tsx`, invoked as plain
functions. Both are hookless on purpose (the harness has no DOM), and the new
cases read `disabled` / `className` / `aria-describedby` straight off the
returned element. It cannot go in `useEditPraxis.test.ts` — that file is
pure-function only, and the hook is unchanged here anyway.

The loop went red first: with the pre-fix `controls.tsx` in place, 5 of the new
`PublishButton` cases and 3 of the new `CollabSignals` cases fail; with the fix,
all pass.

## What changed

All nine archetypes route their primary through these two components — one choke
point, no bypass, Albescent is a six-line wrapper — so this is one edit for nine
surfaces.

**Gated (they publish):**
- `PublishButton`'s solo cast (`publish()`) **and** its duel branch
  (`requestDuelSeal()`, whose confirm is that same `publish()`).
- `CollabSignals`' Propose / Approve. Propose is `publish()` behind a confirm;
  Approve is `publish()` outright — one endpoint the server tells apart by state.

**Left live (they do not publish):**
- `duelPullBack` — reopening an already-cast side has nothing to do with the
  title, and on the moderated composer it is the author's only way back into the
  text (#1177).
- `markDone` — a social toggle.
- `pullBack` / Withdraw proposal — takes a proposal back.

Each of those branches was re-derived against the current file, not the issue's
line numbers.

**The disabled dress** is `#2573`'s, consumed and not restated: the class
`control-off` is added and nothing else — no opacity, no new tokens, no values
copied out of `index.css`. A test asserts the rendered markup contains no
`opacity` at all. The one exception is `SingularityEditPraxis.tsx`, which now
passes `className: "sg-control-off"` — the token override #2573 minted for
exactly this theme-invariant black chassis, so the house warm-neutral does not
lay a pale slab on the terminal. It declares two custom properties and is inert
while the band is live.

**The disabled state says why.** New shared catalog key
`forms:editPraxis.composer.publishNeedsTitle` — "Add a title before you submit —
the Title box is at the top of this sheet." It is drawn as a `role="status"`
line beside the control and pointed at by the button's `aria-describedby`
(the same shape #2566 landed for the unavailable write-up box hours ago), and it
replaces the Propose/Approve button's `title` tooltip while the gate holds.
`errors.titleRequired` ("Title is required.") is untouched: that is a *refusal*,
this is a *precondition*, and they are different sentences.

When there **is** a title, `PublishButton` returns the bare `<button>` exactly as
before — a titled composer's footer markup is byte-identical to `main`.

## The house-convention tension, on the record

`frontend/CLAUDE.md:8` says "hide unusable controls; don't show them disabled",
and `CollabSignals`' own docblock said "**Hidden, never disabled.**" Read in
context, that rule is about Propose/Approve/Withdraw being **mutually exclusive
by construction** — a signal that does not apply is not drawn. A **precondition**
is a different thing, and hiding is not available for it: untitled is the state a
crew signup and a duel accept both *mint*, so hiding would leave the ordinary
collab composer with no primary action at all — worse than the dead end being
replaced. The docblock now names both halves explicitly so a later census does
not sweep it back.

## The duel path, checked as asked

`accept_duel` (`backend/services/duel.py:438`) mints the opponent's praxis with
`body_text=""` and no title, so an opponent who accepts now lands on a composer
whose Seal band is dead until they name their side. **This reads as intentional,
not as a broken accept:** the title field is already `required` and already
labelled "Title (required)", the write-up is empty too so nothing was
submittable anyway, and the line by the band is phrased as a next step rather
than a rejection. Before this change the same press produced *nothing* — the
sheet closed and the refusal rendered off-screen at the foot of the sheet — so
the affordance can only read better. If the eyeball pass disagrees, the copy is
one catalog value.

## Tests / verification

- `tsc --noEmit` clean; `typecheck:design-sync` clean; `npm run lint` clean.
- `npm test` — **416 files, 7466 passed, 1 skipped**.
- `npm run build` clean. `npm run budget`: JS ok, CSS `WARN` at 22.3 KB against a
  22.2 KB warn line — **pre-existing on `main`, this PR touches no CSS at all**
  (see the diffstat) and the step is non-blocking.
- Backend untouched, so `test` and `api-schema` are unaffected.
- Existing fixtures in both test files gained a `title` — they were building
  states with no title at all, which is now a meaningful state rather than an
  omission.
- The two lifecycle e2e specs still type a title first (#2453). **Left in
  deliberately** — they are correct either way, and Playwright's `click()`
  auto-waits for an enabled control, so the gate makes them more robust rather
  than less.

**Visual QA is outstanding** — no browser tools and no dev stack in this
worktree.

## What to eyeball

**Duel accept** (`accept_duel` mints an untitled opponent praxis):
1. Accept a challenge, land on the composer, and confirm the Seal/Submit band is
   visibly *off* rather than merely un-pressable — light **and** dark.
2. Read the line under/over it and judge whether it reads as "here's your next
   step" or as "the accept broke".
3. Type one character in the Title box and confirm the band comes back to life
   and the line disappears.
4. On a **Singularity** duel specifically: the band should take the terminal's
   own panel + dim ink (`sg-control-off`), not the warm house neutral. It is the
   one skin that re-points the pair.
5. On **Ephemerists** and **S.N.I.D.E.** — the other two near-black composer
   sheets — the house neutral is legible by construction (6.31:1 / 6.49:1 on its
   own opaque fill) but may read *loud* against those sheets. If it does, that is
   a `frontend-style` call, not a contrast bug.

**Collab propose** (`handleSignup` posts a task id and a type, nothing else):
6. Sign up for a task as a collab, invite a second member, and confirm **Propose**
   is off while **Done** stays live — light and dark.
7. Confirm the explainer takes its own line under the signal row rather than
   squeezing the three buttons, at desktop and phone widths.
8. With a proposal live: **Approve** off, **Withdraw proposal** and **Done** live.
9. Type a title and confirm all three read as a normal row again.

**Both:** confirm the seal sheet cannot be opened at all from an untitled duel
composer (the old path opened it, closed it, and refused invisibly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
