### PR TITLE
A vote rung is numbered, not spelled

### DIFF
--- a/frontend/src/components/vote/DefaultVote.tsx
+++ b/frontend/src/components/vote/DefaultVote.tsx
@@ -38,7 +38,9 @@ const HIT_SIZE = 44
 const ROW_GAP = 9
 /** Total row width the single rainbow is stretched across. */
 const ROW_SPAN = DOT_SIZES.length * HIT_SIZE + (DOT_SIZES.length - 1) * ROW_GAP
-const TIER_KEYS = ['so-so', 'decent', 'good', 'great', 'brilliant'] as const
+/** The five rungs, as literal values so `votes:na.tier<N>` typechecks.
+ *  The words themselves live in the catalog, keyed by rung (#2586). */
+const RUNGS = [1, 2, 3, 4, 5] as const
 
 export default function DefaultVote({
   praxisId,
@@ -105,7 +107,7 @@ export default function DefaultVote({
               onMouseEnter={() => setHovered(value)}
               aria-label={t('chrome.rateAria', {
                 value,
-                label: t(`unaffiliated.${TIER_KEYS[index]}`),
+                label: t(`na.tier${RUNGS[index]}`),
               })}
               aria-pressed={picked}
               style={{

--- a/frontend/src/components/vote/__tests__/voteLadders.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteLadders.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * THE NINE VOTE LADDERS, RUNG BY RUNG, AS A VOTER READS THEM (#2586).
+ *
+ * THE SEAM IS THE RENDERED WIDGET'S `aria-label`, per faction, through the real
+ * `VoteUI` dispatcher — not the registry, and not the catalog. #2166 took every
+ * printed caption off the vote control, so `Rate {{value}} — {{label}}` is now
+ * the ONLY place a tier word reaches a person, and a registry-versus-registry
+ * assertion (`VOTE_REFRAMES` compared to itself) would pass while the ladder
+ * rendered upside down.
+ *
+ * WHY THIS EXISTS. #2586 renamed every catalog key from its own English word to
+ * its rung number (`votes:snide.rad` → `votes:snide.tier3`) and renamed the
+ * `unaffiliated` block to `na`. Not one word changed — ADR-0061 keeps vote
+ * vocabulary as a sanctioned per-faction carve-out, and #1864 kept the star
+ * ladder in faction voice. The one way that change can go wrong is silent: a
+ * rung renamed to the wrong number reorders a faction's ladder, and every
+ * key-shape test still passes because the keys are consistently, wrongly, named.
+ * So the words below are LITERAL, in ladder order, and they are the words that
+ * shipped before the rename.
+ *
+ * Albescent is the ninth widget and has no ladder: #783 took its "bear witness"
+ * vocabulary away, because a vote word renders to every voter on an Albescent-
+ * filed task and so announced the society to people never revealed to it. It
+ * announces bare arabic numerals (`chrome.rateAriaPlain`), and that absence is
+ * asserted here too, or "no vote voice" is a claim nothing checks.
+ *
+ * SSR-only harness (renderToStaticMarkup, no DOM, effects never run).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+
+// The widgets reach for browser-only context; stub the three seams so server
+// rendering works. None of them touch the vocabulary under test.
+vi.mock('../useVote', () => ({
+  useVote: () => ({ user: { id: 1 }, selected: 0, saving: false, error: '', vote: vi.fn() }),
+}))
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 1 }, refetch: vi.fn() }),
+}))
+// `useTheme()` throws outside a ThemeProvider by design (#701) and CovenVote
+// forks its whole plate on it; the vocabulary is the same on either side.
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light', toggle: () => {} }),
+}))
+
+import VoteUI from '../VoteUI'
+
+/** Every ladder, rung 1 → rung 5, in the words the widget announces. */
+const LADDERS: Record<string, readonly string[]> = {
+  // The metals ladder (#1207): a transmutation, lead → platinum.
+  ephemerists: ['lead', 'copper', 'silver', 'gold', 'platinum'],
+  everymen: ['fair', 'solid', 'good', 'excellent', 'legendary'],
+  // Coven is the cozy-casual voice and WOW the archaic one — #821 had them
+  // wearing each other's and #838 put them back (ADR-0050: go by metaphor, not
+  // label). Reading them side by side here is the point.
+  coven: ['sweet', 'lovely', 'wonderful', 'magical', 'iconic'],
+  wow: ['a start', 'quite solid', 'jolly good', 'splendid!', 'legendary!'],
+  snide: ['meh', 'not bad', 'rad', 'sick', 'ANARCHY'],
+  singularity: ['NOISE', 'WEAK', 'SIGNAL', 'CLEAR', 'VERIFIED'],
+  // The growing-mandala readings (#821): the filed work blooms fuller/warmer.
+  ua: ['faint', 'forming', 'true', 'alive', 'radiant'],
+  // The unaffiliated spectrum sweep — also what every themed-but-unskinned
+  // faction renders, so this row is the widest-reaching of the eight.
+  na: ['so-so', 'decent', 'good', 'great', 'brilliant'],
+}
+
+function render(slug: string): string {
+  return renderToStaticMarkup(<VoteUI factionSlug={slug} praxisId={7} />)
+}
+
+describe('every vote widget announces its ladder in order (#2586)', () => {
+  for (const [slug, words] of Object.entries(LADDERS)) {
+    it(`${slug}: rungs 1–5 read ${words.join(' → ')}`, () => {
+      const html = render(slug)
+      words.forEach((word, index) => {
+        expect(html, `${slug} rung ${index + 1}`).toContain(
+          `aria-label="Rate ${index + 1} — ${word}"`,
+        )
+      })
+    })
+  }
+
+  it('albescent still has no vote voice, and counts in arabic (#783)', () => {
+    const html = render('albescent')
+    for (let value = 1; value <= 5; value++) {
+      expect(html).toContain(`aria-label="Rate ${value} of 5"`)
+    }
+    for (const words of Object.values(LADDERS)) {
+      for (const word of words) expect(html).not.toContain(`— ${word}"`)
+    }
+  })
+})

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -12,96 +12,66 @@ export interface VoteReframe {
   tiers: ReframeTier[]
 }
 
+/** The five rungs, as literal values so `votes:<slug>.tier<N>` typechecks. */
+const RUNGS = [1, 2, 3, 4, 5] as const
+
 /**
- * Per-faction tier vocabulary (structure only; the words live in the copy
- * catalog at locales/en/votes.json and visual tokens stay in each archetype).
- * Labels are resolved through i18n at module load — the catalog is bundled and
- * initialized synchronously, and the app is single-locale (ADR-0032).
+ * The factions with a vote voice, and how each one numbers its discs. The WORDS
+ * are not here: they live in the copy catalog at locales/en/votes.json, under
+ * `<slug>.tier1` … `<slug>.tier5` in ladder order (#2586), and the visual tokens
+ * stay in each archetype. Faction vote vocabulary is ADR-0061's sanctioned
+ * carve-out from the one-voice rule, and #1864 kept the star ladder inside it.
+ *
+ * The per-faction notes below are the ladders' history — read them before
+ * moving a slug in or out of this list.
  */
-export const VOTE_REFRAMES: Record<string, VoteReframe> = {
+const LADDERS = {
   // The metals ladder (#1207): the vote is a transmutation, lead → platinum,
   // and the discs carry I–V. The archive vocabulary this replaces
   // (apocryphal → canonical) is gone from the catalog rather than left behind
-  // as keys holding words they no longer say. Faction vote vocabulary is
-  // ADR-0061's sanctioned carve-out.
-  ephemerists: {
-    numeral: 'roman',
-    tiers: [
-      { value: 1, label: i18n.t('votes:ephemerists.lead') },
-      { value: 2, label: i18n.t('votes:ephemerists.copper') },
-      { value: 3, label: i18n.t('votes:ephemerists.silver') },
-      { value: 4, label: i18n.t('votes:ephemerists.gold') },
-      { value: 5, label: i18n.t('votes:ephemerists.platinum') },
-    ],
-  },
-  everymen: {
-    tiers: [
-      { value: 1, label: i18n.t('votes:everymen.fair') },
-      { value: 2, label: i18n.t('votes:everymen.solid') },
-      { value: 3, label: i18n.t('votes:everymen.good') },
-      { value: 4, label: i18n.t('votes:everymen.excellent') },
-      { value: 5, label: i18n.t('votes:everymen.legendary') },
-    ],
-  },
+  // as keys holding words they no longer say.
+  ephemerists: { numeral: 'roman' },
+  everymen: {},
   // The two ladders below were inverted between these slugs by #821 and are put
   // back by #838. Coven is the cozy-casual voice (moon phases, "how'd this
   // land?"); WOW is the archaic one (balloon verdict, "Cast thy Verdict").
   // ADR-0050 — go by metaphor, not label.
-  coven: {
-    tiers: [
-      { value: 1, label: i18n.t('votes:coven.sweet') },
-      { value: 2, label: i18n.t('votes:coven.lovely') },
-      { value: 3, label: i18n.t('votes:coven.wonderful') },
-      { value: 4, label: i18n.t('votes:coven.magical') },
-      { value: 5, label: i18n.t('votes:coven.iconic') },
-    ],
-  },
-  wow: {
-    tiers: [
-      { value: 1, label: i18n.t('votes:wow.a-start') },
-      { value: 2, label: i18n.t('votes:wow.quite-solid') },
-      { value: 3, label: i18n.t('votes:wow.jolly-good') },
-      { value: 4, label: i18n.t('votes:wow.splendid') },
-      { value: 5, label: i18n.t('votes:wow.legendary') },
-    ],
-  },
-  snide: {
-    tiers: [
-      { value: 1, label: i18n.t('votes:snide.meh') },
-      { value: 2, label: i18n.t('votes:snide.not-bad') },
-      { value: 3, label: i18n.t('votes:snide.rad') },
-      { value: 4, label: i18n.t('votes:snide.sick') },
-      { value: 5, label: i18n.t('votes:snide.anarchy') },
-    ],
-  },
-  singularity: {
-    tiers: [
-      { value: 1, label: i18n.t('votes:singularity.noise') },
-      { value: 2, label: i18n.t('votes:singularity.weak') },
-      { value: 3, label: i18n.t('votes:singularity.signal') },
-      { value: 4, label: i18n.t('votes:singularity.clear') },
-      { value: 5, label: i18n.t('votes:singularity.verified') },
-    ],
-  },
-  ua: {
-    // The growing-mandala vote widget (#821): each rank is a "reading" of the
-    // filed work as the mandala blooms fuller/warmer — faint → radiant. These
-    // words are the mandala's per-rank captions AND UA's app-wide vote
-    // vocabulary (anything labelling a value reads them via reframeLabel).
-    tiers: [
-      { value: 1, label: i18n.t('votes:ua.faint') },
-      { value: 2, label: i18n.t('votes:ua.forming') },
-      { value: 3, label: i18n.t('votes:ua.true') },
-      { value: 4, label: i18n.t('votes:ua.alive') },
-      { value: 5, label: i18n.t('votes:ua.radiant') },
-    ],
-  },
+  coven: {},
+  wow: {},
+  snide: {},
+  singularity: {},
+  // The growing-mandala vote widget (#821): each rank is a "reading" of the
+  // filed work as the mandala blooms fuller/warmer — faint → radiant. These
+  // words are the mandala's per-rank captions AND UA's app-wide vote
+  // vocabulary (anything labelling a value reads them via reframeLabel).
+  ua: {},
   // Albescent has no vote voice (#783). It had the "bear witness" vocabulary
   // (#232), Unseeing → Inscribed — and that was the loudest tell left: a task
   // filed under Albescent labelled its vote tiers in the society's own words
   // for every voter, revealed or not. It now falls through to the plain arabic
-  // numerals that `na` and unknown slugs get.
-}
+  // numerals that `na` and unknown slugs get, which is why it is absent here
+  // rather than present and empty.
+} as const satisfies Record<string, { numeral?: 'roman' }>
+
+/**
+ * Per-faction tier vocabulary (structure only). Labels are resolved through
+ * i18n at module load — the catalog is bundled and initialized synchronously,
+ * and the app is single-locale (ADR-0032).
+ *
+ * `Object.keys` is re-typed rather than `Object.entries`-destructured because
+ * the slug has to stay a literal for `votes:<slug>.tier<N>` to be a real key:
+ * that template is typechecked against the catalog, so a slug with no ladder
+ * fails the build here instead of throwing at first render.
+ */
+export const VOTE_REFRAMES: Record<string, VoteReframe> = Object.fromEntries(
+  (Object.keys(LADDERS) as (keyof typeof LADDERS)[]).map((slug) => [
+    slug,
+    {
+      ...LADDERS[slug],
+      tiers: RUNGS.map((value) => ({ value, label: i18n.t(`votes:${slug}.tier${value}`) })),
+    },
+  ]),
+)
 
 /**
  * Label a vote value in a task faction's vocabulary. Falls back to the arabic

--- a/frontend/src/locales/README.md
+++ b/frontend/src/locales/README.md
@@ -34,13 +34,13 @@ locales/
 
 ## How a key works
 
-Code asks for a key like `votes:ua.masterwork` — that is: file `votes.json`,
-then follow the nesting `ua` → `masterwork`. The value is what renders.
+Code asks for a key like `votes:ua.tier5` — that is: file `votes.json`,
+then follow the nesting `ua` → `tier5`. The value is what renders.
 
 ```json
 {
   "ua": {
-    "masterwork": "masterwork"
+    "tier5": "radiant"
   }
 }
 ```
@@ -52,9 +52,11 @@ why the key survives a rewording: `charLimit.reached` stays `charLimit.reached`
 whether the copy reads "limit reached" or "no more words."
 
 - camelCase per segment, nested by feature: `charLimit.approaching`
-- kebab-case is allowed where the label itself is multi-word data
-  (`a-start`, `not-bad`)
-- Never name a key after its English text (`clickHere`, `noMoreWords` — no)
+- Number a set of rungs rather than naming them: the vote ladder is
+  `tier1` … `tier5`, so every faction's word for the same rung lines up
+- Never name a key after its English text (`clickHere`, `noMoreWords` — no).
+  The vote ladder was the last holdout: `votes:snide.rad` held "rad" and
+  `votes:ua.radiant` held "radiant", which is why #2586 renumbered them
 
 ## Placeholders
 
@@ -74,8 +76,8 @@ faction, same key shape in each branch:
 
 ```json
 {
-  "ephemerists": { "silver": "silver" },
-  "snide": { "rad": "rad" }
+  "ephemerists": { "tier3": "silver" },
+  "snide": { "tier3": "rad" }
 }
 ```
 

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -83,6 +83,52 @@ describe('en copy catalog shape', () => {
   })
 })
 
+/* ========================================================================== *
+ * #2586 — A VOTE-TIER KEY IS A RUNG NUMBER, NOT THE WORD ON THE RUNG.
+ *
+ * THE SEAM IS THE CATALOG'S KEY NAMES. `locales/README.md` states the rule this
+ * pins: "Never name a key after its English text." The vote ladder broke it on
+ * all eight slugs — `votes:snide.rad` held "rad", `votes:ua.radiant` held
+ * "radiant" — so rewording one rung meant renaming its key, and renaming a key
+ * means editing the catalog, the resolver and the tests to change one word. It
+ * also made the copy export 38 rows with a single faction column filled each,
+ * because a key named `radiant` cannot line up with a key named `rad`.
+ *
+ * Numbered, the rungs line up: five rows, eight columns, one row per rung.
+ *
+ * The WORDS are not this test's business and did not change — ADR-0061 makes
+ * per-faction vote vocabulary a sanctioned carve-out and #1864 kept the star
+ * ladder in faction voice. `voteLadders.test.tsx` is what pins the words, at
+ * the rendered widget; this file pins only the shape of the keys holding them.
+ * ========================================================================== */
+describe('vote-tier keys are numbered rungs (#2586)', () => {
+  /** Every ladder block in votes.json — the file's per-slug branches, minus the
+   *  shared `chrome` block, which is widget furniture and not a ladder. */
+  const LADDERS = Object.entries(votes).filter(([slug]) => slug !== 'chrome')
+  const RUNGS = ['tier1', 'tier2', 'tier3', 'tier4', 'tier5']
+
+  it('finds every ladder, so the sweep cannot pass by scanning nothing', () => {
+    expect(LADDERS.map(([slug]) => slug).sort()).toEqual(
+      [...FACTION_SLUGS, 'na'].slice().sort()
+    )
+  })
+
+  it('names each rung by its position, so no key repeats its own value', () => {
+    for (const [slug, ladder] of LADDERS) {
+      // Key ORDER is the ladder order the resolver reads back, so this pins
+      // both the naming and the sequence.
+      expect(Object.keys(ladder), slug).toEqual(RUNGS)
+    }
+  })
+
+  it('spells the unaffiliated ladder `na`, like every other catalog', () => {
+    // votes.json was the last file spelling this slug out in full (#2586); its
+    // one reader is DefaultVote, and every other catalog says `na`.
+    expect(votes).not.toHaveProperty('unaffiliated')
+    expect(Object.keys(votes.na)).toEqual(RUNGS)
+  })
+})
+
 // #1865: every faction body computes the spotlight as the highest ALL-TIME
 // score — there is no time window in the frontend or the backend. Four labels
 // used to name one anyway ("of the week", "of the Fortnight"), so a player who

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -669,26 +669,31 @@ describe('findDuplicateJsonKeys scanner', () => {
 
 describe('i18next runtime', () => {
   it('resolves a nested key', () => {
-    expect(i18n.t('votes:ephemerists.silver')).toBe('silver')
+    expect(i18n.t('votes:ephemerists.tier3')).toBe('silver')
   })
 
   it('interpolates a {{var}}', () => {
     expect(i18n.t('forms:charLimit.reached', { max: 200 })).toBe('200-character limit reached')
   })
 
-  it('resolves kebab-case keys for multi-word labels', () => {
-    expect(i18n.t('votes:wow.a-start')).toBe('a start')
-    expect(i18n.t('votes:snide.not-bad')).toBe('not bad')
+  // Was 'resolves kebab-case keys for multi-word labels', reading `wow.a-start`
+  // and `snide.not-bad`. #2586 numbered the rungs, and those were the catalog's
+  // last kebab-case keys — a key spelling out a two-word label is exactly the
+  // naming the README forbids. The half worth keeping is the other one: that a
+  // multi-word VALUE comes back whole, spaces and all.
+  it('resolves a multi-word label whole', () => {
+    expect(i18n.t('votes:wow.tier1')).toBe('a start')
+    expect(i18n.t('votes:snide.tier2')).toBe('not bad')
   })
 
   it('resolves preserved-case values for all-caps labels', () => {
-    expect(i18n.t('votes:singularity.verified')).toBe('VERIFIED')
-    expect(i18n.t('votes:snide.anarchy')).toBe('ANARCHY')
+    expect(i18n.t('votes:singularity.tier5')).toBe('VERIFIED')
+    expect(i18n.t('votes:snide.tier5')).toBe('ANARCHY')
   })
 
   it('resolves the growing-mandala reading values for UA labels', () => {
-    expect(i18n.t('votes:ua.radiant')).toBe('radiant')
-    expect(i18n.t('votes:ua.faint')).toBe('faint')
+    expect(i18n.t('votes:ua.tier5')).toBe('radiant')
+    expect(i18n.t('votes:ua.tier1')).toBe('faint')
   })
 
   it('throws on a missing key outside production', () => {

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -1,59 +1,59 @@
 {
   "ephemerists": {
-    "lead": "lead",
-    "copper": "copper",
-    "silver": "silver",
-    "gold": "gold",
-    "platinum": "platinum"
+    "tier1": "lead",
+    "tier2": "copper",
+    "tier3": "silver",
+    "tier4": "gold",
+    "tier5": "platinum"
   },
   "everymen": {
-    "fair": "fair",
-    "solid": "solid",
-    "good": "good",
-    "excellent": "excellent",
-    "legendary": "legendary"
+    "tier1": "fair",
+    "tier2": "solid",
+    "tier3": "good",
+    "tier4": "excellent",
+    "tier5": "legendary"
   },
   "coven": {
-    "sweet": "sweet",
-    "lovely": "lovely",
-    "wonderful": "wonderful",
-    "magical": "magical",
-    "iconic": "iconic"
+    "tier1": "sweet",
+    "tier2": "lovely",
+    "tier3": "wonderful",
+    "tier4": "magical",
+    "tier5": "iconic"
   },
   "wow": {
-    "a-start": "a start",
-    "quite-solid": "quite solid",
-    "jolly-good": "jolly good",
-    "splendid": "splendid!",
-    "legendary": "legendary!"
+    "tier1": "a start",
+    "tier2": "quite solid",
+    "tier3": "jolly good",
+    "tier4": "splendid!",
+    "tier5": "legendary!"
   },
   "snide": {
-    "meh": "meh",
-    "not-bad": "not bad",
-    "rad": "rad",
-    "sick": "sick",
-    "anarchy": "ANARCHY"
+    "tier1": "meh",
+    "tier2": "not bad",
+    "tier3": "rad",
+    "tier4": "sick",
+    "tier5": "ANARCHY"
   },
   "singularity": {
-    "noise": "NOISE",
-    "weak": "WEAK",
-    "signal": "SIGNAL",
-    "clear": "CLEAR",
-    "verified": "VERIFIED"
+    "tier1": "NOISE",
+    "tier2": "WEAK",
+    "tier3": "SIGNAL",
+    "tier4": "CLEAR",
+    "tier5": "VERIFIED"
   },
   "ua": {
-    "faint": "faint",
-    "forming": "forming",
-    "true": "true",
-    "alive": "alive",
-    "radiant": "radiant"
+    "tier1": "faint",
+    "tier2": "forming",
+    "tier3": "true",
+    "tier4": "alive",
+    "tier5": "radiant"
   },
-  "unaffiliated": {
-    "so-so": "so-so",
-    "decent": "decent",
-    "good": "good",
-    "great": "great",
-    "brilliant": "brilliant"
+  "na": {
+    "tier1": "so-so",
+    "tier2": "decent",
+    "tier3": "good",
+    "tier4": "great",
+    "tier5": "brilliant"
   },
   "chrome": {
     "loginGate": "Log in to vote",


### PR DESCRIPTION
Every vote-tier key in `votes.json` was named after the word it held —
`votes:snide.rad` → "rad", `votes:ua.radiant` → "radiant" — which is the one
thing `frontend/src/locales/README.md` forbids: *"Never name a key after its
English text."* Rewording a rung meant renaming its key, which meant editing the
catalog, the resolver and three test files to change one word. In the copy
export the ladder read as 38 rows with a single faction column filled each,
because a key called `radiant` cannot line up with a key called `rad`.

Closes #2586

## The seam I tested at

**The rendered `aria-label` of all nine vote widgets, through the real `VoteUI`
dispatcher.** #2166 took every printed caption off the vote control, so
`Rate {{value}} — {{label}}` is now the *only* place a tier word reaches a
person. A registry-versus-registry assertion (`VOTE_REFRAMES` compared to
itself) would pass while a ladder rendered upside down, so the test names the
words literally, in ladder order.

Two guards went in first, in their own commit
(`2242dee`), before the catalog moved:

- `frontend/src/components/vote/__tests__/voteLadders.test.tsx` — **new.** The
  8×5 ladder, rung by rung, plus Albescent's arabic fallback. It was written and
  run **green against unrenamed `main`**, so it is a locked baseline of what
  shipped before, not a description of what I built. It is still green.
- `frontend/src/locales/__tests__/catalog.test.ts` — the shape guard. **Red on
  `main` on all three counts**: rungs named after their words, key order
  unpinned, and an `unaffiliated` block. Green now.

The order the rename had to follow was checked against `VOTE_REFRAMES`'s
existing `value: 1…5` and `DefaultVote`'s `TIER_KEYS` before a single key moved
— that is the one place this change could have gone silently wrong.

## What changed

1. **`frontend/src/locales/en/votes.json`** — `<slug>.<word>` → `<slug>.tier1` …
   `tier5`, in ladder order. `chrome` untouched. **41 insertions, 41 deletions,
   and not one changed value** — the diff is keys only.
2. **The `unaffiliated` block is now `na`**, the spelling every other catalog
   uses. Its one reader was `DefaultVote`.
3. **`frontend/src/components/vote/voteReframes.ts`** — 119 lines → 85. The
   hand-spelled 7×5 table of `i18n.t` calls becomes a slug list carrying only
   the numeral system, plus a derived map. `ReframeTier`, `VoteReframe` and
   `reframeLabel` keep their exact shape; the eight `VOTE_REFRAMES['<slug>']
   .tiers` consumers and the `numeral` assertions were not touched.
   **Every comment is carried across, attached to the slug it explains**: the
   #1207 metals ladder, the #821/#838 coven↔wow inversion with ADR-0050's "go by
   metaphor, not label", the UA mandala captions, and #783 on why Albescent is
   absent rather than present and empty.
4. **`frontend/src/components/vote/DefaultVote.tsx`** — `TIER_KEYS` is gone;
   the label reads `` t(`na.tier${RUNGS[index]}`) ``. `RUNGS` is a
   `[1,2,3,4,5] as const` tuple rather than `index + 1` because the catalog keys
   are **typechecked**: indexing a readonly tuple keeps the rung a literal, so
   `votes:na.tier<N>` resolves against the real key union and a bad rung fails
   the build instead of throwing at first render. Same reason `voteReframes`
   re-types `Object.keys` instead of destructuring `Object.entries`.

## Not a wording change

ADR-0061 makes per-faction vote vocabulary a sanctioned carve-out and #1864
listed the star ladder under the surfaces that keep faction voice. Both hold.
Albescent still has no ladder and still falls through to arabic numerals — no
one was added. **If you see an English string change in this diff, the change is
wrong.**

## Also in the diff

`frontend/src/locales/README.md` — three examples. The "per-faction voice"
snippet demonstrated the rule's breach (`"ephemerists": { "silver": "silver" }`)
three sections below the bullet forbidding it; the "how a key works" example
read `votes:ua.masterwork`, a key retired long ago; and the kebab-case bullet
cited `a-start` / `not-bad`, which were the catalog's **last** kebab-case keys
and are now gone. Rule text is unchanged apart from that bullet.

**Left alone on purpose:** `docs/adr/0032` quotes `votes:ephemerists.plausible`
and `votes:snide.rad`, and `docs/copy/faction-copy-decisions.csv` mentions
`votes:unaffiliated.idle`. The ADR line was already stale before this change
(`plausible` has not existed for a long time) and both are historical records of
a decision, not live keys.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **420 files, 7575 passed**, 1 skipped |
| `npm run build` | ok |
| `npm run budget` | exit 0 — JS ok at 127.9 KB; the CSS `WARN` at 22.3 KB is **pre-existing**, no `.css` file is in this diff |

No backend, route or schema change, so `api-schema` and the backend job are not
in play.

**Visual QA is outstanding** — I have no browser and no dev stack. Everything
above is tests, tsc and eslint.

## What to eyeball

Open a praxis filed under each faction and read the star row's ladder — hover or
inspect the `aria-label`s. Each should say the **same words in the same order**
as before this PR:

- [ ] **Ephemerists** — lead · copper · silver · gold · platinum (and the discs
      still carry roman I–V)
- [ ] **Everymen** — fair · solid · good · excellent · legendary
- [ ] **Coven** — sweet · lovely · wonderful · magical · iconic
- [ ] **WOW** — a start · quite solid · jolly good · splendid! · legendary!
      (the archaic one; if this reads like Coven's, #838 has been undone)
- [ ] **S.N.I.D.E.** — meh · not bad · rad · sick · ANARCHY
- [ ] **Singularity** — NOISE · WEAK · SIGNAL · CLEAR · VERIFIED
- [ ] **UA** — faint · forming · true · alive · radiant
- [ ] **na / unaffiliated** — so-so · decent · good · great · brilliant. This is
      the spectrum sweep, and also what every themed-but-unskinned faction
      renders, so it is the widest-reaching row of the eight.
- [ ] **Albescent** — still **no words at all**: "Rate 1 of 5" … "Rate 5 of 5",
      arabic numerals, no ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
