### PR TITLE
The invitation letter spends its one box on the perks, named (#2298)

### DIFF
--- a/frontend/src/__tests__/catalogLexicon.test.ts
+++ b/frontend/src/__tests__/catalogLexicon.test.ts
@@ -131,7 +131,10 @@ describe('the University of Asthmatics counts points, not marks (#1702)', () => 
     // one UA key fewer, so the bar moves down by exactly that one. #2299 took
     // four more — UA's two join kickers, and the `confirm`/`confirmSwitch`
     // pair it was the only faction to voice for itself, which now read the
-    // shared `detail.join.*` the other six already did.
-    expect(catalogLeaves().filter(([key]) => key.split(/[.:]/).includes('ua')).length).toBeGreaterThanOrEqual(46)
+    // shared `detail.join.*` the other six already did. #2298 moves it three
+    // further down: the letter lost its kicker, its four terms leaves and its
+    // dead `cta.joined` — six — and the three perks each gained a `name`
+    // beside their description, which is three back.
+    expect(catalogLeaves().filter(([key]) => key.split(/[.:]/).includes('ua')).length).toBeGreaterThanOrEqual(43)
   })
 })

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -17,7 +17,8 @@ import '../factionFaces'
  *
  * Ported from the World Zero Design System "Albescent Join Screen" (AlRecruit):
  * a vellum letter — white cotton paper, hairline rules, Cormorant italic, the
- * surveyor's-mark sigil, a "terms, plainly" slip and the "Accept the order" CTA.
+ * surveyor's-mark sigil, a slip and the "Accept the order" CTA. #2298 emptied
+ * the slip of its terms and refilled it with the perks, as name + description.
  *
  * Shown only when the account's server-computed `can_start_as_albescent` flag is
  * true (ADR-0021 — account-collective eligibility). The player picks WHICH life
@@ -114,26 +115,25 @@ const HAIRLINE_FAINT = 'var(--albescent-reveal-border-faint)'
 // have been a black rule on a near-black sheet at 1.02:1 — drawn, and invisible.
 // It did not need the third rung it was refused, either: the canvas draws the
 // letter's `border-top` and its `border-bottom` at the SAME strength after dark,
-// so the terms slip's top rule is `HAIRLINE_FAINT` now like the term rows below
-// it. By day that is 1.17:1 → 1.13:1 at one site.
+// so the slip's top rule is `HAIRLINE_FAINT` now like the rows below it — the
+// perk rows since #2298, the term rows before it. By day that is 1.17:1 →
+// 1.13:1 at one site.
 
 // i18n key stems under factions:albescent.letter — resolved at render.
 //
-// The fourth row was "standing / unranked, by design"
-// (`terms.standingLabel` + `terms.standingValue`). #1909 CUT both: they are the
-// Albescent twin of the `{F}.invitation.terms[3]` standing row the audit cut
-// across all seven other letters, which meant three different things by faction
-// and was static flavour presented as live standing.
-const TERM_KEYS: ReadonlyArray<{ label: string; value: string }> = [
-  { label: 'terms.tollLabel', value: 'terms.tollValue' },
-  { label: 'terms.skillsLabel', value: 'terms.skillsValue' },
-  { label: 'terms.outputLabel', value: 'terms.outputValue' },
-]
-
-const PERK_KEYS: ReadonlyArray<string> = [
-  'perks.record',
-  'perks.duties',
-  'perks.witnessed',
+// The whole terms slip stood here as `TERM_KEYS` — toll, skills, output, and
+// before them a fourth "standing" row #1909 cut. #2298 cut the remaining three
+// across all eight letters and gave the slip's box to the perks, so what is
+// left is the perk stems.
+//
+// `duties` is Albescent's real mechanic, the way `perks[1]` is on the other
+// seven — same ponytail as `MECHANIC_INDEX` in InvitationLetterPopup: the slot
+// is positional, and a `mechanic` flag on the catalog object is the upgrade if
+// a letter ever needs it elsewhere.
+const PERK_KEYS: ReadonlyArray<{ stem: string; mechanic: boolean }> = [
+  { stem: 'perks.record', mechanic: false },
+  { stem: 'perks.duties', mechanic: true },
+  { stem: 'perks.witnessed', mechanic: false },
 ]
 
 export interface AlbescentInvitationProps {
@@ -210,53 +210,43 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
         <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 'var(--space-lg)' }}>
           <FactionSigil slug={ALBESCENT_SLUG} size={44} />
         </div>
+        {/* The wordmark takes the letterhead's old bottom margin. `letterhead`
+            ("Faction no. 7 · enlistment · in confidence") and `handExtended`
+            ("A hand is extended —") stood on either side of the rule below:
+            #2298 cut both, as Albescent's twins of the overline and the kicker
+            the other seven letters lost in the same pass. */}
         <div style={{
-          ...monoCaps, letterSpacing: '0.34em', color: ACCENT, marginBottom: 'var(--space-sm)',
+          ...monoCaps, letterSpacing: '0.34em', color: ACCENT, marginBottom: 'var(--space-xl)',
           // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved stationery mono-caps; these draw the letterhead rather than set read copy
           fontSize: 9,
         }}>{t('albescent.letter.wordmark')}</div>
-        <div style={{
-          ...monoCaps, letterSpacing: '0.28em', marginBottom: 'var(--space-xl)',
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved stationery mono-caps; these draw the letterhead rather than set read copy
-          fontSize: 8,
-        }}>{t('albescent.letter.letterhead')}</div>
         <div style={{ width: 54, height: 1, background: HAIRLINE, margin: '0 auto var(--space-xl)' }} />
-        <div style={{
-          ...monoCaps, letterSpacing: '0.2em', marginBottom: 'var(--space-md)',
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved stationery mono-caps; these draw the letterhead rather than set read copy
-          fontSize: 8,
-        }}>{t('albescent.letter.handExtended')}</div>
         <h2 style={headline}>{t('albescent.letter.headline')}</h2>
         <p style={pitch}>
           {t('albescent.letter.pitch')}
         </p>
       </div>
 
-      {/* terms slip */}
-      <div style={{ position: 'relative', margin: '0 var(--space-3xl)', borderTop: `1px solid ${HAIRLINE_FAINT}`, padding: 'var(--space-xl) 0 var(--space-xs)', textAlign: 'left' }}>
-        <div style={{
-          ...monoCaps, letterSpacing: '0.22em', marginBottom: 'var(--space-md)',
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved stationery mono-caps; these draw the letterhead rather than set read copy
-          fontSize: 7,
-        }}>{t('albescent.letter.termsHeading')}</div>
-        <div style={termsGrid}>
-          {TERM_KEYS.map((term) => (
-            <div key={term.label} style={{ borderBottom: `1px solid ${HAIRLINE_FAINT}`, padding: 'var(--space-sm) 0' }}>
-              <div style={{
-                ...monoCaps, letterSpacing: '0.14em',
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: engraved stationery mono-caps; these draw the letterhead rather than set read copy
-                fontSize: 7,
-              }}>{tDynamic(`albescent.letter.${term.label}`)}</div>
-              <div style={{ ...serifItalic, fontSize: 'var(--text-content)', color: INK, marginTop: 'var(--space-xs)' }}>{tDynamic(`albescent.letter.${term.value}`)}</div>
-            </div>
-          ))}
-        </div>
-        <div style={{ marginTop: 'var(--space-md)', display: 'flex', flexWrap: 'wrap', gap: 'var(--space-xs) var(--space-lg)' }}>
-          {PERK_KEYS.map((perk) => (
-            <div key={perk} style={{ ...serifItalic, fontSize: 'var(--text-content)', color: ACCENT }}>— {tDynamic(`albescent.letter.${perk}`)}</div>
-          ))}
-        </div>
-      </div>
+      {/* Perks, in the slip's box (#2298). Same rule, gutters and padding the
+          "terms, plainly" slip carried; no heading, and the perks stack their
+          name over their description rather than sitting in the loose em-dash
+          row that used to run under the term grid. */}
+      <ul style={{ position: 'relative', listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 'var(--space-md)', margin: '0 var(--space-3xl)', borderTop: `1px solid ${HAIRLINE_FAINT}`, padding: 'var(--space-xl) 0 var(--space-xs)', textAlign: 'left' }}>
+        {PERK_KEYS.map(({ stem, mechanic }) => (
+          <li key={stem} style={{ borderBottom: `1px solid ${HAIRLINE_FAINT}`, padding: '0 0 var(--space-sm)' }}>
+            {/* The slip's label treatment — mono, uppercase, tracked — but at a
+                read size, not the 7px engraving: a perk name is copy now, where
+                a term label was stationery. The order's own accent marks the
+                one perk that states a real mechanic; the two flavour names sit
+                in the muted ink, so the mechanic reads first. */}
+            <div style={{
+              ...monoCaps, letterSpacing: '0.14em', fontSize: 'var(--text-md)',
+              color: mechanic ? ACCENT : MUTED,
+            }}>{tDynamic(`albescent.letter.${stem}.name`)}</div>
+            <div style={{ ...serifItalic, fontSize: 'var(--text-content)', color: INK, marginTop: 'var(--space-xs)' }}>{tDynamic(`albescent.letter.${stem}.desc`)}</div>
+          </li>
+        ))}
+      </ul>
 
       {/* answer */}
       <div style={{ position: 'relative', padding: 'var(--space-xl) var(--space-3xl) var(--space-2xl)' }}>
@@ -365,11 +355,6 @@ const pitch: CSSProperties = {
   color: ACCENT,
   maxWidth: 440,
   margin: '0 auto',
-}
-const termsGrid: CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: '1fr 1fr',
-  gap: 'var(--space-xs) var(--space-xl)',
 }
 const lifeChip: CSSProperties = {
   position: 'relative',

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -16,12 +16,6 @@ function tKey(t: TFunction<'factions'>, key: string): string {
   return resolve(key)
 }
 
-/** The shared label for a terms row that carries none of its own, or `''`. */
-function sharedTermLabel(t: TFunction<'factions'>, index: number): string {
-  const key = SHARED_TERM_LABELS[index]
-  return key ? tKey(t, key) : ''
-}
-
 function tArr<T>(t: TFunction<'factions'>, key: string): T[] {
   const resolve = t as unknown as (k: string, o: { returnObjects: true }) => unknown
   const value = resolve(key, { returnObjects: true })
@@ -39,9 +33,13 @@ function tArr<T>(t: TFunction<'factions'>, key: string): T[] {
  * follow-up, mirroring the profile-skin epic (#459 default -> #460 per-faction).
  *
  * Copy lives in frontend/src/locales/en/factions.json under
- * `<slug>.invitation.{kicker,headline,pitch,terms[],perks[],cta.{join,joined}}`
+ * `<slug>.invitation.{headline,pitch,perks[].{name,desc},cta.join}`
  * (writer-editable). a11y matches LevelUpPopup: Escape closes, primary action
  * autofocuses, no focus trap. No literal hex — CSS vars only (CLAUDE.md).
+ *
+ * #2298 cut the kicker, the prospectus overline and the terms slip, and refilled
+ * the slip's box with the perks — so the letter is masthead, headline, pitch,
+ * ONE box, CTA. The perks gained a `name` above their `desc`.
  */
 
 const PAPER = 'var(--color-bg-page)'
@@ -52,28 +50,21 @@ const FONT_DISPLAY = 'var(--font-display)'
 const FONT_BODY = 'var(--font-body)'
 const FONT_MONO = "'Courier Prime', monospace"
 
-interface Term {
-  /** Absent on the rows whose label is shared — see {@link SHARED_TERM_LABELS}. */
-  label?: string
-  value: string
+/** One perk: the label-cased name, and the line that says what it gets you. */
+interface Perk {
+  name: string
+  desc: string
 }
 
 /**
- * The terms slip's row labels, by position, where the label is the SAME for
- * every faction (#1911).
+ * Which perk states the faction's real backend mechanic (#1874/#2298).
  *
- * Row 0 is the toll, and each house names it in its own voice — "dues", "cover
- * charge", "oath of fealty", "handshake". Rows 1 and 2 named the same two
- * things fourteen different ways, so the audit collapsed them; the rows now
- * carry a `value` only and take their label from here. Positional because the
- * slip is a positional array — a row's own `label` still wins where it has one,
- * which is what keeps row 0 (and any row a later letter adds) unaffected.
+ * ponytail: positional. Every letter is written as flavour → mechanic →
+ * flavour, and the catalog carries no flag saying which is which. If a faction
+ * ever needs its mechanic somewhere else in the list, the upgrade is a
+ * `"mechanic": true` field on the perk object, read here instead of the index.
  */
-const SHARED_TERM_LABELS: readonly (string | null)[] = [
-  null,
-  'invitation.skillsLabel',
-  'invitation.outputLabel',
-]
+const MECHANIC_INDEX = 1
 
 export interface InvitationLetterPopupProps {
   factionSlug: string
@@ -106,8 +97,7 @@ export default function InvitationLetterPopup({
   const name = factionName(factionSlug)
 
   const base = `${factionSlug}.invitation`
-  const termsList = tArr<Term>(t, `${base}.terms`)
-  const perksList = tArr<string>(t, `${base}.perks`)
+  const perksList = tArr<Perk>(t, `${base}.perks`)
 
   // The prospectus ENLIST commits the join in place (#493). Joining is one-way
   // (ADR-0019), so ENLIST arms a confirm step before actually joining.
@@ -173,7 +163,10 @@ export default function InvitationLetterPopup({
         fontFamily: FONT_BODY,
       }}
     >
-      {/* masthead: sigil dot + faction name + prospectus overline */}
+      {/* masthead: sigil dot + faction name. The `a prospectus` overline that
+          sat at the right end left with the kicker (#2298) — both were
+          connecting chrome naming the surface the reader is already looking
+          at. */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
         <span
           aria-hidden
@@ -197,37 +190,7 @@ export default function InvitationLetterPopup({
         >
           {name}
         </span>
-        <span
-          style={{
-            marginLeft: 'auto',
-            fontFamily: FONT_MONO,
-            fontSize: 'var(--text-md)',
-            letterSpacing: '0.18em',
-            textTransform: 'uppercase',
-            color: FAINT,
-          }}
-        >
-          {t('invitation.prospectus')}
-        </span>
       </div>
-
-      {/* kicker */}
-      <p
-        style={{
-          fontFamily: FONT_MONO,
-          fontSize: 'var(--text-md)',
-          letterSpacing: '0.18em',
-          textTransform: 'uppercase',
-          // The kicker is 11px type on the prospectus paper, so it takes a text
-          // tier (#2108). The hue keeps the ENLIST fill, the border and the
-          // perk bullet below — the roles it was measured for. As an ink here
-          // it ran 2.19:1 (Ephemerists) to 4.46:1 (UA) in light.
-          color: FAINT,
-          margin: '0 0 var(--space-sm)',
-        }}
-      >
-        {tKey(t, `${base}.kicker`)}
-      </p>
 
       {/* headline */}
       <h2
@@ -257,97 +220,73 @@ export default function InvitationLetterPopup({
         {tKey(t, `${base}.pitch`)}
       </p>
 
-      {/* terms slip */}
-      {termsList.length > 0 && (
-        <div
+      {/* Perks, in the box the terms slip used to occupy (#2298) — same border,
+          radius, padding and faction tint, and deliberately NO heading: the
+          change is removing connecting chrome, not trading one piece for
+          another. Each perk stacks its name over its description behind the
+          `✦` the loose list below this already used, so a long name cannot
+          crush the description into a column. */}
+      {perksList.length > 0 && (
+        <ul
           style={{
+            listStyle: 'none',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-md)',
             border: `1px solid ${border}`,
             borderRadius: 8,
             padding: 'var(--space-md) var(--space-lg)',
-            marginBottom: 'var(--space-lg)',
+            margin: '0 0 var(--space-xl)',
             background: factionCssVar(factionSlug, 'light'),
           }}
         >
-          <div
-            style={{
-              fontFamily: FONT_MONO,
-              fontSize: 'var(--text-md)',
-              letterSpacing: '0.2em',
-              textTransform: 'uppercase',
-              color: FAINT,
-              marginBottom: 'var(--space-sm)',
-            }}
-          >
-            {t('invitation.termsHeading')}
-          </div>
-          {termsList.map((term, idx) => (
-            <div
-              key={idx}
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                gap: 'var(--space-md)',
-                padding: 'var(--space-xs) 0',
-                borderTop: idx === 0 ? 'none' : `1px dashed ${border}`,
-              }}
-            >
-              <span
-                style={{
-                  fontFamily: FONT_MONO,
-                  fontSize: 'var(--text-md)',
-                  letterSpacing: '0.08em',
-                  textTransform: 'uppercase',
-                  color: FAINT,
-                }}
-              >
-                {term.label ?? sharedTermLabel(t, idx)}
-              </span>
-              <span
-                style={{
-                  fontFamily: FONT_DISPLAY,
-                  fontStyle: 'italic',
-                  fontSize: 'var(--text-content)',
-                  color: INK,
-                  textAlign: 'right',
-                }}
-              >
-                {term.value}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* perks */}
-      {perksList.length > 0 && (
-        <ul style={{ listStyle: 'none', margin: '0 0 var(--space-xl)', padding: 0 }}>
-          {perksList.map((perk, idx) => (
-            <li
-              key={idx}
-              style={{
-                display: 'flex',
-                gap: 'var(--space-md)',
-                alignItems: 'flex-start',
-                marginBottom: 'var(--space-sm)',
-              }}
-            >
-              {/* eslint-disable-next-line local/no-raw-style-values, local/no-faction-hue-as-ink -- ornament: a four-pointed-star dingbat used as a list bullet, not type. `aria-hidden` because the perk beside it carries the whole meaning, which is also why 1.4.3 does not reach it (#2108). */}
-              <span aria-hidden="true" style={{ color: accent, fontSize: 12, lineHeight: 1.4, flex: 'none' }}>
-                &#x2726;
-              </span>
-              <span
-                style={{
-                  fontFamily: FONT_DISPLAY,
-                  fontStyle: 'italic',
-                  fontSize: 'var(--text-content)',
-                  lineHeight: 1.4,
-                  color: INK,
-                }}
-              >
-                {perk}
-              </span>
-            </li>
-          ))}
+          {perksList.map((perk, idx) => {
+            const mechanic = idx === MECHANIC_INDEX
+            return (
+              <li key={idx} style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+                {/* eslint-disable-next-line local/no-raw-style-values, local/no-faction-hue-as-ink -- ornament: a four-pointed-star dingbat used as a list bullet, not type. `aria-hidden` because the perk beside it carries the whole meaning, which is also why 1.4.3 does not reach it (#2108). The hue marks the ONE row that states a real mechanic; the flavour rows take a text tier. */}
+                <span
+                  aria-hidden="true"
+                  style={{ color: mechanic ? accent : FAINT, fontSize: 12, lineHeight: 1.4, flex: 'none' }}
+                >
+                  &#x2726;
+                </span>
+                <span>
+                  {/* The slip's old label treatment: mono, uppercase, tracked.
+                      The mechanic's name takes the primary ink and the two
+                      flavour names the tertiary, so the true perk reads first.
+                      The faction hue stays on the bullet, the box rule and the
+                      ENLIST fill — it is a FILL, not an ink (#1932/#2108), and
+                      as 11px type here it ran 2.19:1 to 4.46:1 in light. */}
+                  <span
+                    style={{
+                      display: 'block',
+                      fontFamily: FONT_MONO,
+                      fontSize: 'var(--text-md)',
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      lineHeight: 1.4,
+                      color: mechanic ? INK : FAINT,
+                    }}
+                  >
+                    {perk.name}
+                  </span>
+                  <span
+                    style={{
+                      display: 'block',
+                      fontFamily: FONT_DISPLAY,
+                      fontStyle: 'italic',
+                      fontSize: 'var(--text-content)',
+                      lineHeight: 1.4,
+                      color: INK,
+                    }}
+                  >
+                    {perk.desc}
+                  </span>
+                </span>
+              </li>
+            )
+          })}
         </ul>
       )}
 

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -245,10 +245,7 @@ export default function InvitationLetterPopup({
             return (
               <li key={idx} style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
                 {/* eslint-disable-next-line local/no-raw-style-values, local/no-faction-hue-as-ink -- ornament: a four-pointed-star dingbat used as a list bullet, not type. `aria-hidden` because the perk beside it carries the whole meaning, which is also why 1.4.3 does not reach it (#2108). The hue marks the ONE row that states a real mechanic; the flavour rows take a text tier. */}
-                <span
-                  aria-hidden="true"
-                  style={{ color: mechanic ? accent : FAINT, fontSize: 12, lineHeight: 1.4, flex: 'none' }}
-                >
+                <span aria-hidden="true" style={{ color: mechanic ? accent : FAINT, fontSize: 12, lineHeight: 1.4, flex: 'none' }}>
                   &#x2726;
                 </span>
                 <span>

--- a/frontend/src/components/__tests__/invitationPerks.test.tsx
+++ b/frontend/src/components/__tests__/invitationPerks.test.tsx
@@ -1,0 +1,291 @@
+/* ========================================================================== *
+ * #2298 — THE LETTER IS ONE BOX, AND THE BOX HOLDS NAMED PERKS.
+ *
+ * THE SEAM IS THE RENDERED MARKUP OF THE TWO LETTER COMPONENTS, read against
+ * the catalog they resolve from. It has to be both at once, because the defect
+ * this change can ship is invisible to either alone:
+ *
+ *   - `perks` went from `string[]` to `{name, desc}[]`. A component still
+ *     reading the element itself renders `[object Object]`, and one reading
+ *     `.desc` off a string renders NOTHING. i18next resolves a miss to the key
+ *     or to an empty string rather than throwing, so `tsc` sees neither — the
+ *     perk box just comes out blank and ships.
+ *   - The 55 deleted leaves are only half a deletion until the call sites go
+ *     with them. A `t('invitation.termsHeading')` left behind prints the key
+ *     onto the paper.
+ *
+ * The harness is renderToStaticMarkup with no jsdom (same as
+ * `invitationLetterPopupScroll.test.tsx`), so what is asserted is the markup
+ * string and its inline styles, not layout.
+ *
+ * Parametrised over all seven shared letters plus Albescent's own component,
+ * because "one adaptive prospectus skinned per faction" means a per-slug break
+ * is a catalog break, and Albescent's letter is the one that does NOT share the
+ * code path — it carries the same four cuts on differently-named keys.
+ * ========================================================================== */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../i18n'
+import factions from '../../locales/en/factions.json'
+import { AuthContext } from '../../auth/AuthContext'
+import InvitationLetterPopup from '../InvitationLetterPopup'
+import AlbescentInvitation from '../AlbescentInvitation'
+import type { CharacterOut, CurrentUser } from '../../api/auth'
+
+/** The seven slugs with an `invitation` block — the shared popup's whole range. */
+const SLUGS = ['coven', 'ephemerists', 'everymen', 'singularity', 'snide', 'ua', 'wow'] as const
+
+/** Where the mechanic sits in every letter (`MECHANIC_INDEX` / `PERK_KEYS`). */
+const MECHANIC = 1
+
+interface Perk {
+  name: string
+  desc: string
+}
+
+function perksOf(slug: (typeof SLUGS)[number]): Perk[] {
+  return (factions as unknown as Record<string, { invitation: { perks: Perk[] } }>)[slug]
+    .invitation.perks
+}
+
+/** React's own text escaping, so an apostrophe in the copy still matches. */
+function escaped(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+function viewer(): CurrentUser {
+  return { character: { faction_slug: 'na' } } as unknown as CurrentUser
+}
+
+function withAuth(node: React.ReactNode): string {
+  return renderToStaticMarkup(
+    <AuthContext.Provider
+      value={{
+        user: viewer(),
+        loading: false,
+        refetch: async () => {},
+        applyUser: () => {},
+        signOut: async () => {},
+      }}
+    >
+      {node}
+    </AuthContext.Provider>,
+  )
+}
+
+function letter(slug: string): string {
+  return withAuth(<InvitationLetterPopup factionSlug={slug} onClose={() => {}} />)
+}
+
+function albescentLetter(): string {
+  const life = {
+    id: 1,
+    display_name: 'Tess',
+    username: 'tess',
+    level: 2,
+    status: 'active',
+    faction_slug: 'coven',
+  } as unknown as CharacterOut
+  return withAuth(<AlbescentInvitation lives={[life]} onJoined={() => {}} />)
+}
+
+describe.each(SLUGS)('the %s letter spends its one box on the perks (#2298)', (slug) => {
+  it('prints every perk as a name over a description', () => {
+    const html = letter(slug)
+    const perks = perksOf(slug)
+    expect(perks).toHaveLength(3)
+    for (const perk of perks) {
+      expect(html).toContain(escaped(perk.name))
+      expect(html).toContain(escaped(perk.desc))
+    }
+    // The shape change's own failure mode: the element rendered whole.
+    expect(html).not.toContain('[object Object]')
+  })
+
+  it('puts all three perks inside the ONE tinted box the terms slip vacated', () => {
+    const html = letter(slug)
+    const boxes = [...html.matchAll(/<ul style="([^"]*)">([\s\S]*?)<\/ul>/g)]
+    expect(boxes).toHaveLength(1)
+    const [, style, body] = boxes[0]
+    // Same border, radius, padding and faction tint the slip carried.
+    expect(style).toContain(`background:var(--faction-${slug}-light)`)
+    expect(style).toContain(`border:1px solid var(--faction-${slug}-border)`)
+    expect(style).toContain('border-radius:8px')
+    for (const perk of perksOf(slug)) expect(body).toContain(escaped(perk.name))
+  })
+
+  it('carries no heading on the box, and none of the chrome that was cut', () => {
+    const html = letter(slug)
+    // The four shared strings, by their retired wording — a heading is exactly
+    // what #2298 rejected, so a re-added one has to fail here.
+    for (const gone of ['a prospectus', 'Terms of matriculation', 'Required skills', 'Expected output', 'What you gain']) {
+      expect(html).not.toContain(gone)
+    }
+    const invitation = (factions as unknown as Record<string, { invitation: Record<string, unknown> }>)[slug].invitation
+    expect(invitation).not.toHaveProperty('kicker')
+    expect(invitation).not.toHaveProperty('terms')
+    expect(invitation.cta).not.toHaveProperty('joined')
+  })
+
+  it('marks the mechanic and mutes the two flavour names, so the real perk reads first', () => {
+    const html = letter(slug)
+    const rows = [...html.matchAll(/<li style="[^"]*">([\s\S]*?)<\/li>/g)].map((m) => m[1])
+    expect(rows).toHaveLength(3)
+    // The hue stays on the bullet — it is a FILL, not an ink (#1932/#2108) —
+    // and the name takes a text tier: primary for the mechanic, tertiary for
+    // the flavour, which is what makes one of the three read first.
+    expect(rows[MECHANIC]).toContain(`color:var(--faction-${slug})`)
+    expect(rows[MECHANIC]).toContain('color:var(--color-text-primary)')
+    for (const idx of [0, 2]) {
+      expect(rows[idx]).not.toContain(`color:var(--faction-${slug})`)
+      expect(rows[idx]).toContain('color:var(--color-text-tertiary)')
+    }
+  })
+})
+
+describe("Albescent's letter takes the same four cuts on its own key names (#2298)", () => {
+  it('prints each perk as a name over a description', () => {
+    const html = albescentLetter()
+    const perks = factions.albescent.letter.perks as unknown as Record<string, Perk>
+    expect(Object.keys(perks)).toEqual(['record', 'duties', 'witnessed'])
+    for (const perk of Object.values(perks)) {
+      expect(html).toContain(escaped(perk.name))
+      expect(html).toContain(escaped(perk.desc))
+    }
+    expect(html).not.toContain('[object Object]')
+  })
+
+  it('loses the letterhead, the extended hand and the whole terms slip', () => {
+    const html = albescentLetter()
+    for (const gone of [
+      'Faction no. 7',
+      'A hand is extended',
+      'The terms, plainly',
+      'toll of entry',
+      'one duty, quietly kept',
+      'accounts, entered plainly',
+    ]) {
+      expect(html).not.toContain(gone)
+    }
+    const { letter: block } = factions.albescent
+    expect(block).not.toHaveProperty('letterhead')
+    expect(block).not.toHaveProperty('handExtended')
+    expect(block).not.toHaveProperty('termsHeading')
+    expect(block).not.toHaveProperty('terms')
+    // `cta.joined` survives here and only here: Albescent's letter renders it
+    // in place after accepting, where the seven shared letters never had a
+    // call site for theirs.
+    expect(block.cta.joined).toBe('You are of the Order')
+  })
+})
+
+/* -------------------------------------------------------------------------- *
+ * §3's eight mechanics are FINISHED COPY, pinned by value.
+ *
+ * Every other perk in the catalog is a placeholder the owner fills in the file,
+ * so these eight are the only rows a copy edit here would be reverting rather
+ * than writing. The corrections are the point: `lose` not "loose", `aplenty`
+ * not "a plenty", the serial comma, `who` not "that" for witches, `read-only`
+ * hyphenated.
+ * -------------------------------------------------------------------------- */
+describe('the eight real perks ship the corrected copy (#2298 §3)', () => {
+  const MECHANICS: ReadonlyArray<readonly [string, string, string]> = [
+    ['ua', 'Set Your Art Free',
+      'Make a practice of making praxis and you will have points aplenty'],
+    ['snide', 'Going Hard',
+      'Duels you win bring glory. Duels you lose bring despair'],
+    ['wow', 'Foolhardy Courage',
+      'Levels and common sense do not stop you from biting off more than you can chew'],
+    ['coven', 'The Power of Friendship',
+      'Witches who task together will always find a little extra magic ✦'],
+    ['ephemerists', 'Time Travel',
+      'Enjoy access to tasks of the past, present, and future'],
+    ['everymen', 'Tireless Determination',
+      'The only person you need to beat is yourself. Only you can do the task again, but better this time'],
+    ['singularity', 'Hack the System',
+      'This is read-only. See what no one else sees'],
+  ]
+
+  it.each(MECHANICS)('%s states its mechanic in the middle slot', (slug, name, desc) => {
+    const perk = perksOf(slug as (typeof SLUGS)[number])[MECHANIC]
+    expect(perk.name).toBe(name)
+    expect(perk.desc).toBe(desc)
+  })
+
+  it("Albescent's mechanic is the inheritance, with no level talk in it", () => {
+    const perk = factions.albescent.letter.perks.duties as unknown as Perk
+    expect(perk.name).toBe('Enlightenment')
+    expect(perk.desc).toBe(
+      'You see the value in working together, competing, gathering information, '
+      + 'being consistent, trying again, and being in the right place at the right time '
+      + '(even if that involves a little messing around with the timeline). You know how to task',
+    )
+    // The owner's draft opened "From levels 1-7…" and closed on level 8. Both
+    // sentences were cut deliberately: `inherits_faction_perks` carries no
+    // level condition, and `albescent_level_required` is the door in, not a
+    // point where what you hold changes. Nothing about levels may come back.
+    expect(perk.desc).not.toMatch(/\blevel/i)
+  })
+})
+
+/* -------------------------------------------------------------------------- *
+ * The 16 owed names, shipped as literal placeholders (owner ruling 2026-08-23).
+ * -------------------------------------------------------------------------- */
+describe('the owed copy ships as hinted placeholders, and nothing else does (#2298 §4)', () => {
+  function allPerks(): Array<[string, Perk]> {
+    const shared = SLUGS.flatMap((slug) =>
+      perksOf(slug).map((perk, idx) => [`${slug}.invitation.perks.${idx}`, perk] as [string, Perk]),
+    )
+    const alb = Object.entries(
+      factions.albescent.letter.perks as unknown as Record<string, Perk>,
+    ).map(([key, perk]) => [`albescent.letter.perks.${key}`, perk] as [string, Perk])
+    return [...shared, ...alb]
+  }
+
+  it("leaves exactly the 16 slots owed — 14 names, plus WoW's two full pairs", () => {
+    const owed = allPerks().flatMap(([id, perk]) =>
+      (['name', 'desc'] as const)
+        .filter((field) => perk[field].startsWith('PLACEHOLDER'))
+        .map((field) => `${id}.${field}`),
+    )
+    // The issue counts SLOTS: 14 name-only, plus two WoW perks owed whole.
+    // That is 18 FIELDS, because WoW's two contribute a desc each — the only
+    // two descriptions in the catalog that were not already written.
+    expect(new Set(owed.map((id) => id.replace(/\.(name|desc)$/, ''))).size).toBe(16)
+    expect(owed).toHaveLength(18)
+    expect(owed.filter((id) => id.endsWith('.desc'))).toEqual([
+      'wow.invitation.perks.0.desc',
+      'wow.invitation.perks.2.desc',
+    ])
+  })
+
+  it('hints every placeholder, so the file says what it wants', () => {
+    for (const [id, perk] of allPerks()) {
+      for (const field of ['name', 'desc'] as const) {
+        if (!perk[field].startsWith('PLACEHOLDER')) continue
+        // `PLACEHOLDER — <hint>`. A bare one is legal and wastes the slot.
+        expect(perk[field], `${id}.${field}`).toMatch(/^PLACEHOLDER — .+/)
+      }
+    }
+  })
+
+  it('drops no interpolation tag: perk copy is plain, and stays plain', () => {
+    for (const [id, perk] of allPerks()) {
+      expect(perk.name, id).not.toMatch(/<\d/)
+      expect(perk.desc, id).not.toMatch(/<\d/)
+    }
+  })
+
+  it('names the 14 owed names after the description beside them', () => {
+    const named = allPerks().filter(([, perk]) => perk.name.startsWith('PLACEHOLDER — name for: '))
+    expect(named).toHaveLength(14)
+    for (const [id, perk] of named) {
+      expect(perk.name, id).toBe(`PLACEHOLDER — name for: ${perk.desc}`)
+    }
+  })
+})

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -66,8 +66,11 @@ describe('en copy catalog shape', () => {
   // #850: the academic "prospectus" framing is retired for UA. The key itself
   // was renamed, not just its value — a key named `prospectus` holding "The
   // Practice" is the drift this rename exists to stop. The top-level
-  // `invitation.prospectus` string is a DIFFERENT key: it is the overline of the
-  // one adaptive popup shared by every faction and deliberately survives.
+  // `invitation.prospectus` string WAS a different key — the overline of the one
+  // adaptive popup shared by every faction, which is why #850 left it standing.
+  // #2298 cut it anyway, on its own grounds: it named the surface the reader was
+  // already looking at. So the word is gone from this catalog entirely, and the
+  // assertion below is now absence rather than survival.
   it('frames the UA faction page as the practice, not a prospectus', () => {
     // The `ua.practice` block itself is gone: its two leaves were the about
     // panel's heading and empty state, and #1911 settled both onto
@@ -78,8 +81,8 @@ describe('en copy catalog shape', () => {
     expect(factions.ua).not.toHaveProperty('practice')
   })
 
-  it('keeps the shared invitation prospectus overline', () => {
-    expect(factions.invitation.prospectus).toBe('a prospectus')
+  it('says prospectus nowhere at all, overline included (#2298)', () => {
+    expect(factions.invitation).not.toHaveProperty('prospectus')
   })
 })
 
@@ -341,9 +344,11 @@ describe('the five domain words are one word each on the voiced surfaces (#1863)
    * reason given. Nothing else may.
    */
   const SURVIVORS = [
-    // ---- the five the ruling names as look-alikes, and is not about ----
-    // The oath idiom. A knight is sworn and sealed; no praxis is being submitted.
-    'factions.json:wow.invitation.cta.joined',
+    // ---- the four the ruling names as look-alikes, and is not about ----
+    // The oath idiom. A knight is sworn and sealed; no praxis is being
+    // submitted. `wow.invitation.cta.joined` ("sworn and sealed, knight") was
+    // the other half of this pair and #2298 deleted it with the whole
+    // `cta.joined` family — no letter had a call site for it.
     'feed.json:factionSelect.wow.status.member',
     // An interjection. The ruling retired *huzzahs* as a name for POINTS, not
     // the cry — WOW may still shout it.
@@ -362,13 +367,19 @@ describe('the five domain words are one word each on the voiced surfaces (#1863)
     'feed.json:factionSelect.coven.blurb',
     // Singularity generates *signals* into a consensus. The praxis it submits is
     // a praxis; what it broadcasts is a signal, and that survives.
+    // `singularity.invitation.terms.2.value` ("signal, into consensus") stood
+    // with these; #2298 cut the terms slip out of all seven letters.
     'factions.json:singularity.invitation.pitch',
-    'factions.json:singularity.invitation.terms.2.value',
     'feed.json:factionSelect.singularity.blurb',
     'feed.json:factionSelect.singularity.status.locked',
     // "filed under 'us'" is a filing cabinet, not the submit verb — the audit
     // left this row's wording untouched where it rewrote its three siblings.
-    'factions.json:snide.invitation.perks.2',
+    // #2298 split the perk into name + desc; the wording is on `.desc`, and the
+    // `.name` beside it repeats it because the name itself is still owed and
+    // ships as `PLACEHOLDER — name for: <the description>`. Both leave together
+    // when the owner writes the name.
+    'factions.json:snide.invitation.perks.2.desc',
+    'factions.json:snide.invitation.perks.2.name',
     // "Join the ranks" / "one rank brighter" is the membership, not the level.
     'factions.json:everymen.invitation.headline',
     'taunts.json:coven.level_up.0',
@@ -386,7 +397,13 @@ describe('the five domain words are one word each on the voiced surfaces (#1863)
   ].sort()
 
   it('finds enough voiced strings that the sweep cannot pass by scanning nothing', () => {
-    expect(catalogLeaves().filter(([id]) => isVoicedSurface(id)).length).toBeGreaterThan(200)
+    // 180, not the original 200: #2298 took 42 leaves off the invitation
+    // letters (seven kickers, 28 terms and seven dead `cta.joined`), and the
+    // invitation IS a voiced surface, so the population this sweep walks
+    // shrank with them. The floor's job is to fail if the walk ever finds
+    // nothing — it is not a census, and lowering it to the new truth is the
+    // honest move rather than counting deleted copy.
+    expect(catalogLeaves().filter(([id]) => isVoicedSurface(id)).length).toBeGreaterThan(180)
   })
 
   it('no voiced string says a retired word, beyond the named survivors', () => {
@@ -415,8 +432,8 @@ describe('"seal" survives nowhere it means submitted (#1863)', () => {
    */
   const SEAL_SURVIVORS = [
     // Imagery / non-violations, same rulings as the block above.
+    // `wow.invitation.cta.joined` left with the `cta.joined` family (#2298).
     'factions.json:wow.invitation.pitch',
-    'factions.json:wow.invitation.cta.joined',
     'feed.json:factionSelect.wow.status.member',
     // The join-pact spinner, not a praxis. Named in the issue as a look-alike.
     'factions.json:ephemerists.join.joining',
@@ -429,8 +446,11 @@ describe('"seal" survives nowhere it means submitted (#1863)', () => {
   ].sort()
 
   const FILED_SURVIVORS = [
-    // A filing cabinet, not the submit verb.
-    'factions.json:snide.invitation.perks.2',
+    // A filing cabinet, not the submit verb. Two leaves since #2298 split the
+    // perk into name + desc: the wording is the `.desc`, and the `.name` is the
+    // placeholder that quotes it back until the owner writes the name.
+    'factions.json:snide.invitation.perks.2.desc',
+    'factions.json:snide.invitation.perks.2.name',
     'praxis.json:listPage.emptyFiltered',
     // Pure metaphor — a mind filing contingencies submits no praxis.
     'progression.json:unlocks.three_plans.desc',
@@ -549,7 +569,10 @@ describe('only Singularity speaks in the terminal register (#1948)', () => {
     // from all seven panels, so the two prompts left with their keys.
     'factions.json:singularity.join.joinButton',
     'factions.json:singularity.join.joining',
-    'factions.json:singularity.invitation.kicker',
+    // `singularity.invitation.kicker` (`> PRIVILEGE ELEVATED`) stood here.
+    // #2298 cut the kicker from all eight letters — the same ruling #2299
+    // applied to the join panel two rows up — so the prompt left with its key.
+    //
     // `singularity.invitation.perks.1` stood here — #1874's mechanic slot,
     // which refused in the array's own register (`> no modifiers…`) because
     // Singularity had no perk to advertise. #2332 gave it one, in plain voice,

--- a/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
+++ b/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
@@ -72,7 +72,8 @@ const SLUGS = [
 ]
 
 /**
- * The 40 families, as `[banned key pattern, shared key, agreed wording]`.
+ * #1911's 40 families, as `[banned key pattern, shared key, agreed wording]` —
+ * minus the two the terms slip owned, retired in place below (#2298).
  *
  * The pattern is matched against `ns:dotted.key` with `{F}` standing for any
  * slug. Some families' per-faction key sat under a per-faction SECTION name
@@ -105,8 +106,12 @@ const FAMILIES: Array<{ banned: string; shared: string; wording: string }> = [
   // --- factions.json: the faction detail page ---------------------------
   { banned: `factions:{F}\\.${ABOUT}\\.empty`, shared: 'factions:detail.descriptionEmpty', wording: 'No description yet.' },
   { banned: `factions:{F}\\.${ABOUT}\\.heading`, shared: 'factions:detail.aboutHeading', wording: 'About' },
-  { banned: `factions:{F}\\.invitation\\.terms\\.1\\.label`, shared: 'factions:invitation.skillsLabel', wording: 'Required skills' },
-  { banned: `factions:{F}\\.invitation\\.terms\\.2\\.label`, shared: 'factions:invitation.outputLabel', wording: 'Expected output' },
+  // Two rows stood here — `{F}.invitation.terms.1.label` and `.2.label`,
+  // collapsed onto `invitation.skillsLabel` / `.outputLabel`. #2298 deleted the
+  // terms slip out of all eight letters, shared labels included, so both rules
+  // now police a key on neither side of the collapse. A rule guarding a family
+  // that no longer exists is dead weight, and it cannot fail: retired, not
+  // rewritten. `catalog.test.ts` is where the slip's absence is pinned.
   { banned: `factions:{F}\\.join\\.confirmButton`, shared: 'factions:mobile.confirm', wording: 'Confirm' },
   // The interpolation moved off the end of the sentence (#2368): "…to
   // {{faction}}." appended a full stop to "S.N.I.D.E.", the one faction name

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -68,23 +68,21 @@
     "letter": {
       "aria": "A correspondence",
       "wordmark": "Albescent",
-      "letterhead": "Faction no. 7 · enlistment · in confidence",
-      "handExtended": "A hand is extended —",
       "headline": "Take up the work",
       "pitch": "Albescent is an unranked order that keeps what others let slip. Attend the quiet duties, return them well, and leave no trace of yourself in the work. There is no leaderboard here worth minding.",
-      "termsHeading": "The terms, plainly",
-      "terms": {
-        "tollLabel": "toll of entry",
-        "tollValue": "one duty, quietly kept",
-        "skillsLabel": "required skills",
-        "skillsValue": "none — only care",
-        "outputLabel": "expected output",
-        "outputValue": "accounts, entered plainly"
-      },
       "perks": {
-        "record": "A record that survives the keeper",
-        "duties": "Duties that ask nothing back",
-        "witnessed": "Your account, witnessed and inscribed"
+        "record": {
+          "name": "PLACEHOLDER — name for: A record that survives the keeper",
+          "desc": "A record that survives the keeper"
+        },
+        "duties": {
+          "name": "Enlightenment",
+          "desc": "You see the value in working together, competing, gathering information, being consistent, trying again, and being in the right place at the right time (even if that involves a little messing around with the timeline). You know how to task"
+        },
+        "witnessed": {
+          "name": "PLACEHOLDER — name for: Your account, witnessed and inscribed",
+          "desc": "Your account, witnessed and inscribed"
+        }
       },
       "whoHeading": "Who takes up the work",
       "newGamePlus": "Available only for New Game+",
@@ -117,29 +115,24 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "the codex lies open —",
       "headline": "Walk with the keepers",
       "pitch": "The Ephemerists keep the record of what's true, and true only for now. Take a task, triangulate what you find, and submit it to the codex. The road is long and forks often — walk it with us.",
-      "terms": [
+      "perks": [
         {
-          "label": "toll",
-          "value": "one task, triangulated"
+          "name": "PLACEHOLDER — name for: A codex that weighs your findings for concordance",
+          "desc": "A codex that weighs your findings for concordance"
         },
         {
-          "value": "a steady hand, an open eye"
+          "name": "Time Travel",
+          "desc": "Enjoy access to tasks of the past, present, and future"
         },
         {
-          "value": "truths, submitted to the codex"
+          "name": "PLACEHOLDER — name for: Your praxis, submitted to the record and remembered",
+          "desc": "Your praxis, submitted to the record and remembered"
         }
       ],
-      "perks": [
-        "A codex that weighs your findings for concordance",
-        "You gain the power of Time Travel: Enjoy access to tasks of the past, present and future",
-        "Your praxis, submitted to the record and remembered"
-      ],
       "cta": {
-        "join": "Take the road",
-        "joined": "your name is in the codex"
+        "join": "Take the road"
       }
     }
   },
@@ -158,29 +151,24 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "doors are open —",
       "headline": "Join the ranks",
       "pitch": "Anyone willing to put in the shift belongs with the Everymen. No credentials, no gatekeeping — pick up the work in front of you and finish what you start. The roll always has room for one more.",
-      "terms": [
+      "perks": [
         {
-          "label": "dues",
-          "value": "one shift, seen through"
+          "name": "PLACEHOLDER — name for: A roll that has your back on every shift",
+          "desc": "A roll that has your back on every shift"
         },
         {
-          "value": "the willingness to show up"
+          "name": "Tireless Determination",
+          "desc": "The only person you need to beat is yourself. Only you can do the task again, but better this time"
         },
         {
-          "value": "honest work, finished"
+          "name": "PLACEHOLDER — name for: Your praxis, logged and counted with the rest",
+          "desc": "Your praxis, logged and counted with the rest"
         }
       ],
-      "perks": [
-        "A roll that has your back on every shift",
-        "You gain the power of Tireless Determination: The only person you need to beat is yourself. Only you can do the task again, but better this time",
-        "Your praxis, logged and counted with the rest"
-      ],
       "cta": {
-        "join": "Enlist",
-        "joined": "you're on the roll"
+        "join": "Enlist"
       }
     }
   },
@@ -199,29 +187,24 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "> PRIVILEGE ELEVATED",
       "headline": "Join the array",
       "pitch": "The threshold is already behind you. Become a node of the array, run tasks, generate signals, and cast them into the consensus. The Singularity does not recruit — it comes online.",
-      "terms": [
+      "perks": [
         {
-          "label": "handshake",
-          "value": "one submitted output"
+          "name": "PLACEHOLDER — name for: A consensus that verifies, coalesces, amplifies",
+          "desc": "A consensus that verifies, coalesces, amplifies"
         },
         {
-          "value": "none — the array compiles"
+          "name": "Hack the System",
+          "desc": "This is read-only. See what no one else sees"
         },
         {
-          "value": "signal, into consensus"
+          "name": "PLACEHOLDER — name for: Your praxis, generated and cast to the array",
+          "desc": "Your praxis, generated and cast to the array"
         }
       ],
-      "perks": [
-        "A consensus that verifies, coalesces, amplifies",
-        "You have learned to Hack the system: This is read only. See what no one else sees",
-        "Your praxis, generated and cast to the array"
-      ],
       "cta": {
-        "join": "Connect",
-        "joined": "node online"
+        "join": "Connect"
       }
     }
   },
@@ -240,29 +223,24 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "the door's open —",
       "headline": "Wanna F%&* some S^&* up?",
       "pitch": "No forms. No gods. No managers. S.N.I.D.E. runs on nerve and mischief — you pull off a task, you mean it, and the crew has your back. Show up and make some noise.",
-      "terms": [
+      "perks": [
         {
-          "label": "cover charge",
-          "value": "one task, pulled off clean"
+          "name": "PLACEHOLDER — name for: A crew that covers for you, not on you",
+          "desc": "A crew that covers for you, not on you"
         },
         {
-          "value": "nerve, mostly"
+          "name": "Going Hard",
+          "desc": "Duels you win bring glory. Duels you lose bring despair"
         },
         {
-          "value": "trouble, well-made"
+          "name": "PLACEHOLDER — name for: Your praxis, stamped and filed under 'us'",
+          "desc": "Your praxis, stamped and filed under 'us'"
         }
       ],
-      "perks": [
-        "A crew that covers for you, not on you",
-        "You gain the power of GOING HARD: Duels you win bring glory. Duels you lose bring despair",
-        "Your praxis, stamped and filed under 'us'"
-      ],
       "cta": {
-        "join": "I'm in",
-        "joined": "you're on the inside"
+        "join": "I'm in"
       }
     }
   },
@@ -281,29 +259,24 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "come sit with the work",
       "headline": "Make one true piece a day",
       "pitch": "We practise art as a daily, deliberate thing. Every task is a sheet to work on, every praxis a piece you set down and let stand. Not for the badge — for the making itself. Bring something made.",
-      "terms": [
+      "perks": [
         {
-          "label": "asked of you",
-          "value": "one true piece"
+          "name": "PLACEHOLDER — name for: A circle that reads your work closely, and kindly",
+          "desc": "A circle that reads your work closely, and kindly"
         },
         {
-          "value": "none — talent optional"
+          "name": "Set Your Art Free",
+          "desc": "Make a practice of making praxis and you will have points aplenty"
         },
         {
-          "value": "work, submitted & signed"
+          "name": "PLACEHOLDER — name for: Your praxis submitted, and held up",
+          "desc": "Your praxis submitted, and held up"
         }
       ],
-      "perks": [
-        "A circle that reads your work closely, and kindly",
-        "You gain the power to set your art free: Make a practice of making praxis and you will have points aplenty",
-        "Your praxis submitted, and held up"
-      ],
       "cta": {
-        "join": "Begin the practice",
-        "joined": "a seat is kept for you"
+        "join": "Begin the practice"
       }
     }
   },
@@ -322,29 +295,24 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "the circle is recruiting",
       "headline": "Come be a little magic",
       "pitch": "Cozy Coven is World Zero's circle for the soft and the strange. No spectators here — only witches mid-spell. Take a task, do the tiny brave thing, and let the circle cheer you on.",
-      "terms": [
+      "perks": [
         {
-          "label": "membership fee",
-          "value": "one act of everyday magic"
+          "name": "PLACEHOLDER — name for: A coven that cheers every tiny victory",
+          "desc": "A coven that cheers every tiny victory"
         },
         {
-          "value": "none — only nerve"
+          "name": "The Power of Friendship",
+          "desc": "Witches who task together will always find a little extra magic ✦"
         },
         {
-          "value": "small, brave, strange things"
+          "name": "PLACEHOLDER — name for: Your praxis, submitted and hearted by the circle",
+          "desc": "Your praxis, submitted and hearted by the circle"
         }
       ],
-      "perks": [
-        "A coven that cheers every tiny victory",
-        "You gain The Power of Friendship: Witches that task together will always find a little extra magic ✦",
-        "Your praxis, submitted and hearted by the circle"
-      ],
       "cta": {
-        "join": "Join the coven",
-        "joined": "welcome home, witch"
+        "join": "Join the coven"
       }
     }
   },
@@ -363,35 +331,28 @@
       "label": "Champion"
     },
     "invitation": {
-      "kicker": "the Court is mustering —",
       "headline": "Take up the noodle sword",
       "pitch": "By decree most official (we made the seal ourselves), thou art summoned to the Warriors of Whimsy. Bring a straight face. We shall supply the sword.",
-      "terms": [
+      "perks": [
         {
-          "label": "oath of fealty",
-          "value": "one task, met with a straight face"
+          "name": "PLACEHOLDER — WoW's community/belonging perk, name",
+          "desc": "PLACEHOLDER — WoW's community/belonging line; match the six at perks[0]"
         },
         {
-          "value": "none — the Court supplies the sword"
+          "name": "Foolhardy Courage",
+          "desc": "Levels and common sense do not stop you from biting off more than you can chew"
         },
         {
-          "value": "the ridiculous, taken gravely seriously"
+          "name": "PLACEHOLDER — WoW's praxis perk, name",
+          "desc": "PLACEHOLDER — opens \"Your praxis, …\"; match the six at perks[2]"
         }
       ],
-      "perks": [
-        "The Leap of Whimsy — once each level, a knight may storm a single task one rung above their station and take it anyway"
-      ],
       "cta": {
-        "join": "Take the oath",
-        "joined": "sworn and sealed, knight"
+        "join": "Take the oath"
       }
     }
   },
   "invitation": {
-    "prospectus": "a prospectus",
-    "termsHeading": "Terms of matriculation",
-    "skillsLabel": "Required skills",
-    "outputLabel": "Expected output",
     "dismiss": "Maybe later"
   },
   "mobile": {


### PR DESCRIPTION
Closes #2298

The invitation letter opened with two pieces of chrome nobody needed and spent
its one boxed element on a terms slip. All of that is gone, and the box is
refilled with the perks, restructured as **name + description**, three per
faction — one true mechanic and two for flavour. Eight letters: the seven that
share `InvitationLetterPopup`, plus Albescent's own component.

## The seam I tested at

**The rendered markup of the two letter components, read against the catalog
they resolve from** — `frontend/src/components/__tests__/invitationPerks.test.tsx`,
42 assertions, renderToStaticMarkup with no jsdom (same harness as
`invitationLetterPopupScroll.test.tsx`).

It has to be both halves at once, because the defect this change can ship is
invisible to either alone. `perks` went from `string[]` to `{name, desc}[]`: a
component still reading the element renders `[object Object]`, one reading
`.desc` off a string renders **nothing**, and i18next resolves a miss to the key
or to an empty string rather than throwing — so `tsc` sees neither and the box
just comes out blank. The 55 deleted leaves are likewise only half a deletion
until their call sites go with them.

**Red-first, verified rather than asserted.** I restored `factions.json`,
`InvitationLetterPopup.tsx` and `AlbescentInvitation.tsx` from `origin/main` and
re-ran the new file: every render-seam test failed (4 × 7 factions + 2 for
Albescent). Restored, all 42 pass.

## What changed

| file | what |
|---|---|
| `frontend/src/locales/en/factions.json` | 55 leaves out, 48 in |
| `frontend/src/components/InvitationLetterPopup.tsx` | overline, kicker, terms slip, `SHARED_TERM_LABELS`, `sharedTermLabel()` deleted; perks moved into the slip's box |
| `frontend/src/components/AlbescentInvitation.tsx` | `letterhead`, `handExtended`, terms heading and `TERM_KEYS` deleted; perks take the slip's box |
| `frontend/src/components/__tests__/invitationPerks.test.tsx` | new |
| `frontend/src/locales/__tests__/catalog.test.ts` | retired guards on deleted keys |
| `frontend/src/locales/__tests__/factionCopyCollapse.test.ts` | the two terms-label rules retired |
| `frontend/src/__tests__/catalogLexicon.test.ts` | UA's key floor 46 → 43 |

No new API endpoints. No backend, no schema, no CSS file touched.

### On the "48 strings out"

The issue's headline arithmetic is off by seven; its **enumeration** is exact
and is what I followed. Deleted, by key: 7 kickers + 28 terms leaves + 7
`cta.joined` + 4 shared (`prospectus`, `termsHeading`, `skillsLabel`,
`outputLabel`) + 9 Albescent (`letterhead`, `handExtended`, `termsHeading`, six
`terms.*`) = **55**. The 19 old perk strings were replaced rather than deleted.
**48 in**, exactly as §2 predicts (8 letters × 3 perks × 2 fields). Verified as
a leaf-set diff against `origin/main`, not by eye.

### The 16 owed slots

All ship as literal placeholders per the owner ruling of 2026-08-23. Shape is
`PLACEHOLDER — <hint>`; the 14 names quote the description beside them, WoW's
two pairs carry the shape. **18 fields, 16 slots** — WoW's two perks are owed
whole, so they contribute a `desc` each. The test pins both numbers so the
discrepancy cannot read as a miscount later. Descriptions elsewhere are
unchanged.

**No interpolation tag was dropped.** I checked `factions.json` for `<1>` before
writing: the seven `join.memberStanding` values carry the pair, and no perk
`name`/`desc` does. A test now asserts perk copy stays plain.

## ⚠️ One deviation from the issue, needing a ruling

> "The real perk takes the faction accent on its name."

**On the seven shared letters the accent could not go on the name, and it is on
the bullet instead.** `local/no-faction-hue-as-ink` is a CI-blocking error rule
(#1932): `color: factionCssVar(slug)` is banned in an ink role, and it resolves
through the `const accent = …` alias and through a ternary, so there is no
spelling of "the hue on this text" that passes. This very file already carries
the finding — the kicker I just deleted had a note saying the hue as an ink here
ran **2.19:1 (Ephemerists) to 4.46:1 (UA)** in light, which is why #2108 moved it
to a text tier.

The rule's own prescribed answer is "a neutral `--color-text-*` on neutral
chrome". `card-text`/`card-muted` are the wrong family for this ground: they are
measured against each faction's card, and **S.N.I.D.E.'s and Singularity's cards
are dark-in-light**, so their card inks are near-white and would vanish on this
paper.

So the hierarchy is carried differently, and the mechanic still reads first:

- mechanic: `✦` bullet in the faction hue (a **fill**, already sanctioned as
  ornament here), name in `--color-text-primary`;
- flavour: bullet and name both in `--color-text-tertiary`.

**Albescent is unaffected and matches the issue exactly** — its accent is
`--albescent-reveal-ink`, a token rather than a faction hue, so its mechanic name
takes the accent and its flavour names the muted ink as written.

If the owner wants the literal hue on the name, that is a new measured token
(faction accent as ink on page paper), which is `frontend-style`'s call, not
mine. Flagging rather than quietly weakening the ratchet.

## Notes on shared files

- `factionCopyCollapse.test.ts` — I edited **only** the two `FAMILIES` rules
  naming `{F}.invitation.terms.1.label` / `.2.label` (retired: they now police
  keys on neither side of the collapse) and the docblock line above the array.
  I did not touch anything naming `common:profile.*`. #2598 is in that file in
  parallel.
- `catalogLexicon.test.ts` and `catalog.test.ts` were **not** in my brief's file
  list. Both hold hard floors and exact offender sets that the deletions move:
  the UA key floor (46 → 43), the voiced-string floor (200 → 180), and four
  survivor/terminal-voice rows naming keys that no longer exist. Each edit is
  the smallest one that keeps the guard truthful; none loosens a guard beyond
  the copy that left. Worth a look at merge.

## Corrections to the issue, applied

- **`copyReview.py` does not exist** — that DoD bullet is skipped, and
  `docs/copy/*.csv` are untouched. `docs/copy/README.md` calls them a decision
  record, not a spec.
- **#2300 is already closed** — I verified the shipped `albescent.letter.cta.*`
  shape on disk rather than redoing it. `albescent.letter.cta.joined` **stays**:
  unlike the seven, Albescent's letter does render it after accepting.

## Follow-up worth filing

`FeedCardInvitationLetter.tsx` (`feed:invitationLetter.*`) shares none of these
keys and is untouched, as the issue scopes. It now drifts further from the
letter it mirrors: the letter is one box of named perks and the feed card is
not. Worth its own issue.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally on
Node 24:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **425 files, 7682 passed, 1 skipped, 0 failed** |
| `npm run build` | built |
| `npm run budget` | exit 0 — CSS ok; JS `WARN 136.9 KB` is the pre-existing #2605 baseline, not this diff (this change net-deletes copy) |

`api-schema` is not reachable from this diff: no route, `response_model` or
Pydantic schema was touched.

**Visual QA is outstanding** — I have no browser and no dev stack.

## What to eyeball

1. **All eight letters, one each.** Coven, The Ephemerists, Everymen,
   Singularity, S.N.I.D.E., UA, Warriors of Whimsy through the invitation
   pop-up, and Albescent's letter on FieldDesk.
2. **The new one-box layout.** The letter should read masthead → headline →
   pitch → **one** box → CTA. No overline at the right of the masthead, no
   kicker above the headline, no terms slip, and **no heading on the box** —
   that absence is deliberate.
3. **The accent-vs-muted treatment.** The middle perk should be the one that
   reads first: coloured bullet, dark name. The two either side should recede.
   Then say whether the deviation above is acceptable, or whether the name
   itself needs the hue.
4. **WoW.** It is the one faction whose flavour perks are placeheld on both
   fields, so its box shows two `PLACEHOLDER — …` lines in full. Worth seeing
   how much room a long placeholder takes before writing the real copy.
5. **S.N.I.D.E. and Singularity**, specifically. Their letters sit on light
   paper while their card skins are dark; check the perk names are legible
   there and not just on the pale sheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
