### PR TITLE
Settings grows an Account card, and the NavBar loses its sign-out button (#2155)

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -158,6 +158,10 @@ export function characterFor(
 // mid-level character can. Faction fan-outs can clone this via makeCharacter.
 export const mockUser: CurrentUser = {
   account_id: 1,
+  // Per-ACCOUNT, and only ever the caller's own (#2155) — the Settings Account
+  // card is the one surface that prints either.
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
   character: makeCharacter(),
   is_admin: false,
   can_create_additional_character: true,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1658,6 +1658,11 @@
               }
             ]
           },
+          "email": {
+            "default": "",
+            "title": "Email",
+            "type": "string"
+          },
           "era_name": {
             "default": "",
             "title": "Era Name",
@@ -1678,6 +1683,11 @@
             "title": "Level Jump Reach",
             "type": "integer"
           },
+          "provider": {
+            "default": "",
+            "title": "Provider",
+            "type": "string"
+          },
           "second_character_level_required": {
             "default": 0,
             "title": "Second Character Level Required",
@@ -1691,6 +1701,8 @@
         },
         "required": [
           "account_id",
+          "email",
+          "provider",
           "character",
           "is_admin",
           "can_create_additional_character",

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -11,6 +11,20 @@ class CurrentUser(WireModel):
     # The /auth/me endpoint is authenticated — it returns the caller's own account_id only.
     # Authorization: SPEC-backend-architecture.md §4
     account_id: int
+    # `email` rides that SAME exception, for the same reason (#2155): the
+    # Settings Account card prints the address the player signed up with, and
+    # /auth/me is authenticated and answers with the caller's own only. The rule
+    # is unchanged for everything else: the only other schemas carrying an email
+    # are admin-guarded or a request body, and nothing inherits or reuses this
+    # model. `tests/integration/test_auth_me_account_fields.py` ratchets that
+    # list, so a future inheritance cannot widen it quietly.
+    email: str = ""
+    # Which identity this account signs in through — an ``AuthProvider`` value
+    # read off ``OAuthProvider.provider`` (#2155). DISPLAY ONLY: the card says
+    # "Signed in with Google" and offers no button, because the link-a-second-
+    # provider flow (ADR-0075) does not exist and the owner ruled display-only
+    # on 2026-08-17. "" when the account holds no OAuth row at all.
+    provider: str = ""
     character: Optional[CharacterOut] = None
     is_admin: bool = False
     # Capability flags computed server-side so the frontend can hide controls it

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -15,8 +15,16 @@ class CurrentUser(WireModel):
     # Settings Account card prints the address the player signed up with, and
     # /auth/me is authenticated and answers with the caller's own only. The rule
     # is unchanged for everything else: the only other schemas carrying an email
-    # are admin-guarded or a request body, and nothing inherits or reuses this
-    # model. `tests/integration/test_auth_me_account_fields.py` ratchets that
+    # are admin-guarded or a request body.
+    #
+    # THIS MODEL ANSWERS THREE ROUTES, NOT ONE, and all three are self-scoped:
+    # `GET /auth/me`, `POST /factions/choose` and `POST /me/active-character`
+    # each resolve their account through `Depends(get_current_account)` and take
+    # no account or character id from the caller, so none of them can be aimed
+    # at somebody else's row. The exception rests on that property — not on
+    # `/auth/me` being the only reader — so a FOURTH route returning
+    # `CurrentUser` has to be checked for it before it ships.
+    # `tests/integration/test_auth_me_account_fields.py` ratchets the carrier
     # list, so a future inheritance cannot widen it quietly.
     email: str = ""
     # Which identity this account signs in through — an ``AuthProvider`` value

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -13,11 +13,12 @@ and the two eligibility flags share one level query.
 """
 from dataclasses import asdict
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dependencies import account_has_admin_role
 from game_config import CURRENT_ERA, EraConfig
-from models.account import Account
+from models.account import Account, OAuthProvider
 from schemas.auth import CurrentUser
 from services.albescent_reveal import is_albescent_revealed
 from services.character import (
@@ -61,6 +62,19 @@ async def build_current_user(
 
     is_admin = await account_has_admin_role(account.id, session)
 
+    # The one round trip #2155 adds, and it reads a single column rather than
+    # the `oauth_providers` relationship — which is `lazy="raise"` anyway, so
+    # there is no accidental load to inherit. `LIMIT 1` because an account holds
+    # exactly one identity: there is no link-a-second-provider flow (ADR-0075),
+    # and if one ever lands, "the provider you signed in with" is a session
+    # fact this payload could not answer from the account row regardless.
+    provider = await session.scalar(
+        select(OAuthProvider.provider)
+        .where(OAuthProvider.account_id == account.id)
+        .order_by(OAuthProvider.id)
+        .limit(1)
+    )
+
     eligibility = (
         await load_account_eligibility(account.id, era_row.id, session, era)
         if era_row is not None
@@ -77,6 +91,10 @@ async def build_current_user(
 
     return CurrentUser(
         account_id=account.id,
+        email=account.email,
+        # "" rather than None: a demo/seeded account can carry no OAuth row, and
+        # the card's provider line is simply absent then — see `AccountSection`.
+        provider=provider or "",
         character=char_out,
         is_admin=is_admin,
         can_create_additional_character=eligibility.can_create_additional_character,

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -106,17 +106,32 @@ async def test_auth_me_not_admin_by_default(
 
 
 @pytest.mark.asyncio
-async def test_auth_me_does_not_expose_email(
+async def test_auth_me_exposes_the_callers_own_email_and_no_other(
     client: AsyncClient,
     account: Account,
+    account2: Account,
     auth_headers: dict,
 ):
-    """GET /auth/me must never return email in the response body."""
+    """GET /auth/me returns the caller's own address, and only ever that.
+
+    THIS TEST WAS THE OTHER WAY ROUND UNTIL #2155, and the reversal is a ruling,
+    not a relaxation. It asserted "never return email in the response body" with
+    no ADR behind it; the Settings Account card needs the address a player signed
+    up with, and ``/auth/me`` is authenticated and answers about the caller
+    alone — the same reasoning that already makes ``account_id`` the documented
+    exception on this one endpoint (SPEC-backend-architecture.md §4).
+
+    What has NOT changed is the rule the old test was reaching for: an email
+    belongs to exactly one reader. That half is what is asserted here, and the
+    "which schemas may carry an email at all" half is ratcheted in
+    ``test_auth_me_account_fields.py`` — a leak would now show up there as a new
+    carrier rather than here as a new field.
+    """
     resp = await client.get("/auth/me", headers=auth_headers)
+
     assert resp.status_code == 200
-    body_text = resp.text
-    assert account.email not in body_text
-    assert "email" not in resp.json()
+    assert resp.json()["email"] == account.email
+    assert account2.email not in resp.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_auth_me_account_fields.py
+++ b/backend/tests/integration/test_auth_me_account_fields.py
@@ -1,0 +1,103 @@
+"""The two per-ACCOUNT fields the Settings Account card reads (#2155).
+
+SEAM: the wire. These are contract facts, not composition details — the card
+prints ``email`` verbatim and maps ``provider`` to a brand name, so what matters
+is that ``GET /auth/me`` carries both and that neither leaks anywhere else.
+
+The last test is the one worth having. ``email`` on a response model is the rule
+this repo otherwise enforces absolutely ("never expose ``account_id`` or
+``email`` publicly"); it rides ``/auth/me``'s documented exception, and that
+exception is only safe while it stays a single site.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account, AuthProvider, OAuthProvider
+
+
+@pytest.mark.asyncio
+async def test_auth_me_carries_the_signed_in_email(
+    client: AsyncClient,
+    account: Account,
+    auth_headers: dict,
+) -> None:
+    resp = await client.get("/auth/me", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["email"] == account.email
+
+
+@pytest.mark.asyncio
+async def test_auth_me_carries_the_identity_provider(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+) -> None:
+    db_session.add(
+        OAuthProvider(
+            account_id=account.id,
+            provider=AuthProvider.GOOGLE,
+            provider_user_id="sub-2155",
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.get("/auth/me", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == "google"
+
+
+@pytest.mark.asyncio
+async def test_auth_me_answers_empty_provider_when_no_oauth_row_exists(
+    client: AsyncClient,
+    account: Account,
+    auth_headers: dict,
+) -> None:
+    """A seeded/demo account holds no identity row.
+
+    "" is the card's absent case — it must not be ``null`` and it must not 500.
+    """
+    resp = await client.get("/auth/me", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["provider"] == ""
+
+
+# Every schema that was allowed to carry `email` before #2155, with the reason
+# each is not the leak the rule is about. A RATCHET: adding a name here is a
+# deliberate act that has to be argued for in review, which is the whole point.
+EMAIL_CARRIERS = {
+    # #2155. Authenticated, and answers with the CALLER'S OWN address only —
+    # the same documented exception `account_id` already rides.
+    "CurrentUser",
+    # `/admin/accounts` and `/admin/accounts/{id}`, both behind the admin guard.
+    "AccountSummary",
+    "AccountDetail",
+    # A REQUEST body: the address is typed by the sender, about themselves.
+    "ContactMessageIn",
+    # `/admin/contact-messages` — reading back what a sender typed, admin-only.
+    "routers__admin__ContactMessageOut",
+}
+
+
+@pytest.mark.asyncio
+async def test_email_reaches_no_new_response_model(client: AsyncClient) -> None:
+    """`email` on the wire stays confined to the sites that argued for it.
+
+    Read off the live OpenAPI rather than by grep, so a field arriving through
+    inheritance — or through a model quietly reused as a response — is caught
+    too. That is the failure mode this guards: not somebody typing `email:` into
+    a player-facing schema, but somebody making `CurrentUser` a base class.
+    """
+    schemas = (await client.get("/openapi.json")).json()["components"]["schemas"]
+
+    carriers = {
+        name
+        for name, schema in schemas.items()
+        if "email" in (schema.get("properties") or {})
+    }
+
+    assert carriers == EMAIL_CARRIERS, carriers - EMAIL_CARRIERS

--- a/docs/spec/SPEC-backend-architecture.md
+++ b/docs/spec/SPEC-backend-architecture.md
@@ -126,9 +126,15 @@ public response.** Public responses key on `character_id` / `username`.
   — do include them. These ride behind `Depends(require_admin)` and are
   the only blessed exception.
 - `/auth/me` response (`schemas/auth.py::CurrentUser`) — includes
-  `account_id`. This is **acknowledged and narrow**: the endpoint is
-  auth-only and the frontend needs an opaque account handle. The rest of
-  the API key on character.
+  `account_id`, and since #2155 `email` and `provider` as well. This is
+  **acknowledged and narrow**: the endpoint is auth-only and answers about
+  the caller alone, so none of the three is a fact about a third party.
+  `email` is there because the Settings Account card has to show a player
+  which address they signed up with; `provider` is display-only (ADR-0075's
+  linking flow does not exist). The rest of the API keys on character.
+  `tests/integration/test_auth_me_account_fields.py` ratchets the set of
+  schemas allowed to carry an `email` at all, so widening this exception —
+  including by making `CurrentUser` a base class — fails CI.
 
 Anti-self-voting is the other half of the identity boundary: enforced at the
 **account** level, not the character level. `Vote.voter_account_id` is

--- a/frontend/.ds-kit/provider.tsx
+++ b/frontend/.ds-kit/provider.tsx
@@ -30,6 +30,8 @@ import type { CurrentUser } from "../src/api/auth";
 
 const MOCK_USER: CurrentUser = {
   account_id: 1,
+  email: "wayfarer@example.com",
+  provider: "google",
   character: {
     id: 1,
     username: "wayfarer",

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -2586,6 +2586,11 @@ export interface components {
             can_start_as_albescent: boolean;
             character: components["schemas"]["CharacterOut"] | null;
             /**
+             * Email
+             * @default
+             */
+            email: string;
+            /**
              * Era Name
              * @default
              */
@@ -2605,6 +2610,11 @@ export interface components {
              * @default 0
              */
             level_jump_reach: number;
+            /**
+             * Provider
+             * @default
+             */
+            provider: string;
             /**
              * Second Character Level Required
              * @default 0

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -22,7 +22,7 @@ interface NavLinkSpec {
 
 export default function NavBar() {
   const { t } = useTranslation('common')
-  const { user, signOut } = useAuth()
+  const { user } = useAuth()
   const { adminMode, toggleAdminMode } = useAdminMode()
   /**
    * WHY THE NAV LINK CARRIES THE PENDING COUNT TOO (#1457)
@@ -222,14 +222,11 @@ export default function NavBar() {
                   {t('nav.createCharacter')}
                 </NavLink>
               )}
-              {/* STILL HERE ON PURPOSE — the port is not incomplete. #2154's
-                  brief has sign-out leaving the bar for the Settings Account
-                  section, but that section is #2155 and it has not landed.
-                  Removing it now would ship a desktop with no way to sign out,
-                  and `main` auto-deploys. #2155 is its remover. */}
-              <button onClick={signOut} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)' }}>
-                {t('nav.logout')}
-              </button>
+              {/* Sign out is GONE from the bar (#2155). It now lives once, in
+                  the Settings Account card, which the theme toggle beside this
+                  is the way in to. Removed only in the PR that shipped that
+                  card — these were the app's two sign-out call sites, and
+                  `main` auto-deploys. */}
             </>
           ) : (
             /* One button, two ways in (#1773) — so it opens the choice rather

--- a/frontend/src/components/vote/__tests__/albescentVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/albescentVote.test.tsx
@@ -38,6 +38,8 @@ import { resolvedArchetype } from '../../../factions/lazyArchetype'
 function currentUser(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: {
       id: 9,
       username: 'ada',

--- a/frontend/src/components/vote/__tests__/covenVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/covenVote.test.tsx
@@ -57,6 +57,8 @@ const HEX = /#[0-9a-fA-F]{3,8}\b/
 function currentUser(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: {
       id: 9,
       username: 'ada',

--- a/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
@@ -41,6 +41,8 @@ const HEX = /#[0-9a-fA-F]{3,8}\b/
 function currentUser(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: {
       id: 9,
       username: 'ada',

--- a/frontend/src/components/vote/__tests__/voteUI.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteUI.test.tsx
@@ -35,6 +35,8 @@ import VoteUI from '../VoteUI'
 function currentUser(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: {
       id: 9,
       username: 'ada',

--- a/frontend/src/components/vote/__tests__/voteWidgetSilent.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteWidgetSilent.test.tsx
@@ -98,6 +98,8 @@ const TIER_5_WORD: Record<string, string> = {
 function currentUser(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: {
       id: 9,
       username: 'ada',

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -340,13 +340,26 @@
     "eyebrow": "{{faction}} · {{name}}",
     "lead": "Changes save the moment you make them.",
     "account": {
-      "eyebrow": "Signed in as",
+      "eyebrow": "Account",
+      "lead": "One account, one email, and however many lives you carry.",
       "viewProfile": "View profile",
-      "noCharacter": "No character yet"
+      "noCharacter": "No character yet",
+      "email": "Email address",
+      "emailHelp": "Where World Zero writes to you. It comes from your sign-in, so it changes there rather than here.",
+      "provider": "Signed in with",
+      "providerHelp": "World Zero never sees a password — your provider vouches for you each time.",
+      "providers": {
+        "google": "Google",
+        "discord": "Discord",
+        "dev": "Developer sign-in",
+        "demo": "Demo account"
+      }
     },
     "characters": {
       "label": "Characters",
-      "hint": "Switch or edit your lives"
+      "hint": "Switch or edit your lives",
+      "manage": "Manage",
+      "create": "Create one"
     },
     "appearance": {
       "eyebrow": "Appearance",
@@ -357,6 +370,7 @@
       "animationsSystemNote": "Your device is set to reduce motion.",
       "animationsSystemName": "Animations — off, because your device is set to reduce motion"
     },
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "signOutHelp": "Ends this session on this device."
   }
 }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -210,7 +210,6 @@
       "disableTitle": "Admin mode ON — click to disable"
     },
     "createCharacter": "create character",
-    "logout": "logout",
     "login": "Login"
   },
   "footer": {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { factionName } from '../utils/factions'
+import AccountSection from './settings/sections/AccountSection'
 import AppearanceSection from './settings/sections/AppearanceSection'
 
 /**
@@ -55,6 +56,7 @@ interface SettingsSection {
  */
 export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
   { key: 'appearance', labelKey: 'settings.appearance.eyebrow', Component: AppearanceSection },
+  { key: 'account', labelKey: 'settings.account.eyebrow', Component: AccountSection },
 ]
 
 /** The design's `sec-<key>`; one derivation, used by the anchor and the rail. */

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -76,6 +76,8 @@ function character(faction_slug: string): CharacterOut {
 function currentUser(faction_slug: string, canCreateAdditional = false): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: character(faction_slug),
     is_admin: false,
     // #1560: the desktop roster is only drawn when it has a choice to offer, so

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterGate.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterGate.test.tsx
@@ -81,6 +81,8 @@ function life(overrides: Partial<CharacterOut> = {}): CharacterOut {
 function currentUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: life(),
     is_admin: false,
     can_create_additional_character: false,

--- a/frontend/src/pages/fieldDesk/__tests__/homeTrackBand.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/homeTrackBand.test.tsx
@@ -65,6 +65,8 @@ function currentUser(faction_slug: string): CurrentUser {
   }
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character,
     is_admin: false,
     can_create_additional_character: false,

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -127,6 +127,8 @@ function character(id: number): CharacterOut {
 function user(characterId: number): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: character(characterId),
     is_admin: false,
     can_create_additional_character: false,

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -165,6 +165,8 @@ function character(): CharacterOut {
 function user(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: character(),
     is_admin: false,
     can_create_additional_character: false,

--- a/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
@@ -135,6 +135,8 @@ function user(): CurrentUser {
   }
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character,
     is_admin: false,
     can_create_additional_character: false,

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -152,6 +152,8 @@ function user(): CurrentUser {
   }
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character,
     is_admin: false,
     can_create_additional_character: false,

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -64,6 +64,8 @@ const PRAXIS = aPraxis({
 function viewer(): CurrentUser {
   return {
     account_id: 1,
+    email: 'wz_pilgrim@example.com',
+    provider: 'google',
     character: {
       id: 3,
       username: "ada",

--- a/frontend/src/pages/settings/__tests__/accountSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/accountSection.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * #2155 — the Settings Account section.
+ *
+ * SEAM: the rendered `/settings` page, in the repo's DOM-less node env
+ * (`renderToStaticMarkup`) — the same posture as `settingsChassis.test.tsx`
+ * next door, and rendering the whole page rather than the section alone so
+ * these also prove the section is REGISTERED. A card that renders perfectly and
+ * is missing from `SETTINGS_SECTIONS` is the failure this file has to catch.
+ *
+ * THE SIGN-OUT TEST IS THE ONE THAT MATTERS. This PR removes the NavBar's
+ * sign-out button, and these were the only two sign-out call sites in the app —
+ * so if the control below stops rendering, `main` auto-deploys a site nobody
+ * can sign out of. It is a load-bearing assertion, not a smoke test.
+ *
+ * `useAuth` is mocked rather than driven through `AuthProvider`: the provider
+ * fetches `/auth/me` on mount, and what is under test is what the card does
+ * with a `CurrentUser`, not how one is obtained.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { CurrentUser } from '../../../api/auth'
+
+const harness = vi.hoisted(() => ({
+  formFactor: 'desktop' as 'mobile' | 'desktop',
+  user: null as CurrentUser | null,
+  signOut: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  MOBILE_QUERY: '(max-width: 767px)',
+  formFactorFor: (matches: boolean) => (matches ? 'mobile' : 'desktop'),
+  useFormFactor: () => harness.formFactor,
+}))
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: harness.user, signOut: harness.signOut }),
+}))
+
+import '../../../i18n'
+import Settings from '../../Settings'
+import { MotionProvider } from '../../../hooks/useMotion'
+import { ThemeProvider } from '../../../hooks/useTheme'
+
+const LIFE = {
+  id: 3,
+  username: 'wz_pilgrim',
+  display_name: 'WZ Pilgrim',
+  faction_slug: 'ua',
+  level: 4,
+  avatar_url: '',
+}
+
+/** A `CurrentUser` shaped for this card. Only the fields the card reads are
+ *  meaningful; the capability flags are irrelevant here and are cast past. */
+function viewer(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    account_id: 1,
+    email: 'pilgrim@example.com',
+    provider: 'google',
+    character: LIFE,
+    ...overrides,
+  } as unknown as CurrentUser
+}
+
+function render(): string {
+  // `useMotion` reads `window.matchMedia`; there is no window in this env.
+  const holder = globalThis as { window?: unknown }
+  const previous = holder.window
+  holder.window = {
+    matchMedia: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+  }
+  try {
+    return renderToStaticMarkup(
+      <MemoryRouter>
+        <ThemeProvider>
+          <MotionProvider>
+            <Settings />
+          </MotionProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    )
+  } finally {
+    if (previous === undefined) delete holder.window
+    else holder.window = previous
+  }
+}
+
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
+const tagged = (html: string, testId: string) =>
+  new RegExp(`<[a-z]+[^>]*data-testid="${testId}"[^>]*>[^<]*`).exec(html)?.[0] ?? ''
+
+afterEach(() => {
+  harness.formFactor = 'desktop'
+  harness.user = null
+})
+
+describe('the two per-account facts', () => {
+  it('prints the signed-in email', () => {
+    harness.user = viewer()
+    expect(tagged(render(), 'settings-account-email')).toContain('pilgrim@example.com')
+  })
+
+  it('names the provider as a brand, never as the wire slug', () => {
+    harness.user = viewer({ provider: 'google' })
+    const pill = tagged(render(), 'settings-account-provider')
+    expect(pill).toContain('Google')
+    expect(pill, 'the raw enum value must not reach a reader').not.toContain('>google')
+  })
+
+  /**
+   * Display only, and that is a ruling (owner, 2026-08-17): the
+   * link-a-second-provider flow (ADR-0075) does not exist, so a button beside
+   * this row would be a control that does nothing.
+   */
+  it('offers no control beside the provider', () => {
+    harness.user = viewer()
+    const html = render()
+    const row = html.slice(html.indexOf('Signed in with'), html.indexOf('settings-characters-link'))
+    expect(row).not.toContain('<button')
+  })
+
+  it('drops the provider row entirely when the account holds no identity row', () => {
+    harness.user = viewer({ provider: '' })
+    expect(text(render()), 'no empty pill, no raw ""').not.toContain('Signed in with')
+  })
+})
+
+describe('the carried life', () => {
+  it('shows the active character with its faction and level', () => {
+    harness.user = viewer()
+    const body = text(render())
+    expect(body).toContain('WZ Pilgrim')
+    expect(body).toContain('Level 4')
+  })
+
+  it('points character management at that life', () => {
+    harness.user = viewer()
+    expect(tagged(render(), 'settings-characters-link')).toContain('href="/characters/3/edit"')
+  })
+
+  it('points at creation instead for an account playing nobody', () => {
+    harness.user = viewer({ character: null })
+    const html = render()
+    expect(tagged(html, 'settings-characters-link')).toContain('href="/characters/create"')
+    expect(text(html)).toContain('No character yet')
+  })
+})
+
+/**
+ * THE NAVBAR GUARD. `main` auto-deploys, and this PR deletes the only other
+ * sign-out control in the app. If this goes red, the NavBar button must go back
+ * before anything ships.
+ */
+describe('the way out', () => {
+  it('renders a sign-out control on the Settings page', () => {
+    harness.user = viewer()
+    expect(tagged(render(), 'settings-sign-out')).toContain('Sign out')
+  })
+
+  it('renders it on a phone too — the phone has no NavBar to fall back on', () => {
+    harness.formFactor = 'mobile'
+    harness.user = viewer()
+    expect(tagged(render(), 'settings-sign-out')).toContain('Sign out')
+  })
+})
+
+/**
+ * `/settings` is a `ProtectedRoute`, so this state is unreachable in the app —
+ * but the shell asserts one anchor per registered section, and a section that
+ * returns `null` for a missing user is a rail item pointing at nothing.
+ */
+it('still renders its anchor when there is no user at all', () => {
+  harness.user = null
+  expect(render()).toContain('id="sec-account"')
+})

--- a/frontend/src/pages/settings/__tests__/accountSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/accountSection.test.tsx
@@ -33,7 +33,13 @@ vi.mock('../../../hooks/useFormFactor', () => ({
   useFormFactor: () => harness.formFactor,
 }))
 
-vi.mock('../../../auth/AuthContext', () => ({
+// Partial, not wholesale. `AuthContext` also exports `SESSION_HINT_KEY`, which
+// the Cookies section (#2156) imports so its storage inventory names the real
+// key instead of a retyped copy. A wholesale factory blanks every export it
+// does not list, so mocking this module for `useAuth` alone took that constant
+// down with it and the whole Settings tree failed to render.
+vi.mock('../../../auth/AuthContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../auth/AuthContext')>()),
   useAuth: () => ({ user: harness.user, signOut: harness.signOut }),
 }))
 

--- a/frontend/src/pages/settings/sections/AccountSection.tsx
+++ b/frontend/src/pages/settings/sections/AccountSection.tsx
@@ -1,0 +1,210 @@
+import type { CSSProperties } from 'react'
+import type { ParseKeys } from 'i18next'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../../auth/AuthContext'
+import { factionCssVar, factionName } from '../../../utils/factions'
+import { mediaUrl } from '../../../utils/media'
+import SettingsCard from '../SettingsCard'
+import SettingsRow from '../SettingsRow'
+
+/**
+ * Account (#2155) — the two per-ACCOUNT facts, the carried life, and the way
+ * out.
+ *
+ * THIS SECTION IS WHY THE NAVBAR NO LONGER HAS A SIGN-OUT BUTTON. Until this
+ * file existed there were exactly two sign-out call sites in the app: the
+ * NavBar's button and the phone's `DefaultSettings`. #2154 deleted the second
+ * and deliberately left the first alone — removing it before this landed would
+ * have shipped a site with no way out, and `main` auto-deploys. The button goes
+ * in the same PR as this card, not before it.
+ *
+ * THE DESIGN DOES NOT DRAW THIS CARD. `Settings.dc.html`'s `#sec-account` holds
+ * only the danger zone (#2161), so the geometry here is the card/row rhythm of
+ * the sections that ARE drawn: the display-only rows follow `sec-language`'s
+ * "static value in a pill on the right", and the buttons follow its
+ * `secondaryBtn` — which is `.btn-outline`, already in the repo.
+ *
+ * THE HEADER AND THE CHARACTER LINK ARE LIFTED, NOT REDRAWN. Both come from
+ * the deleted `mobileArchetypes/DefaultSettings.tsx` (`6ddde148^`) — the
+ * spectrum ring around the avatar, the faction·level line, and the
+ * `edit`-or-`create` href are that file's working code.
+ *
+ * PROVIDER IS DISPLAY ONLY AND THAT IS A RULING, NOT AN OMISSION. There is no
+ * button beside it because the link-a-second-provider flow (ADR-0075) does not
+ * exist; the owner ruled display-only on 2026-08-17. A button here would be the
+ * false-affordance class of #1263.
+ */
+
+/**
+ * `AuthProvider` (backend/models/account.py) → catalog key.
+ *
+ * Written out literally rather than interpolated into `t()`, for the two
+ * reasons the chassis gives about `labelKey`: a typo fails the build, and a
+ * locale grep can see the keys. A value not in this map — including the ""
+ * the wire sends for an account holding no OAuth row at all — renders no row
+ * rather than a raw slug.
+ */
+const PROVIDER_LABEL_KEY: Readonly<Record<string, ParseKeys<'common'>>> = {
+  google: 'settings.account.providers.google',
+  discord: 'settings.account.providers.discord',
+  dev: 'settings.account.providers.dev',
+  demo: 'settings.account.providers.demo',
+}
+
+/** The design's static-value pill (`sec-language`), mapped to tokens: `10px
+ *  14px` to the space scale, `--wz-well` to the `--filter-*` control-chrome
+ *  family that already holds that exact `color-mix`, and 13px up to the content
+ *  floor. `overflowWrap` because an email address is the one value here that
+ *  can be longer than a phone is wide. */
+const VALUE_PILL: CSSProperties = {
+  minWidth: 0,
+  padding: 'var(--space-sm) var(--space-md)',
+  borderRadius: 999,
+  border: '1px solid var(--color-border)',
+  background: 'var(--filter-well)',
+  fontSize: 'var(--text-content)',
+  color: 'var(--color-text-primary)',
+  overflowWrap: 'anywhere',
+}
+
+const AVATAR: CSSProperties = {
+  width: 52,
+  height: 52,
+  // eslint-disable-next-line local/no-raw-style-values -- ornament: spectrum ring thickness drawn around a 52px avatar; the nearest rung (4px) thickens the band by a third. Lifted verbatim from DefaultSettings.tsx.
+  padding: 3,
+  background: 'var(--faction-default-rainbow-conic)',
+}
+
+export default function AccountSection({ sectionId }: { readonly sectionId: string }) {
+  const { t } = useTranslation('common')
+  const { user, signOut } = useAuth()
+
+  const character = user?.character ?? null
+  // The carried life's own management surface, or make one if there is none.
+  const charactersHref = character ? `/characters/${character.id}/edit` : '/characters/create'
+  const providerKey = PROVIDER_LABEL_KEY[user?.provider ?? '']
+
+  // The card renders whether or not there is a `user`. `/settings` is a
+  // `ProtectedRoute`, so a signed-out reader never reaches it — but the shell
+  // asserts one anchor per registered section, and a section that returns
+  // `null` is a rail item pointing at nothing.
+  return (
+    <SettingsCard
+      sectionId={sectionId}
+      title={t('settings.account.eyebrow')}
+      lead={t('settings.account.lead')}
+    >
+      {/* ── The carried life ── lifted from DefaultSettings.tsx */}
+      <div style={{ marginTop: 'var(--space-lg)' }}>
+        {character ? (
+          <div className="flex items-center gap-3.5">
+            <div className="shrink-0 rounded-full" style={AVATAR}>
+              {character.avatar_url ? (
+                <img
+                  src={mediaUrl(character.avatar_url)}
+                  alt={character.display_name}
+                  className="w-full h-full rounded-full"
+                  style={{ objectFit: 'cover' }}
+                />
+              ) : (
+                <div
+                  className="w-full h-full rounded-full"
+                  style={{
+                    background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${factionCssVar(character.faction_slug)})`,
+                  }}
+                />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div
+                className="font-display italic truncate"
+                style={{
+                  fontSize: 'var(--text-title)',
+                  lineHeight: 1.05,
+                  color: 'var(--color-text-primary)',
+                }}
+              >
+                {character.display_name}
+              </div>
+              <div
+                className="truncate"
+                style={{
+                  marginTop: 'var(--space-xs)',
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 'var(--text-base)',
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                {t('sidebar.characterCard.factionLevel', {
+                  faction: factionName(character.faction_slug),
+                  level: character.level,
+                })}
+              </div>
+            </div>
+            <Link
+              to={`/characters/${character.id}`}
+              className="shrink-0 label-caption"
+              style={{
+                textDecoration: 'none',
+                border: '1px solid var(--color-border-strong)',
+                borderRadius: 999,
+                padding: 'var(--space-sm) var(--space-md)',
+              }}
+            >
+              {t('settings.account.viewProfile')}
+            </Link>
+          </div>
+        ) : (
+          <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)', margin: 0 }}>
+            {t('settings.account.noCharacter')}
+          </p>
+        )}
+      </div>
+
+      {user?.email && (
+        <SettingsRow title={t('settings.account.email')} help={t('settings.account.emailHelp')}>
+          <div style={VALUE_PILL} data-testid="settings-account-email">
+            {user.email}
+          </div>
+        </SettingsRow>
+      )}
+
+      {providerKey && (
+        <SettingsRow
+          title={t('settings.account.provider')}
+          help={t('settings.account.providerHelp')}
+        >
+          <div style={VALUE_PILL} data-testid="settings-account-provider">
+            {t(providerKey)}
+          </div>
+        </SettingsRow>
+      )}
+
+      <SettingsRow title={t('settings.characters.label')} help={t('settings.characters.hint')}>
+        <Link
+          to={charactersHref}
+          className="btn-outline shrink-0"
+          style={{ borderRadius: 'var(--radius-md)', textDecoration: 'none' }}
+          data-testid="settings-characters-link"
+        >
+          {character ? t('settings.characters.manage') : t('settings.characters.create')}
+        </Link>
+      </SettingsRow>
+
+      <SettingsRow last title={t('settings.signOut')} help={t('settings.signOutHelp')}>
+        <button
+          type="button"
+          onClick={signOut}
+          className="btn-outline shrink-0"
+          style={{ borderRadius: 'var(--radius-md)' }}
+          data-testid="settings-sign-out"
+        >
+          {t('settings.signOut')}
+        </button>
+      </SettingsRow>
+    </SettingsCard>
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -35,6 +35,8 @@ const TASK = aTask({
 
 const VIEWER: CurrentUser = {
   account_id: 1,
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
   // Carries a character: the eligibility rail is gated on a LIFE, not on a
   // session (#1972), and the browse's signed-in cases are all played by a
   // player. An account between characters is `metataskFilterGate`'s viewer.

--- a/frontend/src/pages/tasks/__tests__/eligibilityRailGate.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/eligibilityRailGate.test.tsx
@@ -23,6 +23,8 @@ import TaskFilterBar from '../TaskFilterBar'
 
 const BASE_VIEWER: CurrentUser = {
   account_id: 1,
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
   character: null,
   is_admin: false,
   can_create_additional_character: false,

--- a/frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx
@@ -60,6 +60,8 @@ const TASK = aTask({
 
 const VIEWER: CurrentUser = {
   account_id: 1,
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
   character: null,
   is_admin: false,
   can_create_additional_character: false,

--- a/frontend/src/pages/tasks/__tests__/metataskFilterGate.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/metataskFilterGate.test.tsx
@@ -21,6 +21,8 @@ import TaskFilterBar from '../TaskFilterBar'
 
 const BASE_VIEWER: CurrentUser = {
   account_id: 1,
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
   character: null,
   is_admin: false,
   can_create_additional_character: false,

--- a/frontend/src/pages/tasks/__tests__/proposeEntryPoint.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/proposeEntryPoint.test.tsx
@@ -34,6 +34,8 @@ vi.mock('../../../hooks/useFormFactor', () => ({
 
 const VIEWER: CurrentUser = {
   account_id: 1,
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
   character: null,
   is_admin: false,
   can_create_additional_character: false,


### PR DESCRIPTION
Closes #2155

Part of #2153. Second section into the #2154 chassis: one file under
`settings/sections/`, one line in `SETTINGS_SECTIONS`, nothing else in
`Settings.tsx` moved.

## What lands

An **Account** card in the Settings pane, holding the four things the design's
`#sec-account` never drew:

- **Signed-in email** — a new `CurrentUser.email`.
- **Provider, display only** — a new `CurrentUser.provider`, read off
  `OAuthProvider.provider` and printed as a brand name ("Google"). **No button:**
  the link-a-second-provider flow (ADR-0075) does not exist, and the owner ruled
  display-only on 2026-08-17. A button there would be the false-affordance class
  of #1263. The row is dropped entirely when the account holds no OAuth row
  (seeded/demo accounts).
- **The carried life** — avatar with its spectrum ring, display name,
  faction·level, and the profile link. Lifted verbatim from the deleted
  `mobileArchetypes/DefaultSettings.tsx` (`6ddde148^`), not redrawn.
- **Character management** — `/characters/:id/edit`, or `/characters/create` when
  the account is playing nobody. Same lift.
- **Sign out** — `useAuth().signOut`, behaviour unchanged.

## I removed the NavBar's sign-out button

`NavBar.tsx` carried a comment reading *"STILL HERE ON PURPOSE — the port is not
incomplete… #2155 is its remover."* That is this PR. The button and the comment
are gone, and `nav.logout` — orphaned by the removal — goes with them.

**The Account card ships sign-out in the same commit range, so the site is never
without one.** These were the app's only two sign-out call sites and `main`
auto-deploys, so the guard is a load-bearing test rather than a promise:
`accountSection.test.tsx` asserts a `settings-sign-out` control renders on the
Settings page in **both** form factors. If that goes red, the NavBar button has
to go back before anything ships.

## Backend: two fields on a response model

`CurrentUser` gains `email` and `provider`. Both are per-**account**; the header
shows the active character.

`email` on the wire rides the exception `account_id` already documents in
`schemas/auth.py`: `/auth/me` is authenticated and answers with the caller's own
value only. I checked nothing inherits or reuses `CurrentUser` — its three
producers (`/auth/me`, `/factions/choose`, `/me/active-character`) are all
authenticated self-reads through `build_current_user`.

The "one site" claim turned out to need a caveat, and the test found it: four
other schemas already carry an `email` — `AccountSummary` / `AccountDetail` /
`routers__admin__ContactMessageOut` (all admin-guarded) and `ContactMessageIn`
(a request body, the sender's own address). So the check is a **ratchet** over
the live OpenAPI rather than an equality to `{CurrentUser}`: any *new* carrier
fails, including one arriving by inheritance. That is the failure mode worth
guarding — not somebody typing `email:` into a player-facing schema, but
somebody making `CurrentUser` a base class.

### A standing test said the opposite, and I inverted it rather than deleting it

`test_auth.py::test_auth_me_does_not_expose_email` asserted *"GET /auth/me must
never return email in the response body"* — no ADR, no spec citation behind it.
#2155 rules the other way and gives the reasoning, so this is a supersession, not
a relaxation. The test is now
`test_auth_me_exposes_the_callers_own_email_and_no_other`, which keeps the half
that is still true — an email belongs to exactly one reader — and says in its
docstring why it flipped. **Flagging it explicitly because it is the one place in
this PR where I changed an existing security assertion.**

`SPEC-backend-architecture.md` §4 enumerated `/auth/me` as carrying `account_id`
only; it is the "one source of truth" the code comment cites, so it now records
all three fields and points at the ratchet.

`provider` costs `build_current_user` one extra SELECT. It reads the single
column rather than the `lazy="raise"` relationship, and `test_auth_me_query_count`
still passes at its existing `<= 8` budget, so no budget was raised.

## Seams I tested at

- **The wire** (`backend/tests/integration/test_auth_me_account_fields.py`) —
  `GET /auth/me` carries both fields, `provider` is `""` and not `null` when no
  OAuth row exists, and the email ratchet above. These are contract facts, which
  is why they are asserted on the response and not on the composition.
- **The rendered `/settings` page** (`frontend/src/pages/settings/__tests__/accountSection.test.tsx`)
  — `renderToStaticMarkup` in the repo's DOM-less node env, the same posture as
  `settingsChassis.test.tsx`. Rendering the whole page rather than the section
  alone also proves the section is **registered**: a card that renders perfectly
  and is missing from `SETTINGS_SECTIONS` is exactly the failure the chassis
  warns about.

## Deviations from the design

1. **There is no drawn Account card.** `Settings.dc.html`'s `#sec-account` is the
   danger zone (#2161) and nothing else, so every measurement here is borrowed
   from a sibling that *is* drawn — the display-only rows follow `sec-language`'s
   "static value in a pill on the right", the buttons follow its `secondaryBtn`.
   Nothing was invented beyond that.
2. **Pill type is `--text-content` (18px), not the canvas's 13px.** The content
   floor (#627) — the same call `SettingsRow` already documents for its help
   line. An email address is content a reader reads.
3. **Pill padding is `--space-sm var(--space-md)` (8/12), not 10px/14px.** The
   space scale has no such rungs, and raw px fails `no-raw-style-values`.
4. **`--wz-well` → `--filter-well`.** Already in `index.css` and byte-identical,
   per the chassis PR's note. No `--wz-*` minted.
5. **`secondaryBtn` → the repo's `.btn-outline`.** Same face (1px
   `--color-border-strong`, `--radius-md`) and already the app's button voice, so
   this is a reuse rather than a fifth hand-rolled copy. It differs from the
   canvas in being uppercase and tracked, and filled with `--color-bg-surface`
   rather than `transparent` — that is the repo's, and it wins.
6. **My entry is LAST in `SETTINGS_SECTIONS`,** matching the design's own
   `SECTIONS` order where `account` is sixth of six — and so the danger zone
   (#2161) lands below this card as the issue requires.
7. **`settings.account.eyebrow` is repurposed** from "Signed in as" (orphaned
   when #2154 deleted `DefaultSettings.tsx`) to "Account", rather than minting a
   `settings.nav.account` twin holding the same word. Same collapse the catalog
   just spent five PRs on, and the same shape `settings.appearance.eyebrow`
   already has.

### One expected fan-out

`WireModel` marks default-carrying response fields **required** (#1400,
deliberately), so two new fields broke every hand-rolled `CurrentUser` literal in
the test tree. There is no shared factory for it, so this adds the two lines to
each: **18 test files, `.ds-kit/provider.tsx`, and
`.design-sync/previews/_fixtures.tsx`** — 2 lines apiece, no logic touched. I did
not introduce a factory; that is a refactor this PR should not be carrying.

## Verification

Every step in `.github/workflows/test.yml`, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 429 files, 7788 passed / 1 skipped |
| `npm run build` | ok |
| `npm run budget` | exit 0 — JS in the **pre-existing** WARN band (#2605); CSS ok. This section is lazy-loaded and not on the initial-load path |
| `regen_api_client.py` + `git diff --exit-code` | clean — both artifacts committed, script-produced |
| backend `pytest --cov --cov-fail-under=80` | 1589 passed, 94.40% coverage |

Backend ran against a dedicated `wz2155_test`, not the shared `worldzero_test`.

## ⚠️ Visual QA is outstanding

I have no browser tools and no dev stack in this worktree. Nothing below has been
looked at.

**What to eyeball**

- Desktop and mobile, **light and dark** — the card is `--faction-default-*` only;
  Settings is not a manifest surface.
- The **email pill on a narrow phone**: `overflowWrap: 'anywhere'` is meant to
  stop a long address blowing out the row. Check a genuinely long one.
- **Signed in with each provider** — Google, and the dev/demo bypass. And an
  account with **no** OAuth row: the whole provider row should be absent, not an
  empty pill.
- **With and without a character** — the header becomes "No character yet" and the
  management button becomes "Create one" pointing at `/characters/create`.
- The **avatar ring** with a real uploaded avatar and without one (the gradient
  fallback). Note the dev DB has no user media, so an avatar needs seeding.
- The **NavBar after the removal**: the signed-in bar should end at the character
  name / theme toggle with no gap, at every width — including the 768–1023px band
  that gets the bar and no rail.
- The **rail**: "Account" as the second item, and clicking it landing the card
  clear of the sticky NavBar.
