### PR TITLE
The contrast sweep's decisions move under src, and the spec becomes a driver

### DIFF
--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -1,8 +1,17 @@
 import { test, expect, type Page } from '@playwright/test'
 import { appendFileSync } from 'node:fs'
 
-import { baselineKey, triageFindings } from './contrastBaseline'
-import { scanPageForContrast, type Finding } from './contrastScan'
+import { scanPageForContrast, type Finding } from '../src/utils/contrastScan'
+import {
+  assessSweep,
+  routesFor,
+  SWEEP_FACTIONS,
+  SWEEP_THEMES,
+  SWEEP_VIEWPORTS,
+  type SweepFaction,
+  type SweepTheme,
+  type SweepViewport,
+} from '../src/utils/contrastSweep'
 
 /**
  * Part B of the contrast foundation (#651) — the RENDERED contrast sweep.
@@ -15,12 +24,17 @@ import { scanPageForContrast, type Finding } from './contrastScan'
  * rendered. #595 fixed one instance of it by hand; siblings survived. This
  * walks all of them.
  *
- * Coverage: 9 factions x 2 themes x 2 viewports. Both viewports because the
- * mobile archetypes are separate files and diverge (#565) — a desktop-only
- * sweep would report green over half the app.
+ * THIS FILE DECIDES NOTHING (#1780, Molly's ruling of 2026-08-18). It acquires
+ * pages and asserts; every judgement it used to hold — who is swept, which
+ * routes, what the unmeasurable ceiling is, what a failure report says, which
+ * failures may be written back into the baseline — now lives in
+ * `src/utils/contrastSweep.ts`, under the app's own build graph, where
+ * `tsc --noEmit`, `eslint src` and vitest reach it in a PR rather than a
+ * browser reaching it at 3am. Read that module before changing anything here.
  *
  * Nightly, not per-PR: `.github/workflows/e2e.yml` already stands up Postgres
- * + backend + seed + Playwright. No new CI job.
+ * + backend + seed + Playwright. No new CI job, and the browser run stays
+ * nightly-only and not-required — moving the logic out did not move the run.
  *
  * REGENERATING THE BASELINE. Set `CONTRAST_BASELINE_OUT=<path>` and run the
  * suite; every MEASURED failure is appended there as a ready-to-paste entry.
@@ -28,186 +42,16 @@ import { scanPageForContrast, type Finding } from './contrastScan'
  * within a week, which is the whole thesis of this issue. Unmeasurable
  * backdrops are NOT baseline entries (#1762), so nothing is emitted for them;
  * their ceiling comes off the report this prints on every run.
- *
- * The policy itself — which finding fails, which is reported, which allowlist
- * entry has gone stale — is `triageFindings` in contrastBaseline.ts, so that
- * `src/utils/__tests__/contrastTriage.test.ts` can exercise it in a PR without
- * a browser. This file drives the pages and prints; it decides nothing.
  */
 
 const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
 const BASELINE_OUT = process.env.CONTRAST_BASELINE_OUT
 
-/**
- * WHO IS SWEPT (#1903, closed by #1727). Nine slugs — every identity a
- * character can actually carry.
- *
- * `coven` and `na` were the gap. Coven is a registered faction with its own
- * CSS key and its own archetypes (CovenPraxisCard, CovenAvatar,
- * CovenBackdrop); `na` is the unaffiliated identity EVERY player starts in
- * (ADR-0030), reading the `--faction-default-*` set and the rainbow through
- * factionFill. Neither had ever been walked, so the most-worn skin in the app
- * was the one nothing measured. Narrowing what the sweep looks at while two
- * whole identities went unlooked-at would have been optimising the wrong axis.
- *
- * Both are in `CURRENT_ERA.factions`, so `/auth/dev-login?faction=` places a
- * character in either without a new seam. `na` has no faction page of its own
- * — `/factions/na` renders FactionDetail's not-found guard, which is a real
- * chrome surface and worth a look, just not the bespoke one the other eight
- * get.
- *
- * NEITHER HAS AN OBSERVED CEILING. They fall to the `default` row of
- * UNMEASURABLE_CEILING, which is a starting guess, not a measurement — the
- * first run that includes them is the measurement. If they blow it, the
- * failure message prints the whole population and says what to set.
- */
-const FACTIONS = [
-  'ua',
-  'everymen',
-  'wow',
-  'snide',
-  'ephemerists',
-  'singularity',
-  'albescent',
-  'coven',
-  'na',
-] as const
-const THEMES = ['light', 'dark'] as const
-const VIEWPORTS = {
-  // Matches useFormFactor's single 767px breakpoint (#494) — no tablet tier.
-  mobile: { width: 375, height: 812 },
-  desktop: { width: 1280, height: 800 },
-} as const
-
-type Theme = (typeof THEMES)[number]
-type Faction = (typeof FACTIONS)[number]
-type ViewportName = keyof typeof VIEWPORTS
-
-/**
- * Routes whose chrome is skinned by the viewer's faction. `/factions/${slug}`
- * is added per-faction — it is the faction's own bespoke surface.
- *
- * WHAT THIS LIST CANNOT REACH, and why it matters (#694). Every route here is
- * a READ surface reachable from a fresh login. The composer, the collab
- * waiting surface and the praxis detail page are not, because each needs a
- * praxis the bot owns; and some of the worst pairings in the app only exist in
- * a STATE rather than on a route. #694's was one: the collab roster renders
- * nothing below two members, and its filled row only appears once some — not
- * all — of them have cast. No route walk produces that, so a 1.05:1 pairing
- * sat on a faction surface without either guard seeing it.
- *
- * Adding routes is not the fix; the fix is a fixture that puts a praxis into
- * each interesting state before the scan. Until then the token test
- * (`src/utils/__tests__/factionContrast.test.ts`) carries these surfaces, which
- * is why its ROSTER_PAIRS block measures a pairing rather than a documented
- * role — read that block's header before assuming a token is covered here.
- *
- * #1819 IS THE SECOND ONE OF THESE, and it is worth recording what the missing
- * fixture would have to do, because "add the composer" understates it by a lot.
- * The two composer notices — the room CONNECTING and the document FROZEN — sat
- * at 2.01:1 on the Ephemerists plate, and neither is route-reachable:
- *   - FROZEN needs a praxis whose `status !== 'in_progress'`, so the fixture
- *     must create AND submit one, per faction, and the composer must still be
- *     reachable afterwards.
- *   - CONNECTING is `room.body !== null && !room.seeded` — a socket that has
- *     OPENED and not yet been seeded. Blocking the WebSocket does not produce
- *     it (that leaves `body` null and no notice at all); it needs
- *     `page.routeWebSocket` proxying the real server and swallowing the seed
- *     frame. That is a fixture with its own failure modes, and a flaky nightly
- *     is worse than a documented gap.
- * Both are guarded meanwhile at their MOUNT, DOM-lessly and in the PR, by
- * `src/pages/editPraxis/archetypes/__tests__/composerQuietInk.test.tsx` — which
- * asserts the notices carry no inline ink, so the seam the ratio would measure
- * is at least reachable. A ratio still needs this file.
- */
-const SHARED_ROUTES = ['/', '/tasks', '/praxis', '/leaderboard', '/factions']
-
-/**
- * The unmeasurable ratchet (#1675, owner ruling 2026-08-14).
- *
- * An unresolved backdrop used to FAIL. It cannot: the scanner is reporting that
- * it could not measure, not that it measured something bad, and "give every
- * gradient a solid backdrop" fights the faction skins the design system exists
- * to have. So an unmeasurable surface is now REPORTED instead — loudly, with a
- * count and a list, because a silent skip turns a red suite into a green one
- * that checks less.
- *
- * The ceiling is what stops that from being a hole. A NEW unmeasurable surface
- * is a regression in coverage even though it is not a contrast defect, so the
- * count may only ever go down.
- *
- * A SURFACE, NOT A FINDING (#1762). The unit is one distinct `backdropCss`,
- * however many text nodes sit on it. Counting findings made the ceiling churn
- * on every copy edit — add a line of body text to a card on the gilt wordmark
- * and the number moves — while the thing worth ratcheting, a NEW region of the
- * app going unchecked, is exactly one new surface. The report prints both, so
- * the node count is still visible; only the assertion is coarser.
- *
- * PROVENANCE (#1903). These are measured numbers, read off nightly run
- * 31931556465 (2026-08-16, `8153e246`), which prints the whole population per
- * test. That discharges the ponytail #1762 left here — it carried counts
- * guessed in a browserless worktree and said to correct them from the first
- * real run. Two real runs have now happened, and the guesses held exactly on
- * run 31869484266 (08-15): none of the 56 deleted `ratio: null` allowlist
- * entries moved a count, so the +4/+2 exposure it warned about never landed.
- *
- * WHY EVERY ROW WENT UP BY ONE on 08-16. The new surface is UA's three-stop
- * parchment ramp — `--faction-ua-card-parchment` on `UaTaskCard`'s article.
- * Neither that token nor the card changed; #1676 seeded a UA-faction task
- * (`ensure_duel_fixture_task`, dev-only, for the duel fixture) onto the board
- * the sweep walks, and a task card is skinned by the TASK's faction, not the
- * viewer's. So one seeded row put UA's paper stock on all seven runs at once:
- * 22 text nodes for the six non-UA viewers on both viewports, 44 desktop /
- * 37 mobile for a UA viewer, whose own feed and praxis chrome share the ramp
- * (`--faction-ua-parchment` computes byte-identical, so the report cannot tell
- * the two tokens apart — see #857's exception block).
- *
- * RAISED, NOT FLATTENED. The test's own message prefers a solid backdrop, and
- * that is the wrong trade here: the ramp is UA's paper stock, the archetype
- * itself, and "give every gradient a solid backdrop" is precisely the fight
- * the #1675 ruling declined to have. The cost is recorded rather than hidden —
- * 22 more text nodes per run now go unchecked, and `UaTaskCard`'s own header
- * already reasons about its darkest stop (2.93:1), so the token test carries
- * that pairing.
- *
- * THESE NUMBERS ARE NOW SLACK, DELIBERATELY (#1727). Every row above was
- * measured against a scanner that wrote off any fill with an opaque stop.
- * Banding resolves most of them, so the real counts are lower — probably much
- * lower — and the assertion is `<=`, so slack passes. It is not lowered here
- * because a ceiling set from arithmetic in a browserless worktree is the guess
- * #1762 already had to correct once. The next run prints the whole population
- * per test; lower each row to what it prints, then, and not before. Leaving it
- * slack for one night costs a night of ratchet; guessing it low costs a red
- * suite that says nothing about contrast.
- *
- * `coven` and `na` joined the roster in the same change and have no row of
- * their own, so they read `default` — the same guess, with the same
- * instruction.
- *
- * Lower one whenever a fix retires a surface. Raising one is a decision, not a
- * chore: it means a new fill is now hiding text from the sweep.
- */
-const UNMEASURABLE_CEILING: Record<string, Record<ViewportName, number>> = {
-  // WOW's title bars and UA's gilt wordmark are the two kits with extra fills.
-  wow: { desktop: 9, mobile: 8 },
-  ua: { desktop: 9, mobile: 6 },
-  default: { desktop: 8, mobile: 6 },
-}
-
-/** Which row of the table governs this faction — named, so the failure message can quote it. */
-function ceilingKeyFor(faction: Faction): string {
-  return faction in UNMEASURABLE_CEILING ? faction : 'default'
-}
-
-function ceilingFor(faction: Faction, viewport: ViewportName): number {
-  return UNMEASURABLE_CEILING[ceilingKeyFor(faction)][viewport]
-}
-
 // This spec opts out of the shared bot's saved cookie: it re-logs per faction
 // against its own dev account so it can't leave other specs' bot in Snide.
 test.use({ storageState: { cookies: [], origins: [] } })
 
-async function loginAs(page: Page, faction: Faction): Promise<void> {
+async function loginAs(page: Page, faction: SweepFaction): Promise<void> {
   const response = await page.request.post(
     `${API}/auth/dev-login?key=contrast&name=Contrast%20Bot&faction=${faction}`,
   )
@@ -215,7 +59,7 @@ async function loginAs(page: Page, faction: Faction): Promise<void> {
   expect((await response.json()).faction_slug).toBe(faction)
 }
 
-async function useTheme(page: Page, theme: Theme): Promise<void> {
+async function useTheme(page: Page, theme: SweepTheme): Promise<void> {
   // The theme is bootstrapped from localStorage in index.html before React
   // hydrates, so it must be seeded before the first navigation — not toggled
   // after, which would measure a repaint rather than the real first paint.
@@ -224,54 +68,17 @@ async function useTheme(page: Page, theme: Theme): Promise<void> {
   }, theme)
 }
 
-function describeFinding(finding: Finding): string {
-  const size = `${finding.fontSizePx}px/${finding.fontWeight}`
-  return `  ${finding.ratio.toFixed(2)}:1 (needs ${finding.required}:1) — ${finding.text} on ${finding.background}\n    ${finding.where} (${size}) "${finding.sample}"`
-}
-
-/**
- * One line per surface the scanner refused to measure: how many text nodes sit
- * on it, and one of them so a human can go and look. The CSS is the identity,
- * so it leads. Printing every finding instead repeated the same gradient 14-25
- * times per test, which is a report nobody reads.
- */
-function describeSurface(css: string, over: Finding[]): string {
-  const example = over[0]
-  return (
-    `  ${over.length} node(s) over ${css.slice(0, 120)}${css.length > 120 ? '…' : ''}\n` +
-    `    e.g. ${example.where} (${example.fontSizePx}px/${example.fontWeight}) "${example.sample}"`
-  )
-}
-
-/** Emit a ready-to-paste BASELINE entry when regenerating (see header). */
-function emitBaseline(finding: Finding, faction: Faction, theme: Theme, viewport: ViewportName): void {
-  // An unmeasurable backdrop has no ratio to record and is ratcheted by count,
-  // not allowlisted — emitting one would recreate the second mechanism #1762
-  // deleted. `triageFindings` only ever puts measured findings in `failures`;
-  // the guard is belt-and-braces for a hand-called regeneration.
-  if (!BASELINE_OUT || finding.background === null) return
-  const key = baselineKey(theme, finding.text, finding.background, finding.required)
-  const where = `${faction}/${theme}/${viewport} ${finding.where}`.replace(/'/g, '')
-  appendFileSync(
-    BASELINE_OUT,
-    `  ${JSON.stringify(key)}: { ratio: ${finding.ratio.toFixed(2)}, issue: 651, where: '${where}' },\n`,
-  )
-}
-
-for (const faction of FACTIONS) {
-  for (const theme of THEMES) {
-    for (const viewport of Object.keys(VIEWPORTS) as ViewportName[]) {
+for (const faction of SWEEP_FACTIONS) {
+  for (const theme of SWEEP_THEMES) {
+    for (const viewport of Object.keys(SWEEP_VIEWPORTS) as SweepViewport[]) {
       test(`${faction} · ${theme} · ${viewport} clears WCAG AA`, async ({ page }) => {
         test.setTimeout(120_000)
-        await page.setViewportSize(VIEWPORTS[viewport])
+        await page.setViewportSize(SWEEP_VIEWPORTS[viewport])
         await useTheme(page, theme)
         await loginAs(page, faction)
 
-        const combination = `${faction}/${theme}/${viewport}`
-        const routes = [...SHARED_ROUTES, `/factions/${faction}`]
         const findings: Finding[] = []
-
-        for (const route of routes) {
+        for (const route of routesFor(faction)) {
           await page.goto(route)
           // The skin depends on the viewer's faction, which arrives with
           // /auth/me — measuring before it lands would measure the default.
@@ -281,60 +88,18 @@ for (const faction of FACTIONS) {
           findings.push(...((await page.evaluate(scanPageForContrast)) as Finding[]))
         }
 
-        const { failures, stale, unmeasurable, resolvedFills } = triageFindings(theme, findings)
-        for (const finding of failures) emitBaseline(finding, faction, theme, viewport)
+        const verdict = assessSweep({ faction, theme, viewport }, findings)
+
+        if (BASELINE_OUT) appendFileSync(BASELINE_OUT, verdict.baselineEntries.join(''))
 
         // LOUD, always — including on a green run. The whole risk of the #1675
         // ruling is a suite that looks greener because it checks less, and the
         // only defence against that is printing what went unchecked every time.
-        const ceiling = ceilingFor(faction, viewport)
-        const uncheckedNodes = [...unmeasurable.values()].reduce((total, over) => total + over.length, 0)
-        console.log(
-          `\n[contrast] ${combination}: ${unmeasurable.size} unmeasurable surface(s) ` +
-            `(ceiling ${ceiling}), ${uncheckedNodes} text node(s) unchecked.\n` +
-            (unmeasurable.size
-              ? `${[...unmeasurable].map(([css, over]) => describeSurface(css, over)).join('\n')}\n`
-              : '  (none)\n'),
-        )
+        for (const report of verdict.reports) console.log(report)
 
-        // The other half of the same honesty (#1727). These fills used to be
-        // in the block above; they are now measured against their worst stop,
-        // so any pairing appearing here for the first time has its provenance
-        // printed next to it rather than arriving as a mystery failure.
-        console.log(
-          `[contrast] ${combination}: ${resolvedFills.size} fill(s) resolved by banding, ` +
-            `${[...resolvedFills.values()].reduce((total, over) => total + over.length, 0)} text node(s) ` +
-            `newly measured.\n` +
-            (resolvedFills.size
-              ? `${[...resolvedFills].map(([css, over]) => describeSurface(css, over)).join('\n')}\n`
-              : '  (none)\n'),
-        )
-
-        const describedFailures = [...new Set(failures.map(describeFinding))]
-        expect(
-          describedFailures,
-          `${combination}: text below WCAG AA.\n\n` + describedFailures.join('\n\n'),
-        ).toHaveLength(0)
-
-        // Gaining a surface is a coverage regression, not a contrast defect: a
-        // region of the app just stopped being checked at all. Losing one is
-        // progress, and only asks for the ceiling to come down.
-        expect(
-          unmeasurable.size,
-          `${combination}: ${unmeasurable.size} unmeasurable surfaces, up from ${ceiling}. ` +
-            `A new opaque-stop fill is now hiding text from the sweep — that is lost coverage, not a style bug.\n\n` +
-            `TO CORRECT THIS CEILING from this run: the surfaces printed above are the whole population, so ` +
-            `set '${ceilingKeyFor(faction)}'.${viewport} in UNMEASURABLE_CEILING ` +
-            `to ${unmeasurable.size} — but only after checking the new surface against the list above. ` +
-            `If it is one you can give a solid backdrop, do that instead; the ceiling only ever comes down.\n\n` +
-            [...unmeasurable.keys()].join('\n'),
-        ).toBeLessThanOrEqual(ceiling)
-
-        expect(
-          [...new Set(stale)],
-          `These pairs are in RENDERED_BASELINE but now clear AA — delete their entries in contrastBaseline.ts. ` +
-            `The list only ever shrinks.`,
-        ).toHaveLength(0)
+        expect(verdict.failures, verdict.failureMessage).toHaveLength(0)
+        expect(verdict.unmeasurableSurfaces, verdict.ceilingMessage).toBeLessThanOrEqual(verdict.ceiling)
+        expect(verdict.stale, verdict.staleMessage).toHaveLength(0)
       })
     }
   }

--- a/frontend/src/components/selectCard/__tests__/albescentRedactsAndUnlocksTogether.test.tsx
+++ b/frontend/src/components/selectCard/__tests__/albescentRedactsAndUnlocksTogether.test.tsx
@@ -65,7 +65,7 @@ describe("the Albescent tile redacts and locks on one answer (#2409)", () => {
     setAlbescentRevealed(false);
     const html = card();
     // Two halves of one exemption: the class paints the mark in the sheet's own
-    // colour, the attribute is what `e2e/contrastScan.ts` skips on. Split them
+    // colour, the attribute is what `src/utils/contrastScan.ts` skips on. Split them
     // and either the mark becomes legible or the nightly sweep goes red on a
     // 1.00:1 pairing that is never going to be fixed.
     expect(html).toContain('class="redacted"');

--- a/frontend/src/utils/__tests__/contrastSweep.test.ts
+++ b/frontend/src/utils/__tests__/contrastSweep.test.ts
@@ -12,6 +12,9 @@
  *
  * The seam is `assessSweep`: findings in, verdict out, no page, no Playwright.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import { assessSweep, routesFor, SWEEP_FACTIONS, SWEEP_VIEWPORTS } from "../contrastSweep";
@@ -118,6 +121,28 @@ describe("assessSweep", () => {
     );
     expect(verdict.baselineEntries[0]).toContain("ratio: 1.09");
     expect(verdict.baselineEntries[0]).toContain("snide/dark/desktop");
+  });
+
+  /**
+   * The invariant that let the scanner move out of `e2e/` at all (#1780), and
+   * the one an ordinary refactor would break silently. `page.evaluate` ships
+   * the function SOURCE, not its module graph, so an import added to
+   * `contrastScan.ts` compiles, typechecks, lints, and then throws inside the
+   * browser at 3am — the exact latency this issue exists to remove.
+   *
+   * Read off the file rather than the loaded module: an import that vitest has
+   * already resolved is invisible to `Function.prototype.toString`.
+   */
+  it("keeps the scanner importless, because page.evaluate ships no module graph", () => {
+    const scanner = readFileSync(
+      fileURLToPath(new URL("../contrastScan.ts", import.meta.url)),
+      "utf8",
+    );
+    // Strip block comments: the header talks ABOUT imports.
+    const code = scanner.replace(/\/\*[\s\S]*?\*\//g, "");
+
+    expect(code).not.toMatch(/^\s*import\s/m);
+    expect(code).not.toMatch(/\brequire\s*\(/);
   });
 
   it("sweeps every faction on its own detail route plus the shared ones", () => {

--- a/frontend/src/utils/__tests__/contrastSweep.test.ts
+++ b/frontend/src/utils/__tests__/contrastSweep.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Part E of the contrast foundation (#1780) — the sweep's per-run verdict.
+ *
+ * `triageFindings` (part D, `contrastTriage.test.ts`) decides what each
+ * FINDING is. This covers what a whole RUN is: which ceiling governs it, what
+ * the report says when nothing went unmeasured, and which failures are
+ * eligible to be written back into the baseline. Those decisions used to live
+ * in the body of `e2e/contrast.spec.ts`, where the only thing that could
+ * execute them was a nightly browser run — so a wrong ceiling row or a report
+ * that quietly went silent on a green run was discoverable the morning after
+ * merge and no sooner.
+ *
+ * The seam is `assessSweep`: findings in, verdict out, no page, no Playwright.
+ */
+import { describe, expect, it } from "vitest";
+
+import { assessSweep, routesFor, SWEEP_FACTIONS, SWEEP_VIEWPORTS } from "../contrastSweep";
+import type { Finding } from "../contrastScan";
+
+function finding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    text: "rgb(0, 0, 0)",
+    background: "rgb(255, 255, 255)",
+    unresolved: null,
+    unresolvedKind: null,
+    backdropCss: null,
+    backdropBase: null,
+    backdropOverlay: null,
+    ratio: 21,
+    required: 4.5,
+    fontSizePx: 16,
+    fontWeight: 400,
+    where: "div > div > span",
+    sample: "some copy",
+    ...overrides,
+  };
+}
+
+/** A pairing far below AA that is not in RENDERED_BASELINE, so it must fail. */
+function belowAA(overrides: Partial<Finding> = {}): Finding {
+  return finding({
+    text: "rgb(120, 120, 120)",
+    background: "rgb(130, 130, 130)",
+    ratio: 1.09,
+    ...overrides,
+  });
+}
+
+/** A fill the scanner refused to measure and banding cannot rescue (an image). */
+function unmeasurable(css: string): Finding {
+  return finding({
+    background: null,
+    ratio: 0,
+    unresolved: "div paints an image",
+    unresolvedKind: "other",
+    backdropCss: css,
+    backdropBase: null,
+    backdropOverlay: null,
+  });
+}
+
+const run = { faction: "snide", theme: "dark", viewport: "desktop" } as const;
+
+describe("assessSweep", () => {
+  it("fails a measured pairing below AA, and reports each distinct one once", () => {
+    const verdict = assessSweep(run, [belowAA(), belowAA(), belowAA({ where: "div > p" })]);
+
+    // Two distinct descriptions from three findings: the duplicate collapses,
+    // the one at a different DOM path does not.
+    expect(verdict.failures).toHaveLength(2);
+    expect(verdict.failureMessage).toContain("snide/dark/desktop");
+    expect(verdict.failureMessage).toContain("1.09:1");
+  });
+
+  it("is loud about unmeasured surfaces even when there are none", () => {
+    const verdict = assessSweep(run, [finding()]);
+
+    // The whole risk of the #1675 ruling is a suite that looks greener because
+    // it checks less. A silent green run is that failure mode.
+    expect(verdict.reports.join("\n")).toContain("0 unmeasurable surface(s)");
+    expect(verdict.reports.join("\n")).toContain("(none)");
+    expect(verdict.unmeasurableSurfaces).toBe(0);
+  });
+
+  it("counts one unmeasurable SURFACE per distinct CSS, not per text node", () => {
+    const gilt = "linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6))";
+    const verdict = assessSweep(run, [
+      unmeasurable(gilt),
+      unmeasurable(gilt),
+      unmeasurable("url(paper.png)"),
+    ]);
+
+    expect(verdict.unmeasurableSurfaces).toBe(2);
+    expect(verdict.reports.join("\n")).toContain("2 unmeasurable surface(s)");
+    expect(verdict.reports.join("\n")).toContain("3 text node(s) unchecked");
+  });
+
+  it("governs each faction by its own ceiling row, or by 'default'", () => {
+    const wow = assessSweep({ faction: "wow", theme: "dark", viewport: "desktop" }, []);
+    const coven = assessSweep({ faction: "coven", theme: "dark", viewport: "desktop" }, []);
+    const covenMobile = assessSweep({ faction: "coven", theme: "dark", viewport: "mobile" }, []);
+
+    expect(wow.ceiling).toBe(9);
+    expect(coven.ceiling).toBe(8);
+    expect(covenMobile.ceiling).toBe(6);
+    // The message must name the row to edit, or a run that blows the ceiling
+    // sends whoever reads it to the wrong line.
+    expect(coven.ceilingMessage).toContain("'default'.desktop");
+    expect(wow.ceilingMessage).toContain("'wow'.desktop");
+  });
+
+  it("emits a baseline entry for a measured failure and never for an unmeasurable one", () => {
+    const verdict = assessSweep(run, [belowAA(), unmeasurable("linear-gradient(red, blue)")]);
+
+    expect(verdict.baselineEntries).toHaveLength(1);
+    expect(verdict.baselineEntries[0]).toContain(
+      '"dark | rgb(120, 120, 120) on rgb(130, 130, 130) @4.5"',
+    );
+    expect(verdict.baselineEntries[0]).toContain("ratio: 1.09");
+    expect(verdict.baselineEntries[0]).toContain("snide/dark/desktop");
+  });
+
+  it("sweeps every faction on its own detail route plus the shared ones", () => {
+    for (const faction of SWEEP_FACTIONS) {
+      expect(routesFor(faction)).toContain(`/factions/${faction}`);
+      expect(routesFor(faction)).toContain("/leaderboard");
+    }
+    // Both viewports, because the mobile archetypes are separate files (#565).
+    expect(Object.keys(SWEEP_VIEWPORTS).sort()).toEqual(["desktop", "mobile"]);
+  });
+});

--- a/frontend/src/utils/__tests__/contrastTriage.test.ts
+++ b/frontend/src/utils/__tests__/contrastTriage.test.ts
@@ -16,8 +16,8 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { RENDERED_BASELINE, baselineKey, resolveFillBand, triageFindings } from "../../../e2e/contrastBaseline";
-import type { Finding } from "../../../e2e/contrastScan";
+import { RENDERED_BASELINE, baselineKey, resolveFillBand, triageFindings } from "../contrastBaseline";
+import type { Finding } from "../contrastScan";
 
 function finding(overrides: Partial<Finding> = {}): Finding {
   return {

--- a/frontend/src/utils/contrastBaseline.ts
+++ b/frontend/src/utils/contrastBaseline.ts
@@ -38,7 +38,7 @@ import {
   parseColor,
   relativeLuminance,
   type Rgba,
-} from '../src/utils/contrast';
+} from './contrast';
 import type { Finding } from './contrastScan';
 
 export type BaselineEntry = {
@@ -63,14 +63,19 @@ export function baselineKey(theme: string, text: string, background: string, req
 }
 
 /**
- * THE LIST. 185 entries, machine-produced by the sweep itself
+ * THE LIST. Machine-produced by the sweep itself
  * (`CONTRAST_BASELINE_OUT=<path> bash frontend/e2e/run-e2e.sh contrast.spec.ts`),
- * never hand-typed — 185 hand-copied ratios would be wrong within a week,
- * which is this issue's whole thesis.
+ * never hand-typed — hand-copied ratios would be wrong within a week, which is
+ * this issue's whole thesis.
  *
- *   - 7 entries owned by #649 (white `--color-text-on-accent` on a faction
- *     fill). That issue's acceptance, measured as rendered.
- *   - the rest await triage into children off #651.
+ * NO COUNT IS WRITTEN HERE, deliberately (#1780). This header once claimed 269
+ * entries while the object held 241, and nothing could notice. A count is
+ * `Object.keys(RENDERED_BASELINE).length`, and the only honest place to say it
+ * is code that derives it.
+ *
+ * Entries owned by #649 (white `--color-text-on-accent` on a faction fill) are
+ * that issue's acceptance, measured as rendered; the rest await triage into
+ * children off #651. Which is which is the `issue` field, not a tally.
  */
 export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
   "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @3": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
@@ -290,7 +295,7 @@ export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
  * `src/utils/__tests__/contrastTriage.test.ts` for exactly that reason.
  *
  * PURE, AND NODE-SIDE, ON PURPOSE (#1762, #1780). The scanner runs inside
- * `page.evaluate`, which nothing typechecks and no PR exercises. So the
+ * `page.evaluate`, which no PR ever exercises. So the
  * scanner reports facts — the fill's CSS, the background-color under it, the
  * translucent stack over it — and every DECISION lives here, in milliseconds,
  * with no browser.
@@ -354,7 +359,7 @@ function stopsOf(layer: string): Rgba[] | null {
 
 /**
  * Source-over where the BACKDROP may itself be translucent — `compositeOver`
- * in `src/utils/contrast.ts` assumes an opaque ground and hard-codes `a: 1`,
+ * in `./contrast` assumes an opaque ground and hard-codes `a: 1`,
  * which is right for its callers and wrong halfway up a stack of fills.
  */
 function sourceOver(fore: Rgba, back: Rgba): Rgba {

--- a/frontend/src/utils/contrastScan.ts
+++ b/frontend/src/utils/contrastScan.ts
@@ -1,12 +1,18 @@
 /**
  * The in-page half of the rendered contrast sweep (#651).
  *
- * This module is serialized into the browser by `contrast.spec.ts` — it may
- * not import anything (Playwright's `page.evaluate` ships the function source,
- * not its module graph), so the WCAG math it needs is inlined inside
- * `scanPageForContrast`. `src/utils/contrast.ts` remains the source of truth
- * for the node-side math; the duplication here is a constraint of the evaluate
+ * This module is serialized into the browser by `e2e/contrast.spec.ts` — it
+ * may not import anything (Playwright's `page.evaluate` ships the function
+ * source, not its module graph), so the WCAG math it needs is inlined inside
+ * `scanPageForContrast`. `./contrast` remains the source of truth for the
+ * node-side math; the duplication here is a constraint of the evaluate
  * boundary, not a second opinion.
+ *
+ * IT LIVES UNDER `src` (#1780), not under `e2e`, because it imports nothing —
+ * least of all `@playwright/test`. That import is the line between a module
+ * and a spec, and everything on this side of it is reached by `tsc --noEmit`
+ * and by vitest at PR time rather than by a browser at 3am. Nothing in the
+ * shipped bundle imports this file; only the spec and the tests do.
  */
 
 /** One measured text node. `background: null` means "could not resolve to a solid". */
@@ -102,8 +108,9 @@ export type Finding = {
  * and a real test suite, so it is NOT in this file. `resolveFillBand` in
  * `contrastBaseline.ts` does it node-side, from `backdropCss` / `backdropBase`
  * / `backdropOverlay` below. This module gained three reported facts and no
- * new judgement — deliberately, because nothing typechecks the inside of a
- * `page.evaluate` payload (#1780) and no PR runs it.
+ * new judgement — deliberately, because no PR ever RUNS the inside of a
+ * `page.evaluate` payload (#1780). It is typechecked, and since the move it is
+ * lint-covered too, but only the nightly browser executes it.
  */
 export function scanPageForContrast(): Finding[] {
   type Rgba = { r: number; g: number; b: number; a: number };

--- a/frontend/src/utils/contrastSweep.ts
+++ b/frontend/src/utils/contrastSweep.ts
@@ -1,0 +1,319 @@
+/**
+ * Part E of the contrast foundation (#1780) — what one RUN of the rendered
+ * sweep means.
+ *
+ * `contrastScan.ts` reports facts. `contrastBaseline.ts` decides what each
+ * finding is. This decides what a whole `faction · theme · viewport` run is:
+ * which pages it walks, which unmeasurable ceiling governs it, what it prints
+ * on a green run, and which of its failures may be written back into the
+ * baseline.
+ *
+ * IT IS HERE RATHER THAN IN THE SPEC because a decision that only a nightly
+ * browser can execute is a decision nothing checks before merge. Molly's
+ * ruling, 2026-08-18: *"move `e2e/`'s logic into plain modules under the app's
+ * build graph, keep the spec as a thin Playwright driver, so the contrast
+ * scanner becomes reachable from PR-time CI."* `e2e/contrast.spec.ts` now
+ * acquires pages, hands the pixels to `assessSweep`, and asserts what comes
+ * back — it holds no policy of its own.
+ *
+ * NOTHING HERE IMPORTS `@playwright/test`, and nothing here may. That import
+ * is the line between a module and a spec; on this side of it `tsc --noEmit`,
+ * `eslint src` and vitest all reach the code, and `contrastSweep.test.ts`
+ * exercises it in milliseconds with no browser.
+ *
+ * Not in scope, and unchanged: the Playwright RUN. It is nightly-only on
+ * purpose (`e2e.yml`'s own header) and is not a required check. What became
+ * PR-reachable is the deciding, not the browsing.
+ */
+
+import { baselineKey, triageFindings } from './contrastBaseline';
+import type { Finding } from './contrastScan';
+
+/**
+ * WHO IS SWEPT (#1903, closed by #1727). Nine slugs — every identity a
+ * character can actually carry.
+ *
+ * `coven` and `na` were the gap. Coven is a registered faction with its own
+ * CSS key and its own archetypes (CovenPraxisCard, CovenAvatar,
+ * CovenBackdrop); `na` is the unaffiliated identity EVERY player starts in
+ * (ADR-0030), reading the `--faction-default-*` set and the rainbow through
+ * factionFill. Neither had ever been walked, so the most-worn skin in the app
+ * was the one nothing measured. Narrowing what the sweep looks at while two
+ * whole identities went unlooked-at would have been optimising the wrong axis.
+ *
+ * Both are in `CURRENT_ERA.factions`, so `/auth/dev-login?faction=` places a
+ * character in either without a new seam. `na` has no faction page of its own
+ * — `/factions/na` renders FactionDetail's not-found guard, which is a real
+ * chrome surface and worth a look, just not the bespoke one the other eight
+ * get.
+ *
+ * NEITHER HAS AN OBSERVED CEILING. They fall to the `default` row of
+ * UNMEASURABLE_CEILING, which is a starting guess, not a measurement — the
+ * first run that includes them is the measurement. If they blow it, the
+ * failure message prints the whole population and says what to set.
+ */
+export const SWEEP_FACTIONS = [
+  'ua',
+  'everymen',
+  'wow',
+  'snide',
+  'ephemerists',
+  'singularity',
+  'albescent',
+  'coven',
+  'na',
+] as const;
+
+export const SWEEP_THEMES = ['light', 'dark'] as const;
+
+export const SWEEP_VIEWPORTS = {
+  // Matches useFormFactor's single 767px breakpoint (#494) — no tablet tier.
+  mobile: { width: 375, height: 812 },
+  desktop: { width: 1280, height: 800 },
+} as const;
+
+export type SweepFaction = (typeof SWEEP_FACTIONS)[number];
+export type SweepTheme = (typeof SWEEP_THEMES)[number];
+export type SweepViewport = keyof typeof SWEEP_VIEWPORTS;
+
+/** One cell of the 9 × 2 × 2 matrix. */
+export type SweepRun = {
+  faction: SweepFaction;
+  theme: SweepTheme;
+  viewport: SweepViewport;
+};
+
+/**
+ * Routes whose chrome is skinned by the viewer's faction. `/factions/${slug}`
+ * is added per-faction by {@link routesFor} — it is the faction's own bespoke
+ * surface.
+ *
+ * WHAT THIS LIST CANNOT REACH, and why it matters (#694). Every route here is
+ * a READ surface reachable from a fresh login. The composer, the collab
+ * waiting surface and the praxis detail page are not, because each needs a
+ * praxis the bot owns; and some of the worst pairings in the app only exist in
+ * a STATE rather than on a route. #694's was one: the collab roster renders
+ * nothing below two members, and its filled row only appears once some — not
+ * all — of them have cast. No route walk produces that, so a 1.05:1 pairing
+ * sat on a faction surface without either guard seeing it.
+ *
+ * Adding routes is not the fix; the fix is a fixture that puts a praxis into
+ * each interesting state before the scan. Until then the token test
+ * (`src/utils/__tests__/factionContrast.test.ts`) carries these surfaces, which
+ * is why its ROSTER_PAIRS block measures a pairing rather than a documented
+ * role — read that block's header before assuming a token is covered here.
+ *
+ * #1819 IS THE SECOND ONE OF THESE, and it is worth recording what the missing
+ * fixture would have to do, because "add the composer" understates it by a lot.
+ * The two composer notices — the room CONNECTING and the document FROZEN — sat
+ * at 2.01:1 on the Ephemerists plate, and neither is route-reachable:
+ *   - FROZEN needs a praxis whose `status !== 'in_progress'`, so the fixture
+ *     must create AND submit one, per faction, and the composer must still be
+ *     reachable afterwards.
+ *   - CONNECTING is `room.body !== null && !room.seeded` — a socket that has
+ *     OPENED and not yet been seeded. Blocking the WebSocket does not produce
+ *     it (that leaves `body` null and no notice at all); it needs
+ *     `page.routeWebSocket` proxying the real server and swallowing the seed
+ *     frame. That is a fixture with its own failure modes, and a flaky nightly
+ *     is worse than a documented gap.
+ * Both are guarded meanwhile at their MOUNT, DOM-lessly and in the PR, by
+ * `src/pages/editPraxis/archetypes/__tests__/composerQuietInk.test.tsx` — which
+ * asserts the notices carry no inline ink, so the seam the ratio would measure
+ * is at least reachable. A ratio still needs the nightly spec.
+ */
+const SHARED_ROUTES = ['/', '/tasks', '/praxis', '/leaderboard', '/factions'];
+
+/** Every page one run walks: the shared chrome, then the faction's own page. */
+export function routesFor(faction: SweepFaction): string[] {
+  return [...SHARED_ROUTES, `/factions/${faction}`];
+}
+
+/**
+ * The unmeasurable ratchet (#1675, owner ruling 2026-08-14).
+ *
+ * An unresolved backdrop used to FAIL. It cannot: the scanner is reporting that
+ * it could not measure, not that it measured something bad, and "give every
+ * gradient a solid backdrop" fights the faction skins the design system exists
+ * to have. So an unmeasurable surface is now REPORTED instead — loudly, with a
+ * count and a list, because a silent skip turns a red suite into a green one
+ * that checks less.
+ *
+ * The ceiling is what stops that from being a hole. A NEW unmeasurable surface
+ * is a regression in coverage even though it is not a contrast defect, so the
+ * count may only ever go down.
+ *
+ * A SURFACE, NOT A FINDING (#1762). The unit is one distinct `backdropCss`,
+ * however many text nodes sit on it. Counting findings made the ceiling churn
+ * on every copy edit — add a line of body text to a card on the gilt wordmark
+ * and the number moves — while the thing worth ratcheting, a NEW region of the
+ * app going unchecked, is exactly one new surface. The report prints both, so
+ * the node count is still visible; only the assertion is coarser.
+ *
+ * PROVENANCE (#1903). These are measured numbers, read off nightly run
+ * 31931556465 (2026-08-16, `8153e246`), which prints the whole population per
+ * test. That discharges the ponytail #1762 left here — it carried counts
+ * guessed in a browserless worktree and said to correct them from the first
+ * real run. Two real runs have now happened, and the guesses held exactly on
+ * run 31869484266 (08-15): none of the 56 deleted `ratio: null` allowlist
+ * entries moved a count, so the +4/+2 exposure it warned about never landed.
+ *
+ * WHY EVERY ROW WENT UP BY ONE on 08-16. The new surface is UA's three-stop
+ * parchment ramp — `--faction-ua-card-parchment` on `UaTaskCard`'s article.
+ * Neither that token nor the card changed; #1676 seeded a UA-faction task
+ * (`ensure_duel_fixture_task`, dev-only, for the duel fixture) onto the board
+ * the sweep walks, and a task card is skinned by the TASK's faction, not the
+ * viewer's. So one seeded row put UA's paper stock on all seven runs at once:
+ * 22 text nodes for the six non-UA viewers on both viewports, 44 desktop /
+ * 37 mobile for a UA viewer, whose own feed and praxis chrome share the ramp
+ * (`--faction-ua-parchment` computes byte-identical, so the report cannot tell
+ * the two tokens apart — see #857's exception block).
+ *
+ * RAISED, NOT FLATTENED. The test's own message prefers a solid backdrop, and
+ * that is the wrong trade here: the ramp is UA's paper stock, the archetype
+ * itself, and "give every gradient a solid backdrop" is precisely the fight
+ * the #1675 ruling declined to have. The cost is recorded rather than hidden —
+ * 22 more text nodes per run now go unchecked, and `UaTaskCard`'s own header
+ * already reasons about its darkest stop (2.93:1), so the token test carries
+ * that pairing.
+ *
+ * THESE NUMBERS ARE NOW SLACK, DELIBERATELY (#1727). Every row above was
+ * measured against a scanner that wrote off any fill with an opaque stop.
+ * Banding resolves most of them, so the real counts are lower — probably much
+ * lower — and the assertion is `<=`, so slack passes. It is not lowered here
+ * because a ceiling set from arithmetic in a browserless worktree is the guess
+ * #1762 already had to correct once. The next run prints the whole population
+ * per test; lower each row to what it prints, then, and not before. Leaving it
+ * slack for one night costs a night of ratchet; guessing it low costs a red
+ * suite that says nothing about contrast.
+ *
+ * `coven` and `na` joined the roster in the same change and have no row of
+ * their own, so they read `default` — the same guess, with the same
+ * instruction.
+ *
+ * Lower one whenever a fix retires a surface. Raising one is a decision, not a
+ * chore: it means a new fill is now hiding text from the sweep.
+ */
+const UNMEASURABLE_CEILING: Record<string, Record<SweepViewport, number>> = {
+  // WOW's title bars and UA's gilt wordmark are the two kits with extra fills.
+  wow: { desktop: 9, mobile: 8 },
+  ua: { desktop: 9, mobile: 6 },
+  default: { desktop: 8, mobile: 6 },
+};
+
+/** Which row of the table governs this faction — named, so a failure can quote it. */
+function ceilingKeyFor(faction: SweepFaction): string {
+  return faction in UNMEASURABLE_CEILING ? faction : 'default';
+}
+
+function describeFinding(finding: Finding): string {
+  const size = `${finding.fontSizePx}px/${finding.fontWeight}`;
+  return `  ${finding.ratio.toFixed(2)}:1 (needs ${finding.required}:1) — ${finding.text} on ${finding.background}\n    ${finding.where} (${size}) "${finding.sample}"`;
+}
+
+/**
+ * One line per surface the scanner refused to measure: how many text nodes sit
+ * on it, and one of them so a human can go and look. The CSS is the identity,
+ * so it leads. Printing every finding instead repeated the same gradient 14-25
+ * times per test, which is a report nobody reads.
+ */
+function describeSurface(css: string, over: Finding[]): string {
+  const example = over[0];
+  return (
+    `  ${over.length} node(s) over ${css.slice(0, 120)}${css.length > 120 ? '…' : ''}\n` +
+    `    e.g. ${example.where} (${example.fontSizePx}px/${example.fontWeight}) "${example.sample}"`
+  );
+}
+
+function describeSurfaces(surfaces: Map<string, Finding[]>): string {
+  if (surfaces.size === 0) return '  (none)\n';
+  return `${[...surfaces].map(([css, over]) => describeSurface(css, over)).join('\n')}\n`;
+}
+
+function nodesIn(surfaces: Map<string, Finding[]>): number {
+  return [...surfaces.values()].reduce((total, over) => total + over.length, 0);
+}
+
+/** Everything one run of the sweep concluded. The spec asserts on it and prints it. */
+export type SweepVerdict = {
+  /** Distinct AA failures, already deduped and human-described. Must be empty. */
+  failures: string[];
+  failureMessage: string;
+  /** Distinct surfaces the scanner and the banding both gave up on. */
+  unmeasurableSurfaces: number;
+  ceiling: number;
+  ceilingMessage: string;
+  /** Allowlisted pairs that now pass — the list only shrinks, so these fail too. */
+  stale: string[];
+  staleMessage: string;
+  /** Printed on EVERY run, green included — see below. */
+  reports: string[];
+  /** Ready-to-paste `RENDERED_BASELINE` lines, when regenerating the list. */
+  baselineEntries: string[];
+};
+
+/**
+ * Turn one run's findings into a verdict.
+ *
+ * The two report blocks are built unconditionally, and that is load-bearing
+ * rather than tidy: the whole risk of the #1675 ruling is a suite that looks
+ * greener because it checks less, and the only defence against it is printing
+ * what went unchecked every time, including on a green run.
+ */
+export function assessSweep(run: SweepRun, findings: readonly Finding[]): SweepVerdict {
+  const combination = `${run.faction}/${run.theme}/${run.viewport}`;
+  const { failures, stale, unmeasurable, resolvedFills } = triageFindings(run.theme, findings);
+
+  const ceilingKey = ceilingKeyFor(run.faction);
+  const ceiling = UNMEASURABLE_CEILING[ceilingKey][run.viewport];
+
+  const described = [...new Set(failures.map(describeFinding))];
+
+  return {
+    failures: described,
+    failureMessage: `${combination}: text below WCAG AA.\n\n${described.join('\n\n')}`,
+
+    unmeasurableSurfaces: unmeasurable.size,
+    ceiling,
+    // Gaining a surface is a coverage regression, not a contrast defect: a
+    // region of the app just stopped being checked at all. Losing one is
+    // progress, and only asks for the ceiling to come down.
+    ceilingMessage:
+      `${combination}: ${unmeasurable.size} unmeasurable surfaces, up from ${ceiling}. ` +
+      `A new opaque-stop fill is now hiding text from the sweep — that is lost coverage, not a style bug.\n\n` +
+      `TO CORRECT THIS CEILING from this run: the surfaces printed above are the whole population, so ` +
+      `set '${ceilingKey}'.${run.viewport} in UNMEASURABLE_CEILING in src/utils/contrastSweep.ts ` +
+      `to ${unmeasurable.size} — but only after checking the new surface against the list above. ` +
+      `If it is one you can give a solid backdrop, do that instead; the ceiling only ever comes down.\n\n` +
+      [...unmeasurable.keys()].join('\n'),
+
+    stale: [...new Set(stale)],
+    staleMessage:
+      `These pairs are in RENDERED_BASELINE but now clear AA — delete their entries in ` +
+      `src/utils/contrastBaseline.ts. The list only ever shrinks.`,
+
+    reports: [
+      `\n[contrast] ${combination}: ${unmeasurable.size} unmeasurable surface(s) ` +
+        `(ceiling ${ceiling}), ${nodesIn(unmeasurable)} text node(s) unchecked.\n` +
+        describeSurfaces(unmeasurable),
+      // The other half of the same honesty (#1727). These fills used to be in
+      // the block above; they are now measured against their worst stop, so
+      // any pairing appearing here for the first time has its provenance
+      // printed next to it rather than arriving as a mystery failure.
+      `[contrast] ${combination}: ${resolvedFills.size} fill(s) resolved by banding, ` +
+        `${nodesIn(resolvedFills)} text node(s) newly measured.\n` +
+        describeSurfaces(resolvedFills),
+    ],
+
+    // An unmeasurable backdrop has no ratio to record and is ratcheted by
+    // count, not allowlisted — emitting one would recreate the second
+    // mechanism #1762 deleted. `triageFindings` only ever puts measured
+    // findings in `failures`; the guard is belt-and-braces.
+    baselineEntries: failures
+      .filter((finding): finding is Finding & { background: string } => finding.background !== null)
+      .map((finding) => {
+        const key = baselineKey(run.theme, finding.text, finding.background, finding.required);
+        const where = `${combination} ${finding.where}`.replace(/'/g, '');
+        return `  ${JSON.stringify(key)}: { ratio: ${finding.ratio.toFixed(2)}, issue: 651, where: '${where}' },\n`;
+      }),
+  };
+}

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,14 +1,23 @@
 // Typecheck for the Playwright suite (issue #1780).
 //
-// `tsconfig.json` is `include: ["src"]`, so nothing in CI has ever looked at
-// `frontend/e2e/`. That matters because the suite is not all thin driver:
-// `contrastScan.ts`, `contrastBaseline.ts` and `triageFindings` hold real
+// `tsconfig.json` is `include: ["src"]`, so nothing in CI had ever looked at
+// `frontend/e2e/`. That mattered because the suite was not all thin driver:
+// `contrastScan.ts`, `contrastBaseline.ts` and `triageFindings` held real
 // decisions, and #1762 changed `BaselineEntry.ratio` across two of them with
 // no check able to catch getting it wrong.
 //
+// THOSE THREE HAVE SINCE MOVED under `src/utils/` (the second half of #1780,
+// Molly's ruling of 2026-08-18), so `tsconfig.json` covers them directly now
+// and vitest executes their decisions in a PR. What is left under `e2e/` is
+// driver: page acquisition, fixtures, assertions. This config is what keeps
+// THAT typechecked — a thin driver is still code, and `duel.helpers.ts` and
+// the collaboration spec are neither thin nor small.
+//
 // A separate config rather than widening `tsconfig.json`'s `include`: the
 // specs import `@playwright/test`, and the app's own build graph must not
-// reach a test-runner package. Same reasoning, and the same shape, as
+// reach a test-runner package. That import is the line between a module and a
+// spec, and it is the reason the moved files could move at all — none of them
+// imports it. Same reasoning, and the same shape, as
 // `tsconfig.design-sync.json`.
 //
 // Wired into CI by being chained onto the `typecheck` npm script, which the
@@ -19,9 +28,9 @@
 // nightly-only on purpose (see `e2e.yml`'s header). Only the compiler runs here.
 {
   "extends": "./tsconfig.json",
-  // `e2e` only. Files under `src` still arrive — the contrast modules import
-  // `src/utils/contrast` — but they arrive as dependencies of the specs,
-  // checked with the same options `npm run typecheck` already applies to them.
+  // `e2e` only. Files under `src` still arrive — the specs import the contrast
+  // modules — but they arrive as dependencies, checked with the same options
+  // `npm run typecheck` already applies to them.
   "include": ["e2e"],
   // `tsconfig.json` references `tsconfig.node.json`, which is `composite` and
   // owns `vite.config.ts`. Nothing under `e2e` needs it, and inheriting the


### PR DESCRIPTION
Closes #1780

Molly's ruling of 2026-08-18, recorded on #1674:

> *"move `e2e/`'s logic into plain modules under the app's build graph, keep the spec as a thin Playwright driver, so the contrast scanner becomes reachable from PR-time CI and the typecheck gap closes as a side effect. The Playwright browser run stays nightly-only, unchanged."*

## The seam

**The `@playwright/test` import is the line between a module and a spec.** Everything that does not need it is now under `src/`, where `tsc --noEmit`, `eslint src` and vitest already reach it. Everything that does need it stayed in `e2e/` and now decides nothing.

The failing test was written at that seam first: `src/utils/__tests__/contrastSweep.test.ts` imports `assessSweep` from a module that did not exist, because those decisions were inlined in the body of a `for` loop inside a Playwright spec — a file vitest cannot import at all. Red on "there is nowhere to call this from", which is the defect.

## What moved

| Before | After |
|---|---|
| `e2e/contrastScan.ts` | `src/utils/contrastScan.ts` |
| `e2e/contrastBaseline.ts` | `src/utils/contrastBaseline.ts` |
| decisions inlined in `e2e/contrast.spec.ts` | `src/utils/contrastSweep.ts` (new) |

**Why `src/utils/`:** `contrastBaseline.ts` already imported `src/utils/contrast.ts` for its colour math, so the boring home is next to it — no new directory, no new tsconfig, no new npm script, no workflow edit.

`contrast.spec.ts` goes 341 lines → 103. What is left is: log in, set the viewport and theme, `goto`, `page.evaluate(scanPageForContrast)`, `assessSweep(...)`, assert. It holds no policy.

## Which decisions became PR-reachable

Already reachable before this PR (via #1762, through a `src` test importing backwards into `e2e/`): `triageFindings`, `resolveFillBand`, `measureOverFill`, `baselineKey`, `RENDERED_BASELINE`. This PR reverses that import direction so `src` no longer reaches into `e2e/` — nothing about their coverage changed.

**Newly reachable, all of it previously executable only by the nightly browser:**

- **Which unmeasurable ceiling governs a run** — `UNMEASURABLE_CEILING`, and the fall-through to the `default` row that `coven` and `na` take. A wrong row was previously discoverable the morning after merge.
- **That the report is printed on a GREEN run too.** This is the whole defence against the #1675 ruling turning a red suite into a green one that checks less, and it had no test.
- **One unmeasurable SURFACE per distinct `backdropCss`, not per text node** (#1762's coarsening) — asserted end-to-end through `assessSweep` now, not just inside `triageFindings`.
- **What the failure messages say**, including that the ceiling message names the row to edit. A message that sends a reader to the wrong line is a real defect in a ratchet nobody looks at except when it fires.
- **Which failures may be written back into the baseline** — the `background !== null` guard that stops an unmeasurable surface from being allowlisted, recreating the second mechanism #1762 deleted.
- **The importless invariant on the scanner** (new guard). `page.evaluate` ships the function *source*, not its module graph, so an import added to `contrastScan.ts` compiles, typechecks, lints, and *then* throws in the browser at 3am. Asserted off the file on disk, and proved non-vacuous: planting `import { parseColor } from './contrast'` turns it red.

## The nightly is unchanged

`.github/workflows/**` is untouched — no file under it is in this diff. The Playwright **run** is still nightly-only via `e2e.yml`, still **not a required check**, and putting it on the PR-blocking path remains explicitly out of scope. What moved into PR CI is the deciding, not the browsing. `npx playwright test --list contrast.spec.ts` still enumerates the same **36** tests (9 factions × 2 themes × 2 viewports), so the matrix is byte-for-byte the coverage it was.

The `tsconfig.e2e.json` half from #2306 is **not** redone; its header is updated, because the justification it recorded ("`contrastScan.ts`, `contrastBaseline.ts` and `triageFindings` hold real decisions") stopped being true of `e2e/` in this diff. It still earns its place: `duel.helpers.ts` and `collaboration.spec.ts` are neither thin nor small.

## The counted comment

`RENDERED_BASELINE`'s header claimed a hand-typed entry count, and that number has rotted before (269 claimed against 241 held). It is **dropped**, not re-typed — the header now says a count is `Object.keys(RENDERED_BASELINE).length` and that the only honest place to say it is code that derives it. No number introduced anywhere in this diff is hand-maintained.

## What this does NOT claim

**A seed change is still a coverage change** (#1674's standing hazard). Moving a module boundary does nothing about it, and nothing here should be read as if it did — `UNMEASURABLE_CEILING`'s own header still records the run where one seeded UA task moved every row by one.

Nothing here touches #2450 / #2452 / #2453, the current nightly failures. The scanner is now callable at PR time; **it is not yet wired to a rendered page at PR time** — that would need a DOM the vitest harness does not have, and it is a separate decision, not something to slip in under a refactor.

## Verification

Every step `.github/workflows/test.yml` names for the `frontend` job, run locally:

- `eslint src .ds-kit e2e` — exit 0. The moved files now get the full `src/**` rule set (i18n literal rule, the five local style rules, `sonarjs/no-identical-functions`) instead of the axios-import ban alone, and pass it without an exemption or a glob widened.
- `tsc --noEmit` — clean. `tsc -p tsconfig.e2e.json --noEmit` — clean.
- `tsc -p tsconfig.design-sync.json --noEmit` — clean.
- `vitest run` — **431 files, 7831 passed, 1 skipped, 0 failed.**
- `vite build` — clean. Neither moved module appears in `dist/` (nothing in the app imports them; only the spec and the tests do).
- `bundle-budget` — exit 0. JS unchanged at 129.0 KB. The CSS **WARN** at 22.2 KB is pre-existing and unrelated: this PR contains no CSS.
- `npx playwright test --list contrast.spec.ts` — 36 tests, same matrix.

`api-schema` is not implicated: no route, `response_model` or Pydantic schema is touched.

**Visual QA is outstanding and this PR cannot do it** — no browser tools, no dev stack here. It should not need any: no component, no route, no stylesheet and no user-visible string is in this diff.

## What to eyeball

1. **`src/utils/contrastSweep.ts` is the file that matters.** Everything in it was lifted verbatim out of `contrast.spec.ts` — the ceiling table and its long provenance header, the two `console.log` report blocks, `describeFinding` / `describeSurface`, `emitBaseline`'s body. Read it against `git show main:frontend/e2e/contrast.spec.ts` and confirm nothing was quietly reworded, and in particular that **no ceiling number moved**.
2. **Three stale path references I deliberately did not fix**, because they are outside a frontend-feature agent's file scope. All three say `e2e/contrastScan.ts` or `e2e/contrastBaseline.ts` and now point at nothing:
   - `frontend/src/index.css` lines ~7443 and ~7445 (owned by `frontend-style`)
   - `docs/adr/0082-albescent-is-redacted-not-hidden.md` lines 170 and 172 (outside `frontend/`)

   They are comments only — no behaviour depends on them — but they are exactly the rot this issue is about, so they want a follow-up rather than silence.
3. **Is `src/utils/` the right home?** It is the boringest one that `tsc` and vitest already reach and it sits beside `contrast.ts`, which `contrastBaseline.ts` already imported. If you would rather have `src/utils/contrast/` as a folder, that is a rename and nothing else.
4. **The importless guard's blast radius.** It forbids `import` in `contrastScan.ts` forever. That is the actual constraint of `page.evaluate`, but it is now enforced rather than documented, so a future change that wants shared helpers in the scanner will have to argue with a red test — which is the intent.
5. **`assessSweep` returns messages as strings and the spec passes them to `expect(...)`.** If you would rather the spec built its own failure prose, say so; I put it in the module because "what a failure says" was one of the decisions the ruling names, and a message nobody can unit-test is a message that goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
