### PR TITLE
Migrate to React Router 7: the shim keeps 304 imports, and the 57 red suites are a Node 20 loader race

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "react-easy-crop": "^6.2.3",
         "react-i18next": "^17.0.12",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.6",
+        "react-router-dom": "^7.18.2",
         "remark-gfm": "^4.0.1",
         "y-codemirror.next": "^0.3.6",
         "y-indexeddb": "^9.0.12",
@@ -525,15 +525,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
-      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -1689,6 +1680,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/crelt": {
       "version": "1.0.7",
@@ -4616,35 +4620,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
-      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
-      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4",
-        "react-router": "6.30.6"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -4896,6 +4906,12 @@
       "engines": {
         "node": "^14.0.0 || >=16.0.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "react-easy-crop": "^6.2.3",
     "react-i18next": "^17.0.12",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.6",
+    "react-router-dom": "^7.18.2",
     "remark-gfm": "^4.0.1",
     "y-codemirror.next": "^0.3.6",
     "y-indexeddb": "^9.0.12",

--- a/frontend/src/components/__tests__/navCharacterLink.test.tsx
+++ b/frontend/src/components/__tests__/navCharacterLink.test.tsx
@@ -65,7 +65,11 @@ beforeEach(() => {
 describe("the nav's character name leads to the character (#2354)", () => {
   it('points the name at the viewer’s own profile, not at home', () => {
     const html = render()
-    expect(html).toContain('href="/characters/42">Mollusk<')
+    // Matched with a tolerant regex rather than one welded literal: react-router
+    // 7 emits `data-discover="true"` on every <Link>, which lands between the
+    // href and the `>`. The pairing is still asserted — this anchor's href AND
+    // its text — but no longer depends on href being the last attribute.
+    expect(html).toMatch(/href="\/characters\/42"[^>]*>Mollusk</)
   })
 
   it('drops the tooltip that promised a switcher', () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -56,5 +56,33 @@ export default defineConfig({
     // first file to run pays for the whole graph — which overran the default
     // 10s hook timeout and failed three unrelated suites at collection.
     hookTimeout: 60_000,
+    server: {
+      deps: {
+        /**
+         * Transform react-router through Vite instead of letting Node's own
+         * loader import it (#2449).
+         *
+         * Vitest externalises `node_modules`, so an externalised dep is loaded
+         * by Node, not Vite. react-router 6 had no `exports` map, so that load
+         * resolved plain CJS (`dist/main.js`) and Node's ESM machinery was
+         * never involved. react-router 7 ships an `exports` map whose `node`
+         * condition lists `module-sync`, which points at `.mjs` — so the same
+         * `require` became a `require(esm)`, running Node's
+         * `internal/modules/esm/module_job`.
+         *
+         * On the Node 20 CI pins that path is racy under parallel workers:
+         * `this.module` comes back undefined and it dies on
+         * `this.module.getStatus()`, taking the whole suite down at collection
+         * — including suites that never import a router. It is a bad enough
+         * race to be COUNT-UNSTABLE: two runs of the identical commit failed
+         * 57 and then 54 of 422. It does not reproduce on Node 24, whose
+         * `require(esm)` is mature, which is why this is invisible locally.
+         *
+         * Inlining hands the module to Vite's transform pipeline, so Node's
+         * ESM loader never sees it and the race cannot occur on any Node.
+         */
+        inline: [/^react-router/],
+      },
+    },
   },
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -78,10 +78,17 @@ export default defineConfig({
          * 57 and then 54 of 422. It does not reproduce on Node 24, whose
          * `require(esm)` is mature, which is why this is invisible locally.
          *
-         * Inlining hands the module to Vite's transform pipeline, so Node's
-         * ESM loader never sees it and the race cannot occur on any Node.
+         * Inlining hands every dep to Vite's transform pipeline, so Node's ESM
+         * loader never sees them and the race cannot occur on any Node.
+         *
+         * ponytail: `true` rather than a react-router-shaped list because
+         * narrowing it to /^react-router/ did NOT fix CI — the race is in the
+         * loader, not in one package, so the whole externalised set has to stop
+         * going through it. The ceiling is transform cost. The upgrade path is
+         * to delete this block once CI runs Node 22+, where the deprecated
+         * Node 20 loader this works around is gone.
          */
-        inline: [/^react-router/],
+        inline: true,
       },
     },
   },


### PR DESCRIPTION
Closes #2449

Migrates the app to React Router 7. These were the **only two open advisories left in the repo** and the only ones that ship to a visitor's browser; 6.x has no patch for either, so the major *is* the remediation.

```
react-router-dom   ^6.30.6  ->  ^7.18.2
react-router         6.30.3  ->    7.18.2   (transitive)
@remix-run/router    1.23.2  ->   REMOVED   (absorbed into react-router 7)
```

`@remix-run/router` is now at **zero** occurrences in `package-lock.json`, and `npm audit --omit=dev` reports **0 vulnerabilities** — direct confirmation the runtime advisories are cleared rather than merely re-ranged.

## The seams

**Seam 1 — `react-router-dom`'s public import surface, 304 files, observed through the DOM-less `renderToStaticMarkup` harness.**

The load-bearing question was whether those 304 sites had to be rewritten. They do not. v7 collapsed the DOM APIs into `react-router/dom` but **kept `react-router-dom` as a convenience re-export** so v6 imports keep working; it is only *removed* in v8. `react-router-dom@7.18.2` is a shim whose sole dependency is `react-router@7.18.2`. Verified against the changelog via Context7, not from memory.

**Seam 2 — where Vitest hands a dependency to Node's own module loader instead of Vite's.** This is the one that actually cost the work, and it is not where the issue predicted.

## The 57 collection failures: a Node 20 loader race, not react-router

The issue recorded `TypeError: Cannot read properties of undefined (reading 'getStatus')` across 30 suites and reasoned it was "react-router 7 internals reading something the test harness does not provide". **That premise is wrong, and it took three CI runs to establish what is actually happening.**

`getStatus` appears nowhere in `frontend/src` — true — but it also appears **nowhere in `react-router`, nowhere in `react-dom`, and nowhere in `node_modules` at all.** I grepped the installed tree with a control token to prove the grep worked. It is a **Node internal**:

```
internal/modules/esm/module_job:385:  let status = this.module.getStatus();
```

`this.module` is undefined inside Node's ESM `ModuleJob`. So this is Node's own module loader falling over, not our code and not react-router's.

**Why the bump triggers it.** Vitest externalises `node_modules`, so an externalised dep is loaded by *Node*, not Vite:

- **react-router 6 had no `exports` map at all** — just `main: ./dist/main.js`. `require()` got plain CJS and Node's ESM machinery was never involved.
- **react-router 7 ships an `exports` map whose `node` condition lists `module-sync`**, pointing at `.mjs`. The same `require` therefore becomes a `require(esm)`, which runs `internal/modules/esm/module_job`.

Confirmed directly: `require.resolve('react-router')` resolves to `dist/development/index.mjs`, and the required value is a real `[object Module]` namespace — a genuine `require(esm)` load.

On CI's **Node 20** that path is racy under parallel workers. It does not reproduce on **Node 24** locally, whose `require(esm)` is mature — which is exactly why 424/424 passed on my machine while CI was red.

**It is a race, not a deterministic fault, and I proved that rather than assuming it:** three runs failed **57**, then **54**, then **56** of 422 — including suites like `utils/__tests__/errors.test.ts` and `isKnownFaction.test.ts` that never import a router. There is no OOM, no worker kill, and no stack trace; I checked the full log for all three.

### The fix, and the honest account of getting there

`server.deps.inline` in `vite.config.ts`, so Vite transforms deps and Node's ESM loader never sees them.

My first attempt narrowed it to `/^react-router/`. **That did not work** — CI still failed 56 of 422. The repo already ESM-loads 159 packages on green `main`, so the fault is in the loader under load, not in one package, and the whole externalised set has to stop going through it. The committed fix is `inline: true`, carrying a `ponytail:` comment naming the ceiling (transform cost) and the upgrade path: **delete the block once CI runs Node 22+.** The CI log itself prints "Node 20 is being deprecated".

I did not touch `.github/workflows/test.yml` — bumping the runner's Node is the cleaner fix and is the owner's call, not mine.

## The one behavioural failure: the href never changed

The issue asked that this be read as a real behaviour change rather than papered over, since advisory #1 is about how `<Link>` builds hrefs. **It is not one.** The rendered anchor on v7:

```html
<a class="nav-link transition-colors" style="color:var(--color-text-secondary)"
   href="/characters/42" data-discover="true">Mollusk</a>
```

The href **is** `/characters/42` — exactly what #2354 specified. react-router 7 emits `data-discover="true"` on every `<Link>`, and it lands *between* the href and the closing `>`. The assertion was one welded literal requiring href to be the last attribute:

```js
expect(html).toContain('href="/characters/42">Mollusk<')
```

So the expectation moved to a regex that still binds both facts — `[^>]*` cannot cross a tag boundary, so it still proves *this anchor* carries *that href* and *that text*, and still fails if the href regresses to `/`:

```js
expect(html).toMatch(/href="\/characters\/42"[^>]*>Mollusk</)
```

I grepped for siblings first, including **negative** assertions that would now pass vacuously against markup they no longer describe. There is exactly one welded-href assertion in the suite and no vacuous negatives.

## The two places the issue flagged as hard

Both checked first rather than last; neither needed migration work:

- **`ProtectedRoute` (#1483)** — `<Navigate to="/?login=required" replace />`, a literal, on a v7-unchanged API. Its `warm()` chunk-preloading is orthogonal to the router.
- **Route-level code splitting** — 21 `lazy()` routes under `<Suspense>`, untouched.

Also confirmed inert: the repo sets **no v6 `future` flags**, so v7's defaults now apply. The one that could have bitten is `v7_relativeSplatPath` — there are **no splat routes** and **every literal `to=` is absolute**, so it has nothing to change. `main.tsx` is declarative `BrowserRouter` only: no `createBrowserRouter`, no `RouterProvider`, no loaders. (So the `deserializeErrors()` SSR-hydration advisory was never reachable here — remediated regardless.)

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, read off the workflow and run locally, plus CI green on all three jobs. A real `npm ci` in this worktree — no junction to main's `node_modules`.

| step | result |
|---|---|
| Lint (ADR-0032 raw-strings) | pass |
| Typecheck (`tsc --noEmit` + `tsconfig.e2e.json`) | pass |
| Typecheck `/design-sync` preview kit | pass |
| Tests | **424 passed (424) / 7633 passed, 1 skipped** |
| Build | pass |
| Byte budget | WARN — see below |

Rebased onto latest `main` (`29f5177b`). Worth noting: my local runs initially showed 422 files against CI's 424, because CI tests the PR *merge* commit — I chased that down rather than waving it off, and the two extra files were `dotRingBoundary.test.ts` and `composerGround.test.ts` arriving on main. Local and CI now agree at 424/7633.

Backend untouched, so `test` and `api-schema` have nothing to react to: no route signature, `response_model`, or Pydantic schema changed, and `openapi.json` / `schema.d.ts` are unmodified.

## Budget: a real +5.0 KB on top of an inherited WARN

```
           before      after
JS      132.6 KB  ->  137.6 KB   (+5.0 KB gzipped)
CSS      21.5 KB  ->   21.5 KB   (unchanged)
                       warn>130.9 KB   fail>175.8 KB
```

- **The WARN is inherited.** JS was already over the 130.9 KB line at 132.6 KB on `main` — that is #2605, from vite 8's Rolldown baseline. `bundle-budget.mjs` untouched.
- **The +5.0 KB is genuinely this PR.** The entry chunk goes 41.4 -> 45.7 KB and a new 0.7 KB `preload-helper` chunk appears. Well clear of the 175.8 KB fail ceiling, so it does not block — but it is a real payload regression and I would rather state it than hide it under the pre-existing warning.

There is no lazy-loading fix for it: `BrowserRouter` wraps the app at the root, so the router is necessarily in the initial chunk. 5 KB for the repo's only two runtime advisories looks like the right trade, but whether it wants a follow-up against #2605 is the owner's call.

## What to eyeball

**No visual QA has been done — I have no browser tools and no dev stack here.** Verified by tests, tsc, eslint and the build only. Routing is where that gap matters most: all 7,633 green tests render through `renderToStaticMarkup`, which **runs no effects at all**. They can see the markup a `<Link>` produces; they cannot see what happens when you click one. Please click:

- **Every nav link** — Home, Tasks, Praxis, Players, Factions, Updates — and confirm the active-link underline still tracks the page (`aria-current="page"` comes from `NavLink`, whose internals changed).
- **The character name in the nav** — the `/characters/42` link above. Confirm it reaches the profile, and that an account with no character still gets "create character".
- **Deep links / hard refresh** on param routes: `/tasks/:id`, `/praxis/:id`, `/characters/:id`, `/factions/:slug`. Load them cold in a fresh tab, not by clicking in.
- **Back and forward**, including after a `<Navigate replace>` bounce — `replace` semantics and history entries are exactly what a router major can shift.
- **Redirect-after-login**: sign out, hit a protected URL, confirm the bounce to `/?login=required`, sign in, confirm you land somewhere sane. Also the admin-only bounce to `/`.
- **The 404 path** — note there is **no catch-all `path="*"`** in `App.tsx` at all (25 routes, none a catch-all), so an unknown URL renders an empty shell inside the layout. Pre-existing and unchanged here, but worth seeing once.
- **The lazy routes** under `<Suspense>` — pages still resolve and the loading surface does not stick.
- **`data-discover="true"` now appears on every rendered link.** Inert in declarative mode, but if anything downstream (analytics, e2e selectors, CSS attribute selectors) keys off link markup, this is what would surprise it. I found no such consumer in the repo.

## Housekeeping

Dependabot PR **#2436** carries the same bump. It was read as a reference diff and **not** checked out, rebased, or run — it is `DIRTY` and unrebaseable since the `dependabot.yml` entry that created it was deleted. Close it as superseded when this merges, the route #2604 took.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
