### PR TITLE
The mobile FieldDesk is headed by the carried life, not by its own name (#2580)

### DIFF
--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -382,3 +382,55 @@ describe("the WOW crest carries the mobile home's heading (#1817)", () => {
     expect(heads[0], 'and it names the carried life').toContain('Mollusk')
   })
 })
+
+/**
+ * THE PAGE HEADS ITSELF WITH THE CARRIED LIFE (#2580).
+ *
+ * Every mobile skin opened with an app-bar row nobody needed: a `HOME` kicker
+ * naming the page you were already standing on — the bottom nav already marks
+ * that tab — over a `FieldDesk` title naming it again. The owner asked for both
+ * to go.
+ *
+ * Deleting the title element is not the whole job, and this is the guard that
+ * says so. Each skin had exactly ONE `<h1>` and it was that title, so a plain
+ * deletion would leave seven pages with no level-1 heading at all — which is
+ * precisely the defect #1794 was filed and fixed for on the desktop FieldDesk.
+ * The resolution follows the ruling already in `pages/FieldDesk.tsx`: with the
+ * roster hidden the page is not asking whose shoes, its subject is the life
+ * being carried, so the heading names it. No new string — the name is data
+ * already on the page.
+ *
+ * `WowFieldDesk` is the precedent rather than an exception. Its crest has drawn
+ * the carried life as an unconditional `<h1>` since #1817 and has never had the
+ * eyebrow, so it must pass this unchanged.
+ *
+ * A visually-hidden `<h1>` carrying "FieldDesk" was considered and rejected: it
+ * keeps a dead word alive in the accessibility tree only, which is worse than
+ * naming the subject the page is actually about.
+ */
+describe('mobile FieldDesk home — the carried life is the h1 (#2580)', () => {
+  const HOME_KICKER = 'Home'
+  const PAGE_TITLE = 'FieldDesk'
+
+  for (const [slug, Skin] of Object.entries(archetypes)) {
+    it(`${slug} heads the page with the character, exactly once`, () => {
+      const { html } = render(<Skin state={baseState()} />)
+
+      const h1s = html.match(/<h1[\s>]/g) ?? []
+      expect(h1s.length, `${slug} draws exactly one <h1>`).toBe(1)
+
+      const open = html.indexOf('<h1')
+      const inner = html.slice(open, html.indexOf('</h1>', open))
+      expect(inner, `${slug}'s h1 names the carried life`).toContain(
+        CHARACTER.display_name,
+      )
+      expect(inner, `${slug}'s h1 is not the page's own name`).not.toContain(PAGE_TITLE)
+    })
+
+    it(`${slug} draws neither the kicker nor the page title`, () => {
+      const { text } = render(<Skin state={baseState()} />)
+      expect(text, `${slug} dropped the HOME kicker`).not.toContain(HOME_KICKER)
+      expect(text, `${slug} dropped the FieldDesk title`).not.toContain(PAGE_TITLE)
+    })
+  }
+})

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -196,20 +196,6 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
           positioned, so the content sits above it explicitly (#911). */}
       <div style={{ position: 'relative', zIndex: 1, display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
         <header>
-          <div style={CAPTION}>{t('nav.home')}</div>
-          <h1
-            style={{
-              fontFamily: HAND,
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: hand-lettered Caveat — the desk's own hand, not typeset copy.
-              fontSize: 34,
-              fontWeight: 700,
-              lineHeight: 0.9,
-              color: INK,
-              margin: 'var(--space-xs) 0 0',
-            }}
-          >
-            {t('fieldDesk.home.title')}
-          </h1>
           <Braid style={{ marginTop: 'var(--space-sm)' }} />
         </header>
 
@@ -273,13 +259,23 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
               )}
             </div>
             <div className="min-w-0 flex-1">
-              <Link
-                to={`/characters/${character.id}`}
-                className="block truncate"
-                style={{ fontFamily: HAND, fontSize: 'var(--text-heading)', lineHeight: 0.95, color: INK, textDecoration: 'none' }}
-              >
-                {character.display_name}
-              </Link>
+              {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                  a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                  bottom nav already marks as current. Both are gone, and rather than
+                  leave the page with no level-1 heading (#1794's defect) the heading
+                  names the page's real subject: the life being carried. Same ruling
+                  the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                  data already here. The masthead band itself STAYS -- only the two
+                  text elements went, so every kit keeps its own mark. */}
+              <h1 className="m-0">
+                <Link
+                  to={`/characters/${character.id}`}
+                  className="block truncate"
+                  style={{ fontFamily: HAND, fontSize: 'var(--text-heading)', lineHeight: 0.95, color: INK, textDecoration: 'none' }}
+                >
+                  {character.display_name}
+                </Link>
+              </h1>
               <div className="truncate" style={{ ...CAPTION, marginTop: 'var(--space-xs)' }}>
                 {t('sidebar.characterCard.level', { level: character.level })}
               </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -30,12 +30,6 @@ import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 const ROW_SIGIL = 14
 
 // Static style objects, hoisted to module scope (#586) — no closure deps.
-const pageTitleStyle: CSSProperties = {
-  fontSize: 'var(--text-heading)',
-  lineHeight: 1,
-  color: 'var(--color-text-primary)',
-  margin: 0,
-}
 /**
  * Characters / Edit as real controls (#1553). They were bare ~11px caps with no
  * box — a sub-20px hit target on a phone, which is the accessibility half of
@@ -119,16 +113,6 @@ export default function DefaultFieldDesk({
 
   return (
     <div data-skin="default" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
-      {/* App-bar row: kicker + FieldDesk title */}
-      <header>
-        <div className="label-heading">
-          {t('nav.home')}
-        </div>
-        <h1 className="font-display italic" style={pageTitleStyle}>
-          {t('fieldDesk.home.title')}
-        </h1>
-      </header>
-
       {/* ── Identity block ── */}
       <section
         style={{
@@ -222,13 +206,23 @@ export default function DefaultFieldDesk({
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="font-display italic block truncate content-title"
-              style={{ lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                bottom nav already marks as current. Both are gone, and rather than
+                leave the page with no level-1 heading (#1794's defect) the heading
+                names the page's real subject: the life being carried. Same ruling
+                the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                data already here. The masthead band itself STAYS -- only the two
+                text elements went, so every kit keeps its own mark. */}
+            <h1 className="m-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="font-display italic block truncate content-title"
+                style={{ lineHeight: 1.05, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+            </h1>
             <div
               className="truncate"
               style={{

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -11,7 +11,6 @@ import FactionSigil from '../../../components/sigil/FactionSigil'
 import {
   BRASS,
   BRASS_LIGHT,
-  CAPTION,
   DECO,
   INK,
   INNER,
@@ -122,11 +121,7 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
       <header>
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
           <EphemeristsSigil size={13} color={BRASS} />
-          <span style={{ ...kicker, color: CAPTION }}>{t('nav.home')}</span>
         </div>
-        <h1 style={{ fontFamily: DECO, fontSize: 'var(--text-title)', lineHeight: 1.05, letterSpacing: '0.04em', color: INK, margin: 'var(--space-xs) 0 0' }}>
-          {t('fieldDesk.home.title')}
-        </h1>
         {/* A rune band closed the running head until #2210 retired the old
             glyph vocabulary kit-wide. The desk mounts no masthead, so nothing
             takes its place — the column's own `--space-lg` gap parts the head
@@ -187,13 +182,23 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="block truncate"
-              style={{ fontFamily: DECO, fontSize: 'var(--text-title)', lineHeight: 1, letterSpacing: '0.03em', color: INK, textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                bottom nav already marks as current. Both are gone, and rather than
+                leave the page with no level-1 heading (#1794's defect) the heading
+                names the page's real subject: the life being carried. Same ruling
+                the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                data already here. The masthead band itself STAYS -- only the two
+                text elements went, so every kit keeps its own mark. */}
+            <h1 className="m-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="block truncate"
+                style={{ fontFamily: DECO, fontSize: 'var(--text-title)', lineHeight: 1, letterSpacing: '0.03em', color: INK, textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+            </h1>
             <div className="truncate" style={{ marginTop: 'var(--space-xs)', ...trackMetaStyle }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -171,23 +171,8 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
               h1 below already reads the shared `fieldDesk.home.title` — so
               #1911's collapse leaves nothing to put here: the shared string
               would have restated the heading four lines down. */}
-          <span style={{ ...kicker, marginLeft: 'auto', color: CREAM }}>{t('nav.home')}</span>
         </div>
         <div style={{ height: 4, background: GOLD }} />
-        <h1
-          style={{
-            fontFamily: ACCENT_FONT,
-            fontSize: 'var(--text-heading)',
-            lineHeight: 0.95,
-            letterSpacing: '0.02em',
-            color: CREAM,
-            textShadow: `2px 2px 0 ${INK}`,
-            margin: 0,
-            padding: 'var(--space-lg)',
-          }}
-        >
-          {t('fieldDesk.home.title')}
-        </h1>
       </header>
 
       {/* ── The worker on the roll ── */}
@@ -244,13 +229,23 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="block truncate"
-              style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.95, color: PAPER_TEXT, textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                bottom nav already marks as current. Both are gone, and rather than
+                leave the page with no level-1 heading (#1794's defect) the heading
+                names the page's real subject: the life being carried. Same ruling
+                the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                data already here. The masthead band itself STAYS -- only the two
+                text elements went, so every kit keeps its own mark. */}
+            <h1 className="m-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="block truncate"
+                style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-title)', lineHeight: 0.95, color: PAPER_TEXT, textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+            </h1>
             <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)' }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -92,24 +92,6 @@ const TRACK_FILL = `linear-gradient(90deg, ${signal(85)}, ${PHOSPHOR})`
  *  set at 13px, and the mark holds the same line. */
 const ROW_SIGIL = 13
 
-/** Blinking terminal cursor block. */
-function Cursor() {
-  return (
-    <span
-      aria-hidden
-      className="sg-cursor"
-      style={{
-        display: 'inline-block',
-        width: 6,
-        height: 11,
-        marginLeft: 'var(--space-xs)',
-        verticalAlign: 'middle',
-        background: PHOSPHOR,
-      }}
-    />
-  )
-}
-
 /** Void readout panel with a signal-blue hairline and corner brackets. */
 function Panel({ children }: { children: ReactNode }) {
   return (
@@ -143,12 +125,6 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
     >
       {/* Prompt masthead */}
       <header>
-        <div style={kicker}>{t('nav.home')}</div>
-        <h1 style={{ fontFamily: FONT, fontSize: 'var(--text-title)', lineHeight: 1, color: PHOSPHOR, letterSpacing: '0.04em', margin: 'var(--space-xs) 0 0' }}>
-          {'> '}
-          {t('fieldDesk.home.title')}
-          <Cursor />
-        </h1>
         <div style={{ height: 1, marginTop: 'var(--space-md)', background: `linear-gradient(90deg, ${BORDER_HARD}, transparent)` }} />
       </header>
 
@@ -199,13 +175,23 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="block truncate"
-              style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                bottom nav already marks as current. Both are gone, and rather than
+                leave the page with no level-1 heading (#1794's defect) the heading
+                names the page's real subject: the life being carried. Same ruling
+                the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                data already here. The masthead band itself STAYS -- only the two
+                text elements went, so every kit keeps its own mark. */}
+            <h1 className="m-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="block truncate"
+                style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: PHOSPHOR, letterSpacing: '0.03em', textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+            </h1>
             <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -10,7 +10,7 @@ import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
-import { Ransom, WALL } from '../../../components/factionMarks/snideAtoms'
+import { WALL } from '../../../components/factionMarks/snideAtoms'
 
 /**
  * S.N.I.D.E. MOBILE FieldDesk home (#530) — the operative's file on a phone.
@@ -208,17 +208,6 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
     >
       {/* Masthead — the ransom cut over an acid rule */}
       <header>
-        <div style={{ ...kicker, color: NOTE_MUTED }}>{t('nav.home')}</div>
-        {/* THE WORDMARK IS CUT, NOT SET (#2287). It was a plain bold condensed
-            sans, which is the "boring" the report named. The ransom cut is the
-            face this kit already pastes a player's name up in on the comment
-            slip, mounted from the one drawing in `snideAtoms` rather than
-            transcribed a second time. Every letter brings its own opaque scrap,
-            so the mark needs no ink of its own on either ground, and the
-            heading's accessible name is still the whole word. */}
-        <h1 style={{ margin: 'var(--space-xs) 0 0' }}>
-          <Ransom text={t('fieldDesk.home.title')} size="var(--text-display)" />
-        </h1>
         <div style={{ height: 2, marginTop: 'var(--space-sm)', background: ACCENT_WALL }} />
       </header>
 
@@ -256,13 +245,23 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="block truncate"
-              style={{ fontFamily: COND, fontSize: 'var(--text-title)', letterSpacing: '0.03em', lineHeight: 1, color: NOTE_INK, textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                bottom nav already marks as current. Both are gone, and rather than
+                leave the page with no level-1 heading (#1794's defect) the heading
+                names the page's real subject: the life being carried. Same ruling
+                the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                data already here. The masthead band itself STAYS -- only the two
+                text elements went, so every kit keeps its own mark. */}
+            <h1 className="m-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="block truncate"
+                style={{ fontFamily: COND, fontSize: 'var(--text-title)', letterSpacing: '0.03em', lineHeight: 1, color: NOTE_INK, textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+            </h1>
             <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.12em', textTransform: 'uppercase', color: NOTE_MUTED }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
@@ -126,21 +126,6 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
         />
         <div style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
           <UaSigil width={34} height={34} />
-          <div style={{ minWidth: 0 }}>
-            <div style={smallCaps}>{t('nav.home')}</div>
-            <h1
-              style={{
-                fontFamily: DISPLAY,
-                fontWeight: 600,
-                fontSize: 'var(--text-heading)',
-                lineHeight: 1.05,
-                color: INK,
-                margin: 'var(--space-xs) 0 0',
-              }}
-            >
-              {t('fieldDesk.home.title')}
-            </h1>
-          </div>
         </div>
       </header>
 
@@ -191,13 +176,23 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
             )}
           </div>
           <div className="min-w-0 flex-1">
-            <Link
-              to={`/characters/${character.id}`}
-              className="block truncate"
-              style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-title)', lineHeight: 1, color: INK, textDecoration: 'none' }}
-            >
-              {character.display_name}
-            </Link>
+            {/* THE PAGE'S <h1> (#2580). The app-bar row above used to carry it --
+                a `HOME` kicker over a `FieldDesk` title, both naming the page the
+                bottom nav already marks as current. Both are gone, and rather than
+                leave the page with no level-1 heading (#1794's defect) the heading
+                names the page's real subject: the life being carried. Same ruling
+                the desktop FieldDesk took on 2026-08-15; no new string, the name is
+                data already here. The masthead band itself STAYS -- only the two
+                text elements went, so every kit keeps its own mark. */}
+            <h1 className="m-0">
+              <Link
+                to={`/characters/${character.id}`}
+                className="block truncate"
+                style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-title)', lineHeight: 1, color: INK, textDecoration: 'none' }}
+              >
+                {character.display_name}
+              </Link>
+            </h1>
             <div className="truncate" style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -3207,7 +3207,7 @@ describe("the S.N.I.D.E. field desk stands on the wall (#2287)", () => {
     expect(
       source,
       "the wall is drawn once, in `factionMarks/snideAtoms`, because five surfaces wear it.",
-    ).toMatch(/import \{ Ransom, WALL \} from ["'][^"']*factionMarks\/snideAtoms["']/);
+    ).toMatch(/import \{ WALL \} from ["'][^"']*factionMarks\/snideAtoms["']/);
     expect(wallPanelMarkup(source).length, "the panel mounts something").toBeGreaterThan(0);
     expect(source, "`WallPanel` grounds on the imported recipe").toMatch(/background: WALL,/);
     for (const layer of [
@@ -3223,11 +3223,26 @@ describe("the S.N.I.D.E. field desk stands on the wall (#2287)", () => {
     }
   });
 
-  it("the masthead and the comment byline are cut from ONE drawing", () => {
+  /**
+   * #2580 SUPERSEDED THIS TEST'S FIRST HALF, and the reason is a deletion rather
+   * than a redraw. #2287 pinned the FIELDDESK masthead as the per-letter ransom
+   * cut — the repair for a report that the skin read "boring". On 2026-08-23 the
+   * owner cut the masthead's copy itself: the `HOME` kicker and the `FieldDesk`
+   * title both name a page the bottom nav already marks as current, and the
+   * page's `<h1>` is now the carried life. There is no title left to cut, so the
+   * desk no longer mounts `Ransom` at all.
+   *
+   * What #2287 was actually protecting is untouched and still asserted below:
+   * the per-letter cut is drawn ONCE, in `snideAtoms`, and the comment voice
+   * consumes it rather than transcribing a fourth scrap table. The desk simply
+   * stopped being one of its consumers. Snide's acid rule, the flyposted `WALL`
+   * ground and every ink pairing this describe block measures are all unchanged.
+   */
+  it("the comment byline is cut from the ONE shared drawing", () => {
     expect(
       deskSource(),
-      "the FIELDDESK masthead is the ransom cut, mounted — not a bold condensed sans, which is what was reported.",
-    ).toMatch(/<Ransom text=\{t\('fieldDesk\.home\.title'\)\}/);
+      "the masthead's title is gone (#2580), so the desk must not mount the cut for it any more.",
+    ).not.toMatch(/<Ransom text=\{t\('fieldDesk\.home\.title'\)\}/);
     const voice = stripComments(sourceOf(VOICE));
     expect(voice, `${VOICE} mounts the shared cut`).toMatch(
       /import \{ Ransom \} from ["'][^"']*factionMarks\/snideAtoms["']/,


### PR DESCRIPTION
Owner report: *"Remove the small text that says home and the large text that says
FieldDesk."*

Closes #2580

## Seam

Each mobile FieldDesk skin rendered from a hand-built `FieldDeskHomeState`, in
`mobileArchetypeSlots.test.tsx` — the file that already walks
`surfaceMap('mobileFieldDesk')` per skin. The guard is a per-skin census, because
the failure mode it protects against is "one skin gets edited and loses its
heading".

## Why this is not just a deletion

Every mobile skin had **exactly one `<h1>`, and it was the `FieldDesk` title.**
Deleting it outright would leave seven pages with no level-1 heading at all —
precisely the defect #1794 was filed and fixed for on the desktop FieldDesk.

So the heading moves rather than disappears, following the ruling already sitting
in `pages/FieldDesk.tsx`: with the roster hidden the page is not asking whose
shoes, its subject is the life being carried, so the heading names it. **No new
string** — the name is data already on the page, and the existing `<Link>` to the
character stays inside the heading, so the destination and the type are unchanged.

A visually-hidden `<h1>` carrying "FieldDesk" was considered and **rejected**: it
keeps a dead word alive in the accessibility tree only.

## Scope — and one call worth your eye

I first deleted each skin's whole `<header>` and it took every kit's mark with
it — `TS6133` on `UaMandala`, `EverymenCog`, `EphemeristsSigil` and more. That
was wrong, so I reverted and redid it surgically. **Only the two text elements
went. Every masthead band and its ornament stays**: Coven's braid, Ephemerists'
brass sigil, Everymen's billboard cog and gold rule, Singularity's fading prompt
rule, Snide's acid rule, UA's mandala and sigil.

Default is the one skin whose `<header>` held nothing but those two elements, so
it went with them.

**If you want the vestigial bands gone too, that's a follow-up** — say so and it
is a small one. I did not make that call for you, because the issue asked for the
two text elements and the sibling faction issues in this batch explicitly say to
keep each kit's ornament.

Three references died with the title and are deleted rather than left dangling:
Snide's `Ransom` import (the wordmark *was* the title), Singularity's local
`Cursor`, Ephemerists' `CAPTION`. `Ransom` itself is still used by four other
Snide surfaces.

`WowFieldDesk` is **unchanged** — its crest has drawn the carried life as an
unconditional `<h1>` since #1817 and never had the eyebrow, which is why the new
guard passes for it both before and after. `AlbescentFieldDesk` renders
`DefaultFieldDesk` whole and inherits the fix.

## ⚠️ A ruling conflict I had to resolve — please confirm

The full suite caught it; the targeted run did not.

**#2287 pinned Snide's FIELDDESK masthead as the per-letter ransom cut** — the
owner repair for a report that the skin read "boring". #2580 deletes that title,
so the mark it pinned has nothing to render.

I took #2580 as the newer ruling and **retargeted the guard rather than deleting
it**. What #2287 actually protects — the per-letter cut is drawn *once* in
`snideAtoms` and consumed, never transcribed a fourth time — is untouched and
still asserted against the comment voice; the desk simply stopped being one of
its consumers. The case now asserts the *absence* of the old mount, so reverting
#2580 without this file fails loudly instead of passing quietly. Snide's acid
rule, the flyposted `WALL` ground and every ink pairing that block measures are
unchanged.

**If #2287's ransom masthead was meant to survive, this is the line to push back
on.**

## Verification

- `mobileArchetypeSlots.test.tsx` — **181/181**. The new census went red first on
  16 of 18 cases; the 2 that passed were WoW's, which is the precedent.
- `factionContrast.test.ts` — 1016/1016
- **Full suite — 416 files, 7485 tests, 0 failures**
- `npm run typecheck`, `npm run typecheck:design-sync`, `npm run lint` — all clean
- `npm run budget` needs a `dist/`; CI runs it after `build`, so it gates there
- **Visual QA is outstanding.** No browser on this change.

## What to eyeball

All of these are **mobile only** — the phone home screen, one per faction:

- **All nine skins**, top of the page: no `HOME` kicker, no `FieldDesk` title,
  and the character's name reading as the page's heading in each kit's own face.
- **The vestigial bands** — this is the judgment call above. Coven's braid alone,
  Singularity's fading rule alone, Everymen's red billboard band with its cog and
  gold rule but no words, UA's mandala + sigil, Ephemerists' brass sigil, Snide's
  acid rule. Do these read as intentional, or should the bands go too?
- **Snide especially** — its ransom-cut wordmark is gone, per the conflict above.
- **WoW** — should be pixel-identical; it was already in the target state.
- **Albescent** — inherits Default, so check it follows.
- A character with a **long display name**, since the name now carries heading
  type: it should still truncate rather than wrap the layout.
