### PR TITLE
Settings: Cookies and local storage, a truthful disclosure (#2156)

### DIFF
--- a/frontend/src/auth/AdminModeContext.tsx
+++ b/frontend/src/auth/AdminModeContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, type ReactNode } from 'react'
 
-const STORAGE_KEY = 'wz_admin_mode'
+export const ADMIN_MODE_STORAGE_KEY = 'wz_admin_mode'
 
 interface AdminModeState {
   adminMode: boolean
@@ -15,7 +15,7 @@ const AdminModeContext = createContext<AdminModeState>({
 export function AdminModeProvider({ children }: { children: ReactNode }) {
   const [adminMode, setAdminMode] = useState(() => {
     try {
-      return localStorage.getItem(STORAGE_KEY) === 'true'
+      return localStorage.getItem(ADMIN_MODE_STORAGE_KEY) === 'true'
     } catch {
       return false
     }
@@ -25,7 +25,7 @@ export function AdminModeProvider({ children }: { children: ReactNode }) {
     setAdminMode((prev) => {
       const next = !prev
       try {
-        localStorage.setItem(STORAGE_KEY, String(next))
+        localStorage.setItem(ADMIN_MODE_STORAGE_KEY, String(next))
       } catch {
         // localStorage unavailable
       }

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -45,7 +45,7 @@ export const AuthContext = createContext<AuthState>({
   signOut: async () => {},
 })
 
-const SESSION_HINT_KEY = 'wz_session_hint'
+export const SESSION_HINT_KEY = 'wz_session_hint'
 
 /**
  * Whether the last answer from `/auth/me` on this browser was a session.

--- a/frontend/src/components/InvitationWatcher.tsx
+++ b/frontend/src/components/InvitationWatcher.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
 import InvitationLetterPopup from './InvitationLetterPopup'
 
-const STORAGE_PREFIX = 'wz:seenInvites:'
+export const SEEN_INVITES_KEY_PREFIX = 'wz:seenInvites:'
 
 export function seenInvitesKey(characterId: number): string {
-  return `${STORAGE_PREFIX}${characterId}`
+  return `${SEEN_INVITES_KEY_PREFIX}${characterId}`
 }
 
 export interface InviteDiff {

--- a/frontend/src/components/LevelUpWatcher.tsx
+++ b/frontend/src/components/LevelUpWatcher.tsx
@@ -3,10 +3,10 @@ import { useAuth } from '../auth/AuthContext'
 import { useGameConfig } from '../hooks/useGameConfig'
 import LevelUpPopup from './LevelUpPopup'
 
-const STORAGE_PREFIX = 'wz:lastSeenLevel:'
+export const LAST_SEEN_LEVEL_KEY_PREFIX = 'wz:lastSeenLevel:'
 
 export function lastSeenLevelKey(characterId: number): string {
-  return `${STORAGE_PREFIX}${characterId}`
+  return `${LAST_SEEN_LEVEL_KEY_PREFIX}${characterId}`
 }
 
 export interface LevelDiff {

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -357,6 +357,57 @@
       "animationsSystemNote": "Your device is set to reduce motion.",
       "animationsSystemName": "Animations — off, because your device is set to reduce motion"
     },
+    "cookies": {
+      "eyebrow": "Cookies and local storage",
+      "lead": "This card is the whole policy — there is no separate cookie page. Everything World Zero puts on your device is listed here. None of the switches below is a control: they state what is already true.",
+      "essential": {
+        "title": "Essential — required",
+        "help": "One sign-in cookie, plus the choices your browser remembers for you.",
+        "note": "Always on. The site cannot sign you in or hold a preference without these.",
+        "switchName": "Essential storage — always on, because the site cannot sign you in without it"
+      },
+      "analytics": {
+        "title": "Analytics — never used",
+        "help": "Counts of who visits and which pages get used.",
+        "note": "Off, and there is nothing behind it: World Zero runs no analytics, no tracking pixels and no third-party scripts.",
+        "switchName": "Analytics — off, because World Zero collects none"
+      },
+      "marketing": {
+        "title": "Marketing — never used",
+        "help": "Advertising, ad networks and cross-site tracking.",
+        "note": "Off, and there is nothing behind it: World Zero sells nothing and runs no ads.",
+        "switchName": "Marketing — off, because World Zero collects none"
+      },
+      "show": "Show all {{total}} entries",
+      "hide": "Hide all {{total}} entries",
+      "suffix": {
+        "account": "[:account id]",
+        "character": "[character id]"
+      },
+      "where": {
+        "cookie": "Cookie, {{days}} days",
+        "browser": "This browser, until you clear it",
+        "tab": "This tab, until you close it"
+      },
+      "entries": {
+        "session": "Keeps you signed in.",
+        "theme": "Whether you chose the light or the dark palette.",
+        "motion": "Whether you asked for animations to stop.",
+        "sessionHint": "A yes-or-no note that you were signed in last visit, so the likely page can start loading sooner. Never used to decide what you are shown.",
+        "adminMode": "Whether a moderator left the admin view switched on.",
+        "sidebarCollapsed": "Whether the side rail is folded away.",
+        "sidebarPanels": "The order of the side rail's panels and which are folded. One entry for each account signed in on this browser.",
+        "factionSections": "Which galleries on a faction page you left folded. One entry for each account signed in on this browser.",
+        "seenInvites": "Which invitation letters a character has already been shown, so none is announced twice. One entry for each of your characters.",
+        "lastSeenLevel": "The last level a character was congratulated on, so the celebration does not repeat. One entry for each of your characters.",
+        "onboardingHandoff": "A mark that this tab left for Google or Discord partway through signing up, so you come back where you were."
+      },
+      "deletion": {
+        "title": "If you delete your account",
+        "body": "Your praxis photos are removed from the disk and your saved composer drafts are emptied. Your name, email, words and pictures are blanked. The votes you cast stay where they are, so nobody else's score moves.",
+        "hash": "One thing is kept: which provider you signed in with, and a one-way hash of the ID that provider gave us. The hash cannot be turned back into the ID. It exists so that if you come back we can tell you what happened to your old account, and it is deleted the next time that sign-in returns, once it is more than about ninety days old. Nothing sweeps for one that never returns, so a hash you never come back to can outlive that."
+      }
+    },
     "signOut": "Sign out"
   }
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../auth/AuthContext'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { factionName } from '../utils/factions'
 import AppearanceSection from './settings/sections/AppearanceSection'
+import CookiesSection from './settings/sections/CookiesSection'
 
 /**
  * Settings — the responsive chassis (#2154), one component for both form
@@ -55,6 +56,7 @@ interface SettingsSection {
  */
 export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   { key: 'appearance', labelKey: 'settings.appearance.eyebrow', Component: AppearanceSection },
+  { key: 'cookies', labelKey: 'settings.cookies.eyebrow', Component: CookiesSection },
 ]
 
 /** The design's `sec-<key>`; one derivation, used by the anchor and the rail. */

--- a/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * #2156 — the Cookies and local storage section, and the guard that keeps it true.
+ *
+ * THE SEAM IS THE RENDERED SECTION plus a source census of `src/`, in the
+ * repo's DOM-less node env (`renderToStaticMarkup`) — the same posture
+ * `settingsChassis.test.tsx` uses next door. The section itself is rendered
+ * rather than the whole page, because nothing here needs the shell; that the
+ * shell reaches it is one assertion against `SETTINGS_SECTIONS`.
+ *
+ * WHAT THIS FILE IS ACTUALLY FOR. The card's only value is that it is
+ * accurate, and accuracy is exactly the property nothing else in the build can
+ * see. The design it was ported from named five cookies that do not exist and
+ * gave the one real cookie the wrong lifetime; the issue's own hand-checked
+ * inventory was three keys short, because it was produced by grepping for
+ * `'wz-…'` string literals and three of the ten keys are BUILT AT RUNTIME from
+ * a prefix. So the guards below are, in order of what they would have caught:
+ *
+ *   1. A NEW STORAGE WRITER anywhere in `src/` that nobody disclosed. This is
+ *      the census — it greps for the two `setItem` calls, which is the sound
+ *      question ("who writes?") rather than the unsound one ("what literals
+ *      look like keys?").
+ *   2. A RENAMED KEY. Nothing here retypes one: the section imports each from
+ *      its writer, and this file imports the same constants and checks they
+ *      are all disclosed.
+ *   3. THE COOKIE'S LIFETIME DRIFTING FROM THE BACKEND. Read out of
+ *      `routers/auth.py` rather than trusted, because a number crossing the
+ *      stack is precisely how the canvas came to say 30 days.
+ *   4. A CANVAS FALSEHOOD BEING "RESTORED" from the design file.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  MOBILE_QUERY: '(max-width: 767px)',
+  formFactorFor: (matches: boolean) => (matches ? 'mobile' : 'desktop'),
+  useFormFactor: () => 'desktop',
+}))
+
+import '../../../i18n'
+import { ADMIN_MODE_STORAGE_KEY } from '../../../auth/AdminModeContext'
+import { SESSION_HINT_KEY } from '../../../auth/AuthContext'
+import { SEEN_INVITES_KEY_PREFIX } from '../../../components/InvitationWatcher'
+import { LAST_SEEN_LEVEL_KEY_PREFIX } from '../../../components/LevelUpWatcher'
+import { MOTION_STORAGE_KEY } from '../../../hooks/useMotion'
+import { SIDEBAR_COLLAPSED_STORAGE_KEY } from '../../../hooks/useSidebarCollapsed'
+import { SIDEBAR_PANEL_LAYOUT_STORAGE_KEY } from '../../../hooks/useSidebarPanelLayout'
+import { THEME_STORAGE_KEY } from '../../../hooks/useTheme'
+import { FACTION_SECTION_STORAGE_KEY } from '../../factionDetail/sectionDisclosure'
+import { ONBOARDING_HANDOFF_KEY } from '../../../utils/onboardingResume'
+import { SETTINGS_SECTIONS } from '../../Settings'
+import CookiesSection, { SESSION_COOKIE_DAYS, STORED_ENTRIES } from '../sections/CookiesSection'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SRC = join(HERE, '..', '..', '..')
+const REPO = join(SRC, '..', '..')
+
+const html = () => renderToStaticMarkup(<CookiesSection sectionId="sec-cookies" />)
+const text = (markup: string) => markup.replace(/<[^>]*>/g, '')
+const control = (markup: string, testId: string) =>
+  new RegExp(`<button[^>]*data-testid="${testId}"[^>]*>`).exec(markup)?.[0] ?? ''
+
+const names = STORED_ENTRIES.map((entry) => entry.name)
+
+describe('the section reaches the page', () => {
+  it('is registered in the chassis section list', () => {
+    expect(SETTINGS_SECTIONS.map(({ key }) => key)).toContain('cookies')
+  })
+})
+
+/**
+ * The census. Every module in `src/` that writes to a browser store, found by
+ * the WRITE CALL rather than by anything about the key's spelling — the whole
+ * reason three families went undisclosed for a week is that their keys are
+ * assembled at runtime and no literal grep can see them.
+ *
+ * Add a `setItem` anywhere and this goes red. Fixing it means adding the entry
+ * to `STORED_ENTRIES` and its copy, then adding the file here — in that order,
+ * because the list below is the acknowledgement, not the disclosure.
+ */
+const KNOWN_WRITERS = [
+  'auth/AdminModeContext.tsx',
+  'auth/AuthContext.tsx',
+  'components/InvitationWatcher.tsx',
+  'components/LevelUpWatcher.tsx',
+  'hooks/useMotion.tsx',
+  'hooks/useSidebarCollapsed.ts',
+  'hooks/useSidebarPanelLayout.ts',
+  'hooks/useTheme.tsx',
+  'pages/factionDetail/sectionDisclosure.tsx',
+  'utils/onboardingResume.ts',
+]
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : sourceFiles(full)
+    return /\.tsx?$/.test(entry.name) ? [full] : []
+  })
+}
+
+describe('nothing writes to a browser store without being disclosed', () => {
+  it('finds exactly the writers this card knows about', () => {
+    const writers = sourceFiles(SRC)
+      .filter((file) => /(?:local|session)Storage\.setItem\(/.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(SRC, file).split('\\').join('/'))
+      .sort()
+
+    expect(writers, 'an undisclosed storage writer').toEqual([...KNOWN_WRITERS].sort())
+  })
+})
+
+describe('the inventory is pinned to the keys the app really writes', () => {
+  it('discloses all ten storage entries and the one cookie', () => {
+    expect(names).toHaveLength(11)
+  })
+
+  it.each([
+    ['theme', THEME_STORAGE_KEY],
+    ['motion', MOTION_STORAGE_KEY],
+    ['session hint', SESSION_HINT_KEY],
+    ['admin mode', ADMIN_MODE_STORAGE_KEY],
+    ['sidebar collapse', SIDEBAR_COLLAPSED_STORAGE_KEY],
+    ['sidebar panels', SIDEBAR_PANEL_LAYOUT_STORAGE_KEY],
+    ['faction sections', FACTION_SECTION_STORAGE_KEY],
+    ['seen invites', SEEN_INVITES_KEY_PREFIX],
+    ['last seen level', LAST_SEEN_LEVEL_KEY_PREFIX],
+    ['onboarding handoff', ONBOARDING_HANDOFF_KEY],
+  ])('discloses the %s key', (_label, key) => {
+    expect(names).toContain(key)
+  })
+
+  it('marks the four families as families, not as single values', () => {
+    const families = STORED_ENTRIES.filter((entry) => entry.family).map((entry) => entry.name)
+    expect(families).toEqual([
+      SIDEBAR_PANEL_LAYOUT_STORAGE_KEY,
+      FACTION_SECTION_STORAGE_KEY,
+      SEEN_INVITES_KEY_PREFIX,
+      LAST_SEEN_LEVEL_KEY_PREFIX,
+    ])
+  })
+
+  it('has real copy behind every entry, not a bare key echoing back', () => {
+    const catalog = JSON.parse(
+      readFileSync(join(SRC, 'locales', 'en', 'common.json'), 'utf8'),
+    ) as Record<string, unknown>
+    const lookup = (path: string) =>
+      path.split('.').reduce<unknown>((at, step) => (at as Record<string, unknown>)?.[step], catalog)
+
+    for (const entry of STORED_ENTRIES) {
+      expect(typeof lookup(entry.purposeKey), entry.purposeKey).toBe('string')
+      expect(typeof lookup(entry.whereKey), entry.whereKey).toBe('string')
+    }
+  })
+})
+
+describe('the session cookie is described the way the backend sets it', () => {
+  const auth = readFileSync(join(REPO, 'backend', 'routers', 'auth.py'), 'utf8')
+
+  it('quotes the lifetime the backend actually uses, not the canvas\u2019 30 days', () => {
+    const days = /_COOKIE_MAX_AGE = (\d+) \* 24 \* 60 \* 60/.exec(auth)?.[1]
+    expect(days, 'the max-age expression moved — re-read it').toBeDefined()
+    expect(Number(days)).toBe(SESSION_COOKIE_DAYS)
+  })
+
+  it('names the cookie the backend actually sets', () => {
+    expect(auth).toContain('key="access_token"')
+    expect(names).toContain('access_token')
+  })
+})
+
+describe('none of the canvas\u2019 invented storage comes back', () => {
+  it.each(['wz_session', 'wz_csrf', 'wz_prefs', 'wz_anon_id', 'wz_page_ms'])(
+    'does not disclose %s, which does not exist',
+    (invented) => {
+      expect(names).not.toContain(invented)
+    },
+  )
+
+  it('links to no cookie policy page — the card is the policy', () => {
+    expect(html()).not.toContain('cookie-policy')
+    expect(html(), 'no route was added for one either').not.toContain('href=')
+  })
+})
+
+/**
+ * The three switches are a READOUT, not controls. Hiding the two off ones —
+ * which is what the design does to Marketing — would leave the page silent
+ * about the thing it exists to say.
+ */
+describe('all three switches render, all three inert, all three say why', () => {
+  it.each([
+    ['settings-cookies-essential', 'true'],
+    ['settings-cookies-analytics', 'false'],
+    ['settings-cookies-marketing', 'false'],
+  ])('%s renders as a switch reading %s', (testId, checked) => {
+    const button = control(html(), testId)
+    expect(button).toContain('role="switch"')
+    expect(button).toContain(`aria-checked="${checked}"`)
+  })
+
+  it.each(['settings-cookies-essential', 'settings-cookies-analytics', 'settings-cookies-marketing'])(
+    '%s is unmovable but still reachable by keyboard',
+    (testId) => {
+      const button = control(html(), testId)
+      expect(button).toContain('aria-disabled="true"')
+      expect(button, 'a `disabled` button leaves the tab order').not.toMatch(/\sdisabled(=|\s|>)/)
+    },
+  )
+
+  it.each(['settings-cookies-essential', 'settings-cookies-analytics', 'settings-cookies-marketing'])(
+    '%s carries the reason in its accessible name, not only on screen',
+    (testId) => {
+      const button = control(html(), testId)
+      expect(button, 'a screen reader would hear "switch, off" and learn nothing').toMatch(
+        /aria-label="[^"]*because/,
+      )
+      expect(button).toMatch(/aria-describedby="sec-cookies-[a-z]+-note"/)
+    },
+  )
+})
+
+describe('what a reader is told', () => {
+  it('offers the inventory behind an expander that says how much there is', () => {
+    const button = control(html(), 'settings-cookies-disclosure')
+    expect(button).toContain('aria-expanded="false"')
+    expect(button).toContain('aria-controls="sec-cookies-inventory"')
+    expect(text(html())).toContain(`Show all ${STORED_ENTRIES.length} entries`)
+  })
+
+  it('says what a deletion keeps, without promising a ninety-day sweep', () => {
+    const body = text(html())
+    expect(body, 'ADR-0081: the media files leave the disk').toContain('removed from the disk')
+    expect(body, 'ADR-0081: the composer drafts are emptied').toContain('drafts are emptied')
+    expect(body, 'the retained digest is disclosed').toContain('one-way hash')
+    expect(body, 'purge-on-access has no scheduler behind it').toContain('never come back to')
+  })
+})

--- a/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
@@ -51,13 +51,18 @@ import { THEME_STORAGE_KEY } from '../../../hooks/useTheme'
 import { FACTION_SECTION_STORAGE_KEY } from '../../factionDetail/sectionDisclosure'
 import { ONBOARDING_HANDOFF_KEY } from '../../../utils/onboardingResume'
 import { SETTINGS_SECTIONS } from '../../Settings'
-import CookiesSection, { SESSION_COOKIE_DAYS, STORED_ENTRIES } from '../sections/CookiesSection'
+import CookiesSection, {
+  SESSION_COOKIE_DAYS,
+  STORED_ENTRIES,
+  StorageInventory,
+} from '../sections/CookiesSection'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const SRC = join(HERE, '..', '..', '..')
 const REPO = join(SRC, '..', '..')
 
 const html = () => renderToStaticMarkup(<CookiesSection sectionId="sec-cookies" />)
+const list = () => renderToStaticMarkup(<StorageInventory id="sec-cookies-inventory" />)
 const text = (markup: string) => markup.replace(/<[^>]*>/g, '')
 const control = (markup: string, testId: string) =>
   new RegExp(`<button[^>]*data-testid="${testId}"[^>]*>`).exec(markup)?.[0] ?? ''
@@ -220,6 +225,39 @@ describe('all three switches render, all three inert, all three say why', () => 
       expect(button).toMatch(/aria-describedby="sec-cookies-[a-z]+-note"/)
     },
   )
+})
+
+/**
+ * Rendered directly, because the disclosure is shut on first paint and there is
+ * no DOM here to open it with — see the note on `StorageInventory`.
+ */
+describe('the disclosed list, once opened', () => {
+  it('prints every key, with the family markers spelled out', () => {
+    const body = text(list())
+    for (const entry of STORED_ENTRIES) expect(body, entry.name).toContain(entry.name)
+    expect(body).toContain(`${SEEN_INVITES_KEY_PREFIX}[character id]`)
+    expect(body).toContain(`${LAST_SEEN_LEVEL_KEY_PREFIX}[character id]`)
+    expect(body).toContain(`${SIDEBAR_PANEL_LAYOUT_STORAGE_KEY}[:account id]`)
+    expect(body).toContain(`${FACTION_SECTION_STORAGE_KEY}[:account id]`)
+  })
+
+  it('prints resolved copy beside each key, never a raw catalog path', () => {
+    const body = text(list())
+    expect(body, 'a bare key echoing back means the copy is missing').not.toContain(
+      'settings.cookies.',
+    )
+    expect(body).toContain('Keeps you signed in.')
+    expect(body).toContain('One entry for each of your characters.')
+  })
+
+  it('separates the cookie from the two browser stores', () => {
+    const body = text(list())
+    expect(body).toContain(`Cookie, ${SESSION_COOKIE_DAYS} days`)
+    expect(body, 'local storage has no expiry').toContain('until you clear it')
+    expect(body, 'the handoff mark is sessionStorage, not localStorage').toContain(
+      'until you close it',
+    )
+  })
 })
 
 describe('what a reader is told', () => {

--- a/frontend/src/pages/settings/__tests__/settingsChassis.test.tsx
+++ b/frontend/src/pages/settings/__tests__/settingsChassis.test.tsx
@@ -37,7 +37,11 @@ vi.mock('../../../hooks/useFormFactor', () => ({
   useFormFactor: () => harness.formFactor,
 }))
 
-vi.mock('../../../auth/AuthContext', () => ({
+// Partial, not wholesale: `CookiesSection` imports the real `SESSION_HINT_KEY`
+// out of this module to disclose it (#2156), and a bare factory would blank
+// every other export the tree reaches for.
+vi.mock('../../../auth/AuthContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../auth/AuthContext')>()),
   useAuth: () => ({ user: harness.user }),
 }))
 

--- a/frontend/src/pages/settings/sections/CookiesSection.tsx
+++ b/frontend/src/pages/settings/sections/CookiesSection.tsx
@@ -1,0 +1,345 @@
+import { useState, type CSSProperties } from 'react'
+import type { ParseKeys } from 'i18next'
+import { useTranslation } from 'react-i18next'
+import { ADMIN_MODE_STORAGE_KEY } from '../../../auth/AdminModeContext'
+import { SESSION_HINT_KEY } from '../../../auth/AuthContext'
+import { SEEN_INVITES_KEY_PREFIX } from '../../../components/InvitationWatcher'
+import { LAST_SEEN_LEVEL_KEY_PREFIX } from '../../../components/LevelUpWatcher'
+import { useFormFactor } from '../../../hooks/useFormFactor'
+import { MOTION_STORAGE_KEY } from '../../../hooks/useMotion'
+import { SIDEBAR_COLLAPSED_STORAGE_KEY } from '../../../hooks/useSidebarCollapsed'
+import { SIDEBAR_PANEL_LAYOUT_STORAGE_KEY } from '../../../hooks/useSidebarPanelLayout'
+import { THEME_STORAGE_KEY } from '../../../hooks/useTheme'
+import { FACTION_SECTION_STORAGE_KEY } from '../../factionDetail/sectionDisclosure'
+import { ONBOARDING_HANDOFF_KEY } from '../../../utils/onboardingResume'
+import type { SettingsSectionProps } from '../../Settings'
+import SettingsCard from '../SettingsCard'
+import SettingsRow from '../SettingsRow'
+import SettingsSwitch from '../SettingsSwitch'
+
+/**
+ * Cookies and local storage (#2156) — the card IS the policy.
+ *
+ * THE DESIGN FOR THIS SECTION STATES THINGS THAT ARE NOT TRUE, and that is the
+ * whole reason the issue exists. The canvas draws `wz_session` / `wz_csrf` /
+ * `wz_prefs` at 30 days, an Analytics group holding `wz_anon_id` and
+ * `wz_page_ms`, and a link to a `#cookie-policy` page. None of those exist:
+ * there is exactly ONE cookie, there is no analytics tooling of any kind in
+ * either tree, and there is no policy page for a link to reach. Ported as
+ * drawn, this section would have shipped a lie on the one surface whose entire
+ * job is to be true. Do not "restore" any of it from the canvas.
+ *
+ * WHY LOCAL STORAGE IS ON A CARD TITLED "COOKIES". It is not a cookie, but it
+ * is the same category under ePrivacy and it is *most* of what World Zero
+ * actually keeps — one cookie against ten storage entries. A cookies-only card
+ * would make the site look like it stores less than it does.
+ *
+ * ALL THREE SWITCHES RENDER, ALL THREE ARE INERT (owner ruling, 2026-08-17).
+ * The design hides the Marketing toggle (`showToggle: !g.never`); an absent
+ * switch says nothing, whereas a switch pinned OFF beside "never used" is the
+ * statement. This is the `SettingsSwitch` disabled exception the chassis
+ * already documents, used for its second sanctioned reason: not a control the
+ * reader cannot use, but a *readout* of a decision that has already been made.
+ * Each one therefore carries the reason in its accessible name, or a screen
+ * reader hears "switch, off" and learns nothing.
+ *
+ * THE INVENTORY BELOW IMPORTS EVERY KEY FROM ITS WRITER. Not one string is
+ * retyped, so a key that gets renamed renames itself here, and
+ * `__tests__/cookiesSection.test.tsx` fails the build if a NEW writer appears
+ * anywhere in `src/` without an entry. The issue's own hand-written inventory
+ * was three keys short — a literal grep for `'wz-…'` walks straight past the
+ * three families whose keys are built at runtime.
+ */
+
+/** The four keys the app builds by suffixing an id onto a base. */
+type KeyFamily = 'account' | 'character'
+
+interface StoredEntry {
+  /** The literal key, or the base a family's keys are built from. Imported. */
+  readonly name: string
+  /** Present when the writer appends an id — see the copy for each marker. */
+  readonly family?: KeyFamily
+  /** What it remembers, in the reader's words. */
+  readonly purposeKey: ParseKeys<'common'>
+  /** Which store, and how long it lasts. */
+  readonly whereKey: ParseKeys<'common'>
+}
+
+/**
+ * The session cookie's life, in days.
+ *
+ * Mirrors `_COOKIE_MAX_AGE` in `backend/routers/auth.py`, which is the only
+ * place it is set. A number crossing the stack is exactly how the canvas came
+ * to say 30, so the test reads the Python constant and fails if these drift.
+ */
+export const SESSION_COOKIE_DAYS = 7
+
+const COOKIE_WHERE = 'settings.cookies.where.cookie' as const
+const BROWSER_WHERE = 'settings.cookies.where.browser' as const
+const TAB_WHERE = 'settings.cookies.where.tab' as const
+
+/** Everything World Zero puts on the reader's device. The whole list. */
+export const STORED_ENTRIES: readonly StoredEntry[] = [
+  {
+    name: 'access_token',
+    purposeKey: 'settings.cookies.entries.session',
+    whereKey: COOKIE_WHERE,
+  },
+  {
+    name: THEME_STORAGE_KEY,
+    purposeKey: 'settings.cookies.entries.theme',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: MOTION_STORAGE_KEY,
+    purposeKey: 'settings.cookies.entries.motion',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: SESSION_HINT_KEY,
+    purposeKey: 'settings.cookies.entries.sessionHint',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: ADMIN_MODE_STORAGE_KEY,
+    purposeKey: 'settings.cookies.entries.adminMode',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: SIDEBAR_COLLAPSED_STORAGE_KEY,
+    purposeKey: 'settings.cookies.entries.sidebarCollapsed',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: SIDEBAR_PANEL_LAYOUT_STORAGE_KEY,
+    family: 'account',
+    purposeKey: 'settings.cookies.entries.sidebarPanels',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: FACTION_SECTION_STORAGE_KEY,
+    family: 'account',
+    purposeKey: 'settings.cookies.entries.factionSections',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: SEEN_INVITES_KEY_PREFIX,
+    family: 'character',
+    purposeKey: 'settings.cookies.entries.seenInvites',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: LAST_SEEN_LEVEL_KEY_PREFIX,
+    family: 'character',
+    purposeKey: 'settings.cookies.entries.lastSeenLevel',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    name: ONBOARDING_HANDOFF_KEY,
+    purposeKey: 'settings.cookies.entries.onboardingHandoff',
+    whereKey: TAB_WHERE,
+  },
+]
+
+interface OffGroup {
+  readonly key: string
+  readonly titleKey: ParseKeys<'common'>
+  readonly helpKey: ParseKeys<'common'>
+  readonly noteKey: ParseKeys<'common'>
+  readonly switchKey: ParseKeys<'common'>
+}
+
+/**
+ * The two categories World Zero does not use. Every catalog key is written out
+ * rather than interpolated from `key` — a template-literal key typechecks
+ * against nothing and is invisible to a locale grep, which is the shape the
+ * chassis' own section list refuses for the same reason.
+ */
+const OFF_GROUPS: readonly OffGroup[] = [
+  {
+    key: 'analytics',
+    titleKey: 'settings.cookies.analytics.title',
+    helpKey: 'settings.cookies.analytics.help',
+    noteKey: 'settings.cookies.analytics.note',
+    switchKey: 'settings.cookies.analytics.switchName',
+  },
+  {
+    key: 'marketing',
+    titleKey: 'settings.cookies.marketing.title',
+    helpKey: 'settings.cookies.marketing.help',
+    noteKey: 'settings.cookies.marketing.note',
+    switchKey: 'settings.cookies.marketing.switchName',
+  },
+]
+
+const disclosureButton: CSSProperties = {
+  padding: 0,
+  border: 'none',
+  background: 'none',
+  fontSize: 'var(--text-content)',
+  color: 'var(--color-accent-primary)',
+  textDecoration: 'underline',
+  cursor: 'pointer',
+}
+
+const deletionParagraph: CSSProperties = {
+  margin: 'var(--space-sm) 0 0',
+  fontSize: 'var(--text-content)',
+  lineHeight: 1.65,
+  color: 'var(--color-text-secondary)',
+  maxWidth: '62ch',
+}
+
+/** The inventory's own frame — the design's tinted well, minus its raw px. */
+const inventory: CSSProperties = {
+  marginTop: 'var(--space-md)',
+  padding: 'var(--space-md)',
+  borderRadius: 'var(--radius-md)',
+  background: 'var(--color-bg-surface-alt)',
+}
+
+export default function CookiesSection({ sectionId }: SettingsSectionProps) {
+  const { t } = useTranslation('common')
+  const isMobile = useFormFactor() === 'mobile'
+  const [open, setOpen] = useState(false)
+
+  const listId = `${sectionId}-inventory`
+  const noteId = (key: string) => `${sectionId}-${key}-note`
+
+  // Three columns on desktop, one stack on a phone. Sized in `ch` off the
+  // longest key rather than the canvas' `150px 1fr 90px`: the left cell holds
+  // an identifier that must not wrap mid-token, and a fixed px grid is what
+  // `frontend/CLAUDE.md` rules out for layout structure on the mobile path.
+  const entryRow: CSSProperties = isMobile
+    ? {
+        display: 'grid',
+        gap: 'var(--space-xs)',
+        padding: 'var(--space-sm) 0',
+        borderBottom: '1px dotted var(--color-border-strong)',
+      }
+    : {
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 32ch) minmax(0, 1fr) minmax(0, 26ch)',
+        gap: 'var(--space-md)',
+        alignItems: 'baseline',
+        padding: 'var(--space-xs) 0',
+      }
+
+  return (
+    <SettingsCard
+      sectionId={sectionId}
+      title={t('settings.cookies.eyebrow')}
+      lead={t('settings.cookies.lead')}
+    >
+      {/* `last` drops the rule between this row and its own disclosure — the
+          list belongs to Essential, and a rule there would detach it. The
+          disclosure block below carries the separator instead. */}
+      <SettingsRow
+        last
+        title={t('settings.cookies.essential.title')}
+        help={t('settings.cookies.essential.help')}
+        note={t('settings.cookies.essential.note')}
+        noteId={noteId('essential')}
+      >
+        <SettingsSwitch
+          checked
+          disabled
+          describedById={noteId('essential')}
+          label={t('settings.cookies.essential.switchName')}
+          onToggle={() => {}}
+          testId="settings-cookies-essential"
+        />
+      </SettingsRow>
+
+      <div
+        style={{
+          paddingBottom: 'var(--space-lg)',
+          borderBottom: '1px solid var(--color-border)',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen((was) => !was)}
+          aria-expanded={open}
+          aria-controls={listId}
+          style={disclosureButton}
+          data-testid="settings-cookies-disclosure"
+        >
+          {t(open ? 'settings.cookies.hide' : 'settings.cookies.show', {
+            total: STORED_ENTRIES.length,
+          })}
+        </button>
+
+        {open && (
+          <div id={listId} style={inventory}>
+            {STORED_ENTRIES.map((entry) => (
+              <div key={entry.name} style={entryRow}>
+                <code
+                  style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}
+                >
+                  {entry.name}
+                  {entry.family === 'account' && t('settings.cookies.suffix.account')}
+                  {entry.family === 'character' && t('settings.cookies.suffix.character')}
+                </code>
+                <span
+                  style={{
+                    fontSize: 'var(--text-content)',
+                    lineHeight: 1.6,
+                    color: 'var(--color-text-secondary)',
+                  }}
+                >
+                  {t(entry.purposeKey)}
+                </span>
+                <span
+                  style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)' }}
+                >
+                  {t(entry.whereKey, { days: SESSION_COOKIE_DAYS })}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {OFF_GROUPS.map(({ key, titleKey, helpKey, noteKey, switchKey }) => (
+        <SettingsRow
+          key={key}
+          title={t(titleKey)}
+          help={t(helpKey)}
+          note={t(noteKey)}
+          noteId={noteId(key)}
+        >
+          <SettingsSwitch
+            checked={false}
+            disabled
+            describedById={noteId(key)}
+            label={t(switchKey)}
+            onToggle={() => {}}
+            testId={`settings-cookies-${key}`}
+          />
+        </SettingsRow>
+      ))}
+
+      {/* #2162's disclosure line lands here rather than on a Privacy card,
+          because there is no Privacy card. What survives a deletion is
+          ADR-0081's tombstone; the ninety days are deliberately worded as a
+          floor and not a promise, because purge-on-access has no scheduler
+          behind it and a tombstone nobody returns to keeps its digest. */}
+      <div style={{ paddingTop: 'var(--space-lg)' }}>
+        <h3
+          className="font-display"
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            fontSize: 'var(--text-content)',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          {t('settings.cookies.deletion.title')}
+        </h3>
+        <p style={deletionParagraph}>{t('settings.cookies.deletion.body')}</p>
+        <p style={deletionParagraph}>{t('settings.cookies.deletion.hash')}</p>
+      </div>
+    </SettingsCard>
+  )
+}

--- a/frontend/src/pages/settings/sections/CookiesSection.tsx
+++ b/frontend/src/pages/settings/sections/CookiesSection.tsx
@@ -198,13 +198,15 @@ const inventory: CSSProperties = {
   background: 'var(--color-bg-surface-alt)',
 }
 
-export default function CookiesSection({ sectionId }: SettingsSectionProps) {
+/**
+ * The list itself, split out for ONE reason: the disclosure it lives behind is
+ * shut on first paint, this repo's test env has no DOM to click with, and a
+ * list that never renders under test is a list whose copy nothing checks. It is
+ * the seam `__tests__/cookiesSection.test.tsx` renders directly.
+ */
+export function StorageInventory({ id }: { readonly id: string }) {
   const { t } = useTranslation('common')
   const isMobile = useFormFactor() === 'mobile'
-  const [open, setOpen] = useState(false)
-
-  const listId = `${sectionId}-inventory`
-  const noteId = (key: string) => `${sectionId}-${key}-note`
 
   // Three columns on desktop, one stack on a phone. Sized in `ch` off the
   // longest key rather than the canvas' `150px 1fr 90px`: the left cell holds
@@ -224,6 +226,40 @@ export default function CookiesSection({ sectionId }: SettingsSectionProps) {
         alignItems: 'baseline',
         padding: 'var(--space-xs) 0',
       }
+
+  return (
+    <div id={id} style={inventory}>
+      {STORED_ENTRIES.map((entry) => (
+        <div key={entry.name} style={entryRow}>
+          <code style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}>
+            {entry.name}
+            {entry.family === 'account' && t('settings.cookies.suffix.account')}
+            {entry.family === 'character' && t('settings.cookies.suffix.character')}
+          </code>
+          <span
+            style={{
+              fontSize: 'var(--text-content)',
+              lineHeight: 1.6,
+              color: 'var(--color-text-secondary)',
+            }}
+          >
+            {t(entry.purposeKey)}
+          </span>
+          <span style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)' }}>
+            {t(entry.whereKey, { days: SESSION_COOKIE_DAYS })}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function CookiesSection({ sectionId }: SettingsSectionProps) {
+  const { t } = useTranslation('common')
+  const [open, setOpen] = useState(false)
+
+  const listId = `${sectionId}-inventory`
+  const noteId = (key: string) => `${sectionId}-${key}-note`
 
   return (
     <SettingsCard
@@ -270,35 +306,7 @@ export default function CookiesSection({ sectionId }: SettingsSectionProps) {
           })}
         </button>
 
-        {open && (
-          <div id={listId} style={inventory}>
-            {STORED_ENTRIES.map((entry) => (
-              <div key={entry.name} style={entryRow}>
-                <code
-                  style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}
-                >
-                  {entry.name}
-                  {entry.family === 'account' && t('settings.cookies.suffix.account')}
-                  {entry.family === 'character' && t('settings.cookies.suffix.character')}
-                </code>
-                <span
-                  style={{
-                    fontSize: 'var(--text-content)',
-                    lineHeight: 1.6,
-                    color: 'var(--color-text-secondary)',
-                  }}
-                >
-                  {t(entry.purposeKey)}
-                </span>
-                <span
-                  style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)' }}
-                >
-                  {t(entry.whereKey, { days: SESSION_COOKIE_DAYS })}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
+        {open && <StorageInventory id={listId} />}
       </div>
 
       {OFF_GROUPS.map(({ key, titleKey, helpKey, noteKey, switchKey }) => (

--- a/frontend/src/utils/onboardingResume.ts
+++ b/frontend/src/utils/onboardingResume.ts
@@ -27,12 +27,12 @@
  * simply absent under the DOM-less test harness and any SSR-shaped render. A
  * refusal degrades to "no mark", which costs the resume and nothing else.
  */
-const HANDOFF_KEY = 'wz_onboarding_handoff'
+export const ONBOARDING_HANDOFF_KEY = 'wz_onboarding_handoff'
 
 /** Called immediately before the flow hands the browser to a provider. */
 export function markOnboardingHandoff(): void {
   try {
-    sessionStorage.setItem(HANDOFF_KEY, 'true')
+    sessionStorage.setItem(ONBOARDING_HANDOFF_KEY, 'true')
   } catch {
     // Storage refused. The player lands at `/` signed in and browses from
     // there — the pre-resume behaviour, not a broken one.
@@ -42,7 +42,7 @@ export function markOnboardingHandoff(): void {
 /** Whether this tab left the flow for a provider and has not been back since. */
 export function onboardingHandoffPending(): boolean {
   try {
-    return sessionStorage.getItem(HANDOFF_KEY) === 'true'
+    return sessionStorage.getItem(ONBOARDING_HANDOFF_KEY) === 'true'
   } catch {
     return false
   }
@@ -51,7 +51,7 @@ export function onboardingHandoffPending(): boolean {
 /** Forget the mark. The flow does this on mount, having already read it. */
 export function clearOnboardingHandoff(): void {
   try {
-    sessionStorage.removeItem(HANDOFF_KEY)
+    sessionStorage.removeItem(ONBOARDING_HANDOFF_KEY)
   } catch {
     // Nothing was stored if the write refused, so nothing needs removing.
   }


### PR DESCRIPTION
Closes #2156

Part of #2153. Adds the **Cookies and local storage** section to the Settings chassis: one
file under `settings/sections/`, one line in `SETTINGS_SECTIONS`, nothing else in
`pages/Settings.tsx` moved.

## The seam I tested at

**The rendered section, in the repo's DOM-less node env (`renderToStaticMarkup`)**, plus a
**source census of `frontend/src/`**. Same posture as `settingsChassis.test.tsx` next door.
`__tests__/cookiesSection.test.tsx` (34 assertions) carries four guards, each verified red by
mutation before being left green:

| mutation | what went red |
|---|---|
| appended `localStorage.setItem(...)` to a new module in `src/` | `finds exactly the writers this card knows about` |
| deleted the `wz:lastSeenLevel:` entry from `STORED_ENTRIES` | 3 tests, including the family check |
| `SESSION_COOKIE_DAYS = 7` → `30` (the canvas' number) | `quotes the lifetime the backend actually uses` |

The census greps for **the write call** (`localStorage.setItem` / `sessionStorage.setItem`),
not for `'wz-…'` string literals. That distinction is the whole point — see below.

The lifetime guard reads `_COOKIE_MAX_AGE` out of `backend/routers/auth.py` with a regex and
compares it to the exported constant, because a number crossing the stack is exactly how the
canvas came to say 30 days.

## The inventory was an undercount, and it is now ten, not seven

The issue lists seven localStorage keys. **There are ten**, because three are built at runtime
from a prefix and a literal grep walks straight past them:

- `wz-faction-sections` (`pages/factionDetail/sectionDisclosure.tsx`)
- `wz:seenInvites:<characterId>` (`components/InvitationWatcher.tsx`)
- `wz:lastSeenLevel:<characterId>` (`components/LevelUpWatcher.tsx`)

**And a fourth family the brief did not have either:** `wz-sidebar-panels` is *also*
account-suffixed — `sidebarPanelLayoutStorageKey(accountId)` returns
`` `${SIDEBAR_PANEL_LAYOUT_STORAGE_KEY}:${accountId}` ``. So four of the eleven entries are
families, and the card says so rather than implying a single value: the two account-scoped
ones render as `wz-sidebar-panels[:account id]` (square brackets = the suffix is optional; the
bare key is what a signed-out visitor gets), the two character-scoped ones as
`wz:seenInvites:[character id]`.

`wz_onboarding_handoff` is **`sessionStorage`, not localStorage** — the card says "This tab,
until you close it" where the other ten say "This browser, until you clear it".

**Not one key string is retyped.** The section imports each from its writer, which meant
exporting five that were module-private: `SESSION_HINT_KEY`, `ADMIN_MODE_STORAGE_KEY` (was
`STORAGE_KEY`), `ONBOARDING_HANDOFF_KEY` (was `HANDOFF_KEY`), `SEEN_INVITES_KEY_PREFIX` and
`LAST_SEEN_LEVEL_KEY_PREFIX` (both were `STORAGE_PREFIX`). A rename now renames itself here.

## Deviations from the design — there are many, and they are the point

**Falsehoods removed (per the issue's owner ruling):**

1. `wz_session`, `wz_csrf`, `wz_prefs` — **deleted.** They exist nowhere in the repo. The one
   real cookie is `access_token`.
2. **30 days → 7.** `_COOKIE_MAX_AGE = 7 * 24 * 60 * 60`, and the test now pins it.
3. The Analytics group's `wz_anon_id` / `wz_page_ms` and its expander — **deleted.** There is
   no analytics tooling in either tree. The row says "we never collect these" and has nothing
   to list.
4. `<a href="#cookie-policy">` — **deleted, and no `/cookies` route added.** The card is the
   policy. The test asserts the section renders no `href=` at all.
5. **No consent banner.** Essential-only storage does not require one; explicitly not built.
6. Title `Privacy and cookies` → **`Cookies and local storage`.** Local storage is not a
   cookie, but it is the same ePrivacy category and it is ten of the eleven entries.

**Shape changes:**

7. `showToggle: !g.never` → **all three switches render, all three inert.** The design hides
   Marketing's toggle; a missing switch says nothing, a switch pinned OFF beside "never used"
   is the statement.
8. The three bordered group wells become **`SettingsRow`s inside the one `SettingsCard`** —
   the chassis owns the row rhythm, and a bordered box inside a bordered card doubles the
   frame. The tinted `--color-bg-surface-alt` well is kept for the inventory list itself.
9. `gridTemplateColumns: '150px 1fr 90px'` → `minmax(0, 32ch) minmax(0, 1fr) minmax(0, 26ch)`.
   Fixed-px inline grids for layout structure are what `frontend/CLAUDE.md` rules out on the
   mobile path, and the left cell holds an identifier that must not wrap mid-token.
10. 12px/11px type → `var(--text-content)` throughout, with hierarchy carried by ink
    (primary / secondary / tertiary). Same call `SettingsRow` already documents for the
    content floor (#627).
11. The design's canvas scaffolding (`frameStyle`, the VIEW chip bar, `--wz-*`, `m`) ships
    none of it; `--wz-*` did not need minting — `SettingsSwitch` already reads the
    `--filter-*` family, per the chassis' note.

**#2162's disclosure line lands here**, since there is no Privacy card for it to land on. From
ADR-0081: the media files leave the disk, the composer's stored drafts are emptied, and what
survives is `provider` plus a salted SHA-256 of the provider's user id. The copy deliberately
does **not** promise ninety-day deletion — purge-on-access has no scheduler, so it reads
"deleted the next time that sign-in returns, once it is more than about ninety days old.
Nothing sweeps for one that never returns, so a hash you never come back to can outlive that."

## Accessibility

Each of the three switches is `aria-disabled` (never the `disabled` attribute — that would
drop the one reader who needs the explanation out of the tab order), carries the reason in its
`aria-label` ("Marketing — off, because World Zero collects none"), and points
`aria-describedby` at a visible note saying the same thing. Same shape `AppearanceSection`
uses for the reduced-motion veto. The expander is a real `aria-expanded` / `aria-controls`
pair.

## One thing that touched a shared file

`settingsChassis.test.tsx` mocked `auth/AuthContext` wholesale, which blanked
`SESSION_HINT_KEY` for anything that imports it. Changed to a partial mock via
`importOriginal`; four lines, and the chassis' own 17 tests still pass.

## Verification

All of `.github/workflows/test.yml`'s `frontend` job, locally on Node 24:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **429 files, 7815 passed, 1 skipped**
- `npm run build` — clean
- `npm run budget` — **JS 138.5 KB (WARN), CSS 21.5 KB (ok)**

`api-schema` not applicable: no route, `response_model` or Pydantic schema touched.

**Budget note.** JS was already in WARN on `origin/main` at **137.4 KB**; this adds **+1.1 KB
gzipped, all of it in the eager `i18n` chunk** (26.2 → 27.3 KB) — the new `settings.cookies.*`
copy. The initial `index` chunk did not move (45.9 KB before and after), so importing
`sectionDisclosure` for its key cost nothing. The structural fix — `settings.*` copy is only
ever needed on a lazy route and does not belong in eagerly-loaded `common.json` — is a
separate question from this issue, and I have not touched it.

**Visual QA is outstanding.** I have no browser and no dev stack; everything above is
tests / tsc / eslint / build.

## What to eyeball

1. **The three inert switches together.** Essential lit-and-dimmed at 45% over the spectrum
   edge, Analytics and Marketing dimmed-off. Is the dimmed-ON essential switch legible enough
   to read as "on and locked" rather than "broken"? `.control-off` was not applied — the
   switch's own `disabled` styling is the chassis'.
2. **The inventory grid at desktop width.** `32ch` for the key column against
   `wz-faction-sections[:account id]` (31 chars) — does anything wrap awkwardly, and is the
   `26ch` right column too generous for "This browser, until you clear it"?
3. **The same list on a phone**, stacked with the dotted rule between entries. Eleven stacked
   triplets is a long scroll — is it too long behind one expander?
4. **The seam between the Essential row and its disclosure.** The row sets `last` (no rule) so
   the list reads as belonging to it, and the disclosure block below carries the separator.
   Check it does not read as a floating orphan.
5. **The `--color-accent-primary` underlined expander** against the card ground, both themes.
   It is the design's link treatment at content size; it may be the only link-coloured thing
   on the page.
6. **Deletion block at the bottom** — an `h3` at `--text-content` over two paragraphs. Does it
   read as part of this card, or does it want a rule above it?
7. **Copy tone**, especially the hash paragraph. It is long, and it is deliberately hedged
   about the ninety days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
