### PR TITLE
The Players roster gives the faction a column, and the sigil in it is the link (#2245)

### DIFF
--- a/frontend/src/components/avatar/CovenAvatar.tsx
+++ b/frontend/src/components/avatar/CovenAvatar.tsx
@@ -27,11 +27,12 @@ import { CovenSigil } from '../sigil/CovenSigil'
  * what the design letters a disc in, and one hand-script capital inside a 24px
  * circle loses its stroke contrast. `INK` on `CARD` is a measured pair.
  */
-export default function CovenAvatar({ character, size }: FactionAvatarProps) {
+export default function CovenAvatar({ character, size, badge }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
       size={size}
+      badge={badge}
       circle={{
         borderColor: BORDER,
         bg: CARD,

--- a/frontend/src/components/avatar/EphemeristsAvatar.tsx
+++ b/frontend/src/components/avatar/EphemeristsAvatar.tsx
@@ -22,11 +22,12 @@ import { BAND, BAND_INK, BRASS, CAPS, DISC, GOLD, PLATE } from "../factionMarks/
  * pair went to 1.00:1 — an invisible initial with every check still green,
  * because both ends are real tokens. The disc's ink budget is the band's.
  */
-export default function EphemeristsAvatar({ character, size }: FactionAvatarProps) {
+export default function EphemeristsAvatar({ character, size, badge }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
       size={size}
+      badge={badge}
       circle={{
         borderColor: BRASS,
         bg: DISC,

--- a/frontend/src/components/avatar/EverymenAvatar.tsx
+++ b/frontend/src/components/avatar/EverymenAvatar.tsx
@@ -5,11 +5,12 @@ import { EverymenSigil } from '../sigil/EverymenSigil'
  * Everymen avatar — the standard circle plus a red union membership badge
  * (cog sigil) clipped to the lower-right.
  */
-export default function EverymenAvatar({ character, size }: FactionAvatarProps) {
+export default function EverymenAvatar({ character, size, badge }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
       size={size}
+      badge={badge}
       circle={{
         borderColor: 'var(--everymen-ink)',
         bg: 'var(--everymen-paper)',

--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -24,6 +24,23 @@ export interface FactionAvatarProps {
   size?: 'sm' | 'md' | number
   /** Cast a faction-coloured glow around the ring. Off unless a surface asks. */
   glow?: boolean
+  /**
+   * Draw the membership sigil clipped to the disc's lower-right. On by default:
+   * the badge is what makes this an avatar rather than a portrait.
+   *
+   * A surface turns it OFF only when it states membership somewhere else and
+   * the badge would be the smaller, mute copy of that statement. The desktop
+   * Players roster is the first (#2245): the owner gave the faction its own
+   * column with a large, clickable, linked sigil in it, "as opposed to putting
+   * it on top of their profile pic".
+   *
+   * THIS ONE *IS* ON `FactionAvatarProps`, unlike `DefaultAvatar`'s `ornament`
+   * slot a few lines down, and the difference is the point. `ornament` is one
+   * component's internal seam; a badge is drawn by all nine skins, so "do not
+   * draw one" has to be a promise all nine keep. Forwarding it costs each skin
+   * one destructured name and one prop.
+   */
+  badge?: boolean
 }
 
 /** 'sm' | 'md' | px → px. The two string steps keep their original values. */
@@ -118,6 +135,7 @@ export function userMediaHook(character: CharacterOut): string | undefined {
 export function DefaultAvatar({
   character,
   size = 'md',
+  badge: showBadge = true,
   ornament,
 }: FactionAvatarProps & { ornament?: ReactNode }) {
   const dim = avatarDim(size)
@@ -169,23 +187,25 @@ export function DefaultAvatar({
       </span>
       {ornament}
       {/* seven-segment sigil corner mark */}
-      <span
-        style={{
-          position: 'absolute',
-          right: -3,
-          bottom: -3,
-          width: badge,
-          height: badge,
-          borderRadius: '50%',
-          background: 'var(--faction-default-card-bg)',
-          boxShadow: '0 0 0 1.5px var(--faction-default-card-bg)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <DefaultSigil size={badge - 3} />
-      </span>
+      {showBadge && (
+        <span
+          style={{
+            position: 'absolute',
+            right: -3,
+            bottom: -3,
+            width: badge,
+            height: badge,
+            borderRadius: '50%',
+            background: 'var(--faction-default-card-bg)',
+            boxShadow: '0 0 0 1.5px var(--faction-default-card-bg)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <DefaultSigil size={badge - 3} />
+        </span>
+      )}
     </span>
   )
 }
@@ -247,6 +267,7 @@ function FactionCircle({
 export function BadgedAvatar({
   character,
   size = 'md',
+  badge: showBadge = true,
   circle,
   initialFontSize = [13, 16],
   badgeBg,
@@ -283,30 +304,32 @@ export function BadgedAvatar({
         }
         style={circle}
       />
-      <span
-        style={{
-          position: 'absolute',
-          right: -3,
-          bottom: -3,
-          width: badge,
-          height: badge,
-          borderRadius: '50%',
-          background: badgeBg,
-          border: `1.5px solid ${badgeRing}`,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        {glyph(badge - 5, badgeRing)}
-      </span>
+      {showBadge && (
+        <span
+          style={{
+            position: 'absolute',
+            right: -3,
+            bottom: -3,
+            width: badge,
+            height: badge,
+            borderRadius: '50%',
+            background: badgeBg,
+            border: `1.5px solid ${badgeRing}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {glyph(badge - 5, badgeRing)}
+        </span>
+      )}
     </span>
   )
 }
 
-export default function FactionAvatar({ character, size, glow = false }: FactionAvatarProps) {
+export default function FactionAvatar({ character, size, glow = false, badge }: FactionAvatarProps) {
   const Variant = pickVariant(surfaceMap('avatar'), character.faction_slug, DefaultAvatar)
-  const avatar = <Variant character={character} size={size} />
+  const avatar = <Variant character={character} size={size} badge={badge} />
   if (!glow) return avatar
 
   // ponytail: the glow is applied once here on a wrapper rather than threaded

--- a/frontend/src/components/avatar/SingularityAvatar.tsx
+++ b/frontend/src/components/avatar/SingularityAvatar.tsx
@@ -7,11 +7,12 @@ import { SingularitySigil } from "../sigil/SingularitySigil";
  * always-dark: its tokens are identical across themes, so no theme mutation is
  * needed. Colors via --faction-singularity-* tokens.
  */
-export default function SingularityAvatar({ character, size }: FactionAvatarProps) {
+export default function SingularityAvatar({ character, size, badge }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
       size={size}
+      badge={badge}
       circle={{
         borderColor: "var(--faction-singularity-border-hard)",
         bg: "var(--faction-singularity-card-bg)",

--- a/frontend/src/components/avatar/SnideAvatar.tsx
+++ b/frontend/src/components/avatar/SnideAvatar.tsx
@@ -5,11 +5,12 @@ import { SnideSigil } from '../sigil/SnideSigil'
  * S.N.I.D.E. avatar — the standard circle on photocopier ink with an acid
  * circled-A membership badge clipped to the lower-right.
  */
-export default function SnideAvatar({ character, size }: FactionAvatarProps) {
+export default function SnideAvatar({ character, size, badge }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
       size={size}
+      badge={badge}
       circle={{
         borderColor: 'var(--faction-snide-acid)',
         bg: 'var(--faction-snide-ink)',

--- a/frontend/src/components/avatar/UaAvatar.tsx
+++ b/frontend/src/components/avatar/UaAvatar.tsx
@@ -14,11 +14,12 @@ import { UaSigil } from "../sigil/UaSigil";
  * Both themes come from the `[data-theme="dark"]` cascade; the badge sits on
  * `--faction-ua-lift`, which dims with everything else.
  */
-export default function UaAvatar({ character, size }: FactionAvatarProps) {
+export default function UaAvatar({ character, size, badge }: FactionAvatarProps) {
   return (
     <BadgedAvatar
       character={character}
       size={size}
+      badge={badge}
       circle={{
         borderColor: "var(--faction-ua)",
         bg: "var(--faction-ua-panel)",

--- a/frontend/src/components/avatar/WowAvatar.tsx
+++ b/frontend/src/components/avatar/WowAvatar.tsx
@@ -69,7 +69,7 @@ const RANK_PILL_FLOOR_PX = 64;
 /** Smallest legible pill type, once the proportional size drops under it. */
 const RANK_PILL_MIN_FONT_PX = 9;
 
-export default function WowAvatar({ character, size }: FactionAvatarProps) {
+export default function WowAvatar({ character, size, badge }: FactionAvatarProps) {
   const dim = avatarDim(size);
   // The kit's plate: 5px of ring round the field, on 118px. The 2px rim inside
   // it is the shared circle's border.
@@ -96,6 +96,7 @@ export default function WowAvatar({ character, size }: FactionAvatarProps) {
         <BadgedAvatar
           character={character}
           size={dim - 2 * ring}
+          badge={badge}
           circle={{
             borderColor: "var(--faction-wow-crest-field-rim)",
             bg: "var(--faction-wow-avatar-field)",

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -7,6 +7,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 import type { CharacterOut } from "../../../api/auth";
+import { ALBESCENT_FACTION_SLUG, FACTION_RAINBOW_ORDER } from "../../../utils/factions";
 import FactionAvatar from "../FactionAvatar";
 
 function character(overrides: Partial<CharacterOut> = {}): CharacterOut {
@@ -191,5 +192,60 @@ describe("FactionAvatar — WOW wears its crown at the corner (#2241, #2242)", (
     expect(html).toContain("var(--faction-wow-avatar-ring)");
     expect(html).toContain("var(--faction-wow-crest-field-rim)");
     expect(html).toContain("var(--faction-wow-avatar-pill-text)");
+  });
+});
+
+/**
+ * #2245 — `badge={false}`, and it has to be a promise ALL NINE skins keep.
+ *
+ * The desktop Players roster gives the faction a column of its own with a large
+ * linked sigil in it, so the 17px mark welded to the face two columns left says
+ * the same thing again and smaller. That is the only caller today, and the flag
+ * would be worse than useless if it were honoured by eight skins out of nine:
+ * one faction's members would keep a badge nobody else's has, and the surface
+ * that asked has no way to tell.
+ *
+ * SEAM: the badge's own clip, `right: -3px; bottom: -3px`, which `DefaultAvatar`
+ * and `BadgedAvatar` both write and nothing else on an avatar does. Asserting
+ * on the clip rather than on nine glyphs is what lets one loop cover the lot —
+ * and what keeps this passing when a faction changes its mark, which #2217 and
+ * #2241 have both already done.
+ *
+ * The loop is derived, not typed out: a skin added to the manifest without a
+ * line here would otherwise be exactly the one that gets it wrong.
+ */
+describe("an avatar can be asked not to wear its badge (#2245)", () => {
+  const CLIP = "right:-3px;bottom:-3px";
+  const SLUGS = ["na", ALBESCENT_FACTION_SLUG, ...FACTION_RAINBOW_ORDER];
+
+  it("covers every skin the app can dispatch to", () => {
+    // Nine: the na ring, Albescent's wrapper, and the seven in the rainbow.
+    expect(SLUGS).toHaveLength(9);
+  });
+
+  it.each(SLUGS)("%s badges by default", (slug) => {
+    expect(
+      renderToStaticMarkup(<FactionAvatar character={character({ faction_slug: slug })} />),
+    ).toContain(CLIP);
+  });
+
+  it.each(SLUGS)("%s drops the badge when the surface asks", (slug) => {
+    expect(
+      renderToStaticMarkup(
+        <FactionAvatar character={character({ faction_slug: slug })} badge={false} />,
+      ),
+    ).not.toContain(CLIP);
+  });
+
+  it("drops the badge and nothing else — the disc, its ring and the face stay", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar
+        character={character({ faction_slug: "ua", avatar_url: "/media/isolde.png" })}
+        badge={false}
+      />,
+    );
+    expect(html).toContain("isolde.png");
+    expect(html).toContain("var(--faction-ua)");
+    expect(html).not.toContain("/factionMarks/enso.webp");
   });
 });

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -76,6 +76,7 @@
       "railFoes": "Foes",
       "colRank": "Rank",
       "colPlayer": "Player",
+      "colFaction": "Faction",
       "colLevel": "Lvl",
       "colPoints": "Pts",
       "you": "you",

--- a/frontend/src/pages/players/DesktopPlayers.tsx
+++ b/frontend/src/pages/players/DesktopPlayers.tsx
@@ -28,7 +28,19 @@ import {
 /** Row geometry, straight from the design. Ornament dimensions, not spacing. */
 const PODIUM_COLUMNS = '1.12fr 1fr 1fr'
 const RACE_COLUMNS = '26px 26px 1fr 1fr 108px'
-const ROSTER_COLUMNS = '56px 1fr 84px 90px'
+/**
+ * Rank · Player · Faction · Lvl · Pts. The faction column is #2245's — it was
+ * a word inside the player column until the owner ruled it a column of its own
+ * — and it takes the LEVEL column's width so the two marks it stands beside,
+ * the sigil and the gem, are centred on the same rhythm.
+ */
+const ROSTER_COLUMNS = '56px 1fr 84px 84px 90px'
+/**
+ * The roster's faction mark, at the level gem's own size — the ruling asks for
+ * "a larger more clickable sigil, size similar with the level diamond", and the
+ * gem in this row is 34.
+ */
+const ROSTER_SIGIL = 34
 const RACE_STAGGER_MS = 90
 /** Decorative marks. Expressions, so they are not user-facing copy. */
 const ELLIPSIS_GLYPH = '⋮'
@@ -168,6 +180,9 @@ export default function DesktopPlayers({
                 >
                   <span className="label-heading">{t('leaderboard.roster.colRank')}</span>
                   <span className="label-heading">{t('leaderboard.roster.colPlayer')}</span>
+                  <span className="label-heading" style={{ textAlign: 'center' }}>
+                    {t('leaderboard.roster.colFaction')}
+                  </span>
                   <span className="label-heading" style={{ textAlign: 'center' }}>
                     {t('leaderboard.roster.colLevel')}
                   </span>
@@ -460,10 +475,63 @@ function FactionLaneName({ slug }: { slug: string }) {
 }
 
 /**
+ * The roster's faction COLUMN (#2245), and the row's second link.
+ *
+ * Owner ruling: "Have a column for faction as opposed to putting it on top of
+ * their profile pic (you can use a larger more clickable sigil, size similar
+ * with the level diamond) and link that sigil to the faction page." So three
+ * things happen at once, and none of them survives on its own:
+ *
+ *   - the mark moves off the profile picture. `FactionAvatar` takes
+ *     `badge={false}` in the row above for exactly this mount; every other
+ *     avatar on the page, the podium's included, still wears its badge.
+ *   - the WORD goes from the name stack. That is #2245's ruling 1: the sigil
+ *     carries membership, and the word beside it was the restatement. The race
+ *     lanes keep theirs — a lane is a surface ABOUT the society, where naming
+ *     it is the content (ADR-0082 §2).
+ *   - the mark inherits the word's LINK (#1953). Deleting the word would
+ *     otherwise delete the only route from a roster row to a faction page.
+ *
+ * THE LABEL IS THE PART THAT IS EASY TO DROP. #2245's ruling 2 keeps every
+ * faction glyph `aria-hidden`, and each of the nine sigils says so in its own
+ * file — on the reasoning that the faction is spelled out in text beside it.
+ * Here it is not, so the anchor has to carry the name itself or the roster
+ * hands a screen reader a link that announces nothing. `factionName()` supplies
+ * it, which keeps the Albescent mask intact (#1926): an unrevealed viewer is
+ * told "Unaffiliated", exactly what the visible word told them before.
+ *
+ * LIFTED ABOVE THE ROW'S OVERLAY, for the reason the word was — see `RosterRow`
+ * below. The anchor fills its cell rather than hugging the 34px mark, which is
+ * the "more clickable" half of the ruling; the row-wide target stays the
+ * player's.
+ *
+ * AND IT IS ONLY A LINK WHEN `factionHref` SAYS SO. Unaffiliated has no page,
+ * and an unrevealed viewer must not be handed `/factions/albescent`. Unlinked,
+ * it is a labelled image — not a focusable control that goes nowhere.
+ */
+function RosterFaction({ slug }: { slug: string | null | undefined }) {
+  const href = factionHref(slug)
+  const label = factionName(slug)
+  const mark = <FactionSigil slug={slug} size={ROSTER_SIGIL} />
+  if (href === null) {
+    return (
+      <span role="img" aria-label={label} className="flex justify-center">
+        {mark}
+      </span>
+    )
+  }
+  return (
+    <Link to={href} aria-label={label} className="flex justify-center" style={{ position: 'relative', zIndex: 1 }}>
+      {mark}
+    </Link>
+  )
+}
+
+/**
  * One roster row. The whole row still navigates to the player — the design
- * draws no link at all and that is a bug — but the faction line under the name
- * now opens that faction's page (#1953), and those two facts cannot both be
- * anchors nested one inside the other.
+ * draws no link at all and that is a bug — but the faction sigil in its own
+ * column now opens that faction's page (#1953, moved there by #2245), and those
+ * two facts cannot both be anchors nested one inside the other.
  *
  * So the row takes the shape #1893 settled for feed cards: the row's ROOT is a
  * plain positioned `<div>`, ONE anchor inside it (the player's name) carries a
@@ -473,15 +541,13 @@ function FactionLaneName({ slug }: { slug: string }) {
  * hit-tests — above it. The name anchor itself must NOT be positioned, or the
  * overlay collapses to the name's own box.
  *
- * The faction name is the lifted link, and it is only a link at all when
- * `factionHref` says so: unaffiliated has no page, and an unrevealed viewer must
- * not be handed `/factions/albescent` behind a word `factionName` has already
- * masked to "Unaffiliated" (#1926).
+ * `RosterFaction` above is the lifted link. It was the faction WORD under the
+ * player's name until #2245 gave the faction a column; the gymnastics are
+ * unchanged, only what is lifted moved.
  */
 function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
   const { t } = useTranslation('common')
   const { character, rank, points } = row
-  const href = factionHref(character.faction_slug)
 
   return (
     <div
@@ -518,54 +584,33 @@ function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
       </span>
 
       <div className="flex items-center min-w-0" style={{ gap: 'var(--space-md)' }}>
+        {/* No membership badge on this one disc: the faction column beside it
+            draws the same mark at twice the size and links it (#2245). */}
         <span style={{ flex: 'none', lineHeight: 0 }}>
-          <FactionAvatar character={character} size={34} />
+          <FactionAvatar character={character} size={34} badge={false} />
         </span>
-        <span className="flex flex-col min-w-0" style={{ gap: 'var(--space-xs)' }}>
-          {/* The row's one anchor. NOT positioned — the overlay it carries has
-              to cover the row's root, not this name. */}
-          <Link
-            to={`/characters/${character.id}`}
-            className="font-display truncate"
-            style={{ fontSize: 'var(--text-content)', color: 'inherit', textDecoration: 'none' }}
-          >
-            {character.display_name}
-            {isMe && (
-              <>
-                {' '}
-                <span className="label-heading">{t('leaderboard.roster.you')}</span>
-              </>
-            )}
-            <span aria-hidden style={{ position: 'absolute', inset: 0 }} />
-          </Link>
-          {/* The faction's NAME, in the label tier's own ink (#1932). It used
-              to be printed in the faction hue, which is 2.09:1 for WOW on the
-              frost this row wears when it is yours. Nothing is lost: the word
-              is the identity, and the avatar's ring and the gem's outline
-              beside it are still hue-coded.
-
-              It links to that faction's page (#1953) — lifted above the row's
-              overlay so the click reaches it — unless `factionHref` withholds
-              one, in which case the word stays exactly what it was. */}
-          {href === null ? (
-            <span className="label-heading truncate">
-              {factionName(character.faction_slug)}
-            </span>
-          ) : (
-            <Link
-              to={href}
-              className="label-heading truncate"
-              // No inline `color`: `.label-heading` owns `--label-ink` and an
-              // inline declaration outranks the class, which is the #1932
-              // regression. Tailwind's preflight `a { color: inherit }` is an
-              // element selector and loses to the class, so the ink is right.
-              style={{ position: 'relative', zIndex: 1 }}
-            >
-              {factionName(character.faction_slug)}
-            </Link>
+        {/* The row's one anchor. NOT positioned — the overlay it carries has to
+            cover the row's root, not this name. It was a stacked pair until
+            #2245 took the faction word out from under it, so the column that
+            stacked them is gone with it; `min-w-0` moves onto the name, which
+            is what `truncate` needs from a flex item. */}
+        <Link
+          to={`/characters/${character.id}`}
+          className="font-display truncate min-w-0"
+          style={{ fontSize: 'var(--text-content)', color: 'inherit', textDecoration: 'none' }}
+        >
+          {character.display_name}
+          {isMe && (
+            <>
+              {' '}
+              <span className="label-heading">{t('leaderboard.roster.you')}</span>
+            </>
           )}
-        </span>
+          <span aria-hidden style={{ position: 'absolute', inset: 0 }} />
+        </Link>
       </div>
+
+      <RosterFaction slug={character.faction_slug} />
 
       <span className="flex justify-center">
         <LevelGem level={character.level} factionSlug={character.faction_slug} size={34} />

--- a/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
@@ -207,7 +207,17 @@ describe('form factors are structurally different, not a breakpoint', () => {
     const mobile = render(<MobilePlayers {...props()} />)
     expect(desktop.text, 'desktop names its columns').toContain('Lvl')
     expect(mobile.text, 'the phone has no column header').not.toContain('Lvl')
-    expect(desktop.text, 'desktop names the row faction').toContain(factionName('ephemerists'))
+    // #2245 GAVE THE FACTION A COLUMN AND TOOK AWAY THE WORD, and this line
+    // used to read `toContain(factionName('ephemerists'))` with the message
+    // "desktop names the row faction". That assertion did not fail when the row
+    // stopped naming it — the faction race prints every faction's name a few
+    // hundred pixels higher up, so it went on passing for the wrong reason.
+    // Assert the header, which only this surface draws, and leave the word
+    // itself to `playersFactionLinks.test.tsx`, which counts it.
+    // Not asserted of mobile: its race heading reads "Faction Points", so the
+    // absence of the column cannot be shown by the absence of the word. 'Lvl'
+    // above already carries "the phone draws no column header at all".
+    expect(desktop.text, 'desktop names the faction column').toContain('Faction')
     expect(mobile.html).toContain('data-testid="mobile-players-directory"')
   })
 

--- a/frontend/src/pages/players/__tests__/playersFactionLinks.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersFactionLinks.test.tsx
@@ -42,7 +42,13 @@ vi.mock('../../../hooks/useTheme', () => ({
 
 import DesktopPlayers from '../DesktopPlayers'
 import MobilePlayers from '../MobilePlayers'
-import { NO_RELATIONSHIPS, factionHref, rankPlayers, type PlayersViewProps } from '../playersData'
+import {
+  NO_RELATIONSHIPS,
+  PODIUM_SIZE,
+  factionHref,
+  rankPlayers,
+  type PlayersViewProps,
+} from '../playersData'
 
 function render(element: ReactElement): string {
   return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
@@ -133,13 +139,52 @@ describe('the faction race', () => {
   })
 })
 
+/**
+ * #2245 MOVED THIS LINK. The faction used to be a WORD under the player's name;
+ * the owner ruled it a column of its own carrying "a larger more clickable
+ * sigil, size similar with the level diamond", linked to the faction page. The
+ * seam is the same one — which element is an `<a href>` — but three things move
+ * with it, and each is a way to get this wrong:
+ *
+ *   - the word goes, so the link's accessible name has to become EXPLICIT. Every
+ *     faction mark is `aria-hidden` (each sigil says so in its own file), so a
+ *     bare anchor around one names nothing at all. That reverses ruling 2 of
+ *     #2245 for this one mount, on the issue's own reasoning: an unlabelled link
+ *     is a worse trade than the duplication being removed.
+ *   - the badge welded to the profile picture goes with it — the ruling is a
+ *     column "as opposed to putting it on top of their profile pic".
+ *   - `factionHref` can still withhold a link, and then the mark must not be a
+ *     focusable control that goes nowhere.
+ */
 describe('a roster row', () => {
-  it("links the faction line under a player's name to that faction", () => {
-    const html = render(<DesktopPlayers {...props([player({ id: 77, faction_slug: 'snide', score: 10 })])} />)
+  const roster = (slug: string) =>
+    render(<DesktopPlayers {...props([player({ id: 77, faction_slug: slug, score: 10 })])} />)
+
+  it("links the faction sigil in the row's own column to that faction", () => {
+    const html = roster('snide')
     expect(hrefs(html)).toContain('/factions/snide')
     // And the row still goes to the player: the two live in one row without
     // nesting, which is what the stretched overlay buys (#1893).
     expect(hrefs(html)).toContain('/characters/77')
+  })
+
+  it('names that link, because the word it replaced is gone', () => {
+    expect(roster('snide')).toContain(`aria-label="${factionName('snide')}"`)
+  })
+
+  it('prints the faction word once on the page — the race lane, not the row', () => {
+    // Two before #2245: the lane and the row. The lane is exempt (ADR-0082 §2 —
+    // that surface is ABOUT the society); the row was the duplicate.
+    const text = roster('snide').replace(/<[^>]*>/g, '')
+    expect(text.split(factionName('snide')).length - 1).toBe(1)
+  })
+
+  it('takes the membership badge off the roster avatar, leaving it to the podium', () => {
+    // `right:-3px;bottom:-3px` is the clip BOTH avatar roots share — the na ring
+    // in `DefaultAvatar`, the eight registered skins in `BadgedAvatar` — so this
+    // counts badged discs without naming a skin. The only ones left on the page
+    // are the podium's, where the mark is not duplicated by a column.
+    expect(roster('snide').split('right:-3px;bottom:-3px').length - 1).toBe(PODIUM_SIZE)
   })
 
   it('nests no anchor inside another', () => {
@@ -157,11 +202,13 @@ describe('a roster row', () => {
   })
 
   it('does not link an unaffiliated player — there is no page for a non-faction', () => {
-    const html = render(<DesktopPlayers {...props([player({ id: 78, faction_slug: 'na', score: 10 })])} />)
+    const html = roster('na')
     expect(hrefs(html)).not.toContain('/factions/na')
-    // The word is still printed; only the link is withheld.
-    expect(html).toContain(factionName('na'))
-    expect(hrefs(html)).toContain('/characters/78')
+    // The mark is still drawn and still named — as a labelled image, not as a
+    // focusable control that goes nowhere. The accessible name sits where the
+    // visible word used to, so nothing about membership is lost on this row.
+    expect(html).toContain(`aria-label="${factionName('na')}"`)
+    expect(hrefs(html)).toContain('/characters/77')
   })
 })
 
@@ -177,7 +224,10 @@ describe('Albescent is not linked to a viewer who has not been revealed to it', 
     // Belt and braces: the word must not appear anywhere in the markup either,
     // href or not. This is #1926's guarantee, restated where a link could undo it.
     expect(html).not.toContain(ALBESCENT_FACTION_SLUG)
-    // The row still renders, still names the player, still reads "Unaffiliated".
+    // The row still renders, still names the player, and still says
+    // "Unaffiliated" — on the sigil's own label since #2245, which is exactly
+    // what the visible word said before it. The labyrinth is drawn either way:
+    // the owner accepted a stranger meeting an unfamiliar SHAPE, never a name.
     expect(html).toContain('Ash')
     expect(html).toContain(factionName('na'))
   })


### PR DESCRIPTION
Closes #2245

## What the ruling asked for

> *"Have a column for faction as opposed to putting it on top of their profile pic (you can use a larger more clickable sigil, size similar with the level diamond) and link that sigil to the faction page."* — owner, 2026-08-24

The issue's scope had already collapsed to one surface: rulings 2 and 3 shipped on their own, the podium and the mobile roster row already comply deliberately, and the race lanes are exempt under ADR-0082 §2. What was left is the **desktop Players roster row**, and this is it.

## The seam I tested at

**The anchors `DesktopPlayers` emits given props** — which element carries the `href`, what its accessible name is, and which faction marks are drawn. That is the seam `playersFactionLinks.test.tsx` already owns, and it is where all three ways to get this wrong live. `renderToStaticMarkup`, no DOM, no effects.

Four cases went red first (commit `81cdf0d8`), on the real defect each time:

| red assertion | before |
|---|---|
| the sigil link has an `aria-label` | no such attribute anywhere |
| the faction word prints once on the page | 2 — the race lane *and* the row |
| badged avatars on the page = `PODIUM_SIZE` | 4 — the roster row wore one too |
| an unaffiliated row still announces its state | only the deleted word said it |

Then green.

## What changed

**`ROSTER_COLUMNS` grows a column** — `56px 1fr 84px 84px 90px`, Rank · Player · **Faction** · Lvl · Pts. It takes the level column's width so the sigil and the gem are centred on the same rhythm. New key `leaderboard.roster.colFaction` in `common.json` (semantic, matching `colRank`/`colPlayer`/`colLevel`/`colPoints`).

**`RosterFaction`** draws the mark at `ROSTER_SIGIL = 34` — the level gem's own size in this row, which is what "size similar with the level diamond" asks for. The anchor fills its cell rather than hugging the 34px mark: that is the "more clickable" half. It is **lifted above the row's stretched overlay** with `position: relative; z-index: 1`, exactly as the faction word was, so the click reaches it and the row-wide target stays the player's name.

**The faction word leaves the name stack** (ruling 1), and the now-single-child `flex-col` wrapper that stacked it under the name goes with it — `min-w-0` moves onto the name link, which is what `truncate` needs from a flex item.

**The badge comes off this one avatar.** `FactionAvatar` had no way to be asked; the badge is drawn by `DefaultAvatar` (na) and `BadgedAvatar` (the other eight), and each skin destructures its own props. So `badge?: boolean` goes on `FactionAvatarProps` — the manifest's contract — rather than being a private slot like `DefaultAvatar`'s `ornament`, because *every* skin draws a badge and so "do not draw one" has to be a promise every skin keeps. Seven skins forward one prop; Albescent gets it free (it spreads). A derived `it.each` over `['na', albescent, ...FACTION_RAINBOW_ORDER]` asserts all **nine** honour it, keyed on the badge's shared clip rather than on nine glyphs, so it survives a faction changing its mark (#2217 and #2241 both already did).

## The two constraints the issue records

**Accessibility — the link is named.** Ruling 2 keeps every faction glyph `aria-hidden`, and each of the nine sigils says so in its own file, on the reasoning that the faction is spelled out in text beside it. With the word gone that reasoning lapses here, and an unlabelled link is a worse trade than the duplication removed. The anchor takes `aria-label={factionName(slug)}`.

This keeps the Albescent mask intact by construction: `factionName()` answers "Unaffiliated" to an unrevealed viewer (#1926), so the label says exactly what the visible word said, and `not.toContain('albescent')` over the whole markup still passes. The labyrinth itself was already accepted on this roster — a stranger meets an unfamiliar shape, never a name.

**`factionHref` can withhold a link, and that branch is preserved.** Unaffiliated has no page and an unrevealed viewer must not be handed `/factions/albescent`. Unlinked, the mark renders as `<span role="img" aria-label=…>` — a labelled image, **not** a focusable control that goes nowhere.

## One assertion elsewhere was already lying

`playersDirectory.test.tsx` asserted `desktop.text` contains `factionName('ephemerists')` with the message *"desktop names the row faction"*. It would **not** have failed when the row stopped naming it — the faction race prints every faction's name a few hundred pixels higher on the same page, so it went on passing for the wrong reason. Rewritten to assert the column header, which only this surface draws; counting the word is left to `playersFactionLinks.test.tsx`, which now does it properly.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit` + e2e project) — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **430 files, 7848 passed, 1 skipped**
- `npm run build` — built
- `npm run budget` — JS ok (129.0 KB). **CSS warns at 22.2 KB against a 22.2 KB warn line**; this PR touches no CSS at all, so the warn is inherited from `main`, not grown here.

`api-schema` is not implicated: no route, `response_model` or Pydantic schema is touched.

## I could not run the browser

**No visual QA was performed.** I have no browser tools and no dev stack; everything above is markup, types and lint. The layout claims in this PR are reasoned from the emitted `grid-template-columns` and the sizes, not observed.

### What to eyeball

1. **The roster at several viewport widths.** The row gained a fixed 84px column plus one `--space-lg` gap, all taken out of the `1fr` player column. Check a long display name still truncates rather than shoving the sigil, and that the header cells stay over their columns.
2. **A player with no faction page** — an unaffiliated row, and (as a revealed viewer, then not) an Albescent one. The mark should be drawn and not clickable, with no hover/focus affordance suggesting otherwise.
3. **Your own highlighted row.** It carries the frost background, the spectrum edge bled into the gutter, and `padding-left`; the new column sits inside that.
4. **Both themes.** The sigils are now drawn bare on the page ground at 34px rather than on a faction-coloured badge plate — the same treatment the race lane already gives them at 22px, so there is precedent on this page, but S.N.I.D.E.'s acid and Ephemerists' brass are the two to look at in light.
5. **The mark's weight at 34px** across all nine. Sizes in use elsewhere are 18/22/26/28/44/72; 34 is new, and whether every sigil reads well there is a design call, not a mechanical one.

### Deferred to `frontend-style`

Nothing was restyled — no CSS file is touched and no new class invented. Two questions I deliberately did not answer:

- **Should the linked sigil grow a hover/focus affordance?** `FactionLaneName`'s docblock already parks the same question for the lane, and it is still parked.
- **Is 34px the right weight for every mark**, or should the column take a size that suits the nine rather than matching the gem exactly? The ruling says "similar with the level diamond"; I read that as the gem's own 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
