### PR TITLE
One carrier per plate: the hairline yields to the ring (#2576)

### DIFF
--- a/frontend/src/pages/factionDetail/__tests__/defaultFactionHero.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/defaultFactionHero.test.tsx
@@ -180,10 +180,16 @@ describe("a faction with no bespoke hero gets the na frontispiece (#2504)", () =
   });
 
   it("the two card plates keep the plate's own hairline", () => {
-    // What they carry INSTEAD of the edge, and it is na's own: every plate draws
-    // `.spectrum-rule` beside its kicker, and none of them lost it.
+    // What they carry INSTEAD of the edge, and it is na's own.
+    //
+    // THE COUNT WAS 5 AND IS NOW 2 (#2576), which is the first time it has
+    // matched this test's own name. Five meant every plate drew the hairline --
+    // including the three that also mount the 3px `.alb-plate-edge` ring, so
+    // those three carried two structural rainbows at once. ADR-0083 3b: one
+    // carrier per object, and the thinner one yields. Two is the two card
+    // plates, which mount no ring and therefore keep it.
     const html = page(FALL_THROUGH, [aCharacter({ id: 1, username: "topdog" })]);
-    expect(html.split("faction-plate-rule").length - 1).toBe(5);
+    expect(html.split("faction-plate-rule").length - 1).toBe(2);
   });
 });
 

--- a/frontend/src/pages/factionDetail/__tests__/defaultFactionPlate.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/defaultFactionPlate.test.tsx
@@ -84,7 +84,13 @@ describe("the Default faction body draws real plates (#2497)", () => {
     expect((html.match(/faction-plate-kicker/g) ?? []).length).toBe(4);
     // The hairline is the shared spectrum ramp, not a rule of its own — that is
     // what lets Albescent move it with the cards' bands (#2500).
-    expect((html.match(/spectrum-rule faction-plate-rule/g) ?? []).length).toBe(4);
+    //
+    // TWO, not four (#2576). `DEFAULT_SLUG` is "albescent" despite its name, so
+    // this fixture's four plates are two TEXT plates (About, Members — Champion
+    // is absent on an empty roster) and two CARD plates. The text pair mount the
+    // 3px `.alb-plate-edge` ring, and a plate may carry one structural rainbow,
+    // not two, so the hairline yields there and stays on the card pair.
+    expect((html.match(/spectrum-rule faction-plate-rule/g) ?? []).length).toBe(2);
   });
 
   it("keeps the plate OUTSIDE the disclosure, so a fold hides the gallery alone", () => {

--- a/frontend/src/pages/factionDetail/__tests__/factionLayoutAudit.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionLayoutAudit.test.tsx
@@ -256,3 +256,83 @@ describe("D. the champion is the highest ALL-TIME score, everywhere", () => {
     });
   }
 });
+
+describe("E. one carrier per plate (#2576, ADR-0083 3b)", () => {
+  /**
+   * The three text-holding plates each mounted TWO spectrum carriers at once:
+   * `plateOrnament` — Albescent's 3px `.alb-plate-edge` ring around the whole
+   * plate — and `PLATE_RULE`, na's 2px/0.55 hairline under the heading. Nothing
+   * suppressed the hairline, so both painted: two rainbows on one object, the
+   * same doubling #2527 took off the field desk, #2559 off the score stamp and
+   * #2553 off the composer. This was the fourth site and the last the sweep
+   * found.
+   *
+   * ASSERTED BY NAME, not by counting. The issue asks for it explicitly, and the
+   * reason is that a census which counts spectrum rules per page lets a NEW plate
+   * be wrong twice and still total correctly. So each case below names a plate
+   * by its own heading and says which carrier that plate is allowed to hold.
+   *
+   * `PLATE_RULE` is NOT deleted: it is correct for the seven factions that hand
+   * no ornament, where it is the only spectrum on the plate. It yields to the
+   * thicker carrier and to nothing else.
+   */
+
+  /** The open tag of the `.faction-plate` section that holds `heading`. */
+  function plateOf(html: string, heading: string): string {
+    const at = html.indexOf(heading);
+    expect(at, `a plate carries ${JSON.stringify(heading)}`).toBeGreaterThan(-1);
+    const open = html.lastIndexOf('<section class="faction-plate"', at);
+    expect(open, `${JSON.stringify(heading)} sits inside a .faction-plate`).toBeGreaterThan(-1);
+    const close = html.indexOf("</section>", at);
+    return html.slice(open, close);
+  }
+
+  /** na hands no ornament, so every plate keeps the hairline it always had. */
+  it("na keeps its hairline on all five plates", () => {
+    const html = markup("na", DefaultFactionBody as Body);
+    for (const heading of [
+      i18n.t("factions:detail.aboutHeading"),
+      i18n.t("factions:detail.spotlightLabel"),
+      membersHeading(),
+      i18n.t("factions:detail.default.tasksHeading", { total: 0 }),
+      i18n.t("factions:detail.default.recentHeading"),
+    ]) {
+      const plate = plateOf(html, heading);
+      expect(plate, `na's ${heading} plate draws the hairline`).toContain("faction-plate-rule");
+      expect(plate, `na's ${heading} plate mounts no 3px carrier`).not.toContain("alb-plate-edge");
+    }
+  });
+
+  /**
+   * Albescent's three TEXT plates take the ring and give up the hairline; its two
+   * CARD plates never had a ring (the cards carry their own edges) so they keep
+   * the hairline. Both halves matter: dropping the rule everywhere would strip
+   * the card plates of their only spectrum.
+   */
+  it("albescent's text plates carry the ring alone", () => {
+    const html = markup("albescent", AlbescentFactionBody as Body);
+    for (const heading of [
+      i18n.t("factions:detail.aboutHeading"),
+      i18n.t("factions:detail.spotlightLabel"),
+      membersHeading(),
+    ]) {
+      const plate = plateOf(html, heading);
+      expect(plate, `${heading} mounts the 3px carrier`).toContain("alb-plate-edge");
+      expect(plate, `${heading} draws no second, thinner rainbow`).not.toContain(
+        "faction-plate-rule",
+      );
+    }
+  });
+
+  it("albescent's card plates keep the hairline, having no ring", () => {
+    const html = markup("albescent", AlbescentFactionBody as Body);
+    for (const heading of [
+      i18n.t("factions:detail.default.tasksHeading", { total: 0 }),
+      i18n.t("factions:detail.default.recentHeading"),
+    ]) {
+      const plate = plateOf(html, heading);
+      expect(plate, `${heading} mounts no ring`).not.toContain("alb-plate-edge");
+      expect(plate, `${heading} keeps its hairline`).toContain("faction-plate-rule");
+    }
+  });
+});

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -25,6 +25,27 @@ const NA_SLUG = "na";
  */
 const PLATE_RULE = <span aria-hidden className="spectrum-rule faction-plate-rule" />;
 
+/**
+ * ONE CARRIER PER OBJECT (ADR-0083 3b, #2576).
+ *
+ * `PLATE_RULE` is na's plate hairline -- 2px at 0.55 -- and on the seven
+ * factions that hand no ornament it is the only spectrum on the plate, so it is
+ * correct and it stays. But a plate that mounts `plateOrnament` already has a
+ * structural rainbow: Albescent's `.alb-plate-edge` is a 3px spectrum ring
+ * around the whole plate. Drawing the hairline underneath the heading as well
+ * put two rainbows on one object -- the same doubling #2527 took off the field
+ * desk, #2559 off the score stamp and #2553 off the composer.
+ *
+ * The fix is not to delete the rule, which would strip the other seven; it is to
+ * let the thicker carrier claim the object, exactly as those three did. Stated
+ * once here rather than three times at the call sites, and applied to all five
+ * plates: the two card-holding ones mount no ornament, so nothing changes for
+ * them, and a plate that gains one later gets the rule for free.
+ */
+function plateRule(ornament: ReactNode): ReactNode {
+  return ornament ? null : PLATE_RULE;
+}
+
 /** Flex-wrap card grid — varied card sizes are intentional, not a CSS grid.
  *  The recently-completed PRAXIS gallery only, since #1945: the task row above
  *  wears `.task-card-row`, which keeps the widths ragged and levels the bottom
@@ -251,7 +272,7 @@ export default function DefaultFactionBody({
           {plateOrnament}
           <div className="faction-plate-kicker">
             <h2 className="label-heading">{t("detail.aboutHeading")}</h2>
-            {PLATE_RULE}
+            {plateRule(plateOrnament)}
           </div>
           {paragraphs.length === 0 ? (
             <p className="font-body text-muted content-text">{t("detail.descriptionEmpty")}</p>
@@ -277,6 +298,8 @@ export default function DefaultFactionBody({
                 label={t("detail.default.tasksHeading", { total: tasks.length })}
               />
             </h2>
+            {/* Unconditional: this plate mounts no ornament (see above), so
+                there is no thicker carrier for the hairline to yield to. */}
             {PLATE_RULE}
           </div>
           <SectionPanel section={sections.tasks}>
@@ -308,6 +331,7 @@ export default function DefaultFactionBody({
             <h2 className="label-heading">
               <SectionToggle section={sections.praxis} label={t("detail.default.recentHeading")} />
             </h2>
+            {/* Unconditional, for the same reason as the Tasks plate above. */}
             {PLATE_RULE}
           </div>
           <SectionPanel section={sections.praxis}>
@@ -394,7 +418,7 @@ export default function DefaultFactionBody({
             {plateOrnament}
             <div className="faction-plate-kicker">
               <h2 className="label-heading">{t("detail.spotlightLabel")}</h2>
-              {PLATE_RULE}
+              {plateRule(plateOrnament)}
             </div>
             <div className="flex flex-wrap items-center gap-3">
               <CharacterBadge character={champion} />
@@ -419,7 +443,7 @@ export default function DefaultFactionBody({
             <h2 className="label-heading">
               {t("detail.default.membersHeading", { total: members.length })}
             </h2>
-            {PLATE_RULE}
+            {plateRule(plateOrnament)}
           </div>
           {roll.length === 0 ? (
             <p className="font-body text-muted content-text">


### PR DESCRIPTION
The fourth and last doubled carrier the #2575 sweep found.

Closes #2576

## Seam

`factionLayoutAudit.test.tsx`, block **E** — each plate located **by its own
heading**, then asserted on which carrier that plate is allowed to hold.

By name, not by count, because the issue asks for it and the reason is concrete:
a census that counts spectrum rules across a page cannot say *which* plate is
wrong, and reads identically whether one plate has two carriers or two plates
have one each. Two existing tests in this repo were doing exactly that — see
below.

## The defect

The three text-holding plates each mounted two spectrum carriers at once:

- `plateOrnament` — for Albescent, the 3px `.alb-plate-edge` ring around the
  whole plate
- `PLATE_RULE` — na's 2px/0.55 hairline under the heading

Nothing suppressed the hairline, so both painted. Two rainbows on one object,
which is what ADR-0083 3b forbids and what #2527 took off the field desk, #2559
off the score stamp and #2553 off the composer.

## The fix — the same shape as those three

**`PLATE_RULE` is not deleted.** It is correct for the seven factions that hand
no ornament, where it is the only spectrum on the plate. It now yields to the
thicker carrier and to nothing else, stated once at the declaration rather than
three times at the call sites.

**The two card-holding plates deliberately do not route through the helper.**
They mount no ornament by construction — their cards carry edges of their own —
so passing them `plateOrnament` asks the wrong question: the prop is truthy for
Albescent whether or not *that* plate draws it. My first version did exactly
that and silently stripped their hairline; the by-name guard caught it, which is
the argument for by-name in one sentence.

## Two existing guards were pinning the bug

The full suite caught both. Neither is weakened — both are restated, and both now
read **2**:

- `defaultFactionHero.test.tsx` asserted the hairline appeared **5** times on an
  Albescent page. The test is called *"the two card plates keep the plate's own
  hairline"* — this is the first time its number has matched its name.
- `defaultFactionPlate.test.tsx` asserted **4**. Worth flagging for anyone
  reading it: its `DEFAULT_SLUG` constant is `"albescent"`, not na.

## Verification

- `factionLayoutAudit.test.tsx` — **66/66**; reverting the archetype fails
  *"albescent's text plates carry the ring alone"*
- `src/pages/factionDetail` — **266/266**
- **Full suite — 7559 tests, 0 failures**
- `typecheck`, `typecheck:design-sync`, `lint` — all clean
- **Visual QA is outstanding.** No browser on this change.

## What to eyeball

- **The Albescent faction page, both themes** — the About, Champion and Members
  plates. The 3px spectrum edge around each plate stays; the thin 2px rainbow
  under each heading should be **gone**.
- **The Tasks and Recently-completed plates on that same page** — these must be
  unchanged, still showing their hairline under the heading. That is the half a
  blunter fix would have broken.
- **Any of the other seven faction pages** — completely unchanged; they hand no
  ornament, so every plate keeps its hairline.
- Landing right after #2591, which re-parented these same plates into the
  main/rail grid — so it is worth confirming the plates look right in both
  columns at once.
