### PR TITLE
The desktop home's player cards carry the edit door the phone has (#2552)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -885,8 +885,15 @@ export default function Sidebar() {
                  ONE door, since #2354. The `CHARACTERS` pill that stood here
                  opened the account's roster in a bottom sheet — the same roster,
                  on the same `rosterOffersAChoice` gate, that the desktop home
-                 lays out in the page behind this rail. `EDIT` stays: it leads
-                 somewhere the home page does not. ── */}
+                 lays out in the page behind this rail.
+
+                 `EDIT` stays, but not for the reason it used to: since #2552 the
+                 home page's roster cards each carry this same door, so it is no
+                 longer the only one. It is the only one the viewer is CERTAIN to
+                 have — those cards live behind `rosterOffersAChoice`, and the
+                 commonest state of all (one life, gate shut) draws no roster at
+                 all. Two doors to the same room while the gate is open; this one
+                 while it is shut. ── */}
           <div className="flex justify-end gap-2 mb-4">
             <Link
               to={`/characters/${character.id}/edit`}

--- a/frontend/src/components/layout/__tests__/sidebarCharacterCardDoors.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarCharacterCardDoors.test.tsx
@@ -10,9 +10,16 @@
  * 38x4 drag handle, all unconditional — so on a desktop it drew a full-width
  * phone sheet with a drag handle across the bottom of the window.
  *
- * The pill goes; the `EDIT` pill beside it stays, because it leads somewhere the
- * home page does not. Both halves are asserted: a deletion test that only says
- * "gone" passes just as well on a card that lost its whole action row.
+ * The pill goes; the `EDIT` pill beside it stays. Both halves are asserted: a
+ * deletion test that only says "gone" passes just as well on a card that lost
+ * its whole action row.
+ *
+ * WHY `EDIT` STAYS changed under this test in #2552, though the assertion did
+ * not. It used to be "it leads somewhere the home page does not"; the home
+ * page's roster cards each carry the same door now. What keeps this one is that
+ * those cards sit behind `rosterOffersAChoice` — one life and a shut gate, the
+ * commonest state there is, draws no roster — so the rail is the door that is
+ * always there. Removing it is still a separate call, and still nobody's here.
  *
  * The roster is stubbed OPEN (`can_create_additional_character`), which is the
  * state the pill used to render in — otherwise the absence proves nothing.
@@ -69,7 +76,7 @@ function render(): string {
 }
 
 describe("the rail's character card holds one door, not two (#2354)", () => {
-  it('keeps the EDIT pill, which leads where the home page cannot', () => {
+  it('keeps the EDIT pill — the one door a gated-away roster cannot take away', () => {
     expect(i18n.t('common:sidebar.characterCard.edit'), 'guard: key resolves').toBe('Edit')
     const html = render()
     expect(html).toContain('href="/characters/42/edit"')

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -195,25 +195,13 @@ export default function FieldDesk() {
         ) : (
           <div style={rosterRow}>
             {lives.map((life, index) => (
-              <button
+              <RosterLifeCard
                 key={life.id}
-                type="button"
-                onClick={() => enterLife(life.id)}
-                disabled={switching != null}
-                className="fielddesk-life"
-                style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
-                title={t('fieldDesk.stepInto', { name: life.display_name })}
-              >
-                <CredentialCard
-                  displayName={life.display_name}
-                  handle={life.username}
-                  factionSlug={life.faction_slug}
-                  level={life.level}
-                  score={life.score}
-                  avatarUrl={mediaUrl(life.avatar_url)}
-                  rotation={TILTS[index % TILTS.length]}
-                />
-              </button>
+                life={life}
+                rotation={TILTS[index % TILTS.length]}
+                switching={switching != null}
+                onEnter={() => enterLife(life.id)}
+              />
             ))}
 
             {/* "Begin a new self" — the dossier has no locked face any more
@@ -280,6 +268,81 @@ type FooterKey = 'fieldDesk.footer' | 'fieldDesk.footerFirstLife' | 'fieldDesk.f
 export function rosterFooterKey(lifeCount: number, canCreateAdditional: boolean): FooterKey {
   if (lifeCount === 0) return 'fieldDesk.footerFirstLife'
   return canCreateAdditional ? 'fieldDesk.footer' : 'fieldDesk.footerNoNewSelf'
+}
+
+/**
+ * One life in the roster: the credential card that steps into it, and the door
+ * that edits it (#2552).
+ *
+ * The edit door is what the phone has had all along — all nine
+ * `mobileArchetypes/*FieldDesk.tsx` draw an `Edit` pill in the identity card's
+ * action row — and what the laptop did not, leaving the rail's identity card as
+ * the only non-mobile way into `/characters/:id/edit`. Same placement as the
+ * phone's and the rail's, right-aligned above the card, so the two form factors
+ * agree about where the door is. Same catalog string, too: no new copy for a
+ * door that already exists ten times over.
+ *
+ * It is a SIBLING of the card's button rather than a child of it, because the
+ * card is itself a button and an anchor inside one is invalid DOM. That is also
+ * why the pill sits outside the tilt: the rotation is the card's.
+ *
+ * OWNERSHIP is structural, not a branch. The roster is `getMyCharacters()` —
+ * the account's own lives and nothing else — so every card here is one the
+ * viewer owns and the door is never a control that would only refuse them.
+ * Nothing else on this page draws a `CredentialCard` from someone else's life.
+ *
+ * Exported for its test: `renderToStaticMarkup` never runs effects, so
+ * `FieldDesk` itself can only be rendered with an unresolved roster and there
+ * are no cards in that markup to look at. Same reason `rosterFooterKey` is.
+ */
+export function RosterLifeCard({
+  life,
+  rotation,
+  switching,
+  onEnter,
+}: {
+  life: CharacterOut
+  rotation: number
+  /** True while ANY life is being stepped into — the whole roster goes inert. */
+  switching: boolean
+  onEnter: () => void
+}) {
+  const { t } = useTranslation('common')
+  return (
+    <div>
+      {/* The link's accessible name is just "Edit", as it is on the phone and in
+          the rail. Several cards means several of them, and what tells them
+          apart is this wrapper: WCAG 2.4.4 is link purpose *in context*, and the
+          context is the card named directly below. */}
+      <div style={rosterEditRow}>
+        <Link
+          to={`/characters/${life.id}/edit`}
+          className="hover:opacity-80 active:opacity-60"
+          style={rosterEditPill}
+        >
+          {t('sidebar.characterCard.edit')}
+        </Link>
+      </div>
+      <button
+        type="button"
+        onClick={onEnter}
+        disabled={switching}
+        className="fielddesk-life"
+        style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+        title={t('fieldDesk.stepInto', { name: life.display_name })}
+      >
+        <CredentialCard
+          displayName={life.display_name}
+          handle={life.username}
+          factionSlug={life.faction_slug}
+          level={life.level}
+          score={life.score}
+          avatarUrl={mediaUrl(life.avatar_url)}
+          rotation={rotation}
+        />
+      </button>
+    </div>
+  )
 }
 
 /**
@@ -644,6 +707,35 @@ const rosterRow: CSSProperties = {
   gap: 'var(--space-2xl)',
   alignItems: 'flex-start',
   marginTop: 'var(--space-2xl)',
+}
+/** The edit door's row: right-aligned over the card, as on the phone (#2552). */
+const rosterEditRow: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginBottom: 'var(--space-sm)',
+}
+/**
+ * The edit door itself — the rail's `identityActionStyle` and the phone desks'
+ * `actionPillStyle` at the same measurements, minus the `--rail-*` seam those
+ * two read, which does not reach the page body. 44 is the WCAG 2.5.5 target
+ * floor and is GEOMETRY, not spacing: deliberately not on the --space-* ramp.
+ */
+const rosterEditPill: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  minHeight: 44,
+  boxSizing: 'border-box',
+  padding: '0 var(--space-lg)',
+  borderRadius: 999,
+  border: '1px solid var(--color-border-strong)',
+  background: 'var(--color-bg-surface-alt)',
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: 'var(--color-text-primary)',
+  textDecoration: 'none',
+  transition: 'opacity 120ms ease',
 }
 const footerHint: CSSProperties = {
   fontFamily: 'var(--font-display)',

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterEditDoor.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterEditDoor.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * #2552 — the desktop home's player cards carry an edit door.
+ *
+ * On a phone every character card draws one; all nine `mobileArchetypes/
+ * *FieldDesk.tsx` put an `Edit` pill in the identity card's action row. On a
+ * laptop the same page drew the same cards and none of them did, so the only
+ * non-mobile way to reach `/characters/:id/edit` was the rail's identity card —
+ * a door nobody looks for. Owner ruling: edit belongs on the home page's player
+ * cards.
+ *
+ * THE SEAM is one roster card, not the page. `renderToStaticMarkup` never runs
+ * effects, so `getMyCharacters` never resolves and `FieldDesk` can only ever be
+ * rendered in its "roster still loading" state — there are no cards in that
+ * markup to look for a link on. `RosterLifeCard` is exported for exactly this
+ * reason, the same way `rosterFooterKey` and `rosterOffersAChoice` are: a page
+ * whose cards have no door renders perfectly.
+ *
+ * Ownership needs no assertion here because it is structural: the roster is
+ * `getMyCharacters()`, the account's own lives and nothing else, so every card
+ * this component ever draws is one the viewer owns. `fieldDeskRosterGate` pins
+ * the page-level half — which viewers see a roster at all.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { CharacterOut } from '../../../api/auth'
+import { RosterLifeCard } from '../../FieldDesk'
+
+function life(overrides: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    id: 42,
+    username: 'molly',
+    display_name: 'Mollusk',
+    bio: '',
+    tagline: '',
+    avatar_url: '',
+    location: '',
+    level: 2,
+    score: 120,
+    all_time_score: 120,
+    faction_slug: 'na',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [],
+    invitations: [],
+    ...overrides,
+  }
+}
+
+function render(overrides: Partial<CharacterOut> = {}): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <RosterLifeCard life={life(overrides)} rotation={0} switching={false} onEnter={() => {}} />
+    </MemoryRouter>,
+  )
+}
+
+/** Every `/characters/:id/edit` href in the markup, in document order. */
+function editHrefs(html: string): string[] {
+  return [...html.matchAll(/href="(\/characters\/\d+\/edit)"/g)].map((m) => m[1])
+}
+
+describe('a desktop roster card leads to its own edit page (#2552)', () => {
+  it('draws exactly one edit link, pointing at that life', () => {
+    expect(editHrefs(render())).toEqual(['/characters/42/edit'])
+    expect(editHrefs(render({ id: 7 }))).toEqual(['/characters/7/edit'])
+  })
+
+  it('wears the string the rail and all nine phone desks already wear', () => {
+    // No new copy for a door that exists nine times over (ADR-0032). If this
+    // key ever moves, the phone desks break with it — which is the point.
+    expect(i18n.t('common:sidebar.characterCard.edit'), 'guard: key resolves').toBe('Edit')
+    expect(render()).toContain(i18n.t('common:sidebar.characterCard.edit'))
+  })
+
+  it('navigates with a link, not a button', () => {
+    // The phone desks use `<Link>`; so does the rail. It also has to be a
+    // SIBLING of the card's button — the card is itself a button, and an
+    // anchor nested in one is invalid DOM that a browser will re-parent.
+    const html = render()
+    expect(html).toMatch(/<a\b[^>]*href="\/characters\/42\/edit"/)
+    expect(html).not.toMatch(/<button[^>]*>(?:(?!<\/button>)[\s\S])*<a\b/)
+  })
+
+  it('still steps into the life when the card itself is pressed', () => {
+    // A deletion-shaped assertion on its own would pass on a card that lost
+    // its whole body, so the card's own affordance is pinned beside the door.
+    const html = render()
+    expect(html).toContain('class="fielddesk-life"')
+    expect(html).toContain(i18n.t('common:fieldDesk.stepInto', { name: 'Mollusk' }))
+  })
+})


### PR DESCRIPTION
Closes #2552

On a phone every character card carries an `Edit` link — all nine
`mobileArchetypes/*FieldDesk.tsx` draw one. On a laptop the same page drew the
same cards and none of them did, so the only non-mobile way into
`/characters/:id/edit` was the rail's identity card: a door nobody looks for.
Owner ruling: edit belongs on the home page's player cards.

## The seam

**One roster card, not the page.** `renderToStaticMarkup` never runs effects, so
`getMyCharacters` never resolves and `FieldDesk` can only ever be rendered in its
"roster still loading" state — there are no cards in that markup to look for a
link on. So the per-life card is extracted as `RosterLifeCard` and exported for
its test, exactly the way `rosterFooterKey` and `rosterOffersAChoice` already are
in this file. The new test went red first on the real defect (no such door), then
green.

`frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterEditDoor.test.tsx` pins:
one edit link per card, pointing at that life; the catalog string; that it is an
`<a>` and **not** nested inside the card's `<button>`; and that the card's own
"step into" affordance survives (a deletion-shaped assertion alone would pass on
a card that lost its whole body).

## What changed

- `frontend/src/pages/FieldDesk.tsx` — the roster's `lives.map` body becomes
  `RosterLifeCard`: a right-aligned `Edit` pill above the credential card, then
  the card's button. Placement matches the phone's identity-card action row and
  the rail's, so the two form factors agree about where the door is.
- `frontend/src/components/layout/Sidebar.tsx` + its test's docblock — the
  comment claiming `EDIT` stays "because it leads somewhere the home page does
  not" is now false, and is corrected rather than left to become a future
  misdiagnosis. The rail's link itself is untouched, per the issue.

### No new string

`sidebar.characterCard.edit` ("Edit") — it is the *only* candidate: the rail and
all nine phone desks read that one key, and there is no `fieldDesk.*` edit key to
choose between. If it ever moves, the phone desks break with it, which is the
point.

### A link, not a button, and a sibling not a child

The credential card is already a `<button>` (step into this life). An anchor
nested inside a button is invalid DOM that a browser re-parents, so the pill sits
outside it — which also keeps it upright while the card keeps its tilt.

### Ownership is structural

The roster is `getMyCharacters()` — the account's own lives and nothing else — so
every card this renders is one the viewer owns. No branch, so no chance of a
control that only refuses. Nothing else on this page draws a `CredentialCard` from
someone else's life. "Begin a new self" is not a character and gets nothing.

Note the one thing this does *not* change: the roster is gated on
`rosterOffersAChoice`, so a viewer with one life and a shut second-character gate
sees no cards and therefore no new door. The rail remains the door that is always
there — that is the corrected reason it stays.

## Verification

Run locally, all green: `npm run lint`, `npm run typecheck`,
`npm run typecheck:design-sync`, `npm test` (419 files / 7563 tests),
`npm run build`, `npm run budget`.

`budget` prints a **pre-existing** CSS WARN (22.3 KB vs a 22.2 KB warn line, fail
at 24.4). Non-blocking, and not from this diff: no `.css` file is touched and both
Tailwind utilities used (`hover:opacity-80`, `active:opacity-60`) already ship
from `Sidebar.tsx` and `DefaultFieldDesk.tsx`, so the CSS bundle is byte-identical
to main. `api-schema` is untouched — no route, `response_model` or schema in this
diff.

**Visual QA is outstanding**: this branch had no browser and no dev stack.

## What to eyeball

- **The desktop Field Desk at laptop width (≈1280)**, roster open — i.e. an
  account with two lives, or one life with the second-character gate open.
- An **owned** card: the `Edit` pill sits right-aligned above the card, upright,
  while the card keeps its tilt. Does an upright 44px pill over a rotated card
  read right, or should it hug the tilt / move below? That is a styling call I
  deliberately did not make — `frontend-style`'s if it needs one.
- **Not-owned**: there is no such card on this page, so what to check is the
  absence — no `Edit` anywhere in the "Begin a new self" dossier, and none in the
  Continue / Browse sections below.
- **Wrapping**: several cards in the flex-wrap row still line up, and the extra
  pill row has not changed the gap rhythm between rows.
- Dark mode, and a themed faction card (Coven, S.N.I.D.E.) beside an `na` one —
  the pill reads from page tokens, not the card's `--fc-*` skin.
- The rail's own `Edit` is still there and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
