### PR TITLE
Praxis cards read a body through the real parser, flattened (#2578)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/excerptFlattensMarkdown.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/excerptFlattensMarkdown.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * #2578 — the praxis card printed the raw markdown SOURCE of a body.
+ *
+ * Reported from an Everymen card, which showed
+ * `## ****I be this is invalid**** **Let's GO** *Le…` — syntax and all. Every
+ * praxis DETAIL page already renders the same text through `MarkdownPreview`
+ * (react-markdown + remark-gfm), so one body read two different ways depending
+ * on which surface you were standing on.
+ *
+ * SEAM: `PraxisExcerpt` itself. It is the only card-side render of a praxis
+ * body — `praxisCard/shared.tsx` and `praxisCard/desktop/shared.tsx` are its
+ * two consumers and nothing else mounts it — so all nine cards inherit whatever
+ * it does, and a fix here is a fix everywhere.
+ *
+ * THE RULING (owner, 2026-08-23) HAS TWO HALVES, and both are asserted below.
+ *
+ *  1. **Rendering it AS markdown is not the fix.** A `##` would become a
+ *     heading and a list a `<ul>`, inside a two-line clamp, inside a card that
+ *     is itself a link — and a nested `<a>` is invalid HTML, not merely untidy.
+ *     So the parser's output is flattened to inline text.
+ *
+ *  2. **Reuse the real parser; do NOT hand-roll a stripper.** A regex that
+ *     removes syntax is a second markdown implementation, and it would disagree
+ *     with remark on exactly the input that produced this report:
+ *     `****I be this is invalid****` is malformed, and two parsers resolve
+ *     malformed emphasis differently. Reusing remark makes the card's reading of
+ *     a body identical to the detail page's BY CONSTRUCTION rather than by
+ *     maintenance — which is the property worth having, and the one a
+ *     hand-rolled stripper cannot offer at any level of care.
+ *
+ * The reported string is used verbatim as a case, so the specific input that
+ * embarrassed the card is the one that can never regress.
+ */
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import "../../../i18n";
+import type { PraxisCardOut } from "../../../api/praxis";
+import { PraxisExcerpt } from "../shared";
+import { aPraxisCard } from "../../../test/fixtures";
+
+function excerpt(body: string): { html: string; text: string } {
+  const praxis: PraxisCardOut = { ...aPraxisCard(), body_text: body };
+  const element: ReactElement = <PraxisExcerpt praxis={praxis} />;
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: decode(html.replace(/<[^>]*>/g, "")) };
+}
+
+/** `renderToStaticMarkup` escapes `& < > " '`; undo it so `text` is what the card SAYS. */
+function decode(value: string): string {
+  return value
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+describe("praxis card excerpt — markdown resolves to its text (#2578)", () => {
+  it("prints the reported body as words, not as source", () => {
+    // Verbatim from the report.
+    const { text } = excerpt("## ****I be this is invalid**** **Let's GO** *Level up*");
+    expect(text, "no heading marker").not.toContain("#");
+    expect(text, "no emphasis markers").not.toContain("*");
+    expect(text, "the words survive").toContain("I be this is invalid");
+    expect(text, "and the rest of them").toContain("Let's GO");
+    expect(text, "and the rest of them").toContain("Level up");
+  });
+
+  it("draws no block structure inside the clamp", () => {
+    const { html } = excerpt(
+      "# Heading\n\n- first item\n- second item\n\n> quoted\n\n```\ncode\n```",
+    );
+    for (const tag of ["<h1", "<h2", "<ul", "<ol", "<li", "<blockquote", "<pre", "<hr"]) {
+      expect(html, `${tag} must not reach the card`).not.toContain(tag);
+    }
+    // The words themselves still have to be there — a flattener that ate the
+    // content would pass every assertion above.
+    expect(decode(html.replace(/<[^>]*>/g, "")), "list items survive").toContain("first item");
+  });
+
+  it("draws no nested anchor, because the card is itself a link", () => {
+    const { html, text } = excerpt("see [the write-up](https://example.com/x) for more");
+    expect(html, "no nested <a>").not.toContain("<a ");
+    expect(html, "no href at all").not.toContain("href");
+    expect(text, "the link's words stay").toContain("the write-up");
+    expect(text, "and the URL does not").not.toContain("example.com");
+  });
+
+  it("drops an image to its alt text rather than fetching it", () => {
+    const { html, text } = excerpt("before ![a pressed flower](https://example.com/p.png) after");
+    expect(html, "no <img> on a card").not.toContain("<img");
+    expect(text, "the alt is the text").toContain("a pressed flower");
+    expect(text, "the surrounding words survive").toContain("before");
+    expect(text, "the surrounding words survive").toContain("after");
+  });
+
+  it("keeps blocks from running into one word", () => {
+    // `## Title` immediately followed by a paragraph must not read "TitleBody".
+    const { text } = excerpt("## Title\n\nBody follows");
+    expect(text).not.toContain("TitleBody");
+    expect(text).toContain("Title");
+    expect(text).toContain("Body follows");
+  });
+
+  it("still renders nothing at all for an empty body", () => {
+    const praxis: PraxisCardOut = { ...aPraxisCard(), body_text: "" };
+    expect(renderToStaticMarkup(<PraxisExcerpt praxis={praxis} />)).toBe("");
+  });
+
+  it("keeps the two-line clamp it always had", () => {
+    const { html } = excerpt("plain words with no syntax in them");
+    expect(html, "the clamp is the point of the slot").toContain("-webkit-line-clamp:2");
+    expect(html, "still one paragraph box").toContain("<p");
+  });
+});

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -586,29 +586,50 @@ export function PraxisStats({
  * resolves to its alt text — that IS its text — and fetches nothing. `hr` and
  * the GFM task-list checkbox have no text, so they leave nothing behind.
  */
-const FLATTENED: Components = (() => {
-  const block = ({ children }: { children?: ReactNode }) => <>{children} </>;
-  const inline = ({ children }: { children?: ReactNode }) => <>{children}</>;
-  const map: Components = {
-    br: () => <> </>,
-    hr: () => null,
-    input: () => null,
-    img: ({ alt }) => <>{alt}</>,
-  };
-  for (const tag of [
-    "p", "h1", "h2", "h3", "h4", "h5", "h6",
-    "blockquote", "li", "pre", "tr", "th", "td",
-  ] as const) {
-    map[tag] = block;
-  }
-  for (const tag of [
-    "a", "em", "strong", "del", "code",
-    "ul", "ol", "table", "thead", "tbody", "tfoot",
-  ] as const) {
-    map[tag] = inline;
-  }
-  return map;
-})();
+/** A block: its text, then a space, so two blocks never read as one word. */
+const Block = ({ children }: { children?: ReactNode }) => <>{children} </>;
+/** An inline wrapper: its text and nothing else. */
+const Inline = ({ children }: { children?: ReactNode }) => <>{children}</>;
+
+/*
+ * Written out one tag at a time on purpose. A loop over the tag list assigning
+ * into `Components` makes TypeScript widen across every key of
+ * `JSX.IntrinsicElements` at once and it gives up: `TS2590: Expression produces
+ * a union type that is too complex to represent`. The literal is longer and
+ * completely boring, which is the trade to take here — and a tag the parser can
+ * emit that is missing from this list simply renders as itself, which the tests
+ * catch rather than the types.
+ */
+const FLATTENED: Components = {
+  p: Block,
+  h1: Block,
+  h2: Block,
+  h3: Block,
+  h4: Block,
+  h5: Block,
+  h6: Block,
+  blockquote: Block,
+  li: Block,
+  pre: Block,
+  tr: Block,
+  th: Block,
+  td: Block,
+  a: Inline,
+  em: Inline,
+  strong: Inline,
+  del: Inline,
+  code: Inline,
+  ul: Inline,
+  ol: Inline,
+  table: Inline,
+  thead: Inline,
+  tbody: Inline,
+  tfoot: Inline,
+  br: () => <> </>,
+  hr: () => null,
+  input: () => null,
+  img: ({ alt }) => <>{alt}</>,
+};
 
 /** Slot: a 1–2 line body-text excerpt, clamped. Renders nothing without body. */
 export function PraxisExcerpt({

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -1,6 +1,8 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
+import Markdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { CharacterOut } from "../../api/auth";
 import { UNSCORED_MODERATION_STATUSES, type PraxisCardOut } from "../../api/praxis";
 import { factionCssVar } from "../../utils/factions";
@@ -558,6 +560,56 @@ export function PraxisStats({
   );
 }
 
+/**
+ * Every node the parser can emit, resolved to plain inline text (#2578).
+ *
+ * The card printed `body_text` straight into the clamp, so a body written in
+ * markdown arrived as its SOURCE — `## ****I be this is invalid****` is the
+ * report. Meanwhile every praxis DETAIL page renders the same field through
+ * `MarkdownPreview`, so one body read two ways depending on the surface.
+ *
+ * Owner ruling: rendering it AS markdown is not the fix either. A `##` would
+ * become a heading and a list a `<ul>`, inside a two-line clamp, inside a card
+ * that is itself a link — and a nested `<a>` is invalid HTML rather than merely
+ * untidy. So the real parser runs and its output is flattened.
+ *
+ * WHY THE PARSER AND NOT A REGEX. A hand-rolled stripper is a second markdown
+ * implementation, and it would disagree with remark on exactly the input that
+ * produced this report: `****…****` is malformed emphasis, and two parsers
+ * resolve malformed emphasis differently. Going through remark makes the card's
+ * reading of a body identical to the detail page's BY CONSTRUCTION rather than
+ * by maintenance. That property is the whole point; it is not available at any
+ * level of care from a regex.
+ *
+ * Blocks emit a trailing space so `## Title` followed by a paragraph does not
+ * read `TitleBody`. Anchors keep their words and drop their href. An image
+ * resolves to its alt text — that IS its text — and fetches nothing. `hr` and
+ * the GFM task-list checkbox have no text, so they leave nothing behind.
+ */
+const FLATTENED: Components = (() => {
+  const block = ({ children }: { children?: ReactNode }) => <>{children} </>;
+  const inline = ({ children }: { children?: ReactNode }) => <>{children}</>;
+  const map: Components = {
+    br: () => <> </>,
+    hr: () => null,
+    input: () => null,
+    img: ({ alt }) => <>{alt}</>,
+  };
+  for (const tag of [
+    "p", "h1", "h2", "h3", "h4", "h5", "h6",
+    "blockquote", "li", "pre", "tr", "th", "td",
+  ] as const) {
+    map[tag] = block;
+  }
+  for (const tag of [
+    "a", "em", "strong", "del", "code",
+    "ul", "ol", "table", "thead", "tbody", "tfoot",
+  ] as const) {
+    map[tag] = inline;
+  }
+  return map;
+})();
+
 /** Slot: a 1–2 line body-text excerpt, clamped. Renders nothing without body. */
 export function PraxisExcerpt({
   praxis,
@@ -584,7 +636,9 @@ export function PraxisExcerpt({
         ...style,
       }}
     >
-      {praxis.body_text}
+      <Markdown remarkPlugins={[remarkGfm]} components={FLATTENED}>
+        {praxis.body_text}
+      </Markdown>
     </p>
   );
 }


### PR DESCRIPTION
A praxis card printed the raw markdown **source** of a body. Reported from an
Everymen card as `## ****I be this is invalid**** **Let's GO** *Le…`.

Closes #2578

## Seam

`PraxisExcerpt` in `components/praxisCard/shared.tsx`, rendered through
`renderToStaticMarkup`. It is the **only** card-side render of a praxis body —
`praxisCard/shared.tsx` and `praxisCard/desktop/shared.tsx` are its two
consumers and nothing else mounts it — so this is one edit for all nine cards.

Meanwhile every praxis **detail** page already renders the same field through
`MarkdownPreview`. One body, two readings, depending which surface you stood on.

## Both halves of the ruling

**Rendering it as markdown is not the fix.** A `##` becomes a heading and a list
a `<ul>`, inside a two-line clamp, inside a card that is itself a link — and a
nested `<a>` is invalid HTML, not merely untidy. So remark runs and every node it
emits resolves to plain inline text.

**A regex stripper stays rejected, and it is worth restating why.** It would be a
second markdown implementation, and it would disagree with remark on precisely
the input that produced this report: `****…****` is malformed emphasis, and two
parsers resolve malformed emphasis differently. Going through the parser makes
the card's reading identical to the detail page's **by construction** rather than
by maintenance. That property is the point, and it is not available at any level
of care from a regex.

Details: blocks emit a trailing space so `## Title` over a paragraph does not
read `TitleBody`; anchors keep their words and drop their href; an image resolves
to its **alt** — that is its text — and fetches nothing; `hr` and the GFM
task-list checkbox have no text and leave nothing behind.

The map is written out one tag at a time. A loop assigning into `Components`
makes TypeScript widen across every key of `JSX.IntrinsicElements` and give up
(`TS2590`, union too complex) — caught by `typecheck`, not by vitest. The literal
is longer and completely boring, which is the right trade.

## Payload — measured, as the issue required

|  | before (`main`) | after |
|---|---|---|
| initial-load JS (gzip) | **128.0 KB** | **128.0 KB** |
| initial-load CSS (gzip) | **22.3 KB** | **22.3 KB** (identical hash) |
| total `dist/assets` | 3,669,886 B | 3,672,244 B (**+2,358, +0.06%**) |
| chunks carrying the markdown stack | **1** | **1** |

The initial-load budget is unchanged, but that only covers blocking assets and
`PraxisCard` is on lazy routes — so I measured total emitted JS too. The markdown
stack lives in exactly **one** chunk on both sides, so Vite had already hoisted
it somewhere these routes reach and **nothing was duplicated**. The guess in the
issue was right; it costs essentially nothing.

The **CSS budget WARN is pre-existing on `main`** (#2469) — the before build
warns identically, with the same CSS hash. Not introduced here.

## Verification

- New `excerptFlattensMarkdown.test.tsx` — **7/7**. It went red first on the two
  cases that prove the defect (raw `#` in the output, and the raw URL reaching
  the card). The structural cases passed vacuously against raw text and only
  become load-bearing after the fix — they are what catch a *naive* markdown
  render.
- **Full suite — 417 files, 7474 tests, 0 failures**
- `typecheck`, `typecheck:design-sync`, `lint` — all clean
- **Visual QA is outstanding.** No browser on this change.

## Not in scope

Comment bodies (`components/comments/**` via `MentionText`) and
`pages/admin/ModerationTab.tsx`, which quotes a comment body raw on an admin
surface. Both untouched.

## What to eyeball

- **A praxis card whose body has markdown in it** — ideally the Everymen one from
  the report. The excerpt should read as words, still clamped to two lines.
- **All nine card skins**, since they share this slot: the excerpt should look
  unchanged in every kit's typography (it is still one `<p>` with the same class
  and fonts).
- **A card with a plain-text body** — must be visually identical to before.
- **A body that starts with a heading or a list** — should read as a sentence,
  not as a bulleted fragment, and must not blow the two-line clamp.
- **The praxis detail page** for the same praxis, to confirm the card and the
  detail now agree about what the body says.
