### PR TITLE
The task browse and the praxis feed stop refetching a view you just left (#2432)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,7 @@ import createClient, {
 } from 'openapi-fetch'
 
 import { ApiError, ApiNetworkError } from './apiError'
+import { dropCachesAfterWrite } from '../hooks/cachedResource'
 import type { paths } from './generated/schema'
 import { returnToLandingIfSessionExpired } from './sessionRedirect'
 
@@ -98,6 +99,7 @@ type SettledResult = { data?: unknown; error?: unknown; response: Response }
  */
 function throwOnFailure<Method extends HttpMethod>(
   call: (url: never, init?: never) => Promise<SettledResult>,
+  mutates = false,
 ): ThrowingMethod<Method> {
   return (async (url: never, init?: never) => {
     let settled: SettledResult
@@ -111,12 +113,24 @@ function throwOnFailure<Method extends HttpMethod>(
     if (!settled.response.ok) {
       throw new ApiError(settled.response, settled.error)
     }
+    // A WRITE INVALIDATES THE CACHED LISTS (#2432, ADR-0072). Signing up for a
+    // task, publishing a praxis and archiving one all move a row in the task
+    // browse or the praxis feed, and a five-minute stale read of your own
+    // action reads as a bug rather than as a cache.
+    //
+    // Here rather than in each mutating api function because every one of them
+    // already passes through this seam, so a route added later cannot forget
+    // it. Only a SUCCEEDING write drops — a rejected one threw above and
+    // changed nothing. It over-invalidates on purpose: a vote does not change
+    // which tasks exist, and one extra refetch is cheaper than an enumeration
+    // that rots.
+    if (mutates) dropCachesAfterWrite()
     return { data: settled.data, response: settled.response }
   }) as ThrowingMethod<Method>
 }
 
 export const apiGet = throwOnFailure<'get'>(client.GET)
-export const apiPost = throwOnFailure<'post'>(client.POST)
-export const apiPut = throwOnFailure<'put'>(client.PUT)
-export const apiPatch = throwOnFailure<'patch'>(client.PATCH)
-export const apiDelete = throwOnFailure<'delete'>(client.DELETE)
+export const apiPost = throwOnFailure<'post'>(client.POST, true)
+export const apiPut = throwOnFailure<'put'>(client.PUT, true)
+export const apiPatch = throwOnFailure<'patch'>(client.PATCH, true)
+export const apiDelete = throwOnFailure<'delete'>(client.DELETE, true)

--- a/frontend/src/hooks/__tests__/pagedResourceCache.test.ts
+++ b/frontend/src/hooks/__tests__/pagedResourceCache.test.ts
@@ -209,6 +209,30 @@ describe('a write invalidates — no five-minute wait on your own action', () =>
     await loadPage(fetchPage, 50, 50, ['standard'], cached)
     expect(fetchPage).toHaveBeenCalledTimes(2)
   })
+
+  it('a read in flight when the write lands does not file its pre-write rows', async () => {
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch())
+    const cached: PagedCache<string> = { cache, viewer: VIEWER }
+    let release: (rows: string[]) => void = () => {}
+    const fetchPage = vi.fn(
+      () => new Promise<string[]>((resolve) => { release = resolve }),
+    )
+
+    // A slow board read goes out under some filter...
+    const inFlight = loadPage(fetchPage, 50, 50, ['standard'], cached)
+    // ...and the player signs up for a row still on screen before it lands.
+    dropCachesAfterWrite()
+    release(['task-still-claimable'])
+    await inFlight
+
+    // The pre-write answer must NOT have become the cache entry. Unlike the era
+    // rollover this drop does not advance the epoch, so the guard has to be the
+    // cache's own generation.
+    const afterWrite = loadPage(fetchPage, 50, 50, ['standard'], cached)
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+    release(['task-now-claimed'])
+    expect(await afterWrite).toEqual(['task-now-claimed'])
+  })
 })
 
 describe('createKeyedResourceCache — the mechanics the singleton cache does not cover', () => {

--- a/frontend/src/hooks/__tests__/pagedResourceCache.test.ts
+++ b/frontend/src/hooks/__tests__/pagedResourceCache.test.ts
@@ -1,0 +1,258 @@
+/**
+ * #2432 — Class B's first consumers: the task browse and the praxis feed read
+ * through a keyed, TTL'd cache instead of a bare fetch per filter change.
+ *
+ * SEAM: `loadPage` — the pure first-page-only cache decision `usePagedResource`
+ * makes inside its `useResource` closure — over `createKeyedResourceCache`. The
+ * repo has no DOM harness (SPEC-testing.md), so the acceptance test the issue
+ * names ("toggle a faction off, toggle it back on, and the second read is a
+ * cache hit with no network request") is driven here by counting fetch
+ * invocations across a params round trip, not in a Network panel.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createCacheEpoch } from '../../utils/cacheEpoch'
+import {
+  AMBIENT_TTL_MS,
+  createKeyedResourceCache,
+  dropCachesAfterWrite,
+} from '../cachedResource'
+import {
+  DEFAULT_PAGE_SIZE,
+  loadPage,
+  pageCacheKey,
+  viewerCacheKey,
+  type PagedCache,
+} from '../usePagedResource'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** A viewer id shaped like `viewerCacheKey` builds them. */
+const VIEWER = '7:12'
+
+function harness(): {
+  fetchPage: ReturnType<typeof vi.fn>
+  cached: PagedCache<string>
+  read: (deps: unknown[], limit?: number) => Promise<string[]>
+} {
+  const fetchPage = vi.fn((limit: number) => Promise.resolve([`rows-${limit}`]))
+  const cached: PagedCache<string> = {
+    cache: createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch()),
+    viewer: VIEWER,
+  }
+  return {
+    fetchPage,
+    cached,
+    read: (deps, limit = DEFAULT_PAGE_SIZE) =>
+      loadPage(fetchPage, limit, DEFAULT_PAGE_SIZE, deps, cached),
+  }
+}
+
+describe('the acceptance test: a filter round trip is one request, not two', () => {
+  it('toggling a faction off and back on serves the second read from cache', async () => {
+    const { fetchPage, read } = harness()
+
+    // The board as it opens.
+    await read(['standard', 'level', 'All', '', false, '', false])
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+
+    // Toggle a faction on — a filter combination never seen, so a real request.
+    await read(['standard', 'level', 'All', 'coven', false, '', false])
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+
+    // Clear it again. THIS is the reported symptom ("clearing factions also has
+    // a delay"): the same query as the opening read, so no request at all.
+    await read(['standard', 'level', 'All', '', false, '', false])
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+
+    // ...and back to the faction view, also free.
+    await read(['standard', 'level', 'All', 'coven', false, '', false])
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  it('keys on EVERY axis that rides in the URL, not just the factions', async () => {
+    const { fetchPage, read } = harness()
+    const base = ['standard', 'level', 'All', '', false, '', false]
+
+    await read(base)
+    // One axis moved per read: type, sort, status, eligibility, search.
+    await read(['metatask', 'level', 'All', '', false, '', false])
+    await read(['standard', 'newest', 'All', '', false, '', false])
+    await read(['standard', 'level', 'active', '', false, '', false])
+    await read(['standard', 'level', 'All', '', true, '', false])
+    await read(['standard', 'level', 'All', '', false, 'bread', false])
+    expect(fetchPage).toHaveBeenCalledTimes(6)
+
+    // Every one of them is a hit on the way back.
+    await read(base)
+    expect(fetchPage).toHaveBeenCalledTimes(6)
+  })
+})
+
+describe('loadPage — first page only', () => {
+  it('caches the first page and refetches every grown window', async () => {
+    const { fetchPage, read } = harness()
+    const deps = ['standard']
+
+    await read(deps)
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+
+    // "Load more" — a wider window is never cached (#2432, the named ceiling).
+    await read(deps, DEFAULT_PAGE_SIZE * 2)
+    await read(deps, DEFAULT_PAGE_SIZE * 2)
+    expect(fetchPage).toHaveBeenCalledTimes(3)
+
+    // ...and the first page it grew out of is still held.
+    await read(deps)
+    expect(fetchPage).toHaveBeenCalledTimes(3)
+  })
+
+  it('an uncached caller (no PagedCache) is exactly the old bare fetch', async () => {
+    const fetchPage = vi.fn((limit: number) => Promise.resolve([`rows-${limit}`]))
+    await loadPage(fetchPage, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE, ['standard'], undefined)
+    await loadPage(fetchPage, DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE, ['standard'], undefined)
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('the rows are viewer-relative', () => {
+  it('two viewers on the same query never share an entry', async () => {
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch())
+    const fetchPage = vi.fn(() => Promise.resolve(['eligible-for-me']))
+    const deps = ['standard', 'level', 'All', '', true, '', false]
+
+    await loadPage(fetchPage, 50, 50, deps, { cache, viewer: '7:12' })
+    await loadPage(fetchPage, 50, 50, deps, { cache, viewer: '9:31' })
+    // `can_sign_up` / `signup_reason` / `allowed_modes` are computed for the
+    // authenticated caller — serving one viewer's row to another is the
+    // correctness failure, not a stale number.
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  it('viewerCacheKey separates anonymous, account and carried character', () => {
+    expect(viewerCacheKey(null)).toBe('anon')
+    const user = { account_id: 7, character: { id: 12 } }
+    // Two characters on one account see different eligibility.
+    expect(viewerCacheKey(user as never)).not.toBe(
+      viewerCacheKey({ account_id: 7, character: { id: 13 } } as never),
+    )
+    // ...and an account carrying no life is neither of them, nor anonymous.
+    const lifeless = viewerCacheKey({ account_id: 7, character: null } as never)
+    expect(lifeless).not.toBe(viewerCacheKey(user as never))
+    expect(lifeless).not.toBe('anon')
+  })
+
+  it('pageCacheKey cannot collide across an axis boundary', () => {
+    // Two dep lists whose naive concatenation would be the same string.
+    expect(pageCacheKey(VIEWER, ['a', 'bc'])).not.toBe(pageCacheKey(VIEWER, ['ab', 'c']))
+  })
+})
+
+describe('the era epoch outranks the TTL', () => {
+  it('an era rollover drops every held page, mid-window', async () => {
+    const epoch = createCacheEpoch()
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, epoch)
+    const fetchPage = vi.fn(() => Promise.resolve(['task']))
+
+    epoch.noteEraStamp('Era One')
+    await loadPage(fetchPage, 50, 50, ['standard'], { cache, viewer: VIEWER })
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+
+    // The era rolls over: the board retires, scores reset. A five-minute bound
+    // would have shown tasks from a world that no longer exists.
+    epoch.noteEraStamp('Era Two')
+    await loadPage(fetchPage, 50, 50, ['standard'], { cache, viewer: VIEWER })
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  it('a request in flight when the era rolls is not written back in behind the drop', async () => {
+    const epoch = createCacheEpoch()
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, epoch)
+    let release: (rows: string[]) => void = () => {}
+    const fetchPage = vi.fn(
+      () => new Promise<string[]>((resolve) => { release = resolve }),
+    )
+
+    epoch.noteEraStamp('Era One')
+    const inFlight = loadPage(fetchPage, 50, 50, ['standard'], { cache, viewer: VIEWER })
+    epoch.noteEraStamp('Era Two')
+    release(['old-era-task'])
+    await inFlight
+
+    // The pre-drop answer must not have become the post-drop cache entry: the
+    // next read issues a fresh request rather than being served the old world.
+    const afterRollover = loadPage(fetchPage, 50, 50, ['standard'], {
+      cache,
+      viewer: VIEWER,
+    })
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+    release(['new-era-task'])
+    expect(await afterRollover).toEqual(['new-era-task'])
+  })
+})
+
+describe('a write invalidates — no five-minute wait on your own action', () => {
+  it('dropCachesAfterWrite empties every keyed cache', async () => {
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch())
+    const fetchPage = vi.fn(() => Promise.resolve(['task']))
+    const cached: PagedCache<string> = { cache, viewer: VIEWER }
+
+    await loadPage(fetchPage, 50, 50, ['standard'], cached)
+    await loadPage(fetchPage, 50, 50, ['standard'], cached)
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+
+    // Signing up for a task posts a praxis: `in_progress_count` moves and, with
+    // the eligibility filter on, the row leaves the list (gate 5, #2264).
+    dropCachesAfterWrite()
+
+    await loadPage(fetchPage, 50, 50, ['standard'], cached)
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('createKeyedResourceCache — the mechanics the singleton cache does not cover', () => {
+  it('dedupes concurrent readers of ONE key into one request', async () => {
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch())
+    const fetchPage = vi.fn(() => Promise.resolve(['task']))
+
+    await Promise.all([
+      cache.read('k', fetchPage),
+      cache.read('k', fetchPage),
+      cache.read('k', fetchPage),
+    ])
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('goes stale at the ambient bound', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-24T12:00:00Z'))
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch())
+    const fetchPage = vi.fn(() => Promise.resolve(['task']))
+
+    await cache.read('k', fetchPage)
+    vi.setSystemTime(Date.now() + AMBIENT_TTL_MS - 1)
+    await cache.read('k', fetchPage)
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(Date.now() + 1)
+    await cache.read('k', fetchPage)
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  it('RETHROWS a failure and caches nothing — the page still shows its error', async () => {
+    const cache = createKeyedResourceCache<string[]>(AMBIENT_TTL_MS, createCacheEpoch())
+    let attempt = 0
+    const fetchPage = vi.fn(() => {
+      attempt += 1
+      return attempt === 1 ? Promise.reject(new Error('offline')) : Promise.resolve(['task'])
+    })
+
+    // Unlike the Class A singleton, which resolves null and keeps the last good
+    // value: `useResource` owns this page's error state, and swallowing here
+    // would render a failed read as an empty board.
+    await expect(cache.read('k', fetchPage)).rejects.toThrow('offline')
+    expect(await cache.read('k', fetchPage)).toEqual(['task'])
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/hooks/cachedResource.ts
+++ b/frontend/src/hooks/cachedResource.ts
@@ -271,8 +271,19 @@ export function createKeyedResourceCache<T>(
 ): KeyedResourceCache<T> {
   const entries = new Map<string, CacheEntry<T>>()
   const inFlight = new Map<string, Promise<T>>()
+  // Advanced by EVERY drop, not just the epoch's. `epoch.version()` alone is
+  // not enough here: `dropCachesAfterWrite` empties these maps directly and
+  // deliberately does not touch the epoch, because bumping it would also evict
+  // the deploy-scoped Class A caches on every mutation. Without a local
+  // generation, a GET already in the air when a write landed would resolve,
+  // still believe it was current, and file its PRE-write rows in the cache it
+  // was just evicted from -- serving the row you just claimed as claimable for
+  // the rest of the TTL, which is the exact failure the invalidation exists to
+  // prevent.
+  let generation = 0
 
   const drop = (): void => {
+    generation += 1
     entries.clear()
     inFlight.clear()
   }
@@ -289,11 +300,15 @@ export function createKeyedResourceCache<T>(
       const existing = inFlight.get(key)
       if (existing !== undefined) return existing
 
-      // Stamped at issue time: an answer describing the era we were in when the
-      // request went out must not be written back in behind a drop that landed
-      // while it was in the air (mirrors `createResourceCache`).
+      // Stamped at issue time: an answer describing the world we were in when
+      // the request went out must not be written back in behind a drop that
+      // landed while it was in the air (mirrors `createResourceCache`). Both
+      // stamps are read -- the epoch for an era rollover, the local generation
+      // for a write.
       const issuedAtVersion = epoch.version()
-      const isCurrent = (): boolean => epoch.version() === issuedAtVersion
+      const issuedAtGeneration = generation
+      const isCurrent = (): boolean =>
+        epoch.version() === issuedAtVersion && generation === issuedAtGeneration
       const promise = fetchFn().then(
         (value) => {
           if (isCurrent()) {

--- a/frontend/src/hooks/cachedResource.ts
+++ b/frontend/src/hooks/cachedResource.ts
@@ -19,9 +19,12 @@ import { CACHE_EPOCH, type CacheEpoch } from '../utils/cacheEpoch'
  *  - **A — deploy-scoped.** `/game-config`, `/factions`. {@link SESSION_TTL_MS}.
  *    Not "a long TTL": the data cannot go stale within a session at all, because
  *    changing it takes a deploy.
- *  - **B — social / ambient.** Leaderboard, another player's profile, the global
- *    activity feed. {@link AMBIENT_TTL_MS}. A minute-old ranking harms nobody.
- *    Nothing in this class is cached yet; the bound is here for when it is.
+ *  - **B — social / ambient.** The task browse, the praxis feed, leaderboards,
+ *    another player's profile. {@link AMBIENT_TTL_MS}, and a KEY per query —
+ *    see {@link createKeyedResourceCache}, which is what a filtered list needs
+ *    that a Class A singleton does not. A minute-old ranking harms nobody; a
+ *    minute-old list of your own just-completed action does, so a write empties
+ *    them ({@link dropCachesAfterWrite}).
  *  - **C — obligations.** Pending collab invites, duel challenges, awaiting
  *    submission, and any number the viewer just moved. **These do not belong in
  *    this module at all.** A live Accept button beside an already-answered
@@ -56,10 +59,15 @@ export const SESSION_TTL_MS = Number.POSITIVE_INFINITY
 /**
  * **Class B — social / ambient. Five minutes.**
  *
- * Rankings, other players' profiles, the global feed. What breaks if the bound
- * is exceeded: a number is a few minutes old. Who notices: nobody — none of it
- * is a control the viewer is about to act on, and none of it is a claim about
- * the viewer's own obligations.
+ * Rankings, other players' profiles, the global feed, and since #2432 the task
+ * browse and the praxis feed. What breaks if the bound is exceeded: a number is
+ * a few minutes old. Who notices: nobody — none of it is a claim about the
+ * viewer's own obligations.
+ *
+ * The task browse does carry a Sign up button, which ADR-0072's Class C note
+ * warns about. What answers that is not a shorter bound but the invalidation:
+ * every write empties these caches ({@link dropCachesAfterWrite}), so the only
+ * rows that can age are ones nobody in this tab has acted on.
  *
  * Five is the smallest number that keeps ordinary browsing at zero requests: a
  * player crossing /tasks → /players → a profile → /praxes does it in well under
@@ -194,5 +202,114 @@ export function createCachedResource<T>(
     }, [])
 
     return value
+  }
+}
+
+/**
+ * Every keyed cache built below, so a WRITE can empty them all in one call.
+ *
+ * Class B lists are the only caches a mutation invalidates: Class A is
+ * deploy-scoped (a write cannot change `/game-config`) and Class C never enters
+ * this module at all. Registration is automatic rather than a list some future
+ * third consumer has to remember to join.
+ */
+const writeSensitiveCaches = new Set<() => void>()
+
+/**
+ * Empty every keyed list cache — call after any mutating request.
+ *
+ * A five-minute stale read of your OWN action reads as a bug, not a cache
+ * (ADR-0072), and signing up for a task, publishing a praxis or archiving one
+ * each move a row in these lists. So the invalidation is explicit, not a TTL
+ * wait — `utils/requestsBus` is the precedent for wiring one.
+ *
+ * Called from `api/client.ts`, the one seam every POST/PUT/PATCH/DELETE in the
+ * app already passes through, so a mutation added later cannot forget it. It
+ * over-invalidates on purpose: a vote does not change which tasks exist, and
+ * paying one refetch for that is cheaper than an enumeration that rots.
+ */
+export function dropCachesAfterWrite(): void {
+  for (const drop of writeSensitiveCaches) drop()
+}
+
+/**
+ * A cache holding MANY entries under caller-supplied keys — the Class B shape.
+ *
+ * {@link createResourceCache} holds one value because a Class A endpoint takes
+ * no arguments. A list read does: the task browse and the praxis feed are one
+ * endpoint under a dozen filter combinations, and the win only exists if a
+ * combination you have already seen is a hit (#2432). Hence a key, rather than
+ * a second singleton per filter set.
+ */
+export interface KeyedResourceCache<T> {
+  /**
+   * The entry held under `key` if it is still fresh, else `fetchFn()`.
+   * Concurrent readers of one key share a single in-flight request.
+   *
+   * A rejection PROPAGATES, unlike the singleton's swallow-and-keep: the caller
+   * is `useResource`, which owns the page's error state, and a resolved-null
+   * failure would paint an empty list where an error belongs.
+   */
+  read: (key: string, fetchFn: () => Promise<T>) => Promise<T>
+  /** Forget every key. The epoch and {@link dropCachesAfterWrite} call this. */
+  drop: () => void
+}
+
+/**
+ * Build a keyed cache. `ttlMs` has no default for the reason the singleton
+ * gives: naming the class is the point (ADR-0072).
+ *
+ * ponytail: entries are never individually evicted — the map is emptied whole,
+ * by the epoch or by a write, and is bounded in practice by how many filter
+ * combinations one person visits inside a five-minute window (tens of small
+ * arrays). If a caller ever keys on something unbounded — a per-row id, a
+ * keystroke — the upgrade is an LRU bound here, not a second cache.
+ */
+export function createKeyedResourceCache<T>(
+  ttlMs: number,
+  epoch: CacheEpoch = CACHE_EPOCH,
+): KeyedResourceCache<T> {
+  const entries = new Map<string, CacheEntry<T>>()
+  const inFlight = new Map<string, Promise<T>>()
+
+  const drop = (): void => {
+    entries.clear()
+    inFlight.clear()
+  }
+  epoch.register(drop)
+  writeSensitiveCaches.add(drop)
+
+  return {
+    drop,
+    read: (key, fetchFn) => {
+      const entry = entries.get(key) ?? null
+      if (entry !== null && isFresh(entry, Date.now(), ttlMs)) {
+        return Promise.resolve(entry.value)
+      }
+      const existing = inFlight.get(key)
+      if (existing !== undefined) return existing
+
+      // Stamped at issue time: an answer describing the era we were in when the
+      // request went out must not be written back in behind a drop that landed
+      // while it was in the air (mirrors `createResourceCache`).
+      const issuedAtVersion = epoch.version()
+      const isCurrent = (): boolean => epoch.version() === issuedAtVersion
+      const promise = fetchFn().then(
+        (value) => {
+          if (isCurrent()) {
+            inFlight.delete(key)
+            entries.set(key, { value, fetchedAt: Date.now() })
+          }
+          return value
+        },
+        (cause: unknown) => {
+          // Nothing is cached, and the key is released so the next read retries.
+          if (isCurrent()) inFlight.delete(key)
+          throw cause
+        },
+      )
+      inFlight.set(key, promise)
+      return promise
+    },
   }
 }

--- a/frontend/src/hooks/usePagedResource.ts
+++ b/frontend/src/hooks/usePagedResource.ts
@@ -1,5 +1,8 @@
-import { useState, type DependencyList } from 'react'
+import { useEffect, useState, type DependencyList } from 'react'
 import { useResource } from './useResource'
+import type { KeyedResourceCache } from './cachedResource'
+import { CACHE_EPOCH } from '../utils/cacheEpoch'
+import type { CurrentUser } from '../api/auth'
 
 /** Default page size — one "load more" grows the window by this step. */
 export const DEFAULT_PAGE_SIZE = 50
@@ -18,6 +21,83 @@ export function pageHasMore(pageLength: number | null | undefined, limit: number
 /** Grow the window by one page. Pure, extracted alongside {@link pageHasMore}. */
 export function growLimit(current: number, pageSize: number): number {
   return current + pageSize
+}
+
+/**
+ * Opt one paged list into the Class B cache (#2432, ADR-0072).
+ *
+ * The cache is the caller's, built once at module scope beside its own hook, so
+ * the two lists cannot serve each other's rows; the KEY is built here, from the
+ * dep list the caller already passes plus the viewer, so it cannot drift out of
+ * step with what triggers a refetch.
+ */
+export interface PagedCache<T> {
+  /** `createKeyedResourceCache<T[]>(AMBIENT_TTL_MS)` at the caller's module scope. */
+  cache: KeyedResourceCache<T[]>
+  /**
+   * Who is asking — {@link viewerCacheKey}. These rows are VIEWER-RELATIVE
+   * (`TaskOut.can_sign_up`, `signup_reason`, `allowed_modes` and
+   * `eligible_for_current_user` are all computed for the authenticated caller),
+   * so a key without the viewer would serve one player's eligibility to
+   * another after a sign-in. Correctness, not tidiness.
+   */
+  viewer: string
+}
+
+/**
+ * The viewer half of a page key.
+ *
+ * `account_id` alone is not enough: one account can carry more than one life
+ * and eligibility is the CHARACTER's. Anonymous is its own key rather than a
+ * missing one — `/tasks` is public, and a stranger's board (all rows, no
+ * eligibility) is a real answer worth caching.
+ *
+ * Stays in memory, never in a URL or a request — the "don't expose account_id"
+ * rule is about what leaves the client.
+ */
+export function viewerCacheKey(user: CurrentUser | null): string {
+  if (user === null) return 'anon'
+  return `${user.account_id}:${user.character?.id ?? '-'}`
+}
+
+/**
+ * The full cache key: the viewer, then every axis the caller re-fetches on.
+ *
+ * `JSON.stringify` rather than a joined separator: one axis is a free-text
+ * search box, so any separator a player could type is a real collision —
+ * `['a','bc']` and `['ab','c']` must not be one key. Every dep is a string,
+ * boolean or number (arrays travel as a joined key already), so the encoding is
+ * total and stable.
+ */
+export function pageCacheKey(viewer: string, deps: DependencyList): string {
+  return JSON.stringify([viewer, ...deps])
+}
+
+/**
+ * One page read, cached or not — the decision `usePagedResource` makes inside
+ * its fetch closure, extracted so the round trip is provable without a DOM.
+ *
+ * **First page only.** A grown window ("load more") always refetches. Caching
+ * every page of a deep scroll is a memory question nobody has asked, and the
+ * first page is where the repeat views are: a filter toggle collapses the
+ * window back to one page (`resetWindow`), so the reported symptom — leaving a
+ * view and coming back — is entirely a first-page event.
+ *
+ * ponytail: the ceiling is that a player who loads three pages, filters, and
+ * comes back pays for pages 2 and 3 again. The upgrade path is to key on the
+ * limit as well (`[...deps, limit]`), which is one line here and a bounded-map
+ * question in `createKeyedResourceCache` — do it if a real list ever gets deep
+ * enough for anyone to notice.
+ */
+export function loadPage<T>(
+  fetchPage: (limit: number) => Promise<T[]>,
+  limit: number,
+  pageSize: number,
+  deps: DependencyList,
+  cached: PagedCache<T> | undefined,
+): Promise<T[]> {
+  if (cached === undefined || limit !== pageSize) return fetchPage(limit)
+  return cached.cache.read(pageCacheKey(cached.viewer, deps), () => fetchPage(limit))
 }
 
 export interface PagedResource<T> {
@@ -46,6 +126,11 @@ export interface PagedResource<T> {
  * appended automatically). Callers wrap their filter setters with
  * `resetWindow()` so narrowing the feed collapses the window (see `usePraxes`).
  *
+ * Pass `cached` to opt the FIRST page into the Class B cache (#2432, ADR-0072)
+ * — this is the seam, not the call sites, so both list pages inherit one
+ * policy. See {@link PagedCache} for what the key carries and {@link loadPage}
+ * for why page 2 is not cached.
+ *
  * Deliberately a growing window, not offset accumulation: growing is what the
  * praxis feed proved, needs no total count, and none of the current lists are
  * large enough to feel the refetch. Offset accumulation is the named upgrade
@@ -55,10 +140,24 @@ export function usePagedResource<T>(
   fetchPage: (limit: number) => Promise<T[]>,
   deps: DependencyList,
   pageSize: number = DEFAULT_PAGE_SIZE,
+  cached?: PagedCache<T>,
 ): PagedResource<T> {
   const [limit, setLimit] = useState(pageSize)
 
-  const { data, loading, error } = useResource(() => fetchPage(limit), [...deps, limit])
+  const { data, loading, error, refetch } = useResource(
+    () => loadPage(fetchPage, limit, pageSize, deps, cached),
+    [...deps, limit],
+  )
+
+  // The epoch outranks the TTL (ADR-0072), so a cached list re-reads the moment
+  // an era rollover empties the cache — the same `onDrop` subscription the
+  // Class A hooks take, and for the same reason: without it whatever is on
+  // screen sits there showing the retired world until the next navigation.
+  const isCached = cached !== undefined
+  useEffect(
+    () => (isCached ? CACHE_EPOCH.onDrop(refetch) : undefined),
+    [isCached, refetch],
+  )
 
   return {
     data,

--- a/frontend/src/pages/praxes/usePraxes.ts
+++ b/frontend/src/pages/praxes/usePraxes.ts
@@ -24,7 +24,8 @@ import { listPraxes, type PraxisCardOut } from '../../api/praxis'
 import type { FactionOut } from '../../api/factions'
 import { useAuth } from '../../auth/AuthContext'
 import { useFactions } from '../../hooks/useFactions'
-import { usePagedResource } from '../../hooks/usePagedResource'
+import { usePagedResource, viewerCacheKey } from '../../hooks/usePagedResource'
+import { AMBIENT_TTL_MS, createKeyedResourceCache } from '../../hooks/cachedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useSearchQueryParam } from '../../hooks/useSearchQueryParam'
 import {
@@ -48,6 +49,18 @@ import {
 
 /** How many rows a page fetches; "load more" grows the window by this step. */
 const PAGE_LIMIT = 50
+
+/**
+ * The feed's first page, per filter combination, for five minutes (#2432) —
+ * **Class B** (ADR-0072), alongside the task browse.
+ *
+ * Keyed on the viewer as well as the filters: `voted` is answered against the
+ * caller's own votes, so a key without the viewer would show one player's
+ * "already voted" set to another after a sign-in. Emptied by an era rollover
+ * and by any write — voting is a write, so a card's counts cannot age behind
+ * your own tap.
+ */
+const PRAXIS_PAGE_CACHE = createKeyedResourceCache<PraxisCardOut[]>(AMBIENT_TTL_MS)
 
 export type { PraxisFeedFilters, VotedFilter, SortOrder, EraScope } from './feedFilterParams'
 
@@ -103,7 +116,7 @@ export interface PraxesFeedState {
 export function usePraxes(): PraxesFeedState {
   // App-wide cached, one request per page load across all five consumers (#1284).
   const factions: FactionOut[] = useFactions() ?? []
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
   const [query, setQueryState] = useSearchQueryParam()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -132,6 +145,14 @@ export function usePraxes(): PraxesFeedState {
       }),
     [taskId, factionKey, filters.voted, filters.sort, filters.eraScope, trimmedQuery],
     PAGE_LIMIT,
+    // Nothing is HELD until the viewer is known. Unlike the task browse this
+    // feed does not wait for `/auth/me` before reading (#644's cold-paint
+    // budget), and the cookie rides along regardless — so a cold read is
+    // already viewer-relative while `user` still says anonymous, and filing it
+    // under `anon` would be a lie. Skipping the write costs one page.
+    authLoading
+      ? undefined
+      : { cache: PRAXIS_PAGE_CACHE, viewer: viewerCacheKey(user) },
   )
 
   // Every filter/search change resets the window so "load more" can't strand a

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -57,7 +57,8 @@ import { useGameConfig } from '../../hooks/useGameConfig'
 import { readOneOf } from '../../utils/urlParams'
 import { hadSessionLastVisit, useAuth } from '../../auth/AuthContext'
 import { computeDisplayPoints, computeFactionMultiplier } from '../../utils/points'
-import { usePagedResource } from '../../hooks/usePagedResource'
+import { usePagedResource, viewerCacheKey } from '../../hooks/usePagedResource'
+import { AMBIENT_TTL_MS, createKeyedResourceCache } from '../../hooks/cachedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useTaskSignup } from '../../hooks/useTaskSignup'
 import {
@@ -68,6 +69,20 @@ import type { CurrentUser } from '../../api/auth'
 
 /** How many rows a page fetches; "load more" grows the window by this step. */
 const PAGE_LIMIT = 50
+
+/**
+ * The browse's first page, per filter combination, for five minutes (#2432) —
+ * **Class B** (ADR-0072), and one of the class's first two consumers.
+ *
+ * Every filter change used to be a full uncached `GET /tasks`, clearing a
+ * filter included, so leaving a view and coming back cost exactly what arriving
+ * at it cost. Keyed on the viewer plus every axis in the URL, so a combination
+ * you have already seen is free; emptied by an era rollover and by any write.
+ *
+ * Module scope, not the hook body: the point is that the desktop list and the
+ * mobile browse skin, and a second visit to either, share one held page.
+ */
+const TASK_PAGE_CACHE = createKeyedResourceCache<TaskOut[]>(AMBIENT_TTL_MS)
 
 /**
  * The URL params the task browse owns, beside `useSearchQueryParam`'s `?q=`.
@@ -486,6 +501,11 @@ export function useTasks(): TasksState {
           }),
     [taskType, sort, status, factionKey, canSignUp, trimmedQuery, viewerPending],
     PAGE_LIMIT,
+    // No cache while the viewer is unknown: that read resolves `[]` without
+    // asking the server, and holding a placeholder under a key is worse than
+    // not holding one. The key carries the viewer for the reason `TaskOut`
+    // gives — `can_sign_up` and friends are computed for the caller.
+    viewerPending ? undefined : { cache: TASK_PAGE_CACHE, viewer: viewerCacheKey(user) },
   )
   const tasks = data ?? []
 


### PR DESCRIPTION
Closes #2432

The task browse and the praxis feed become **ADR-0072 Class B's first two consumers**. Toggling a faction off and back on is now one request, not two; so is leaving `/tasks` and coming back four seconds later.

## The seam

**`usePagedResource`, not the call sites.** Both pages already read through it, so the cache is fitted once there and both inherit it. Patching `pages/tasks/useTasks.ts` alone would have left the praxis feed on the bare fetch.

Concretely, three pieces:

1. **`createKeyedResourceCache(ttlMs, epoch)`** in `hooks/cachedResource.ts` — the Class B shape. `createResourceCache` holds one value because a Class A endpoint takes no arguments; a list read takes a dozen filter combinations, so this holds a `Map` keyed on the query. Same dedupe, same epoch stamping, same `isFresh(entry, now, ttlMs)` predicate — no new TTL machinery, and no query-cache library (#1347's ruling).
2. **`loadPage(fetchPage, limit, pageSize, deps, cached)`** in `hooks/usePagedResource.ts` — the pure first-page-only decision the hook makes inside its `useResource` closure. Extracted so the round trip is provable without a DOM.
3. **`viewerCacheKey(user)` + `pageCacheKey(viewer, deps)`** — the key is built from the dep list the caller already passes, so it **cannot drift out of step with what triggers a refetch**. Every axis in the URL is in the dep key, therefore every axis is in the cache key.

## The four things that had to be got right

**The era epoch outranks the TTL.** Routed through `utils/cacheEpoch` exactly as `useGameConfig`/`useFactions` do: `epoch.register(drop)` on construction, an issue-time version stamp so a response in flight when the era rolls is *not* written back in behind the drop, and — new for a list — `usePagedResource` subscribes to `epoch.onDrop` and refetches, so a mounted board does not sit there showing a retired world. A task bank surviving an era reset for five minutes was the failure mode that mattered.

**The rows are viewer-relative.** `TaskOut.can_sign_up` / `signup_reason` / `allowed_modes` / `eligible_for_current_user` are computed for the authenticated caller, and the feed's `voted` axis is answered against the caller's own votes. The key carries `account_id:character_id` (or `anon`) — `account_id` alone is not enough, since one account can carry two lives with different eligibility. It stays in memory and never enters a URL or a request.

On the auth transition: **sign-out already calls `dropAllCaches()`** (`auth/AuthContext.tsx`, added with ADR-0072), and I did not add a second drop — a sign-in is either a full page load, which starts with empty module caches, or leaves the anon-keyed entry unreadable because the key changed. Both call sites additionally decline to *write* an entry while `/auth/me` is still in the air, so nothing is ever filed under `anon` that was actually fetched with a cookie.

**A write must invalidate.** `dropCachesAfterWrite()` empties every keyed cache and is called from `api/client.ts` — the single seam every `POST`/`PUT`/`PATCH`/`DELETE` in the app already passes through, so a route added later cannot forget it. Only a *succeeding* write drops. It over-invalidates on purpose (a vote does not change which tasks exist); one extra refetch is cheaper than an enumeration that rots. This also answers ADR-0072's Class C warning about the browse's live Sign up button: what makes those rows safe is not a shorter bound, it is that the only rows able to age are ones nobody in this tab has acted on.

**Pagination: first page only** — a grown window always refetches. A filter change collapses the window (`resetWindow`), so the reported symptom is entirely a first-page event. Marked with a `ponytail:` comment naming the ceiling (a deep scroll re-pays for pages 2+) and the upgrade path (key on `limit` too, plus a bounded map).

## Verification

`frontend/src/hooks/__tests__/pagedResourceCache.test.ts` — 13 cases at the seam above, driving the issue's own acceptance test by counting fetch invocations across a params round trip:

- base filters → add `coven` → clear `coven` → re-add `coven` = **2 fetches, not 4**
- one read per axis (type/sort/status/eligibility/search), then all of them free on the way back
- two viewers on the same query never share an entry
- a grown window is never cached, and the first page it grew out of is still held
- an era rollover drops every held page, including one in flight
- `dropCachesAfterWrite()` empties everything
- a rejection propagates and caches nothing (the singleton's swallow-and-keep would have painted a failed read as an empty board)

Full CI locally, every step in `.github/workflows/test.yml`'s `frontend` job: `lint` clean, `typecheck` clean, `typecheck:design-sync` clean, `npm test` **431 files / 7838 passing**, `build` clean, `budget` — JS 129.2 KB (ok, unchanged), CSS 22.2 KB WARN which is **pre-existing and untouched** (no CSS in this diff). No backend, route or schema change, so `api-schema` has nothing to regenerate.

**Outstanding, for you:** I have no browser, so the Network-panel confirmation the issue asks for has not been done — the acceptance test is encoded as unit assertions at the cache seam instead. Also unverified by me: that five minutes *feels* right rather than merely being the documented Class B bound.

**Follow-up, not done here:** `docs/adr/0072`'s "nothing in this class is cached yet" is now false, and it is outside this agent's file scope. Worth an amendment noting the two consumers and the write-invalidation seam.

## What to eyeball

1. **`/tasks`, faction chips.** Open the board, tick a faction, untick it. The second view should paint instantly with no `GET /tasks` in the Network panel. This is the reported symptom.
2. **`/tasks`, the other axes.** Type → Metatask and back; Sort → Newest and back; Status → Active and back; the eligibility rail on and off. Each should be free the second time.
3. **`/tasks` search box.** Type a query, clear it. Clearing should be a hit (the debounce means only settled values are ever keyed).
4. **`/tasks` → "Load more" → change a filter → change it back.** The window collapses to one page, so this should be a hit; the *grown* page is deliberately not cached.
5. **Sign up for a task, then come back to `/tasks`.** The row's in-progress count and, with the eligibility filter on, its presence must be up to date — no five-minute stale board after your own action. Same for the mobile browse skin.
6. **`/praxis` feed.** Faction filter, `voted` rail, sort, era scope, and `?task_id=` narrowing — same off/on round trip. Then vote on a card and reload the feed: the counts must move.
7. **Sign out, sign back in as a different account, open `/tasks`.** No sign-up buttons or eligibility from the previous viewer. This is the correctness case, not a performance one.
8. **Both pages on a cold load while signed in.** They should still paint on one round trip and must not flash an empty board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
