### PR TITLE
The sealed page's denial is read, not whispered (#2523)

### DIFF
--- a/frontend/src/pages/AlbescentSecretPlaceholder.tsx
+++ b/frontend/src/pages/AlbescentSecretPlaceholder.tsx
@@ -10,9 +10,10 @@
  * below. This docstring used to end "Albescent surfaces never dim in dark mode —
  * the `--albescent-reveal-*` tokens carry identical values in both themes", and
  * that is no longer true: the reveal register has a dark half whose values are
- * the na card's own. Every colour on this page is either `BG`/`INK` or `ink()`
- * mixed down from `INK`, so the sheet, the rules and the glyph all invert
- * through the cascade with nothing branching on a `dark` boolean.
+ * the na card's own. Every colour on this page is a `--albescent-reveal-*`
+ * token — `BG`, `INK`, `MUTED` — or an `ink()` wash mixed down from `INK`, so
+ * the sheet, the rules and the glyph all invert through the cascade with
+ * nothing branching on a `dark` boolean.
  *
  * ADR-0017's ruling 7 used to say Albescent's surfaces are "always-light
  * (identical values in both the light and dark cascades, exactly as
@@ -35,10 +36,26 @@ import '../factionFaces'
 
 const BG = 'var(--albescent-reveal-surface)'
 const INK = 'var(--albescent-reveal-text)'
+/**
+ * The register's quiet TEXT tier — 4.64:1 by day, 5.44:1 at night, both
+ * measured on this sheet by `factionContrast.test.ts` (#2523).
+ *
+ * The eyebrow used to be `ink(30)`, 1.92:1 in light, and the reason nothing
+ * caught that is the reason this constant exists: a per-site mix is a fourth
+ * tier on a register that names three, and no value-level sweep can reach one.
+ * Reading the token is what makes the line measurable, not merely lighter.
+ */
+const MUTED = 'var(--albescent-reveal-text-muted)'
 const FONT = 'var(--font-faction-vellum)'
 const MONO = 'var(--font-body)'
 
-/** A translucent wash of Albescent ink at the given opacity percentage. */
+/**
+ * A translucent wash of Albescent ink at the given opacity percentage.
+ *
+ * ORNAMENT ONLY. Its three callers are the card's hairline, the fleur-de-lis
+ * and the 64px rule — marks that owe no contrast ratio and are meant to stay
+ * whispers. Anything that is READ takes a named tier; see `MUTED`.
+ */
 const ink = (percent: number): string => `color-mix(in srgb, ${INK} ${percent}%, transparent)`
 
 function FleurMark({ size = 56 }: { size?: number }) {
@@ -88,7 +105,7 @@ export default function AlbescentSecretPlaceholder() {
             fontSize: 'var(--text-md)',
             letterSpacing: '0.28em',
             textTransform: 'uppercase',
-            color: ink(30),
+            color: MUTED,
             marginBottom: 'var(--space-xl)',
           }}
         >

--- a/frontend/src/pages/__tests__/albescentSealedInk.test.tsx
+++ b/frontend/src/pages/__tests__/albescentSealedInk.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * The sealed page's eyebrow is TEXT, and text is painted from a NAMED tier (#2523).
+ *
+ * SEAM: the ink-role declarations `AlbescentSecretPlaceholder` emits, read
+ * through `utils/__tests__/inkSeam.ts` so there is one definition of "what
+ * counts as an ink" and not a second copy here.
+ *
+ * WHY THIS SEAM AND NOT A CONTRAST ROW. `factionContrast.test.ts` measures
+ * TOKEN PAIRINGS, and its "albescent reveal sheet, muted" row already pins
+ * `--albescent-reveal-text-muted` on `--albescent-reveal-surface` in both
+ * themes — 4.64:1 by day, 5.44:1 at night. That row was live the whole time the
+ * eyebrow was failing at 1.92:1, because the eyebrow was not painted from a
+ * token: it was `color-mix(… --albescent-reveal-text 30%, transparent)`, a
+ * FOURTH tier invented inline on a register that names three. No value-level
+ * sweep can reach a per-site mix, which is precisely how this surface stayed
+ * unmeasured. The missing assertion was never "is the muted tier legible" but
+ * "does the text on this page read a tier at all", and that is a question about
+ * what the component emits.
+ *
+ * THE FLEUR AND THE RULE ARE ORNAMENT AND ARE MEANT TO STAY WHISPERS
+ * (owner ruling on #2523). They are `ink(22)` and `ink(16)` and they owe no
+ * ratio; keeping them exactly where they are is what makes the eyebrow's
+ * promotion a statement about that one line rather than a flat lift of the whole
+ * page. The guard below is written so that it forbids a fourth TEXT tier while
+ * asserting both ornaments still carry their own alpha — a sweep that "fixed"
+ * this page by lifting everything would go red here, and so would one that
+ * deleted the ornament to satisfy the first half.
+ *
+ * The ornament exemption is structural, not a listed escape hatch: the fleur is
+ * an `aria-hidden` `<svg>` whose `color` exists only to feed
+ * `fill="currentColor"`, so the whole element is cut out of the markup before
+ * the text inks are read. A future ornament drawn the same way is covered; a
+ * future `color-mix()` on a paragraph is not.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import '../../i18n'
+import { declarations, INK_PROPS } from '../../utils/__tests__/inkSeam'
+import AlbescentSecretPlaceholder from '../AlbescentSecretPlaceholder'
+
+const html = renderToStaticMarkup(<AlbescentSecretPlaceholder />)
+
+/** The page with its ornament cut out: the `aria-hidden` fleur-de-lis. */
+const textMarkup = html.replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/g, '')
+
+const textInks = declarations(textMarkup)
+  .filter(([property]) => INK_PROPS.has(property))
+  .map(([, value]) => value)
+
+/** The three tiers the reveal register names, and the three it measures. */
+const NAMED_TIERS = new Set([
+  'var(--albescent-reveal-text)',
+  'var(--albescent-reveal-text-muted)',
+  'var(--albescent-reveal-ink)',
+])
+
+const wash = (percent: number) =>
+  `color-mix(in srgb, var(--albescent-reveal-text) ${percent}%, transparent)`
+
+describe("the sealed page's text ink", () => {
+  it('is a named reveal tier at every site, never a per-site fade', () => {
+    expect(textInks.length).toBeGreaterThan(0)
+    expect(textInks.filter((value) => !NAMED_TIERS.has(value))).toEqual([])
+  })
+
+  /**
+   * The eyebrow — `— no such account —`, the page's actual claim, the only line
+   * that says what happened. Asserted by its tier rather than by its copy: the
+   * wording has already moved once (#2409 redacted "SEALED" away) and a
+   * copy-anchored guard would have rotted with it.
+   */
+  it('reaches the muted tier for the eyebrow', () => {
+    expect(textInks).toContain('var(--albescent-reveal-text-muted)')
+  })
+})
+
+describe("the sealed page's ornament", () => {
+  it('keeps the fleur and the 64px rule at their own whisper alphas', () => {
+    const all = declarations(html).map(([property, value]) => `${property}: ${value}`)
+    expect(all).toContain(`color: ${wash(22)}`)
+    expect(all).toContain(`background: ${wash(16)}`)
+  })
+})

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1909,6 +1909,19 @@ const ARCHETYPE_PAIRS: Pair[] = [
   // still carries body text, and it is where #594's 2.78:1 muted ink shipped, so
   // it stays measured. The whole palette is one hue at varying alpha over the
   // sheet, which makes compositing the entire question.
+  //
+  // THE THREE ROWS BELOW ARE THE WHOLE REGISTER, AND #2523 IS WHY THAT SENTENCE
+  // NOW HAS TO BE TRUE RATHER THAN NEARLY TRUE. The secret placeholder's eyebrow
+  // — `— no such account —`, the line that makes the page a dead end instead of
+  // a 404 — was painted `color-mix(… --albescent-reveal-text 30%, transparent)`
+  // inline: a FOURTH tier on a register that names three, at 1.92:1 in light,
+  // sitting beside a "muted" row that was green the entire time. A value-level
+  // sweep cannot reach a per-site mix, so no row here could ever have caught it.
+  // It now reads `-text-muted`, so this block covers it — and the half of the
+  // guard that keeps it covered is `pages/__tests__/albescentSealedInk.test.tsx`,
+  // which reads what that component EMITS and forbids a fifth tier being
+  // invented the same way. Neither file subsumes the other: these rows measure
+  // tokens nothing need render, that one measures ink no token need name.
   {
     what: "albescent reveal sheet, ink",
     surface: "--albescent-reveal-surface",


### PR DESCRIPTION
Closes #2523

The Albescent sealed page's eyebrow — `— no such account —`, the in-world denial that makes `/factions/albescent` a dead end rather than a 404 — was painted `ink(30)`, a 30% per-site fade of the reveal register's ink. That is **1.92:1** on the light sheet. The line that says what happened was the one line you could not read.

Per the owner's ruling on #2523 it is **text**, and it moves to `--albescent-reveal-text-muted`. The fleur-de-lis at `ink(22)` and the 64px rule at `ink(16)` are **untouched** — they are genuinely ornament, and leaving them put is what makes this a promotion of one line rather than a flat lift of the page.

## The seam

**The ink-role declarations `AlbescentSecretPlaceholder` emits**, read through the existing `utils/__tests__/inkSeam.ts` so there is one definition of "what counts as an ink" and not a second copy.

That seam is the finding, not just a convenient place to assert. `factionContrast.test.ts` has held an `albescent reveal sheet, muted` row in both themes the whole time, and it was **green while the eyebrow beside it was failing**, because the eyebrow was not painted from a token at all: `ink(30)` was a fourth tier invented inline on a register that names three, and no value-level sweep can reach a per-site `color-mix()`. The missing assertion was never "is the muted tier legible" — it was "does the text on this page read a tier at all".

New guard `frontend/src/pages/__tests__/albescentSealedInk.test.tsx`, three cases:

1. every text ink on the page is one of the three named reveal tiers (this is DoD item 5 — no *other* `ink(N)` can become a new un-pinned tier either);
2. the eyebrow specifically reaches `--albescent-reveal-text-muted`, asserted by tier and never by copy, since that wording has already moved once under #2409;
3. the fleur and the rule still carry their own 22% and 16% — so a careless sweep that "fixes" this page by lifting everything goes red, and so does one that deletes the ornament to satisfy case 1.

The ornament exemption is structural rather than a listed escape hatch: the fleur is an `aria-hidden` `<svg>` whose `color` only feeds `fill="currentColor"`, so the element is cut from the markup before the text inks are read.

**Red first, on the real defect** — case 1 reported the literal offender `color-mix(in srgb, var(--albescent-reveal-text) 30%, transparent)` and case 3 was green before the fix.

## Measurements — re-derived on the composite, not the declared token

Composited on the sheet the eyebrow actually sits on (`--albescent-reveal-surface`, opaque in both themes), not on the declared value:

| | ground | ink | ratio | AA (11px, `--text-md`) |
|---|---|---|---|---|
| light, before | `#ffffff` | `#1c1c1a` @ 30% → `#babab9` | **1.92:1** | fails 4.5 |
| light, after | `#ffffff` | `#1c1c1a` @ 61% → `#757573` | **4.64:1** | passes |
| dark, after | `#1c1b24` | `#9b9080` | **5.44:1** | passes |

My numbers agree with the issue's 4.64 / 5.44 to two decimals. The eyebrow is `var(--text-md)` = **11px**, so the normal 4.5:1 floor applies — the issue says 12px, which does not change the floor either way.

## DoD

- [x] Eyebrow reads `--albescent-reveal-text-muted`, not `ink(30)`
- [x] Fleur `ink(22)` and rule `ink(16)` unchanged
- [x] `factionContrast.test.ts` pins the eyebrow's pairing in both themes — the `albescent reveal sheet, muted` row **already did**, and adding a duplicate `what` for an identical token pair would measure nothing new and breaks that file's own stated norm. What was missing was the record of *which surface* it covers and *why the row was not enough*, so the comment now says both and names the component guard beside it. If you would rather see a literal fourth row, say so and I will add it.
- [x] No other `ink(N)` on this page becomes a new un-pinned tier — now enforced, not just observed

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally: `lint`, `typecheck`, `typecheck:design-sync`, `test` (**420 files, 7566 passed**), `build`, `budget`. Backend and `api-schema` untouched — no route, `response_model` or Pydantic schema in the diff.

`budget` WARNs on CSS at 22.3 KB against a 22.2 KB warn line. **Pre-existing and not from this PR** — the diff touches zero CSS bytes; three `.tsx`/`.ts` files only, and JS is comfortably `ok`.

**Visual QA is outstanding.** I have no browser and no dev stack; nothing below has been looked at.

## What to eyeball

- `/factions/albescent` in **light** — the eyebrow `— no such account —` should now be a legible quiet mono line under the Cormorant italic, not a near-invisible ghost. It should still read as *quieter* than the italic line above it; 11px mono at `0.28em` tracking is meant to be doing the hierarchy now, not near-erasure.
- `/factions/albescent` in **dark** — same line, same relationship, on the na card's stock.
- **In both themes, that the fleur-de-lis and the 64px rule below the italic are unchanged whispers.** If the whole page looks like it got brighter, that is the failure mode; only the one line should have moved.
- That the page still reads as an in-world dead end rather than an error page — the eyebrow being readable should make the denial land harder, not make the page look like chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
