### PR TITLE
One concept, one key: the shared catalogs stop saying points eight ways and Loading eleven times (#2598)

### DIFF
--- a/frontend/scripts/i18nKeyRefs.py
+++ b/frontend/scripts/i18nKeyRefs.py
@@ -19,8 +19,28 @@ i18next PLURAL forms are probed too: a catalog key ending `_one` / `_other` /
 `_zero` / `_two` / `_few` / `_many` is also considered referenced if its BASE is
 referenced, since call sites write `t('x.count', { count: n })`.
 
-Reports:  KEPT (referenced)  and  DELETABLE (not referenced anywhere).
-Exit code 1 if anything is deletable, so it can gate a commit.
+Reports three columns, because two were not enough (#2598):
+
+    KEPT       referenced by APP code
+    TEST-ONLY  referenced, but only from tests — DEAD, see below
+    DELETABLE  not referenced anywhere
+
+A TEST-ONLY KEY IS A DEAD KEY. This script used to count any reference at all,
+which is how `common:actions.accept` / `.decline` / `.submit` survived it: their
+only references were in `sidebarPendingRequests.test.tsx`, in assertions that
+the rendered HTML does **not** contain them. A key whose only reader asserts its
+own absence is not alive, and a tool built to find orphans reported it KEPT.
+Tests are `__tests__/` directories, `*.test.*` / `*.spec.*` files, and the whole
+`e2e/` tree.
+
+Exit code 1 if anything is deletable OR test-only, so it can gate a commit.
+Pass `--ignore-tests` to drop the distinction and fold TEST-ONLY into DELETABLE,
+which is the same verdict stated in two columns instead of three.
+
+The backtick anchor cannot tell a template literal from PROSE: a key named in a
+`backticked` aside inside a comment counts as a reference. That is why the split
+matters rather than merely being tidier — such a mention in a test now lands in
+TEST-ONLY, where it reads as dead, instead of in KEPT, where it read as alive.
 
 DELETABLE IS A CANDIDATE LIST, NEVER A DELETE ORDER. A key composed at runtime
 has no literal anywhere and reads as deletable while being very much alive.
@@ -61,16 +81,28 @@ def leaf_keys(node, prefix=""):
         yield prefix
 
 
-def source_blob(roots):
-    chunks = []
+def is_test_path(path: str) -> bool:
+    """A test file, whose references do not keep a key alive (#2598)."""
+    normalized = path.replace(os.sep, "/")
+    if "/__tests__/" in normalized or "/e2e/" in normalized:
+        return True
+    name = os.path.basename(normalized)
+    return ".test." in name or ".spec." in name
+
+
+def source_blobs(roots) -> tuple[str, str]:
+    """(app code, test code) — the same walk, split by who is reading."""
+    app, tests = [], []
     for root in roots:
         for directory, subdirectories, filenames in os.walk(root):
             subdirectories[:] = [d for d in subdirectories if d not in SKIP_DIRECTORIES]
             for filename in filenames:
-                if filename.endswith(SOURCE_EXTENSIONS):
-                    path = os.path.join(directory, filename)
-                    chunks.append(io.open(path, encoding="utf-8", errors="ignore").read())
-    return "\n".join(chunks)
+                if not filename.endswith(SOURCE_EXTENSIONS):
+                    continue
+                path = os.path.join(directory, filename)
+                text = io.open(path, encoding="utf-8", errors="ignore").read()
+                (tests if is_test_path(path) else app).append(text)
+    return "\n".join(app), "\n".join(tests)
 
 
 def referenced(key: str, blob: str, namespace: str) -> bool:
@@ -80,24 +112,39 @@ def referenced(key: str, blob: str, namespace: str) -> bool:
 
 
 def main() -> int:
-    namespace = sys.argv[1] if len(sys.argv) > 1 else "praxis"
+    argv = [a for a in sys.argv[1:] if not a.startswith("--")]
+    fold_tests = "--ignore-tests" in sys.argv[1:]
+    namespace = argv[0] if argv else "praxis"
     here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     catalog_path = os.path.join(here, "src", "locales", "en", f"{namespace}.json")
     catalog = json.load(io.open(catalog_path, encoding="utf-8"))
-    blob = source_blob([os.path.join(here, "src"), os.path.join(here, "e2e")])
+    app_blob, test_blob = source_blobs(
+        [os.path.join(here, "src"), os.path.join(here, "e2e")]
+    )
 
-    kept, deletable = [], []
+    kept, test_only, deletable = [], [], []
     for key in leaf_keys(catalog):
         probes = [key]
         for suffix in PLURAL_SUFFIXES:
             if key.endswith(suffix):
                 probes.append(key[: -len(suffix)])
-        (kept if any(referenced(p, blob, namespace) for p in probes) else deletable).append(key)
+        if any(referenced(p, app_blob, namespace) for p in probes):
+            kept.append(key)
+        elif not fold_tests and any(referenced(p, test_blob, namespace) for p in probes):
+            test_only.append(key)
+        else:
+            deletable.append(key)
 
+    for key in test_only:
+        print(f"TEST-ONLY  {key}")
     for key in deletable:
         print(f"DELETABLE  {key}")
-    print(f"\n{len(kept)} kept, {len(deletable)} deletable, {len(kept) + len(deletable)} total")
-    return 1 if deletable else 0
+    total = len(kept) + len(test_only) + len(deletable)
+    summary = f"\n{len(kept)} kept, "
+    if not fold_tests:
+        summary += f"{len(test_only)} test-only, "
+    print(f"{summary}{len(deletable)} deletable, {total} total")
+    return 1 if deletable or test_only else 0
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/__tests__/albescentFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/albescentFeedFrame.test.tsx
@@ -163,12 +163,12 @@ describe('every type this chassis carries', () => {
     const duel = render(item('duel_challenge'))
     expect(duel).toContain('class="alb-feed alb-prism"')
     expect(duel).toContain(i18n.t('feed:duelChallenge.accept'))
-    expect(duel).toContain(i18n.t('feed:duelChallenge.decline'))
+    expect(duel).toContain(i18n.t('common:actions.decline'))
 
     const collab = render(item('collab_invite'))
     expect(collab).toContain('class="alb-feed alb-prism"')
-    expect(collab).toContain(i18n.t('feed:collabInvite.accept'))
-    expect(collab).toContain(i18n.t('feed:collabInvite.decline'))
+    expect(collab).toContain(i18n.t('common:actions.accept'))
+    expect(collab).toContain(i18n.t('common:actions.decline'))
   })
 
   it('forwards the tag slot — an archived challenge still says still waiting', () => {

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -10,7 +10,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
 // Initialize the i18n catalog so the copy keys resolve to English text.
-import '../../i18n'
+import i18n from '../../i18n'
 import CredentialCard from '../CredentialCard'
 import { factionName } from '../../utils/factions'
 
@@ -209,7 +209,13 @@ describe('CredentialCard proportions', () => {
   })
 
   it('sets the level readout at the 12px step', () => {
-    expect(html).toMatch(/font-size:var\(--text-lg\)[^"]*"[^>]*>lvl 4/)
+    // The readout's words come from the catalog, not from here: #2598 took
+    // `common:credential.lvl` from "lvl 4" to "Level 4". The card uppercases
+    // the span, so it still strikes as LEVEL 4 — what this pins is the RUNG.
+    const readout = i18n.t('common:credential.lvl', { level: 4 })
+    expect(html).toMatch(
+      new RegExp(`font-size:var\\(--text-lg\\)[^"]*"[^>]*>${readout}`),
+    )
   })
 })
 

--- a/frontend/src/components/__tests__/feedChassis.test.tsx
+++ b/frontend/src/components/__tests__/feedChassis.test.tsx
@@ -152,12 +152,12 @@ describe('the chassis', () => {
     const duel = render(item('duel_challenge', FAT_PAYLOAD))
     expect(duel, 'chassis kicker').toContain(feedKicker('duel_challenge'))
     expect(duel, 'accept survives').toContain(i18n.t('feed:duelChallenge.accept'))
-    expect(duel, 'decline survives').toContain(i18n.t('feed:duelChallenge.decline'))
+    expect(duel, 'decline survives').toContain(i18n.t('common:actions.decline'))
 
     const collab = render(item('collab_invite', FAT_PAYLOAD))
     expect(collab).toContain(feedKicker('collab_invite'))
-    expect(collab, 'accept survives').toContain(i18n.t('feed:collabInvite.accept'))
-    expect(collab, 'decline survives').toContain(i18n.t('feed:collabInvite.decline'))
+    expect(collab, 'accept survives').toContain(i18n.t('common:actions.accept'))
+    expect(collab, 'decline survives').toContain(i18n.t('common:actions.decline'))
 
     const letter = render(item('invitation_letter', FAT_PAYLOAD))
     expect(letter).toContain(feedKicker('invitation_letter'))

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -13,7 +13,7 @@ import { normalizeFeedItem, FACTION_ROW_TYPES } from '../feed/normalizeFeedItem'
 import FeedRowContent from '../feed/FeedRowContent'
 import { FeedRowSkinContext, type FeedRowSkin } from '../feed/feedRowSkin'
 import type { ActivityFeedItem } from '../../api/activityFeed'
-import '../../i18n'
+import i18n from '../../i18n'
 import { collabCopy } from '../collab/collabCopy'
 import { AA_NORMAL, contrastRatio, formatRatio, parseColor, requiredRatio } from '../../utils/contrast'
 import { readThemes, resolveVar } from '../../utils/__tests__/cssVars'
@@ -40,7 +40,7 @@ describe('normalizeFeedItem', () => {
     expect(row.actorHref).toBe('/characters/3')
     expect(row.headline).toBe('Reforest')
     expect(row.headlineHref).toBe('/praxis/7')
-    expect(row.points).toBe('40 pts')
+    expect(row.points).toBe(i18n.t('feed:row.points', { points: 40, count: 40 }))
     expect(row.badge?.label).toBe('Friend')
   })
 
@@ -58,7 +58,7 @@ describe('normalizeFeedItem', () => {
     expect(row.actorHref).toBe('/characters/8')
     expect(row.headline).toBe('Plant a tree')
     expect(row.headlineHref).toBe('/praxis/12')
-    expect(row.points).toBe('25 pts')
+    expect(row.points).toBe(i18n.t('feed:row.points', { points: 25, count: 25 }))
     expect(row.badge?.label).toBe('Your Stuff')
     expect(row.actions.map((a) => a.id)).toEqual(['fileYours'])
   })
@@ -489,7 +489,7 @@ describe('FeedRowContent skin seam', () => {
     const html = skinned({
       points: (figure) => <b data-plaque>{`${figure.points}/${figure.level}`}</b>,
     })
-    expect(html).toContain('<b data-plaque="true">40 pts/null</b>')
+    expect(html).toContain(`<b data-plaque="true">${i18n.t('feed:row.points', { points: 40, count: 40 })}/null</b>`)
     // The shared eyebrow line is REPLACED, never printed twice — drawing the
     // figure beside the skin's own is the duplication the seam exists to avoid.
     expect(html).not.toContain('class="eyebrow"')

--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -223,11 +223,11 @@ describe('every type the backend emits, inside this chassis', () => {
   it('keeps the companions answerable inside the chassis', () => {
     const duel = card('duel_challenge')
     expect(duel).toContain(i18n.t('feed:duelChallenge.accept'))
-    expect(duel).toContain(i18n.t('feed:duelChallenge.decline'))
+    expect(duel).toContain(i18n.t('common:actions.decline'))
 
     const collab = card('collab_invite')
-    expect(collab).toContain(i18n.t('feed:collabInvite.accept'))
-    expect(collab).toContain(i18n.t('feed:collabInvite.decline'))
+    expect(collab).toContain(i18n.t('common:actions.accept'))
+    expect(collab).toContain(i18n.t('common:actions.decline'))
 
     expect(card('invitation_letter')).toContain(i18n.t('feed:invitationLetter.viewFactions'))
   })

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -340,7 +340,7 @@ export default function CommentThread({
    */
   seed?: CommentOut[] | null
 }) {
-  const { t } = useTranslation('praxis')
+  const { t } = useTranslation(['praxis', 'common'])
   const { user } = useAuth()
   const [comments, setComments] = useState<CommentOut[]>(seed ?? [])
   const [loading, setLoading] = useState(seed == null)
@@ -393,7 +393,7 @@ export default function CommentThread({
       )}
       {loading && (
         <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
-          {t('comments.loading')}
+          {t('common:loading')}
         </p>
       )}
       {error && (

--- a/frontend/src/components/factionMarks/snideAtoms.tsx
+++ b/frontend/src/components/factionMarks/snideAtoms.tsx
@@ -237,6 +237,7 @@ export function PenCircle({
   valueColor = "var(--faction-snide-note-ink)",
   unitColor = "var(--faction-snide-note-pink-ink)",
   valueSize = "var(--text-heading)",
+  unitCaps = false,
   style,
 }: {
   /** The loop's drawn width in px. Ornament geometry (§4a). */
@@ -251,6 +252,14 @@ export function PenCircle({
   unitColor?: string;
   /** The figure's type ramp rung. The two cards take the default. */
   valueSize?: string;
+  /**
+   * Strike the caption in caps. Off by default, and it is a real per-SITE fact
+   * rather than a knob: the task DETAIL shouts its unit, and the score stamp
+   * next to it must not — `praxis:card.stamp.pointsShort` is the deliberately
+   * lowercase "pts" that #2598's ruling names as an exception, so uppercasing
+   * inside this atom would change a surface the ruling protects.
+   */
+  unitCaps?: boolean;
   style?: CSSProperties;
 }) {
   return (
@@ -311,6 +320,7 @@ export function PenCircle({
           // eslint-disable-next-line local/no-raw-style-values -- ornament: the caption's lead inside the drawn loop; a 4px rung pushes it off the numeral.
           marginTop: 2,
           color: unitColor,
+          ...(unitCaps ? { textTransform: "uppercase" as const } : {}),
         }}
       >
         {unit}

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -266,7 +266,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
                 cursor: loading ? "not-allowed" : "pointer",
               }}
             >
-              {i18n.t("feed:collabInvite.accept")}
+              {i18n.t("common:actions.accept")}
             </button>
             <button
               onClick={handleDecline}
@@ -280,7 +280,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
                 cursor: loading ? "not-allowed" : "pointer",
               }}
             >
-              {i18n.t("feed:collabInvite.decline")}
+              {i18n.t("common:actions.decline")}
             </button>
             {error && (
               <span className="label-caption" style={{ color: "var(--color-danger)" }}>

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -306,7 +306,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 cursor: loading || busy ? "not-allowed" : "pointer",
               }}
             >
-              {i18n.t("feed:duelChallenge.decline")}
+              {i18n.t("common:actions.decline")}
             </button>
             {/* Either participant can neutrally call off a pending challenge —
                 the opponent's mirror of the challenger's × (#956). */}

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -297,7 +297,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
                   disabled={joining}
                   style={acceptStyle}
                 >
-                  {i18n.t("feed:invitationLetter.accept")}
+                  {i18n.t("common:actions.accept")}
                 </button>
               )}
               {onNotNow && (

--- a/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
+++ b/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
@@ -53,7 +53,7 @@ function render(factionSlug: string | null, onNotNow?: () => void): string {
 }
 
 const VIEW_FACTIONS = i18n.t('feed:invitationLetter.viewFactions')
-const ACCEPT = i18n.t('feed:invitationLetter.accept')
+const ACCEPT = i18n.t('common:actions.accept')
 const NOT_NOW = i18n.t('feed:invitationLetter.notNow')
 
 describe('acceptMode — the predicate', () => {

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -187,7 +187,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points:
           p.task_point_value != null
-            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            ? i18n.t('feed:row.points', { points: p.task_point_value, count: p.task_point_value })
             : null,
         level: null,
         actions: [],
@@ -205,7 +205,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points:
           p.task_point_value != null
-            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            ? i18n.t('feed:row.points', { points: p.task_point_value, count: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
         actions: [],
@@ -224,7 +224,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points:
           p.task_point_value != null
-            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            ? i18n.t('feed:row.points', { points: p.task_point_value, count: p.task_point_value })
             : null,
         level: null,
         // "File yours" — a plain navigation to the shared editor, which every
@@ -268,7 +268,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points:
           p.task_point_value != null
-            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            ? i18n.t('feed:row.points', { points: p.task_point_value, count: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
         // "File it" is a navigation to the editor. "Drop out" is `leavePraxis`
@@ -304,7 +304,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points:
           p.task_point_value != null
-            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            ? i18n.t('feed:row.points', { points: p.task_point_value, count: p.task_point_value })
             : null,
         level: null,
         // "Answer" — the nudge's whole point, a navigation into your own
@@ -453,7 +453,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points:
           p.task_point_value != null
-            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            ? i18n.t('feed:row.points', { points: p.task_point_value, count: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
         actions: [],

--- a/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
@@ -71,7 +71,13 @@ describe('the rail and its pending requests', () => {
     // compares against the key string itself — which the page never contains,
     // so the guard would pass without looking at anything. `actions.accept` and
     // `actions.decline` below survive and have other readers, so those stay
-    // catalog-driven.
+    // catalog-driven. That claim was FALSE when written (#2598): the two keys
+    // had no reader but this file, and a key whose only reader asserts its
+    // ABSENCE is dead. It is true now — the four feed cards that each kept a
+    // private copy of these two words read the shared block instead:
+    // `FeedCardCollabInvite` (both), `FeedCardDuelChallenge` (decline),
+    // `FeedCardInvitationLetter` (accept). `actions.submit` had no such
+    // successor and was deleted.
     expect(html, 'panel heading').not.toContain('Pending Requests')
     expect(html, 'PendingRequestRow kicker').not.toContain('Collab Invite')
     expect(html, 'PendingRequestRow kicker').not.toContain('Duel Challenge')

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -9,7 +9,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 import type { ReactElement } from 'react'
-import '../../../i18n'
+import i18n from '../../../i18n'
 import type { PraxisCardOut } from '../../../api/praxis'
 import type { TaskOut } from '../../../api/tasks'
 import { PraxisByline, PraxisStats, PraxisVoteFooter } from '../shared'
@@ -258,7 +258,7 @@ describe("the meta line does not restate the stamp (#1833, widened by #2114)", (
     // are stripped, which is what tells it apart from the band's `12 pts` now
     // that a whole score prints without a decimal (#1866).
     expect(html, 'the stamp still carries the figure').toContain('12points')
-    expect(html, 'and the meta line does not repeat it').not.toContain('12 pts')
+    expect(html, 'and the meta line does not repeat it').not.toContain(i18n.t('praxis:card.points', { points: 12, count: 12 }))
     // The line keeps its other three segments and their separators.
     expect(html).toContain('L2')
     expect(html).toContain('solo')
@@ -274,7 +274,7 @@ describe("the meta line does not restate the stamp (#1833, widened by #2114)", (
     // points readout left and suppressing it would leave the card silent.
     const html = body({ score: 12, points_from_votes: 0, moderation_status: 'failed' })
     expect(html, 'no total was banked').not.toContain('12points')
-    expect(html, 'so what the task is worth stays').toContain('12 pts')
+    expect(html, 'so what the task is worth stays').toContain(i18n.t('praxis:card.points', { points: 12, count: 12 }))
   })
 })
 

--- a/frontend/src/components/praxisCard/__tests__/headingRoom.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/headingRoom.test.tsx
@@ -25,7 +25,7 @@ import { describe, it, expect } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
-import '../../../i18n'
+import i18n from '../../../i18n'
 import type { PraxisCardOut } from '../../../api/praxis'
 import { PraxisBody, TEXT_MEASURE } from '../desktop/shared'
 import { aPraxisCard } from '../../../test/fixtures'
@@ -100,7 +100,7 @@ describe('the meta line does not restate the stamp (#2114 supersedes #1833)', ()
     // meta line's `12 pts` is the stamp's own base read out a second time.
     const html = text(body({ score: 16, points_from_votes: 4 }))
     expect(html, 'the stamp still carries both figures').toContain('12')
-    expect(html, 'the meta line does not').not.toContain('12 pts')
+    expect(html, 'the meta line does not').not.toContain(i18n.t('praxis:card.points', { points: 12, count: 12 }))
     expect(html, 'level, mode and date stay').toContain('L2')
     expect(html).toContain('solo')
   })
@@ -110,7 +110,7 @@ describe('the meta line does not restate the stamp (#2114 supersedes #1833)', ()
     // points readout left and suppressing it would leave the card silent.
     const html = text(body({ score: 12, points_from_votes: 0, moderation_status: 'failed' }))
     expect(html, 'no total was banked').not.toContain('12points')
-    expect(html, 'so what the task is worth stays').toContain('12 pts')
+    expect(html, 'so what the task is worth stays').toContain(i18n.t('praxis:card.points', { points: 12, count: 12 }))
   })
 })
 

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -544,7 +544,7 @@ export function PraxisStats({
         <>
           <span aria-hidden>·</span>
           <span style={{ fontWeight: 700 }}>
-            {t("card.points", { points: praxis.task_point_value })}
+            {t("card.points", { points: praxis.task_point_value, count: praxis.task_point_value })}
           </span>
         </>
       )}

--- a/frontend/src/locales/__tests__/countedNouns.test.tsx
+++ b/frontend/src/locales/__tests__/countedNouns.test.tsx
@@ -36,6 +36,14 @@ const POINT_BEARING = [
   'common:sidebar.characterCard.points',
   'common:sidebar.characterCard.eraPoints',
   'factions:detail.spotlightStat',
+  // #2598 took these five from "{{points}} pts" to the long form. An
+  // abbreviation does not inflect, so "1 pts" was merely terse; "1 points" is
+  // wrong, and each needed an `_one` twin on the way out of the short form.
+  'feed:row.points',
+  'forms:proposeTask.preview.points',
+  'forms:taskMeta.points',
+  'praxis:card.points',
+  'praxis:detail.taskRef.points',
 ] as const
 
 const VARS = { era: 'Era One', level: 2, points: '1', score: '1' }

--- a/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
+++ b/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
@@ -157,7 +157,10 @@ const FAMILIES: Array<{ banned: string; shared: string; wording: string }> = [
   // a player reads it.
   { banned: `common:profile\\.{F}\\.praxisEmptyTitle`, shared: 'common:profile.praxisEmptyTitle', wording: 'No praxis submitted yet.' },
   { banned: `common:profile\\.{F}\\.praxisEyebrow`, shared: 'common:profile.praxisEyebrow', wording: 'Submitted by {{name}}' },
-  { banned: `common:profile\\.{F}\\.ringLabel`, shared: 'common:profile.lvl', wording: 'lvl' },
+  // #2598 took the shared wording long: "lvl" -> "Level". The collapse this row
+  // guards is unchanged — what it pins is that the seven `ringLabel` keys are
+  // still gone and the one survivor still says what the owner ruled it says.
+  { banned: `common:profile\\.{F}\\.ringLabel`, shared: 'common:profile.lvl', wording: 'Level' },
 
   // --- votes.json: the vote widget chrome -------------------------------
   { banned: `votes:chrome\\.{F}\\.rateAria`, shared: 'votes:chrome.rateAria', wording: 'Rate {{value}} — {{label}}' },

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -229,7 +229,6 @@
   "actions": {
     "accept": "Accept",
     "decline": "Decline",
-    "submit": "Submit",
     "proposeTask": "Propose a Task",
     "showMore": "+{{count}} more",
     "showFewer": "Show fewer"

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -1,10 +1,9 @@
 {
   "brand": "World Zero",
-  "loading": "Loading...",
+  "loading": "Loading…",
   "states": {
     "tryRefreshing": "Try refreshing.",
-    "characterNotFound": "Character not found.",
-    "loading": "Loading..."
+    "characterNotFound": "Character not found."
   },
   "relationships": {
     "blocked": "Blocked",
@@ -46,7 +45,6 @@
     }
   },
   "leaderboard": {
-    "loading": "Loading...",
     "empty": "No players yet.",
     "loadError": "Couldn't load the leaderboard.",
     "title": "Players",

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -32,7 +32,7 @@
     "proposedTasksTotal": "{{count}} total",
     "proposedTasksEmpty": "No proposed tasks yet.",
     "handleJoined": "@{{username}} · joined {{joined}}",
-    "lvl": "lvl",
+    "lvl": "Level",
     "ptsThisLevel": "{{current}} / {{span}} pts this level",
     "nextLevel": "next · lvl {{level}}",
     "ptsToNext": "{{score}} / {{threshold}} pts",
@@ -55,7 +55,7 @@
     "playersCount_one": "{{count}} player",
     "playersCount_other": "{{count}} players",
     "level": "Level {{level}}",
-    "points": "pts",
+    "points": "Points",
     "podium": {
       "latest": "Latest · {{ago}}"
     },
@@ -97,8 +97,8 @@
   "credential": {
     "fallbackName": "Wanderer",
     "uploadTitle": "Click to upload a photo",
-    "lvl": "lvl {{level}}",
-    "pts": "pts"
+    "lvl": "Level {{level}}",
+    "pts": "Points"
   },
   "fieldDesk": {
     "livesInPlay_one": "{{count}} life in play",
@@ -265,10 +265,10 @@
     }
   },
   "level": {
-    "caption": "lvl"
+    "caption": "Level"
   },
   "avatar": {
-    "rank": "Lvl {{level}}"
+    "rank": "Level {{level}}"
   },
   "praxisType": {
     "solo": "Solo",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -2,10 +2,8 @@
   "page": {
     "title": "Updates",
     "eyebrow": "Activity Feed",
-    "loading": "Loading...",
     "loadError": "Couldn't load the activity feed.",
     "loadMore": "Load older updates",
-    "loadingMore": "Loading…",
     "loadMoreError": "Couldn't load more updates.",
     "showing_one": "Showing {{count}} update",
     "showing_other": "Showing {{count}} updates"

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -109,9 +109,10 @@
       "awaitingSubmission": "Waiting on your submission",
       "mentionedYou": "mentioned you in a comment"
     },
-    "points": "{{points}} pts",
+    "points_one": "{{points}} point",
+    "points_other": "{{points}} points",
     "pointsEarned": "+{{points}} pts",
-    "level": "lvl {{level}}",
+    "level": "Level {{level}}",
     "quotedHeadline": "“{{headline}}”"
   },
   "dateDivider": {

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -123,8 +123,6 @@
   "collabInvite": {
     "sentence": "<1>{{name}}</1> invited you to collaborate",
     "taskMeta": "{{points}} pts · lvl {{level}}",
-    "accept": "Accept",
-    "decline": "Decline",
     "accepted": "Accepted — view collaboration",
     "declined": "Declined",
     "bankFull": {
@@ -139,7 +137,6 @@
     "sentence": "<1>{{name}}</1> has challenged you to a duel",
     "taskMeta": "{{points}} pts · winner takes the points",
     "accept": "Accept Duel",
-    "decline": "Decline",
     "withdraw": "Withdraw",
     "withdrawn": "Withdrawn — the duel was called off",
     "withdrawError": "Could not withdraw the challenge. Try again.",
@@ -165,7 +162,6 @@
     "sentence": "You've received an invitation to join <1>{{faction}}</1>.",
     "body": "Complete faction tasks to prove your dedication, or visit the factions page to make your choice.",
     "viewFactions": "View Factions →",
-    "accept": "Accept",
     "notNow": "Not now",
     "accepted": "Joined {{faction}}",
     "setAside": "Set aside — the invitation still stands",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -33,7 +33,6 @@
     }
   },
   "editCharacter": {
-    "loading": "Loading...",
     "notFound": "Character not found.",
     "notOwner": "You can only edit your own character.",
     "eyebrow": "Unaffiliated · this is who you are",
@@ -100,7 +99,6 @@
   },
   "editPraxis": {
     "loadingPageTitle": "Edit Praxis",
-    "loading": "Loading...",
     "errors": {
       "load": "Couldn't load this praxis.",
       "titleRequired": "Title is required.",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -80,7 +80,8 @@
     "tasks": "Tasks"
   },
   "taskMeta": {
-    "points": "{{points}} pts",
+    "points_one": "{{points}} point",
+    "points_other": "{{points}} points",
     "duel": "duel",
     "collab": "collab"
   },
@@ -289,7 +290,7 @@
       "statusUnsaved": "Not saved yet",
       "statusSubmitted": "Submitted",
       "taskLabel": "The task",
-      "pointsUnit": "pts",
+      "pointsUnit": "Points",
       "levelLabel": "Level {{level}}",
       "titleLabel": "Title (required)",
       "titlePlaceholder": "Title",
@@ -342,11 +343,11 @@
       },
       "basePoints": {
         "label": "Base points",
-        "placeholder": "pts"
+        "placeholder": "Points"
       },
       "bonusPoints": {
         "label": "Bonus points",
-        "placeholder": "pts",
+        "placeholder": "Points",
         "hint": "Flat bonus added to score"
       },
       "minimumLevel": {
@@ -363,8 +364,9 @@
       "metaHeading": "Metatask preview — {{faction}}",
       "taskHeading": "Task preview — {{faction}} · Pending",
       "bonusPoints": "+{{points}} bonus pts",
-      "points": "{{points}} pts",
-      "level": "lvl {{level}}",
+      "points_one": "{{points}} point",
+      "points_other": "{{points}} points",
+      "level": "Level {{level}}",
       "pending": "Pending review"
     },
     "errors": {

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -333,7 +333,6 @@
     "fields": {
       "name": {
         "label": "Task name",
-        "placeholder": "Task Name",
         "tooLong": "Task name must be 200 characters or fewer."
       },
       "description": {
@@ -354,8 +353,7 @@
         "label": "Minimum level"
       },
       "notes": {
-        "label": "Notes to admin (optional)",
-        "placeholder": "Notes to Admin (optional)"
+        "label": "Notes to admin (optional)"
       }
     },
     "metaToggle": {

--- a/frontend/src/locales/en/home.json
+++ b/frontend/src/locales/en/home.json
@@ -49,7 +49,6 @@
         "praxis": "Praxis that needs your vote"
       },
       "seeMore": "See more",
-      "loading": "Loading…",
       "empty": {
         "tasks": "Nothing open to you right now — level up or check back soon.",
         "praxis": "You have voted on everything you can. Nice."

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -73,7 +73,6 @@
     }
   },
   "detail": {
-    "loading": "Loading...",
     "retry": "Try refreshing.",
     "notFound": "Not found.",
     "sections": {
@@ -165,7 +164,6 @@
   "comments": {
     "heading_one": "{{count}} comment",
     "heading_other": "{{count}} comments",
-    "loading": "Loading…",
     "loadError": "Could not load comments.",
     "composerPlaceholder": "Say something worth keeping…",
     "mentionHint": "@ to mention",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -37,7 +37,8 @@
   },
   "card": {
     "level": "L{{level}}",
-    "points": "{{points}} pts",
+    "points_one": "{{points}} point",
+    "points_other": "{{points}} points",
     "solo": "solo",
     "crew": "+{{count}} crew",
     "votedBy": "voted by {{name}}",
@@ -84,7 +85,8 @@
     "taskRef": {
       "label": "Completing task",
       "level": "Level {{level}}",
-      "points": "{{points}} pts"
+      "points_one": "{{points}} point",
+      "points_other": "{{points}} points"
     },
     "filed": "Submitted {{date}}",
     "vote": {

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -37,7 +37,6 @@
     "loadError": "Couldn't load tasks."
   },
   "detail": {
-    "loading": "Loading...",
     "fetchError": "<0>Try refreshing.</0>",
     "notFound": "Task not found.",
     "pageTitle": "Task",

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -54,8 +54,8 @@
     "points": {
       "base": "base",
       "multiplier": "×{{multiplier}}",
-      "total_one": "POINT",
-      "total_other": "POINTS"
+      "total_one": "Point",
+      "total_other": "Points"
     },
     "signup": {
       "cta": "Sign up",

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -223,7 +223,7 @@ export default function CharacterProfile() {
   };
 
   if (loading)
-    return <div className="py-8 font-body text-muted">{t("states.loading")}</div>;
+    return <div className="py-8 font-body text-muted">{t("loading")}</div>;
   if (error)
     return (
       <div className="py-8">

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -90,7 +90,7 @@ export default function EditCharacter() {
 }
 
 function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
-  const { t } = useTranslation('forms')
+  const { t } = useTranslation(['forms', 'common'])
   const navigate = useNavigate()
   const fileRef = useRef<HTMLInputElement>(null)
   const {
@@ -120,7 +120,7 @@ function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
     handleSubmit,
   } = state
 
-  if (loading) return <div className="py-8 font-body text-muted">{t('editCharacter.loading')}</div>
+  if (loading) return <div className="py-8 font-body text-muted">{t('common:loading')}</div>
   if (!character) return <div className="py-8 font-body text-muted">{t('editCharacter.notFound')}</div>
   if (!isOwner) return <div className="py-8 font-body text-muted">{t('editCharacter.notOwner')}</div>
 

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -25,7 +25,7 @@ import MetataskPicker from "../components/metataskSeal/MetataskPicker";
 import MetataskRemoveConfirm from "../components/metataskSeal/MetataskRemoveConfirm";
 
 export default function EditPraxis() {
-  const { t } = useTranslation("forms");
+  const { t } = useTranslation(["forms", "common"]);
   const { id } = useParams<{ id: string }>();
   const state = useEditPraxis(id);
 
@@ -49,7 +49,7 @@ export default function EditPraxis() {
     return (
       <div className="py-8 font-body text-muted">
         <PageTitle title={t("editPraxis.loadingPageTitle")} />
-        {t("editPraxis.loading")}
+        {t("common:loading")}
       </div>
     );
   }

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -539,7 +539,7 @@ const SEE_MORE_HREF: Record<BrowseTab, string> = {
  * landing tab costs one, and the other costs nothing until it is asked for.
  */
 function BrowseSection({ onSignup }: { onSignup: (taskId: number) => void }) {
-  const { t } = useTranslation('home')
+  const { t } = useTranslation(['home', 'common'])
   const { user } = useAuth()
   const [tab, setTab] = useState<BrowseTab>('tasks')
   // `null` = never fetched, `[]` = fetched and empty. The pair is what makes the
@@ -620,7 +620,7 @@ function BrowseSection({ onSignup }: { onSignup: (taskId: number) => void }) {
       </div>
 
       {items === null ? (
-        <p className="font-body text-muted">{t('signedIn.browse.loading')}</p>
+        <p className="font-body text-muted">{t('common:loading')}</p>
       ) : items.length === 0 ? (
         <p className="font-body text-muted">{t(`signedIn.browse.empty.${tab}`)}</p>
       ) : (

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -68,7 +68,7 @@ export default function Leaderboard() {
   if (loading) {
     return (
       <div className="py-8">
-        <p className="font-body content-text text-muted">{t('leaderboard.loading')}</p>
+        <p className="font-body content-text text-muted">{t('loading')}</p>
       </div>
     )
   }

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -36,11 +36,11 @@ import { surfaceMap } from '../factions'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
 
 export default function PraxisDetail() {
-  const { t } = useTranslation('praxis')
+  const { t } = useTranslation(['praxis', 'common'])
   const { id } = useParams<{ id: string }>()
   const state = usePraxisDetail(id)
 
-  if (state.loading) return <div className="py-8 font-body text-muted">{t('detail.loading')}</div>
+  if (state.loading) return <div className="py-8 font-body text-muted">{t('common:loading')}</div>
   if (state.fetchError) return (
     <div className="py-8">
       <p className="font-body content-text danger-text border-2 danger-edge px-3 py-2">

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -32,11 +32,11 @@ import DefaultTaskDetail from "./taskDetail/archetypes/DefaultTaskDetail";
 
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
-  const { t } = useTranslation("tasks");
+  const { t } = useTranslation(["tasks", "common"]);
   const state = useTaskDetail(id);
 
   if (state.loading)
-    return <div className="py-8 font-body text-muted">{t("detail.loading")}</div>;
+    return <div className="py-8 font-body text-muted">{t("common:loading")}</div>;
 
   if (state.fetchError)
     return (

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -89,7 +89,7 @@ export default function Updates() {
 
       {/* ── Feed ── */}
       {loading ? (
-        <div className="py-8 font-body text-muted">{t('page.loading')}</div>
+        <div className="py-8 font-body text-muted">{tc('loading')}</div>
       ) : fetchError ? (
         <p className="font-body content-text danger-text border-2 danger-edge px-3 py-2">
           {fetchError}{' '}
@@ -125,7 +125,7 @@ export default function Updates() {
             disabled={loadingMore}
             className="feed-load-more"
           >
-            {loadingMore ? t('page.loadingMore') : t('page.loadMore')}
+            {loadingMore ? tc('loading') : t('page.loadMore')}
           </button>
         </div>
       )}

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -19,7 +19,7 @@ import { TAGLINE_MAX } from '../useCreateCharacter'
  * (SPEC-faction-ui-profile §1a).
  */
 export default function DefaultEditCharacter({ state }: { state: EditCharacterState }) {
-  const { t } = useTranslation('forms')
+  const { t } = useTranslation(['forms', 'common'])
   const navigate = useNavigate()
   const fileRef = useRef<HTMLInputElement>(null)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
@@ -49,7 +49,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
     handleDelete,
   } = state
 
-  if (loading) return <p className="font-body text-muted">{t('editCharacter.loading')}</p>
+  if (loading) return <p className="font-body text-muted">{t('common:loading')}</p>
   if (!character) return <p className="font-body text-muted">{t('editCharacter.notFound')}</p>
   if (!isOwner) return <p className="font-body text-muted">{t('editCharacter.notOwner')}</p>
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx
@@ -161,7 +161,13 @@ describe("Singularity composer — structure", () => {
       // names the editor through an aria-label a static render cannot see.
       i18n.t("forms:editPraxis.composer.proofLabel"),
       i18n.t("forms:editPraxis.composer.submit"),
-      i18n.t("forms:editPraxis.composer.pointsUnit"),
+      // No `pointsUnit`, and it was never really here (#2598). Its value was
+      // the three letters "pts", which occur incidentally in almost any markup,
+      // so this passed without the composer ever drawing the key — a VACUOUS
+      // assertion. #1828 had already replaced every archetype's composer-only
+      // points mark with the shared `ScoreStamp`, which speaks
+      // `praxis:card.stamp.*`. Lengthening the value to "Points" is what made
+      // the absence visible. The key has no reader; deleting it is on the issue.
     ]) {
       expect(html, phrase).toContain(phrase);
     }

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
@@ -214,13 +214,19 @@ describe("WOW composer — copy is neutral, and the old block is GONE (ADR-0065 
     // `titleLabel` is an aria-label too since #2179 — but on the `<input>`
     // itself, so a static render still sees it. This asserts the wording is the
     // neutral catalog's; that it is no longer DRAWN is composerRule.test.tsx's.
+    // No `pointsUnit` either, and it was never really here (#2598). Its value
+    // was the three letters "pts", which occur incidentally in almost any
+    // markup, so `toContain` passed without the composer ever drawing the key —
+    // a VACUOUS assertion. #1828 had already replaced every archetype's
+    // composer-only points mark with the shared `ScoreStamp`, which speaks
+    // `praxis:card.stamp.*`. Lengthening the value to "Points" is what made the
+    // absence visible. The key has no reader left; deleting it is on the issue.
     for (const key of [
       "taskLabel",
       "titleLabel",
       "modeLabel",
       "proofLabel",
       "submit",
-      "pointsUnit",
     ] as const) {
       expect(markup).toContain(i18n.t(`forms:editPraxis.composer.${key}`));
     }

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -292,7 +292,15 @@ describe("praxis-read earned-points breakdown", () => {
 
 // ─── The task-reference line does not restate the stamp (#1833) ──────────────
 //
-// Each archetype's task-reference band closes with "Level 3 · 30 pts", and the
+/**
+ * What the band says the task is worth, read from the catalog rather than
+ * typed. It was the literal "30 pts" until #2598 took
+ * `praxis:detail.taskRef.points` to the long form — and to an `_one`/`_other`
+ * pair, because "1 points" is wrong where "1 pts" was merely terse.
+ */
+const TASK_WORTH = i18n.t("praxis:detail.taskRef.points", { points: 30, count: 30 });
+
+// Each archetype's task-reference band closes with "Level 3 · 30 points", and the
 // score rail beside it prints 30.0 as the total whenever nothing has moved the
 // score off the base — which, under Era 1's neutral multiplier, is every
 // unvoted praxis. #1131 made the stamp suppress its own base row in exactly
@@ -318,13 +326,13 @@ describe("task-reference points (#1833)", () => {
       // stamp's total and the band's figure are the same string and only the
       // count tells them apart — which is the rule this case is about.
       expect(text.split("30"), "the stamp still carries the total").toHaveLength(2);
-      expect(text, "and the band does not repeat it").not.toContain("30 pts");
+      expect(text, "and the band does not repeat it").not.toContain(TASK_WORTH);
     });
 
     it(`${slug} keeps both figures once votes move the total`, () => {
       // base 30 + 16 from votes = 46: two figures, two questions.
       const { text } = render(<Archetype state={state()} />);
-      expect(text, "what the task is worth").toContain("30 pts");
+      expect(text, "what the task is worth").toContain(TASK_WORTH);
       expect(text, "what this praxis scored").toContain("46");
     });
 
@@ -334,7 +342,7 @@ describe("task-reference points (#1833)", () => {
       const { text } = render(<Archetype state={baseOnly({ moderation_status: "failed" })} />);
       // Stated once again, and this time the one statement is the band's.
       expect(text.split("30"), "no total was banked").toHaveLength(2);
-      expect(text, "so what the task is worth stays").toContain("30 pts");
+      expect(text, "so what the task is worth stays").toContain(TASK_WORTH);
     });
   }
 });

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -88,7 +88,7 @@ export function scoreWasBanked(praxis: PraxisOut): boolean {
 export function taskRefMeta(praxis: PraxisOut, t: TFunction<'praxis'>): string {
   const level = t('detail.taskRef.level', { level: praxis.task_level_required })
   if (stampRestatesTaskPoints(praxis)) return level
-  return `${level} · ${t('detail.taskRef.points', { points: praxis.task_point_value })}`
+  return `${level} · ${t('detail.taskRef.points', { points: praxis.task_point_value, count: praxis.task_point_value })}`
 }
 
 // ── The detail WALL's alarm inks (#1451) ─────────────────────────────────────

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -575,6 +575,10 @@ export default function DefaultProposeTask({
                     <span className="label-caption">
                       {t("proposeTask.preview.points", {
                         points: pointValue || "?",
+                        // `pointValue` is the raw input string. An empty or
+                        // unparseable one draws "?" and takes the PLURAL —
+                        // "? points" reads, "? point" does not (#2598).
+                        count: Number(pointValue) || 0,
                       })}
                     </span>
                   )}

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -302,7 +302,19 @@ export default function DefaultProposeTask({
                   set in the faction's own display face and identified by its
                   placeholder — so the label key it used to render is now what
                   it ANNOUNCES: a placeholder disappears on the first keystroke
-                  (§7). Same for the description and notes below. */}
+                  (§7). Same for the description and notes below.
+
+                  #2598 asked for `fields.name.placeholder` to be DELETED, on
+                  the premise that it merely echoed a visible label. It did not:
+                  per the paragraph above the placeholder IS the only on-screen
+                  identification this field has, so deleting it would leave a
+                  sighted user an unlabelled box. What was actually wrong is
+                  that one field's wording lived in two keys that had already
+                  drifted apart in case ("Task name" / "Task Name"). The second
+                  key is gone and both uses read the label — one concept, one
+                  key, and the screen reader stops hearing two spellings.
+                  Whether these fields should get a visible label back is a
+                  design question, and it is on the issue. */}
               <div style={{ marginBottom: "var(--space-lg)" }}>
                 <input
                   type="text"
@@ -312,7 +324,7 @@ export default function DefaultProposeTask({
                   onChange={(e) => setTitle(e.target.value)}
                   disabled={submitting}
                   aria-label={t("proposeTask.fields.name.label")}
-                  placeholder={t("proposeTask.fields.name.placeholder")}
+                  placeholder={t("proposeTask.fields.name.label")}
                   style={taskNameInputStyle(factionSlug, Boolean(title))}
                 />
                 <span
@@ -482,7 +494,7 @@ export default function DefaultProposeTask({
                   disabled={submitting}
                   maxLength={2000}
                   aria-label={t("proposeTask.fields.notes.label")}
-                  placeholder={t("proposeTask.fields.notes.placeholder")}
+                  placeholder={t("proposeTask.fields.notes.label")}
                   className="content-text"
                   style={notesTextareaStyle}
                   onFocus={(e) => {

--- a/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
@@ -23,12 +23,26 @@ import { MemoryRouter } from "react-router-dom";
 import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 // Initialize the i18n catalog so copy keys resolve to English text.
-import "../../../i18n";
+import i18n from "../../../i18n";
 import AlbescentTaskDetail from "../archetypes/AlbescentTaskDetail";
 import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
 import type { TaskDetailState } from "../useTaskDetail";
 import { aPraxisCard, aTask } from '../../../test/fixtures'
 import { factionName, setAlbescentRevealed } from "../../../utils/factions";
+
+/**
+ * The worth panel's unit word, read from the catalog rather than typed.
+ *
+ * It used to be the literal "POINTS". #2598 moved the shout out of the catalog
+ * value and into CSS — the catalog holds "Point"/"Points" and each of the nine
+ * skins uppercases the element that draws it — so a STATIC render now reads the
+ * catalog's case, while a browser still paints caps. Same move, and the same
+ * reason, as `everymenBillOrnament.test.tsx`'s struck seal.
+ *
+ * 18 is `modifiedPoints` in every state below, so this is the plural.
+ */
+const POINTS_UNIT = i18n.t("tasks:detail.points.total", { count: 18 });
+
 
 const TITLE = "Sit with something until it turns pale";
 const BRIEF =
@@ -119,7 +133,7 @@ describe("Albescent task detail — Default plus the light", () => {
       // identity multiplier, on this skin's own worth slot as on Default's, so
       // at ×1.00 the ring's total is the only worth text. The row's inheritance
       // is asserted below, where a real factor makes it say something.
-      "POINTS",
+      POINTS_UNIT,
     ]) {
       expect(text, `inherited slot: ${shared}`).toContain(shared);
     }
@@ -201,7 +215,7 @@ describe("Albescent task detail — Default plus the light", () => {
   it("shows the worth ring's total and hides the badge at the identity factor", () => {
     const { text } = render(<AlbescentTaskDetail state={baseState()} />);
     expect(text).toContain("18");
-    expect(text).toContain("POINTS");
+    expect(text).toContain(POINTS_UNIT);
     expect(text).not.toContain("×");
 
     const lifted = render(

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -124,9 +124,10 @@ describe("task-detail content-slot invariant", () => {
     });
 
     // #2598. `tasks:detail.points.total` used to be stored as "POINT"/"POINTS",
-    // pre-shouted, and NOT ONE of the nine skins uppercased it in CSS — so the
-    // caps in the catalog value were the only thing shouting on all nine pages,
-    // and an editor could not tell whether they were the design or the copy.
+    // pre-shouted, while only five of the nine skins uppercased it in CSS — so
+    // on the other four the caps in the catalog value were the only thing
+    // shouting, and on all nine an editor could not tell whether they were the
+    // design or the copy.
     //
     // The catalog holds "Point"/"Points" now and the shout moved to the element.
     // Five skins already carried the transform (Everymen's `label`, the

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -31,6 +31,18 @@ import { describe, it, expect } from "vitest";
 import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
 import type { TaskDetailState } from "../useTaskDetail";
 import { aPraxisCard, aTask } from '../../../test/fixtures'
+import i18n from "../../../i18n";
+
+/**
+ * The tag that DIRECTLY encloses the first occurrence of `text`, opening angle
+ * bracket to closing one — so an assertion can ask what dress the element
+ * carries, not merely whether the words are somewhere on the page.
+ */
+function enclosingTag(html: string, text: string): string {
+  const at = html.indexOf(`>${text}<`);
+  expect(at, `"${text}" is not rendered as an element's whole content`).toBeGreaterThan(-1);
+  return html.slice(html.lastIndexOf("<", at), at + 1);
+}
 
 function render(element: ReactElement): { html: string; text: string } {
   const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
@@ -109,6 +121,29 @@ describe("task-detail content-slot invariant", () => {
       expect(html, "all-tasks breadcrumb slot").toContain('href="/tasks"');
       // Praxis gallery: every archetype heads it with the shared count copy.
       expect(text, "praxis-gallery slot").toContain("completed praxis");
+    });
+
+    // #2598. `tasks:detail.points.total` used to be stored as "POINT"/"POINTS",
+    // pre-shouted, and NOT ONE of the nine skins uppercased it in CSS — so the
+    // caps in the catalog value were the only thing shouting on all nine pages,
+    // and an editor could not tell whether they were the design or the copy.
+    //
+    // The catalog holds "Point"/"Points" now and the shout moved to the element.
+    // Five skins already carried the transform (Everymen's `label`, the
+    // Ephemerists' `SMALL_CAPS`, UA's `UA_EYEBROW`, Coven's `CAPTION`,
+    // Singularity's `LABEL`); four gained it (Wow, Default, S.N.I.D.E. via
+    // `PenCircle`'s opt-in, Albescent over `.label-caption`'s explicit
+    // `text-transform: none`). Rendering is unchanged in a browser.
+    //
+    // This is the half a catalog check cannot do: downcasing the value is only
+    // safe while the element still shouts, and losing the transform is silent.
+    it(`${slug} shouts the points unit in CSS, not in the catalog`, () => {
+      const unit = i18n.t("tasks:detail.points.total", { count: 4242 });
+      expect(unit, "the catalog holds sentence case").toBe("Points");
+      const { html } = render(<Archetype state={baseState({})} />);
+      expect(enclosingTag(html, unit), `${slug} lost the shout`).toContain(
+        "text-transform:uppercase",
+      );
     });
 
     it(`${slug} renders the signup CTA when canSignUp`, () => {

--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -28,7 +28,22 @@ import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 import CovenTaskDetail from "../archetypes/CovenTaskDetail";
 import type { TaskDetailState } from "../useTaskDetail";
+import i18n from "../../../i18n";
 import { aTask } from '../../../test/fixtures'
+
+/**
+ * The worth panel's unit word, read from the catalog rather than typed.
+ *
+ * It used to be the literal "POINTS". #2598 moved the shout out of the catalog
+ * value and into CSS — the catalog holds "Point"/"Points" and each of the nine
+ * skins uppercases the element that draws it — so a STATIC render now reads the
+ * catalog's case, while a browser still paints caps. Same move, and the same
+ * reason, as `everymenBillOrnament.test.tsx`'s struck seal.
+ *
+ * 18 is `modifiedPoints` in every state below, so this is the plural.
+ */
+const POINTS_UNIT = i18n.t("tasks:detail.points.total", { count: 18 });
+
 
 const TASK = aTask({
   id: 305,
@@ -271,7 +286,7 @@ describe("Coven task detail — the contract", () => {
   it("shows no action cell at all when the viewer has no move to make", () => {
     const { text } = render(<CovenTaskDetail state={baseState({ canSignUp: false })} />);
     // The worth cell survives — it is a fact about the task, not a control.
-    expect(text).toContain("POINTS");
+    expect(text).toContain(POINTS_UNIT);
     expect(text).not.toContain("Sign up");
     expect(text).not.toContain("Continue editing");
   });

--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -31,8 +31,23 @@ import { describe, it, expect } from "vitest";
 import { surfaceMap } from "../../../factions";
 import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
 import type { TaskDetailState } from "../useTaskDetail";
+import i18n from "../../../i18n";
 import type { CommentOut } from "../../../api/comments";
 import { aTask } from '../../../test/fixtures'
+
+/**
+ * The worth panel's unit word, read from the catalog rather than typed.
+ *
+ * It used to be the literal "POINTS". #2598 moved the shout out of the catalog
+ * value and into CSS — the catalog holds "Point"/"Points" and each of the nine
+ * skins uppercases the element that draws it — so a STATIC render now reads the
+ * catalog's case, while a browser still paints caps. Same move, and the same
+ * reason, as `everymenBillOrnament.test.tsx`'s struck seal.
+ *
+ * 18 is `modifiedPoints` in every state below, so this is the plural.
+ */
+const POINTS_UNIT = i18n.t("tasks:detail.points.total", { count: 18 });
+
 
 /** The comment thread's pre-fetch state — present iff the thread mounted. */
 const THREAD_ANCHOR = "loading…";
@@ -229,7 +244,7 @@ describe("task-detail worth readout", () => {
       const { text } = render(<Archetype state={baseState()} />);
       expect(text).not.toContain(BASE_ROW);
       expect(text).toContain("18");
-      expect(text).toContain("POINTS");
+      expect(text).toContain(POINTS_UNIT);
     });
 
     it(`${slug} keeps base, chip and total once a factor is real`, () => {
@@ -346,7 +361,7 @@ describe("task-detail reading order", () => {
       const description = at(text, "Make something small and honest.");
       const byline = at(text, "Wren Abalone");
       const headcount = at(text, "people working on this");
-      const panel = at(text, "POINTS");
+      const panel = at(text, POINTS_UNIT);
 
       expect(title, "description after the title").toBeLessThan(description);
       expect(description, "byline after the description").toBeLessThan(byline);

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -33,8 +33,23 @@ import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 import EverymenTaskDetail from "../archetypes/EverymenTaskDetail";
 import type { TaskDetailState } from "../useTaskDetail";
+import i18n from "../../../i18n";
 import type { PraxisCardOut } from "../../../api/praxis";
 import { aTask } from '../../../test/fixtures'
+
+/**
+ * The worth panel's unit word, read from the catalog rather than typed.
+ *
+ * It used to be the literal "POINTS". #2598 moved the shout out of the catalog
+ * value and into CSS — the catalog holds "Point"/"Points" and each of the nine
+ * skins uppercases the element that draws it — so a STATIC render now reads the
+ * catalog's case, while a browser still paints caps. Same move, and the same
+ * reason, as `everymenBillOrnament.test.tsx`'s struck seal.
+ *
+ * 18 is `modifiedPoints` in every state below, so this is the plural.
+ */
+const POINTS_UNIT = i18n.t("tasks:detail.points.total", { count: 18 });
+
 
 const TASK = aTask({
   id: 207,
@@ -218,7 +233,7 @@ describe("Everymen task detail — the broadsheet", () => {
     // the stamped total rather than the `base` eyebrow: #1704 drops that row at
     // the identity multiplier, so the total is what "the box is still here"
     // looks like today.
-    expect(text).toContain("POINTS");
+    expect(text).toContain(POINTS_UNIT);
     expect(text).not.toContain("Sign up");
   });
 });

--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -158,6 +158,10 @@ export default function AlbescentTaskDetail({
             style={{
               marginTop: "var(--space-xs)",
               color: "var(--faction-default-gold)",
+              // The shout is CSS, not copy (#2598) — see WowTaskDetail's note.
+              // Inline rather than left to the class: `.label-caption` sets
+              // `text-transform: none` explicitly, so this has to override it.
+              textTransform: "uppercase",
             }}
           >
             {t("detail.points.total", { count: modifiedPoints })}

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -303,6 +303,8 @@ export default function DefaultTaskDetail({
             fontSize: "var(--text-lg)",
             letterSpacing: "0.06em",
             color: "var(--faction-default-gold)",
+            // The shout is CSS, not copy (#2598) — see WowTaskDetail's note.
+            textTransform: "uppercase",
           }}
         >
           {t("detail.points.total", { count: modifiedPoints })}

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -447,6 +447,10 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
         size={desktop ? 128 : 104}
         value={modifiedPoints}
         unit={t("detail.points.total", { count: modifiedPoints })}
+        // The shout is CSS, not copy (#2598) — see WowTaskDetail's note. The
+        // loop is shared, and the score stamp's lowercase "pts" must not move,
+        // so this page opts in rather than the atom deciding for everyone.
+        unitCaps
         valueColor={PLATE_TEXT}
         unitColor={PLATE_ACCENT}
         valueSize={desktop ? "var(--text-display)" : "var(--text-heading)"}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -393,6 +393,12 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
             fontSize: "var(--text-md)",
             color: PLUM,
             marginTop: "var(--space-xs)",
+            // The shout is CSS, not copy (#2598). The catalog used to hold
+            // "POINTS" pre-shouted, which left the next editor unable to tell
+            // whether the caps were the design or the copy. `QUIET` carries no
+            // transform of its own, so this is the sheet's, and the rendering
+            // is unchanged.
+            textTransform: "uppercase",
           }}
         >
           {t("detail.points.total", { count: modifiedPoints })}


### PR DESCRIPTION
Closes #2598

## The seam

**The catalog value meeting its call site.** Every change here is either a key
that stopped existing, a value that changed wording, or a call site that had to
learn something new (a namespace, a `count`, a `text-transform`). So the tests
live at that join: `locales/__tests__/countedNouns.test.tsx` for a count meeting
its noun, and `taskDetail/__tests__/archetypeSlots.test.tsx` for a value meeting
the CSS that dresses it.

Two failures were written first and both were real:

* Lengthening `forms:editPraxis.composer.pointsUnit` from `pts` to `Points`
  turned two composer tests red — and that is the **defect**, not fallout. Their
  `toContain('pts')` had been passing on an incidental substring; nothing has
  rendered that key since #1828 replaced the composer's points mark with the
  shared `ScoreStamp`. Three lowercase letters are too short to assert on.
* The new `archetypeSlots` guard went red on four of nine archetypes before the
  `text-transform` went in, which is how I know it is measuring the right thing.

## Punctuation: `…`, not `...`

A2 asked me to settle on one character. **U+2026.** It is the catalog-wide
majority (26 values to 17), it is what the voiced `fieldDesk.home.switcher`
copy already spells, and it is what every literal assertion in the suite already
anchors on — `detailContract.test.tsx`'s `THREAD_ANCHOR` and
`commentThreadSeed.test.tsx`'s four would all have gone red on the three-dot
spelling. Picking `...` would have meant editing tests to accept worse
typography.

## What changed

**A1** — `common:actions.accept` / `.decline` / `.submit` had no reader in app
code; I re-verified before deleting and the issue's claim is correct (the
comment in `sidebarPendingRequests.test.tsx` claiming otherwise was false, and
now says so). The four feed keys holding the same two words read the shared
block. `feed:duelChallenge.accept` is **"Accept Duel"** — its own wording, so it
stays, which is why the issue's list is four and not five. `actions.submit` is
deleted.

**A2** — eleven keys collapsed onto `common:loading`. Nine call sites moved; six
components widened their `useTranslation` namespace, two already had a `common`
`t` and just dropped the prefix.

**A3** — see "Where I did not do what the issue said" below.

**A4** — `i18nKeyRefs.py` (which is in `frontend/scripts/`, not `scripts/`) now
splits its walk and reports a third column, **TEST-ONLY**, between KEPT and
DELETABLE. `--ignore-tests` folds it back. The dynamic-key warnings in the
docstring are untouched. Run against main's `common.json` it reports
`actions.submit` TEST-ONLY, so the tool would now catch the thing it was built
to catch.

**B1/B2** — the tables as written. B0's two exception lists are untouched. The
five `{{points}} pts` keys became `_one`/`_other` pairs and their call sites
pass `count`; `countedNouns.test.tsx` — this repo's existing guard for exactly
this — grew those five entries rather than me inventing anything.

## §B2b — the premise resolves the opposite way on five of nine

The brief said it had checked all nine task-detail archetypes and **none**
applied `text-transform: uppercase`, so the caps in the catalog were the only
thing shouting. I checked each one, including through spread constants, shared
atoms and `index.css` classes, and the answer is **split**:

| archetype | already uppercased? | where |
|---|---|---|
| Everymen | **yes** | `label`, `EverymenTaskDetail.tsx:156` |
| Ephemerists | **yes** | `SMALL_CAPS`, `ephemeristsPlate.tsx:305` |
| UA | **yes** | `UA_EYEBROW`, `uaAtoms.tsx:35` (via `UaEnsoScore`) |
| Coven | **yes** | `CAPTION`, `CovenTaskDetail.tsx:138` (via `Ward`) |
| Singularity | **yes** | `LABEL`, `SingularityTaskDetail.tsx:103` |
| Wow | no | `QUIET` carries no transform |
| Default | no | inline style, no transform |
| S.N.I.D.E. | no | `PenCircle`'s unit span |
| Albescent | no — **explicitly `text-transform: none`** | `.label-caption`, `index.css:4771` |

So the ruling still holds and rendering is still unchanged, but only **four**
sites needed the transform added, not nine. Double-applying on the other five
would have been noise.

**S.N.I.D.E. is the one that could not be done inline.** Its element lives in
the shared `PenCircle`, whose other caller is the praxis score stamp drawing
`praxis:card.stamp.pointsShort` — the deliberately lowercase `pts` that **B0
protects**. Uppercasing inside the atom would have changed a surface the ruling
says not to touch, so the page opts in through a `unitCaps` prop instead.

There is already precedent for this exact move in the repo:
`everymenBillOrnament.test.tsx` says *"the stamp uppercases it, so the catalog's
'Points' still strikes as POINTS. Do not undo that."*

## Where I did not do what the issue said

**A3's placeholders are not deleted — their duplicate KEYS are.** A3's premise
is that the placeholder "adds nothing on screen" because it echoes a visible
label. **There is no visible label.** `DefaultProposeTask.tsx`'s own §20.4 note
says the visible label was deliberately removed and the field is *"identified by
its placeholder"*. Deleting it leaves a sighted user an unlabelled box.

The real defect was that one field's wording lived in two keys that had drifted
apart in case — "Task name"/"Task **N**ame", "Notes to admin"/"Notes to
**A**dmin". The second key is gone and both uses read the label, so the screen
reader stops hearing two spellings and the box keeps its identification.
**Whether these fields should get a visible label back is a design question and
I have left it for you.**

## Follow-ups I did not silently fix

The issue said to report `common:profile.nextLevel`. It is not the only one — a
whole-word scan for `lvl`/`pts` found **eighteen** keys still holding a short
form that B1/B2 do not enumerate, are not in the "already long" lists, and are
not B0 exceptions:

```
admin:tasks.meta                          {{points}} pts · lvl {{level}} · {{faction}}
common:profile.nextLevel                  next · lvl {{level}}
common:profile.ptsThisLevel               {{current}} / {{span}} pts this level
common:profile.ptsToNext                  {{score}} / {{threshold}} pts
common:fieldDesk.home.switcher.meta       {{faction}} · Level {{level}} · {{points}} pts
common:fieldDesk.home.taskMeta            {{faction}} · {{points}} pts
feed:row.pointsEarned                     +{{points}} pts
feed:collabInvite.taskMeta                {{points}} pts · lvl {{level}}
feed:duelChallenge.taskMeta               {{points}} pts · winner takes the points
forms:createCharacter.startsAt            starts at Lvl 1 · 0 pts
forms:metatasks.bonusPoints               +{{points}} pts
forms:editPraxis.attach.pending           … +{{points}} pts on completion
forms:editPraxis.attach.removeBody        … its +{{points}} pts bonus.
forms:proposeTask.preview.bonusPoints     +{{points}} bonus pts
home:signedIn.continue.meta.draft         Draft · +{{points}} pts
home:signedIn.continue.meta.submitted_*   Submitted · {{points}} pts · …
praxis:detail.seal.bonus                  +{{points}} PTS
tasks:detail.author                       author · lvl {{level}}
```

`feed:row.pointsEarned` is the sharpest one: it now sits two lines below
`feed:row.points` in the same block, one saying `points` and the other `pts`.
The owner ruling ("long form everywhere except stamps and columns") would cover
all eighteen, but the tables do not list them and I was told to take the tables
as written.

**Two dead blocks the new TEST-ONLY column turned up**, neither of them
enumerated and neither deleted:

* `forms:taskMeta.*` — all four keys (`points_one`, `points_other`, `duel`,
  `collab`) have **no reader anywhere**, including tests. B1 asked me to
  lengthen `taskMeta.points`; I did, and it is still dead.
* `forms:editPraxis.composer.pointsUnit` — dead since #1828. B1 asked me to
  lengthen it too. Doing so is what exposed the two vacuous assertions.
* `common:praxisType.solo` / `.collab` — TEST-ONLY.

Say the word and I will delete all seven in a follow-up.

## Shared-file note for the parallel #2298 agent

**`catalog.test.ts` is untouched** — no conflict there. In
`factionCopyCollapse.test.ts` I changed **one line only**, the `FAMILIES` entry
whose `shared` is `common:profile.lvl` (`wording: 'lvl'` → `'Level'`). The two
`terms.1.label` / `terms.2.label` rules are not mine and are exactly as they
were.

## Verification

All run locally in this worktree against a real `npm ci` toolchain (tsc 5.9.3,
vitest 4.1.11, vite 8.2.2, node 24) — not a junction to another checkout.

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean (`tsc --noEmit` + e2e project) |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **424 files, 7656 passed, 1 skipped, 0 failed** |
| `npm run build` | built |
| `npm run budget` | CSS ok; **JS WARN is pre-existing (#2605)** — this branch is net **−12 lines** of catalog, so it shrinks the payload |

`api-schema` is not in play: no route, `response_model` or Pydantic schema is
touched.

**No visual QA has been done — I have no browser.** Everything below is
outstanding.

## What to eyeball

**The four tight-furniture sites from §B2a.** `Lvl 12` → `Level 12` is three
characters wider. I checked each for a *structural* blocker and **none is
impossible** — no hard `width`, no `overflow: hidden` over the text — so I
applied the long form as ruled. They still want your eyes:

1. **`common:avatar.rank` — `WowAvatar.tsx:134`.** The likeliest to look wrong.
   The pill is absolutely positioned, centre-anchored and `whiteSpace: nowrap`,
   so it cannot wrap or clip — it just gets wider and will overhang the avatar
   disc further on both sides.
2. **`common:credential.lvl` / `.pts` — `CredentialCard.tsx:264`.** Both spans
   already uppercase in CSS, so this reads **LVL 4 → LEVEL 4** and **PTS →
   POINTS**, two strings growing at once in a flex row that also carries a 42px
   sigil, inside a **266px** card. Nothing stops it wrapping to two lines.
3. **`common:level.caption` — `LevelGem.tsx:72`.** `.level-gem` is an
   `inline-flex` column with no fixed width, so the caption widens the gem's
   whole inline box and may push neighbours in tight rows (roster, task cards).
4. **`common:profile.lvl` — `DefaultProfileBody.tsx:443`.** The column is
   `flexShrink: 0`, so it will not compress — it pushes its siblings instead.

**The nine task-detail pages from §B2b.** Confirm every one still reads
**POINTS** in caps and that nothing now reads "Points" in sentence case. The
four I changed are the risk (Wow, Default, S.N.I.D.E., Albescent); the five that
already uppercased should be pixel-identical. Albescent is worth a second look —
its transform overrides `.label-caption`'s explicit `text-transform: none`.

**Also worth a glance:** the propose-task form's base/bonus points inputs now
placehold `Points` instead of `pts` in an 80px-wide centred numeric field
(`basePointsInputStyle`), and its name/notes placeholders changed case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
