### PR TITLE
The faction page's spine holds on all nine bodies (#2546, #2547, #2548)

### DIFF
--- a/frontend/src/pages/factionDetail/__tests__/factionLayoutAudit.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionLayoutAudit.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * THE FACTION PAGE'S SPINE, asserted by name for every body (#2546/#2547/#2548).
+ *
+ * Every faction page is the same six regions in the same two columns, and the
+ * shape is NOT a per-skin choice — `.wz-faction-grid` in `index.css` is the
+ * shared seam (`1fr 322px`, 34px gap, one column at `max-width: 860px`).
+ *
+ *   ①  hero                        above, full width — the PAGE draws it
+ *   ②  About                       main
+ *   ④  Tasks                       main
+ *   ⑤  Recently-completed praxis   main
+ *   ③  Join / gate / standing      rail
+ *   ⑥  Champion + Members          rail
+ *
+ * Three separate audit findings all reduced to "one body is not doing that", and
+ * all three are fixed together because this file is the shared artefact they
+ * needed:
+ *
+ *   #2546  `DefaultFactionBody` never mounted `.wz-faction-grid` at all, so
+ *          Albescent — which renders it whole through a six-line wrapper — was
+ *          the one live faction page with no rail on a laptop.
+ *   #2547  `SingularityFactionBody` was the only body on the site that never
+ *          read `detail.aboutHeading`, so its first region was the only one a
+ *          reader met unlabelled.
+ *   #2548  `WowFactionBody` drew its muster roll in the MAIN column and named no
+ *          champion, so Members rendered BEFORE Tasks on that page alone.
+ *
+ * WHY BY NAME AND NOT BY COUNT. A census ("every body draws six regions") passes
+ * for the wrong reason as soon as a body draws one region twice, and it cannot
+ * say WHICH one is missing when it fails. Each assertion below names the body and
+ * the region, so a failure reads as the finding rather than as arithmetic.
+ *
+ * The bodies are imported directly rather than through `surfaceMap('factionBody')`
+ * because that registry hands back `lazyArchetype` wrappers, which
+ * `renderToStaticMarkup` cannot resolve synchronously. `wowFactionBody.test.tsx`
+ * imports directly for the same reason.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ComponentType } from "react";
+import { describe, it, expect } from "vitest";
+// Initialize the i18n catalog so faction copy keys resolve to English text.
+import "../../../i18n";
+import i18n from "../../../i18n";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+import AlbescentFactionBody from "../archetypes/AlbescentFactionBody";
+import CovenFactionBody from "../archetypes/CovenFactionBody";
+import DefaultFactionBody from "../archetypes/DefaultFactionBody";
+import EphemeristsFactionBody from "../archetypes/EphemeristsFactionBody";
+import EverymenFactionBody from "../archetypes/EverymenFactionBody";
+import SingularityFactionBody from "../archetypes/SingularityFactionBody";
+import SnideFactionBody from "../archetypes/SnideFactionBody";
+import UaFactionBody from "../archetypes/UaFactionBody";
+import WowFactionBody from "../archetypes/WowFactionBody";
+
+type Body = ComponentType<{ state: FactionDetailState }>;
+
+/**
+ * Every registered body, keyed by the slug it dresses. `na` is
+ * `DefaultFactionBody`; `albescent` is its wrapper, listed separately because
+ * the wrapper is exactly what #2546's defect reached the site through.
+ */
+const BODIES: Array<[string, Body]> = [
+  ["na", DefaultFactionBody as Body],
+  ["albescent", AlbescentFactionBody as Body],
+  ["coven", CovenFactionBody as Body],
+  ["ephemerists", EphemeristsFactionBody as Body],
+  ["everymen", EverymenFactionBody as Body],
+  ["singularity", SingularityFactionBody as Body],
+  ["snide", SnideFactionBody as Body],
+  ["ua", UaFactionBody as Body],
+  ["wow", WowFactionBody as Body],
+];
+
+function aCharacter(over: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    all_time_score: 100,
+    avatar_url: "",
+    badges: [],
+    bio: "",
+    created_at: "2026-01-01T00:00:00Z",
+    display_name: "Ada",
+    faction_slug: "coven",
+    id: 1,
+    invitations: [],
+    level: 4,
+    location: "",
+    score: 100,
+    status: "active",
+    tagline: "",
+    username: "ada",
+    ...over,
+  };
+}
+
+/**
+ * Two members, so a champion AND a roll below it both exist — the state #2548's
+ * `membersEmptyWithSpotlight` line distinguishes. The scores are deliberately
+ * out of order so a body that forgets to sort names the wrong champion.
+ *
+ * `display_name` and `username` carry the SAME token on purpose. The bodies do
+ * not agree on which one they print — na's champion goes through
+ * `CharacterBadge`, which draws the handle, while the bespoke kits draw the
+ * display name — and a fixture that distinguishes the two members in only one of
+ * those fields makes this file's assertions depend on which field a given kit
+ * happens to pick. Matching them means the probe reads the same either way.
+ */
+const TOP = "TopScorer";
+const RUNNER_UP = "RunnerUp";
+const MEMBERS: CharacterOut[] = [
+  aCharacter({ id: 1, display_name: RUNNER_UP, username: RUNNER_UP, all_time_score: 40 }),
+  aCharacter({ id: 2, display_name: TOP, username: TOP, all_time_score: 900 }),
+];
+
+function stateFor(slug: string): FactionDetailState {
+  return {
+    slug,
+    loading: false,
+    faction: { slug },
+    fetchError: null,
+    members: MEMBERS,
+    tasks: [],
+    recentPraxis: [],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    sections: undefined,
+    membership: {
+      state: "eligible",
+      currentFactionSlug: null,
+      join: async () => {},
+      joining: false,
+      joinError: null,
+    },
+  } as unknown as FactionDetailState;
+}
+
+function markup(slug: string, Body: Body): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Body state={stateFor(slug)} />
+    </MemoryRouter>,
+  );
+}
+
+/** The champion label each kit uses: its own, or na's shared one. */
+function championLabel(slug: string): string {
+  return slug === "na" || slug === "albescent"
+    ? i18n.t("factions:detail.spotlightLabel")
+    : i18n.t(`factions:${slug}.spotlight.label`);
+}
+
+function membersHeading(): string {
+  return i18n.t("factions:detail.default.membersHeading", { total: MEMBERS.length });
+}
+
+describe("A. every faction body roots on the shared main+rail grid", () => {
+  for (const [slug, Body] of BODIES) {
+    it(`${slug} mounts .wz-faction-grid`, () => {
+      // #2546: `DefaultFactionBody` did not, and Albescent inherited that, so a
+      // laptop got one stacked column and the join verb in a bare 420px box.
+      expect(markup(slug, Body)).toContain("wz-faction-grid");
+    });
+  }
+});
+
+describe("B. every faction body draws all six spine regions", () => {
+  for (const [slug, Body] of BODIES) {
+    it(`${slug} draws About`, () => {
+      // #2547: Singularity was the only body that never read this key.
+      expect(markup(slug, Body)).toContain(i18n.t("factions:detail.aboutHeading"));
+    });
+
+    it(`${slug} draws Champion`, () => {
+      // #2548: WOW named no champion — the top scorer was just row 1 of the roll.
+      expect(markup(slug, Body)).toContain(championLabel(slug));
+    });
+
+    it(`${slug} draws Members`, () => {
+      expect(markup(slug, Body)).toContain(membersHeading());
+    });
+
+    it(`${slug} draws Tasks and Recently-completed`, () => {
+      const html = markup(slug, Body);
+      expect(html, "tasks").toContain(i18n.t("factions:detail.default.tasksHeading", { total: 0 }));
+      expect(html, "praxis").toContain(i18n.t("factions:detail.default.recentHeading"));
+    });
+  }
+});
+
+describe("C. the rail regions come after the main-column regions", () => {
+  for (const [slug, Body] of BODIES) {
+    it(`${slug} puts Members below Tasks and Praxis in document order`, () => {
+      // #2548: WOW's Members landed BEFORE its Tasks, because the roll was in the
+      // main column. Document order is the readable proxy for "which column" in a
+      // harness with no layout engine — the rail is the grid's second child, so
+      // everything in it necessarily serialises after everything in main.
+      const html = markup(slug, Body);
+      const members = html.indexOf(membersHeading());
+      const tasks = html.indexOf(i18n.t("factions:detail.default.tasksHeading", { total: 0 }));
+      const praxis = html.indexOf(i18n.t("factions:detail.default.recentHeading"));
+
+      expect(members, "Members rendered").toBeGreaterThan(-1);
+      expect(tasks, "Tasks rendered").toBeGreaterThan(-1);
+      expect(praxis, "Praxis rendered").toBeGreaterThan(-1);
+      expect(members, "Members after Tasks").toBeGreaterThan(tasks);
+      expect(members, "Members after Praxis").toBeGreaterThan(praxis);
+    });
+  }
+});
+
+describe("D. the champion is the highest ALL-TIME score, everywhere", () => {
+  for (const [slug, Body] of BODIES) {
+    it(`${slug} names the top scorer, not the first member given`, () => {
+      // `all_time_score` rather than the era `score`, for the reason every body
+      // already states: the two agree inside an era and only that one survives a
+      // reset, so the card does not blank itself on day one. MEMBERS is supplied
+      // out of order, so a body that skips the sort names "Runner Up".
+      const html = markup(slug, Body);
+      const label = championLabel(slug);
+      const at = html.indexOf(label);
+      expect(at, `${slug} draws its champion label`).toBeGreaterThan(-1);
+      // The champion's name has to appear somewhere after its own label, and
+      // before the runner-up does — the roll is ranked below the card.
+      const top = html.indexOf(TOP, at);
+      const runnerUp = html.indexOf(RUNNER_UP, at);
+      expect(top, "the top scorer is named after the champion label").toBeGreaterThan(-1);
+      expect(top, "and named before the runner-up").toBeLessThan(
+        runnerUp === -1 ? Number.MAX_SAFE_INTEGER : runnerUp,
+      );
+    });
+  }
+});

--- a/frontend/src/pages/factionDetail/__tests__/factionLayoutAudit.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionLayoutAudit.test.tsx
@@ -143,11 +143,36 @@ function markup(slug: string, Body: Body): string {
   );
 }
 
-/** The champion label each kit uses: its own, or na's shared one. */
+/**
+ * The champion label each kit uses: its own, or na's shared one.
+ *
+ * Spelled out rather than built as `factions:${slug}.spotlight.label`. The copy
+ * keys are typed as a literal union, so a template literal widens past it and
+ * `typecheck:design-sync` refuses it (TS2345) — the app typecheck and the
+ * preview-kit typecheck both read this file. Listing them also means a faction
+ * whose label key is renamed fails here by name instead of resolving to a raw
+ * key string that `toContain` would happily match against itself.
+ */
+const CHAMPION_LABEL = {
+  na: "factions:detail.spotlightLabel",
+  albescent: "factions:detail.spotlightLabel",
+  coven: "factions:coven.spotlight.label",
+  ephemerists: "factions:ephemerists.spotlight.label",
+  everymen: "factions:everymen.spotlight.label",
+  singularity: "factions:singularity.spotlight.label",
+  snide: "factions:snide.spotlight.label",
+  ua: "factions:ua.spotlight.label",
+  wow: "factions:wow.spotlight.label",
+} as const;
+
 function championLabel(slug: string): string {
-  return slug === "na" || slug === "albescent"
-    ? i18n.t("factions:detail.spotlightLabel")
-    : i18n.t(`factions:${slug}.spotlight.label`);
+  const key = CHAMPION_LABEL[slug as keyof typeof CHAMPION_LABEL];
+  expect(key, `a champion-label key is listed for ${slug}`).toBeTruthy();
+  const label = i18n.t(key);
+  // A missing key makes i18next echo the key back, which would make every
+  // `toContain` below pass against itself.
+  expect(label, `${key} resolves to real copy`).not.toBe(key);
+  return label;
 }
 
 function membersHeading(): string {

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -211,205 +211,239 @@ export default function DefaultFactionBody({
 
   return (
     <>
-      {/* ── The burn (#1305) ── this viewer left this faction this era, so
-          joining is refused for the rest of it. The phone twin said this in its
-          own words (`mobile.burnedHint`); that delta was cosmetic, so it
-          collapses to the neutral platform wording every other body uses
-          (ADR-0057: the dress is ours, the words are not). ── */}
-      {membership.state === "burned" && (
-        <div
-          className="sidebar-card mb-6"
-          style={{ padding: "var(--space-md) var(--space-lg)" }}
-        >
-          <p className="label-heading mb-1">{t("detail.burned.kicker")}</p>
-          <p className="font-body content-text text-ink">
-            {t("detail.burned.body", { faction: factionName(faction.slug) })}
-          </p>
-        </div>
-      )}
+      {/* THE HOUSE SHAPE, FINALLY (#2546). `.wz-faction-grid` in index.css is the
+          shared main+rail seam -- `1fr 322px`, 34px gap, one column at
+          `max-width: 860px` -- and seven of the eight bodies root on it. This one
+          never did, so every region stacked full width and the join verb sat in a
+          bare 420px column above them all. `AlbescentFactionBody` renders this
+          file whole through a six-line wrapper, which made it the one live
+          faction page with no rail on a laptop; on a phone it looked right only
+          because a one-column page is what the other seven collapse to anyway.
 
-      {/* ── Standing / the soft gate ── the two states a viewer cannot act on.
-          "gate" is "not invited YET" (#454), which is why its copy tells you to
-          keep going; the burn above is a closed door and must stay a different
-          sentence. ── */}
-      {membership.state === "member" && (
-        <p className="label-caption mb-6" style={{ color: accent }}>
-          {t("mobile.memberBadge")}
-        </p>
-      )}
-      {membership.state === "gate" && (
-        <p className="font-body text-muted content-text mb-6">
-          {t("mobile.gateHint", { faction: name })}
-        </p>
-      )}
+          The six regions and their columns, the same everywhere: (1) hero, above
+          and full width, drawn by the page not by this file; (2) About, (4) Tasks
+          and (5) Recently-completed in MAIN; (3) join / gate / standing and
+          (6) Champion + Members in the RAIL.
 
-      {/* ponytail: on a laptop the verb sits here, in a plain 420px column,
-          because this archetype has no rail to put it in — the whole file is
-          placeholder chrome and #951's join/gate design is what will place it
-          properly. On a phone it pins instead, at the bottom of the page. ── */}
-      {!phone && joinAction && (
+          A re-parenting and nothing more. Every plate keeps its dress --
+          `.faction-plate`, `.faction-plate-kicker`, `PLATE_RULE` and the
+          `plateOrnament` slot are untouched. ── */}
+      <div className="wz-faction-grid">
+        {/* ── MAIN COLUMN ── */}
         <div
           style={{
             display: "flex",
             flexDirection: "column",
-            gap: "var(--space-sm)",
-            maxWidth: 420,
-            marginBottom: "var(--space-xl)",
+            gap: "var(--space-2xl)",
           }}
         >
-          {joinAction}
-        </div>
-      )}
-
-      {/* ── About ── the region #2497 deliberately left undressed, because the
-          blurb was still the PAGE's card in `FactionDetail.tsx` and that card
-          had no heading, so plating it meant minting a heading string. It needed
-          neither: the shared `detail.aboutHeading` has existed all along — every
-          one of the seven bespoke bodies draws its About under it, and
-          `factionCopyCollapse.test.ts` names it as the one key the family
-          collapsed onto. So no string is minted here; the region simply moves
-          from the page to the body, where the other seven have always kept it,
-          and #2137's "the body owns the description" finally holds on this
-          branch too. Split on blank lines like every sibling does. ── */}
-      <section className="faction-plate">
-        {plateOrnament}
-        <div className="faction-plate-kicker">
-          <h2 className="label-heading">{t("detail.aboutHeading")}</h2>
-          {PLATE_RULE}
-        </div>
-        {paragraphs.length === 0 ? (
-          <p className="font-body text-muted content-text">{t("detail.descriptionEmpty")}</p>
-        ) : (
-          paragraphs.map((paragraph) => (
-            <p key={paragraph} className="font-body content-text mb-2 last:mb-0">
-              {paragraph}
-            </p>
-          ))
-        )}
-      </section>
-
-      {/* ── Champion ── the highest all-time score on the roll, and NO backend.
-          The list it ranks is the one the page has already fetched, so an
-          endpoint here would be a second, slower answer to a question already
-          answered. Drawn only when there is a member to name; the roll below
-          then drops them, which is what `membersEmptyWithSpotlight` is for. ── */}
-      {champion && (
+        {/* ── About ── the region #2497 deliberately left undressed, because the
+            blurb was still the PAGE's card in `FactionDetail.tsx` and that card
+            had no heading, so plating it meant minting a heading string. It needed
+            neither: the shared `detail.aboutHeading` has existed all along — every
+            one of the seven bespoke bodies draws its About under it, and
+            `factionCopyCollapse.test.ts` names it as the one key the family
+            collapsed onto. So no string is minted here; the region simply moves
+            from the page to the body, where the other seven have always kept it,
+            and #2137's "the body owns the description" finally holds on this
+            branch too. Split on blank lines like every sibling does. ── */}
         <section className="faction-plate">
           {plateOrnament}
           <div className="faction-plate-kicker">
-            <h2 className="label-heading">{t("detail.spotlightLabel")}</h2>
+            <h2 className="label-heading">{t("detail.aboutHeading")}</h2>
             {PLATE_RULE}
           </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <CharacterBadge character={champion} />
-            <span className="font-body text-muted content-text">
-              {t("detail.spotlightStat", {
-                level: champion.level,
-                score: champion.all_time_score.toLocaleString(),
-                count: champion.all_time_score,
-              })}
-            </span>
-          </div>
+          {paragraphs.length === 0 ? (
+            <p className="font-body text-muted content-text">{t("detail.descriptionEmpty")}</p>
+          ) : (
+            paragraphs.map((paragraph) => (
+              <p key={paragraph} className="font-body content-text mb-2 last:mb-0">
+                {paragraph}
+              </p>
+            ))
+          )}
         </section>
-      )}
-
-      {/* ── Members ── no disclosure, by `sectionDisclosure`'s own ruling: the
-          Roll is how a player joins and how the gate explains itself, so it is
-          not foldable. It wears the plate all the same — the plate is the
-          region's dress and the disclosure is a separate job on a separate
-          element. ── */}
-      <section className="faction-plate">
-        {plateOrnament}
-        <div className="faction-plate-kicker">
-          <h2 className="label-heading">
-            {t("detail.default.membersHeading", { total: members.length })}
-          </h2>
-          {PLATE_RULE}
-        </div>
-        {roll.length === 0 ? (
-          <p className="font-body text-muted content-text">
-            {champion ? t("detail.membersEmptyWithSpotlight") : t("detail.membersEmpty")}
-          </p>
-        ) : (
-          <div className="flex flex-wrap gap-3">
-            {roll.map((m) => (
-              <div
-                key={m.id}
-                style={{
-                  border: `1px solid ${accent}`,
-                  padding: "var(--space-sm) var(--space-md)",
-                  background: "var(--color-bg-surface)",
-                }}
-              >
-                <CharacterBadge character={m} size="sm" />
+        {/* ── Tasks ── reuses the per-faction TaskCard archetype ──
+            This body has no `SectionHeading` of its own — it draws the bare
+            `.label-heading` the other seven replaced with a house component — so
+            the disclosure goes straight inside the `<h2>` here (#2311). */}
+        <section className="faction-plate">
+          {/* No `plateOrnament` — see its docstring. This plate holds cards that
+              carry their own edge, so it carries the RULE instead. */}
+          <div className="faction-plate-kicker">
+            <h2 className="label-heading">
+              <SectionToggle
+                section={sections.tasks}
+                label={t("detail.default.tasksHeading", { total: tasks.length })}
+              />
+            </h2>
+            {PLATE_RULE}
+          </div>
+          <SectionPanel section={sections.tasks}>
+            {tasks.length === 0 ? (
+              <p className="font-body text-muted content-text">{t("detail.default.tasksEmpty")}</p>
+            ) : (
+              <div className="task-card-row" style={{ gap: "var(--space-lg)" }}>
+                {tasks.map((task) => (
+                  <TaskCard
+                    key={task.id}
+                    task={task}
+                    basePoints={task.point_value}
+                    multiplier={computeFactionMultiplier(
+                      viewerFactionSlug,
+                      task.primary_faction_slug,
+                      gameFactions,
+                    )}
+                    onSignup={onSignup}
+                  />
+                ))}
               </div>
-            ))}
+            )}
+          </SectionPanel>
+        </section>
+        {/* ── Recently completed ── */}
+        <section className="faction-plate">
+          {/* No `plateOrnament` — the other card-holding plate. */}
+          <div className="faction-plate-kicker">
+            <h2 className="label-heading">
+              <SectionToggle section={sections.praxis} label={t("detail.default.recentHeading")} />
+            </h2>
+            {PLATE_RULE}
+          </div>
+          <SectionPanel section={sections.praxis}>
+            {recentPraxis.length === 0 ? (
+              <p className="font-body text-muted content-text">
+                {t("detail.default.recentEmpty")}
+              </p>
+            ) : (
+              <div style={CARD_GRID}>
+                {recentPraxis.map((p) => (
+                  <PraxisCard key={p.id} praxis={p} />
+                ))}
+              </div>
+            )}
+          </SectionPanel>
+        </section>
+        </div>
+
+        {/* ── RIGHT RAIL ── */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2xl)",
+          }}
+        >
+        {/* ── The burn (#1305) ── this viewer left this faction this era, so
+            joining is refused for the rest of it. The phone twin said this in its
+            own words (`mobile.burnedHint`); that delta was cosmetic, so it
+            collapses to the neutral platform wording every other body uses
+            (ADR-0057: the dress is ours, the words are not). ── */}
+        {membership.state === "burned" && (
+          <div
+            className="sidebar-card"
+            style={{ padding: "var(--space-md) var(--space-lg)" }}
+          >
+            <p className="label-heading mb-1">{t("detail.burned.kicker")}</p>
+            <p className="font-body content-text text-ink">
+              {t("detail.burned.body", { faction: factionName(faction.slug) })}
+            </p>
           </div>
         )}
-      </section>
-
-      {/* ── Tasks ── reuses the per-faction TaskCard archetype ──
-          This body has no `SectionHeading` of its own — it draws the bare
-          `.label-heading` the other seven replaced with a house component — so
-          the disclosure goes straight inside the `<h2>` here (#2311). */}
-      <section className="faction-plate">
-        {/* No `plateOrnament` — see its docstring. This plate holds cards that
-            carry their own edge, so it carries the RULE instead. */}
-        <div className="faction-plate-kicker">
-          <h2 className="label-heading">
-            <SectionToggle
-              section={sections.tasks}
-              label={t("detail.default.tasksHeading", { total: tasks.length })}
-            />
-          </h2>
-          {PLATE_RULE}
-        </div>
-        <SectionPanel section={sections.tasks}>
-          {tasks.length === 0 ? (
-            <p className="font-body text-muted content-text">{t("detail.default.tasksEmpty")}</p>
-          ) : (
-            <div className="task-card-row" style={{ gap: "var(--space-lg)" }}>
-              {tasks.map((task) => (
-                <TaskCard
-                  key={task.id}
-                  task={task}
-                  basePoints={task.point_value}
-                  multiplier={computeFactionMultiplier(
-                    viewerFactionSlug,
-                    task.primary_faction_slug,
-                    gameFactions,
-                  )}
-                  onSignup={onSignup}
-                />
-              ))}
+        {/* ── Standing / the soft gate ── the two states a viewer cannot act on.
+            "gate" is "not invited YET" (#454), which is why its copy tells you to
+            keep going; the burn above is a closed door and must stay a different
+            sentence. ── */}
+        {membership.state === "member" && (
+          <p className="label-caption" style={{ color: accent }}>
+            {t("mobile.memberBadge")}
+          </p>
+        )}
+        {membership.state === "gate" && (
+          <p className="font-body text-muted content-text">
+            {t("mobile.gateHint", { faction: name })}
+          </p>
+        )}
+        {/* ③ THE JOIN VERB — in the rail, where the other seven bodies have
+            always put it. It used to sit in a bare 420px column with a `ponytail:`
+            note saying it was there "because this archetype has no rail to put it
+            in", pending #951's join/gate design. #951 closed without placing it and
+            Albescent is the only live faction still landing here, so the note had
+            stopped describing a deferral and started describing a shipped bug
+            (#2546). The rail is 322px, so the 420 cap and the bottom margin both
+            come off — the rail's own gap parts it from the Champion below. On a
+            phone the grid is one column and the verb still pins instead. ── */}
+        {!phone && joinAction && (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-sm)",
+            }}
+          >
+            {joinAction}
+          </div>
+        )}
+        {/* ── Champion ── the highest all-time score on the roll, and NO backend.
+            The list it ranks is the one the page has already fetched, so an
+            endpoint here would be a second, slower answer to a question already
+            answered. Drawn only when there is a member to name; the roll below
+            then drops them, which is what `membersEmptyWithSpotlight` is for. ── */}
+        {champion && (
+          <section className="faction-plate">
+            {plateOrnament}
+            <div className="faction-plate-kicker">
+              <h2 className="label-heading">{t("detail.spotlightLabel")}</h2>
+              {PLATE_RULE}
             </div>
-          )}
-        </SectionPanel>
-      </section>
-
-      {/* ── Recently completed ── */}
-      <section className="faction-plate">
-        {/* No `plateOrnament` — the other card-holding plate. */}
-        <div className="faction-plate-kicker">
-          <h2 className="label-heading">
-            <SectionToggle section={sections.praxis} label={t("detail.default.recentHeading")} />
-          </h2>
-          {PLATE_RULE}
-        </div>
-        <SectionPanel section={sections.praxis}>
-          {recentPraxis.length === 0 ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <CharacterBadge character={champion} />
+              <span className="font-body text-muted content-text">
+                {t("detail.spotlightStat", {
+                  level: champion.level,
+                  score: champion.all_time_score.toLocaleString(),
+                  count: champion.all_time_score,
+                })}
+              </span>
+            </div>
+          </section>
+        )}
+        {/* ── Members ── no disclosure, by `sectionDisclosure`'s own ruling: the
+            Roll is how a player joins and how the gate explains itself, so it is
+            not foldable. It wears the plate all the same — the plate is the
+            region's dress and the disclosure is a separate job on a separate
+            element. ── */}
+        <section className="faction-plate">
+          {plateOrnament}
+          <div className="faction-plate-kicker">
+            <h2 className="label-heading">
+              {t("detail.default.membersHeading", { total: members.length })}
+            </h2>
+            {PLATE_RULE}
+          </div>
+          {roll.length === 0 ? (
             <p className="font-body text-muted content-text">
-              {t("detail.default.recentEmpty")}
+              {champion ? t("detail.membersEmptyWithSpotlight") : t("detail.membersEmpty")}
             </p>
           ) : (
-            <div style={CARD_GRID}>
-              {recentPraxis.map((p) => (
-                <PraxisCard key={p.id} praxis={p} />
+            <div className="flex flex-wrap gap-3">
+              {roll.map((m) => (
+                <div
+                  key={m.id}
+                  style={{
+                    border: `1px solid ${accent}`,
+                    padding: "var(--space-sm) var(--space-md)",
+                    background: "var(--color-bg-surface)",
+                  }}
+                >
+                  <CharacterBadge character={m} size="sm" />
+                </div>
               ))}
             </div>
           )}
-        </SectionPanel>
-      </section>
+        </section>
+        </div>
+      </div>
 
       {/* ── The pinned action band ── phone only, and the LAST child of the
           page's tall box so `position: sticky` has something to pin against

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -206,10 +206,17 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
           {/* The panel opened on a shell prompt (`singularity.manifest.command`,
               "> cat /faction/manifest.txt"). #1909 cut it: no other faction had
               a command line over its about panel, and the audit ruled the
-              surface generic. Singularity is the one faction with no
-              about-panel HEADING to fall back on — #1910 gives all seven the
-              shared "About", and until it lands this block opens on the
-              description itself. */}
+              surface generic. That left this the ONE about panel on the site with
+              no heading at all, pending #1910 — which closed without giving it
+              one, so the region a reader met first was the only unlabelled one
+              anywhere (#2547).
+
+              `SectionHeading` is this file's own, the same component the Tasks
+              and Praxis sections below already use, so the phosphor title and its
+              signal rule come for free. No string is minted: `detail.aboutHeading`
+              is the shared key the other seven read, and `factionCopyCollapse`
+              names it as the one the family collapsed onto. */}
+          <SectionHeading>{t("detail.aboutHeading")}</SectionHeading>
           <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
             {paragraphs.length ? (
               paragraphs.map((para, i) => (

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -114,6 +114,10 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
   const name = factionName(faction.slug);
   const roll = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
   const champion = roll[0];
+  /* The roll below the champion card. `slice(1)` rather than a filter on id: the
+     card is `roll[0]`, so position is the definition here and an id comparison
+     would be a second way of saying the same thing. */
+  const rest = roll.slice(1);
 
   return (
     // `.wz-faction-grid` is the shared main+rail seam all six other bodies use.
@@ -137,28 +141,6 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
       {/* ── MAIN COLUMN ── */}
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
         <Charter slug={faction.slug} />
-
-        {/* ── the muster roll ── */}
-        <section>
-          <SectionHead>{t("detail.default.membersHeading", { total: members.length })}</SectionHead>
-          {roll.length === 0 ? (
-            <Quiet>{t("detail.membersEmpty")}</Quiet>
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
-              {roll.slice(0, ROLL_LIMIT).map((member, index) => (
-                <MemberRow
-                  key={member.id}
-                  rank={index + 1}
-                  member={member}
-                  champion={member.id === champion?.id}
-                />
-              ))}
-              {/* The champion IS the whole roll — say so rather than leaving one
-                  lonely row reading as a truncated list. */}
-              {roll.length === 1 && <Quiet>{t("detail.membersEmptyWithSpotlight")}</Quiet>}
-            </div>
-          )}
-        </section>
 
         {/* ── quests awaiting a champion ── */}
         <section>
@@ -210,8 +192,50 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
         </section>
       </div>
 
-      {/* ── RIGHT RAIL — standing / enlist / gate ── */}
-      <JoinBlock name={name} membership={membership} />
+      {/* ── RIGHT RAIL ── join, then Champion, then the roll (#2548).
+           This rail held ONLY the enlist block. Every other body puts the
+           Champion card and the Members roll here too, and WOW instead drew its
+           muster roll in the MAIN column between the Charter and the quests and
+           named no champion at all -- the top scorer was simply row 1, flagged by
+           a boolean. The document-order consequence was that Members rendered
+           BEFORE Tasks on this page and after both galleries on every other one.
+
+           Nothing is reskinned: the champion is `MemberRow` in its marked state,
+           WOW's own drawing, under WOW's own `SectionHead`. Every ornament stays
+           -- parchment, the wavy gold/plum rules, the bunting, the balloons. ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
+        <JoinBlock name={name} membership={membership} />
+
+        {/* ⑥ CHAMPION — `wow.spotlight.label` is the key `MemberRow` already
+            reads for its pill, so no string is minted. Ranked on
+            `all_time_score` like every sibling: the two agree inside an era and
+            only that one survives a reset, so the card does not blank itself on
+            day one. */}
+        {champion && (
+          <section>
+            <SectionHead>{t("wow.spotlight.label")}</SectionHead>
+            <MemberRow rank={1} member={champion} champion />
+          </section>
+        )}
+
+        {/* ⑥ MEMBERS — the champion is drawn above, so the roll drops them, which
+            is what `membersEmptyWithSpotlight` has always been for. With a real
+            champion card over it that line finally means what it says. */}
+        <section>
+          <SectionHead>{t("detail.default.membersHeading", { total: members.length })}</SectionHead>
+          {rest.length === 0 ? (
+            <Quiet>
+              {champion ? t("detail.membersEmptyWithSpotlight") : t("detail.membersEmpty")}
+            </Quiet>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
+              {rest.slice(0, ROLL_LIMIT).map((member, index) => (
+                <MemberRow key={member.id} rank={index + 2} member={member} champion={false} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 }
@@ -348,7 +372,12 @@ function MemberRow({
         minHeight: 46,
         display: "flex",
         alignItems: "center",
-        gap: "var(--space-lg)",
+        /* Wraps since #2548 moved the roll into the 322px rail. The row was laid
+           out for the main column, where rank + name + pill + stat fit on one
+           line; in the rail they do not, and a nowrap name beside a nowrap stat
+           would overflow the plate rather than reflow inside it. */
+        flexWrap: "wrap",
+        gap: "var(--space-sm) var(--space-lg)",
         padding: "var(--space-sm) var(--space-lg)",
         background: PLATE,
         border: `1px solid ${HAIR}`,


### PR DESCRIPTION
Three findings from the 2026-08-23 faction-page audit, in one PR.

Closes #2546
Closes #2547
Closes #2548

## Why one PR and not three

#2547 and #2548 each say a case in `factionLayoutAudit.test.tsx` "is red on
`main` and goes green with this fix". **That file did not exist** — #2546 is the
issue that introduces it. As three PRs, #2546 would have had to merge carrying
two knowingly-failing cases, and `test` is a required check, so it could not.
One PR, one audit, three fixes, no deliberately-red intermediate.

## Seam

`factionLayoutAudit.test.tsx` — each body rendered from a controlled
`FactionDetailState` through `renderToStaticMarkup`, asserted **by name**: which
body draws which of the six spine regions, and in which column. Bodies are
imported directly because `surfaceMap('factionBody')` hands back `lazyArchetype`
wrappers that `renderToStaticMarkup` cannot resolve synchronously —
`wowFactionBody.test.tsx` does the same for the same reason.

A count would pass for the wrong reason the moment a body draws one region twice,
and could not say *which* region was missing when it failed.

## The three fixes

**#2546 — `DefaultFactionBody` never mounted `.wz-faction-grid`.** The shared
main+rail seam (`1fr 322px`, 34px gap, one column at `max-width: 860px`) that
seven of the eight bodies root on. `AlbescentFactionBody` renders this file whole
through a six-line wrapper, so **Albescent was the one live faction page with no
rail on a laptop** — About, Champion, Members, Tasks and Recently-completed all
stacked full width, with the Join verb above them in a bare 420px column. A phone
looked right only because one column is what the other seven collapse to.

Now rooted on the grid: About / Tasks / Recent in main; join-gate-standing, then
Champion, then Members in the rail. **A re-parenting only** — `.faction-plate`,
`.faction-plate-kicker`, `PLATE_RULE` and the `plateOrnament` slot are untouched.
The file's own `ponytail:` note saying it had no rail "pending #951" comes out;
#951 closed without placing it, so the note had stopped describing a deferral and
started describing a shipped bug. The three `mb-6` margins go with it — they were
spacing for a stacked column, and the rail supplies its own gap.

**#2547 — Singularity's About had no heading.** Confirmed: it was the only body
that never read `detail.aboutHeading`, so its first region was the only one on the
site a reader met unlabelled. Drawn now through the file's **own**
`SectionHeading` — the component its Tasks and Praxis sections already use — so
the phosphor title and its signal rule come for free. No string minted. The stale
comment citing #1910 comes out with it.

**#2548 — WoW drew no Champion and kept Members in the main column.** Its rail
held only `<JoinBlock>`; the muster roll sat between the Charter and the quests,
and the top scorer was merely row 1 flagged by a boolean. So Members rendered
*before* Tasks on that page and after both galleries everywhere else.

The roll moves to the rail under `JoinBlock`, with a Champion card above it drawn
as `MemberRow` in its **marked state** — WoW's own drawing, under WoW's own
`SectionHead`, reading the `wow.spotlight.label` key `MemberRow` already used. No
string minted. Ranked `all_time_score` like every sibling (the two agree inside
an era and only that one survives a reset, so the card does not blank itself on
day one). **Every ornament stays**: parchment, the wavy gold/plum rules, the
bunting, the balloons.

## ⚠️ One change beyond re-parenting — please look at this

`MemberRow` gains `flexWrap: "wrap"` and a row gap. It was laid out for the main
column, where rank + name + CHAMPION pill + stat fit on one line; **the rail is
322px and they do not.** Both the name and the stat are `white-space: nowrap`, so
without wrapping the row would overflow its plate rather than reflow inside it.

I could not verify this visually — no browser — so **WoW's rail is the first thing
to look at.**

## The audit is load-bearing, not decorative

Reverting the three archetype files fails **7 of 63** cases — one per finding,
plus Albescent's inherited copies:

```
A. na mounts .wz-faction-grid
A. albescent mounts .wz-faction-grid
B. singularity draws About
C. na puts Members below Tasks and Praxis in document order
C. albescent puts Members below Tasks and Praxis in document order
C. wow puts Members below Tasks and Praxis in document order
D. wow names the top scorer, not the first member given
```

It also asserts each champion-label key resolves to real copy — a missing key
makes i18next echo the key back, and every `toContain` would then pass against
itself. And the keys are spelled out rather than built as
`factions:${slug}.spotlight.label`: a template widens past the literal key union
and `typecheck:design-sync` refuses it (TS2345).

## Verification

- `factionLayoutAudit.test.tsx` — **63/63**, and 7 fail on a revert (shown above)
- `src/pages/factionDetail` — **263/263**
- **Full suite — 7531 tests, 0 failures**
- `typecheck`, `typecheck:design-sync`, `lint` — all clean
- **Visual QA is outstanding on all three.**

## What to eyeball

- **WoW's faction page, laptop width** — the new Champion card and the roll in the
  322px rail. This is the wrapping change above; does the row read properly, or
  does it look cramped? Main column should now be Charter → quests → chronicles.
- **Albescent's faction page, laptop width** — it should have a rail for the first
  time: About / Tasks / Recent on the left, Join + Champion + Members on the
  right. Then the same page **on a phone**, which should look as it did before.
- **Albescent's join verb** — it lost its 420px cap and bottom margin; check it
  sits comfortably in the rail in all four states you can reach.
- **Singularity's faction page** — an "About" heading over the MANIFEST panel, in
  phosphor with the signal rule, matching its Tasks and Praxis headings.
- **All nine at ~860px**, the grid's collapse point.
- **Both themes.**
