### PR TITLE
The mobile factions directory centres its tiles (#2579)

### DIFF
--- a/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
+++ b/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
@@ -307,3 +307,26 @@ describe('desktop factions grid — no invitation panel (#2310)', () => {
     expect(without).toBe(withLetters)
   })
 })
+
+describe('mobile factions directory — the tile column centres its tiles (#2579)', () => {
+  /**
+   * `FactionSelectCard`'s contract is a FLUID box: `width: 100%` up to a 360px
+   * max. A flex item with a declared cross size is not stretched, so a column
+   * with the default `align-items: stretch` places each tile at cross-START —
+   * the left edge — and every pixel past 360 opens as dead space on the right.
+   * Below 360 the tile fills the screen and nothing looks wrong, which is why
+   * this read as a tablet bug rather than a phone one.
+   *
+   * Pinned as the declaration rather than a measured box because the harness is
+   * node + renderToStaticMarkup with no layout engine: there is no geometry to
+   * measure here, only the rule that produces it.
+   */
+  it('centres the column so a tile narrower than the viewport is not left-stranded', () => {
+    const { html } = view()
+    const start = html.indexOf('data-testid="faction-tile-column"')
+    expect(start, 'tile column rendered').toBeGreaterThan(-1)
+    const openTag = html.slice(html.lastIndexOf('<', start), html.indexOf('>', start) + 1)
+    expect(openTag, 'column axis').toContain('flex-direction:column')
+    expect(openTag, 'tiles centred on the cross axis').toContain('align-items:center')
+  })
+})

--- a/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
@@ -163,7 +163,18 @@ export default function FactionsDirectoryView({
       ) : error ? (
         <p className="font-body content-text danger-text border-2 danger-edge px-3 py-2">{error}</p>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2xl)' }}>
+        <div
+          data-testid="faction-tile-column"
+          /* `alignItems` centres the tiles. Without it the column takes the
+             default `stretch`, which does NOT apply to a child that declares its
+             own cross size — `FactionSelectCard` is `width: 100%` up to a 360px
+             max — so every tile sat at cross-start and left the space past 360
+             empty on the right (#2579). Below 360 the tile fills the screen and
+             nothing looked wrong, which is why this read as a tablet bug.
+             `pages/Factions.tsx`'s wrapping row is deliberately left alone: its
+             `alignItems: 'flex-start'` is the cross axis of a ROW and is correct. */
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 'var(--space-2xl)' }}
+        >
           {visible.map((f) => (
             <FactionSelectCard
               key={f.slug}


### PR DESCRIPTION
The mobile factions directory stranded every tile at the left edge, leaving the
right half of the screen empty.

Closes #2579

## Seam

`FactionsDirectoryView` — the pure mobile skin — asserted through
`renderToStaticMarkup`, which is the seam the existing
`factionsDirectory.test.tsx` already tests at.

## Cause

The tile column took the default `align-items: stretch`. Stretch does **not**
apply to a flex child that declares its own cross size, and
`FactionSelectCard`'s contract is a fluid box: `width: 100%` up to a 360px max.
So each tile capped itself and then sat at cross-start — the left edge. Below
360px of available width the tile fills the screen and nothing looks wrong,
which is why this read as a tablet/large-phone bug rather than a phone one.

## Fix

One property: `alignItems: 'center'`. Precedent for centring this exact
component is already in the tree (`DefaultCreateCharacter` wraps its select card
in a centring flex).

## Deliberately NOT changed

`pages/Factions.tsx`, the desktop wrapping grid. Its `alignItems: 'flex-start'`
is the cross axis of a **row** — it tops the tiles, which is correct and is not
the same property. A narrow desktop window that fits exactly one 360px column
strands its tiles the same way, but centring a wrapping grid changes the wide
case too: a last row of two under a row of four would centre rather than align
with the column above, which is a different and worse layout. If that case is
worth fixing it wants a width-conditional rule, and that is its own issue.

Recorded here so a later audit reads it as a decision rather than a miss.

## The check

The guard pins the **declaration**, not a measured box. The harness is node +
`renderToStaticMarkup` with no layout engine, so there is no geometry to measure
here — only the rule that produces it. It went red on the real defect first
(`expected '<div data-testid="faction-tile-column…' to contain
'align-items:center'`) before the property was added.

`data-testid="faction-tile-column"` follows the file's own precedent
(`faction-stripe-bar` exists for the same reason).

I did not write a test asserting `pages/Factions.tsx` is unchanged — the diff
proves that, and a test for it would be a test of git.

## Verification

- `vitest src/pages/factions/__tests__/factionsDirectory.test.tsx` — 13/13 pass
- **Visual QA is outstanding.** I have no browser on this change.

## What to eyeball

- The **mobile factions directory** at a width comfortably above 360px — a
  tablet, or a phone in landscape. Tiles should sit centred with even margins
  either side, where before they hugged the left.
- The same page **below 360px** (e.g. 375px phone portrait is above it; try 320):
  tiles should still fill the width edge to edge, unchanged.
- The **desktop factions grid** — should be completely unchanged, tiles
  top-aligned and starting at the left of the row.
