### PR TITLE
Albescent's task-detail light traces the sheet, not the page band (#2549)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6806,11 +6806,19 @@
 .alb-detail-foil,
 .alb-detail-edge {
   position: absolute;
-  /* Default's own py-8 band — the sheet starts here and ends there. */
-  top: var(--space-2xl);
-  right: 0;
-  bottom: var(--space-2xl);
-  left: 0;
+  /* Mounted INSIDE the sheet through `DefaultTaskDetail`'s `sheetOverlay`
+     (#2549), so the containing block IS the box these trace and the inset is
+     zero rather than a guess at where the page band begins. It was
+     `--space-2xl` top and bottom, which held only while the sheet's top edge
+     and `.py-8`'s padding were the same line; #2102 put the shared Breadcrumb
+     between them and the ring's corner drifted 29px up onto the trail.
+
+     Negative by exactly the sheet's 1px border: an absolutely positioned child
+     is inset from its containing block's PADDING box, and the spectrum edge is
+     meant to land ON Default's hairline so the effect reads as that border
+     coming alive. `inset: 0` would sit it one pixel inside and leave the
+     hairline showing through. */
+  inset: -1px;
   z-index: 2;
   pointer-events: none;
   border-radius: 18px;

--- a/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
@@ -319,3 +319,43 @@ describe("the drift stops at user media on this page too (#1942)", () => {
     expect(html).toContain("alb-detail-foil");
   });
 });
+
+describe("Albescent task detail — the overlay traces the sheet (#2549)", () => {
+  /**
+   * The two light layers used to be siblings of `DefaultTaskDetail`, positioned
+   * off `.alb-detail` and inset by `--space-2xl` top and bottom on the stated
+   * assumption that the inset "lands exactly on `DefaultTaskDetail`'s sheet,
+   * whose own `py-8` band that is". #2102 broke that by inserting the shared
+   * `Breadcrumb` INSIDE the band, above the sheet: the bottoms still agreed
+   * exactly, but the top floated free by the breadcrumb's own box, so the ring's
+   * rounded corner landed across the trail.
+   *
+   * The fix is structural rather than arithmetic — the layers are now the
+   * sheet's own first children, so `inset` is measured from the very box they
+   * are supposed to trace and cannot drift again when something else is added
+   * to that band. A guard on the pixel count would have passed just as happily
+   * with a magic offset.
+   *
+   * Read as ORDER, which is what makes it a containment claim: the layers must
+   * now precede the sheet's content. As siblings mounted after the whole column
+   * they came after all of it, so this assertion is the one that separates the
+   * two arrangements.
+   */
+  it("mounts both light layers as the sheet's first children, before its content", () => {
+    const { html } = render(<AlbescentTaskDetail state={baseState()} />);
+    const sheetOpen = html.indexOf('class="task-detail-sheet"');
+    expect(sheetOpen, "the shared sheet rendered").toBeGreaterThan(-1);
+
+    // Content the sheet certainly holds, drawn after the overlay slot. The
+    // brief, not the title: `Breadcrumb` prints the title too, and it sits
+    // ABOVE the sheet, so the title's first occurrence is outside it.
+    const content = html.indexOf(BRIEF);
+    expect(content, "the sheet's content rendered").toBeGreaterThan(sheetOpen);
+
+    for (const layer of ["alb-detail-foil", "alb-detail-edge"]) {
+      const at = html.indexOf(layer);
+      expect(at, `${layer} rendered`).toBeGreaterThan(sheetOpen);
+      expect(at, `${layer} precedes the sheet content`).toBeLessThan(content);
+    }
+  });
+});

--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -167,11 +167,27 @@ export default function AlbescentTaskDetail({
     </div>
   );
 
-  return (
-    <div className="alb-detail alb-moves alb-prism">
-      <DefaultTaskDetail state={state} worthSlot={worth} />
+  /* THE LIGHT GOES INSIDE THE SHEET (#2549). These two were siblings of
+     `DefaultTaskDetail`, positioned off `.alb-detail` and inset by
+     `--space-2xl` top and bottom because that inset used to land on the sheet:
+     the band's padding and the sheet's top edge were the same line. #2102 put
+     the shared `Breadcrumb` in that band, above the sheet, and the two lines
+     parted — the bottoms still agreed exactly, the top floated free by the
+     breadcrumb's own box, and the ring's rounded corner crossed the trail.
+
+     Passing them through `sheetOverlay` makes the sheet their containing block,
+     so they trace the box they dress instead of a band that happens to start
+     where it used to. Nothing here needs to know the breadcrumb exists. */
+  const light = (
+    <>
       <span aria-hidden="true" className="alb-detail-foil" />
       <span aria-hidden="true" className="alb-detail-edge" />
+    </>
+  );
+
+  return (
+    <div className="alb-detail alb-moves alb-prism">
+      <DefaultTaskDetail state={state} worthSlot={worth} sheetOverlay={light} />
     </div>
   );
 }

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -93,14 +93,36 @@ function initialsOf(name: string): string {
  * so the two readouts can never disagree about what a task is worth. Absent, na
  * renders exactly as before; that is why it is optional and why the default
  * {@link scoreBody} stays the only implementation in this file.
+ *
+ * ### `sheetOverlay` — ornament that has to trace the SHEET (#2549)
+ *
+ * The second seam, and it exists for a positioning reason rather than an
+ * arrangement one. A wrapper can only mount its layers as siblings of this
+ * whole component, which puts them in `.py-8`'s box — and that box holds the
+ * shared `Breadcrumb` (#2102) as well as the sheet. Albescent's spectrum ring
+ * was inset by `--space-2xl` on the assumption that the page band and the sheet
+ * began at the same line; once the breadcrumb went in above the sheet they no
+ * longer did, and the ring's top corner landed across the trail.
+ *
+ * So a layer that must trace the sheet has to be a CHILD of the sheet, and only
+ * this file can put it there. Rendered first, before any content: the layers are
+ * absolutely positioned and carry their own `z-index`, so document order among
+ * them does not decide what paints over what — being first simply keeps them out
+ * of the content flow and makes the containment assertable.
+ *
+ * Ornament only. Nothing in this slot may take focus or carry copy; the caller
+ * marks it `aria-hidden`.
  */
 export default function DefaultTaskDetail({
   state,
   worthSlot,
+  sheetOverlay,
 }: {
   state: TaskDetailState;
   /** Replaces the base/`×mult`/total readout with the caller's arrangement. */
   worthSlot?: ReactNode;
+  /** Absolutely-positioned ornament mounted INSIDE the sheet, so it traces it. */
+  sheetOverlay?: ReactNode;
 }) {
   const { t } = useTranslation("tasks");
   const desktop = useFormFactor() !== "mobile";
@@ -852,6 +874,10 @@ export default function DefaultTaskDetail({
           boxSizing: "border-box",
         }}
       >
+        {/* Ornament that has to trace THIS box — see `sheetOverlay` in the
+            docstring. First child, and inert for every skin that passes none. */}
+        {sheetOverlay}
+
         <div
           style={{
             display: "flex",


### PR DESCRIPTION
Albescent's task-detail spectrum ring started 29px above the sheet it traces, so
its rounded top corner landed across the breadcrumb and the trail read as half
inside, half outside the component.

Closes #2549

## Seam

`AlbescentTaskDetail` rendered through `renderToStaticMarkup`, asserted as
document order — the arrangement, not a measured box. The harness is node with
no layout engine, and this repo's browser pane does not composite, so there is
no geometry to measure here; the thing worth pinning is which box the layers
hang off.

## Cause

The two light layers were siblings of `DefaultTaskDetail`, positioned off
`.alb-detail` and inset `top/bottom: var(--space-2xl)`. The block's own docstring
stated the assumption plainly — every layer is inset by `--space-2xl` "to land
exactly on `DefaultTaskDetail`'s sheet, whose own `py-8` band that is."

That held while `.py-8`'s padding edge and the sheet's top edge were the same
line. **#2102 inserted the shared `Breadcrumb` into that band, above the sheet**,
and they parted. The bottoms still agreed exactly — which is the tell that only
one edge was ever wrong.

## Fix — structural, not arithmetic

`DefaultTaskDetail` gains a second slot beside `worthSlot`: **`sheetOverlay`**,
rendered as the sheet's first child. A wrapper can only mount its own layers as
siblings of the whole component, which puts them in the band; only this file can
put something inside the sheet. Albescent now passes its two spans through it, so
their containing block **is** the box they trace.

I deliberately did not compute an offset. A `calc(var(--space-2xl) + …)` would
have matched the screenshot in the issue and drifted again the next time anything
joined that band — which is exactly how this bug was produced.

`inset: -1px` rather than `0`: an absolutely positioned child is inset from its
containing block's **padding** box, and the spectrum edge is meant to land *on*
Default's 1px hairline so the effect reads as that border coming alive. `inset: 0`
would sit it one pixel inside and leave the hairline showing through. The old
arrangement traced the border box (measured bottoms were equal), so this
preserves the look rather than changing it.

## Stacking is unchanged — checked, not assumed

`.alb-detail .task-detail-sheet` is `z-index: auto`, so the sheet is **not** a
stacking context under Albescent. The layers keep `z-index: 2` and still
participate in `.alb-detail`'s context, below the media lift #1942 put above
them. `albescentDriftStopsAtMedia.test.tsx` reads the CSS text and still passes.

## The related pseudo-elements

Checked, as the issue asked: `.alb-detail-foil::before`, its `[data-theme="dark"]`
variant, and `.alb-detail-ring` are all positioned relative to their own element,
not to the page band — none of them inherited the bad assumption, so none needed
changing. `.alb-detail-foil::after` was already retired in #2499.

## Verification

- `albescentDetail.test.tsx` — 13/13; the new guard went red first on the real
  arrangement (`expected 7446 to be less than 2589`)
- `src/pages/taskDetail`, `src/__tests__`, `albescentDriftStopsAtMedia` —
  **686 pass / 48 files**
- `npm run typecheck` and `npm run typecheck:design-sync` — both clean (a shared
  component's props changed, so the preview kit matters here)
- **Visual QA is outstanding.** No browser on this change.

## What to eyeball

- **An Albescent task detail page, both themes.** The spectrum ring and prism
  wheel should start exactly at the sheet's top edge, sitting on the hairline —
  no corner crossing the breadcrumb above it.
- The **bottom** edge, which was already correct: it must not have moved.
- **Mobile** width too — the sheet's padding differs there (`--space-lg` vs
  `--space-2xl`), and the overlay now sits inside that box.
- Any **na / unaffiliated** task detail page, as a no-op check: `sheetOverlay` is
  absent for all eight other skins, so those pages must be byte-identical.
