### PR TITLE
The join trio becomes one control, and the affirmative moves to the right on seven faction pages

### DIFF
--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -324,7 +324,7 @@ export default function InvitationLetterPopup({
               disabled={joining}
               style={{ ...enlistStyle, cursor: joining ? 'not-allowed' : 'pointer' }}
             >
-              {t('mobile.confirm')}
+              {t('detail.join.confirmAction')}
             </button>
             <button
               type="button"

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -503,7 +503,7 @@ describe('the four functional controls say one thing across every faction (#1863
       .filter(([id]) => id.startsWith('factions.json:') && id.endsWith('.confirmButton'))
       .map(([, value]) => value)
     expect(buttons).toEqual([])
-    expect(i18n.t('factions:mobile.confirm')).toBe('Confirm')
+    expect(i18n.t('factions:detail.join.confirmAction')).toBe('Confirm')
   })
 
   it('the task-card signup reads Sign up', () => {

--- a/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
+++ b/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
@@ -112,7 +112,7 @@ const FAMILIES: Array<{ banned: string; shared: string; wording: string }> = [
   // now police a key on neither side of the collapse. A rule guarding a family
   // that no longer exists is dead weight, and it cannot fail: retired, not
   // rewritten. `catalog.test.ts` is where the slip's absence is pinned.
-  { banned: `factions:{F}\\.join\\.confirmButton`, shared: 'factions:mobile.confirm', wording: 'Confirm' },
+  { banned: `factions:{F}\\.join\\.confirmButton`, shared: 'factions:detail.join.confirmAction', wording: 'Confirm' },
   // The interpolation moved off the end of the sentence (#2368): "…to
   // {{faction}}." appended a full stop to "S.N.I.D.E.", the one faction name
   // that already carries one, and rendered "S.N.I.D.E..". The imperative is

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -44,6 +44,9 @@
     "join": {
       "confirmSwitch": "Join {{faction}}? You won't be able to rejoin {{current}} after leaving.",
       "confirm": "Join {{faction}}?",
+      "confirmAction": "Confirm",
+      "joinButton": "Join {{faction}}",
+      "joining": "Joining…",
       "cancel": "Cancel"
     },
     "burned": {
@@ -361,9 +364,6 @@
     "unaffiliatedBody": "Every path is open. Each faction watches its own work — do enough of it, and an invitation finds you.",
     "topMembers": "Top members",
     "recentPraxis": "Recent praxis",
-    "join": "Join {{faction}}",
-    "joining": "Joining…",
-    "confirm": "Confirm",
     "memberBadge": "You're a member",
     "gateHint": "An invitation to {{faction}} is earned. Keep completing tasks.",
     "burnedHint": "You left {{faction}}, and it can't take you back until the next era begins."

--- a/frontend/src/pages/factionDetail/JoinControl.tsx
+++ b/frontend/src/pages/factionDetail/JoinControl.tsx
@@ -1,0 +1,202 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { factionName } from "../../utils/factions";
+import type { Membership } from "./useFactionDetail";
+
+const NA_SLUG = "na";
+
+/**
+ * The paint every kit hands the join trio (#2651).
+ *
+ * A TYPED SKIN, NOT A `style` PROP — `PublishButtonSkin`'s shape
+ * (`editPraxis/archetypes/controls.tsx`), where a kit that forgets a button gets
+ * a compile error rather than an unpainted control. The three button slots are
+ * required for exactly that reason; prose and error are optional because
+ * `DefaultFactionBody` deliberately leaves its confirm sentence uncoloured (it
+ * inherits, see #1819) and a kit that passes nothing renders readable prose.
+ *
+ * The control owns BEHAVIOUR — the confirm step, the handlers, the disabled and
+ * busy states, and the #646 order. The archetype owns every pixel, and the box
+ * these buttons sit in is still the kit's own: S.N.I.D.E.'s plate, Coven's slip
+ * and the Ephemerists' marginalia are not this component's business.
+ */
+export interface JoinControlSkin {
+  /** The primary verb, before the confirm step. Full width in every kit. */
+  openStyle: CSSProperties;
+  /** The affirmative half of the pair — the RIGHT-hand button (#646). */
+  confirmStyle: CSSProperties;
+  /** The quiet half — the LEFT-hand button. */
+  cancelStyle: CSSProperties;
+  /**
+   * For reaching a kit's CSS class, mounted on the two AFFIRMATIVE buttons and
+   * not on the cancel. The Ephemerists' `.eph-cta` is the live case and it
+   * dressed exactly those two before this extraction: an enclosure that changes
+   * width between the cascades has no inline expression (#2146).
+   */
+  className?: string;
+  /** The switch sentence above the pair. */
+  proseStyle?: CSSProperties;
+  /** The `joinError` line, which only ever renders after a FAILED join. */
+  errorStyle?: CSSProperties;
+}
+
+/** The pair's row. Identical in all nine kits before the extraction. */
+const PAIR_ROW: CSSProperties = { display: "flex", gap: "var(--space-sm)" };
+
+/**
+ * The join trio — [Join] → the switch sentence, the error slot and
+ * [Cancel] … [Confirm] — written ONCE for all nine faction bodies (#2651).
+ *
+ * It was written out longhand in eight of them, and seven put the affirmative on
+ * the LEFT. That is a shipped global ruling broken in seven places (#646, stated
+ * at `duel/shared.tsx`'s `SealActions`), and it is the reason the extraction
+ * takes the whole pair rather than the primary button alone: a control that owns
+ * only the primary leaves the defect standing.
+ *
+ * Two drifts fall out of the same cause and are fixed here because the component
+ * now owns the state they describe:
+ *
+ *   THE BUSY OPACITY. `opacity: 0.6` while joining shipped on WOW and the
+ *     fall-through only; the other six disabled the button and showed nothing.
+ *     It is applied uniformly now, on the affirmative alone — which is where
+ *     both of those two put it.
+ *
+ *   THE BUSY CURSOR. Six kits set `cursor: not-allowed` while joining and two
+ *     left `pointer` under a disabled button. Uniform, and on both halves of the
+ *     pair since both are disabled.
+ *
+ * `SealActions` is NOT reused, on the owner's ruling: it paints with the global
+ * `btn-primary` / `btn-outline` and lets a theme override only `fontFamily`, so
+ * nine kits would collapse into one grey pair in nine typefaces. It stays
+ * grandfathered for the duel sheet, untouched.
+ */
+export function JoinControl({
+  membership,
+  name,
+  skin,
+  openLabel,
+  joiningLabel,
+  intro,
+}: {
+  membership: Membership;
+  /** The mounted faction's display name, for the confirm sentence. */
+  name: string;
+  skin: JoinControlSkin;
+  /**
+   * The kit's own verb for opening the confirm step, and its own word for the
+   * pending state. Passed in rather than resolved from the slug so the catalog
+   * keys stay LITERAL at the call site: a `t(\`${slug}.join.joinButton\`)` here
+   * would be invisible to the copy greps and to `eslint-plugin-i18next`.
+   */
+  openLabel: ReactNode;
+  joiningLabel: ReactNode;
+  /**
+   * The kit's title and blurb above the primary verb. Drawn in the open state
+   * only — the confirm step replaces the pitch with the question.
+   */
+  intro?: ReactNode;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (!confirming) {
+    return (
+      <>
+        {intro}
+        <button
+          type="button"
+          data-join="open"
+          className={skin.className}
+          onClick={() => setConfirming(true)}
+          style={skin.openStyle}
+        >
+          {openLabel}
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <JoinConfirm
+      membership={membership}
+      name={name}
+      skin={skin}
+      joiningLabel={joiningLabel}
+      onCancel={() => setConfirming(false)}
+    />
+  );
+}
+
+/**
+ * The confirm step: prose, then the error slot, then the pair.
+ *
+ * THE UNIT IS ALL THREE. The error only renders on a failed join, so no browser
+ * pass and no screenshot can catch its absence — it is the piece an extraction
+ * drops silently, which is why it lives inside the control rather than being
+ * left to nine call sites.
+ *
+ * Exported STATELESS, the same shape `SealActions` has, so the order ruling can
+ * be asserted against rendered markup: this harness renders with
+ * `renderToStaticMarkup` and has no DOM to click, so a `confirming` reachable
+ * only through a click event would be a rule with no test. `joinControlOrder`
+ * is the guard.
+ */
+export function JoinConfirm({
+  membership,
+  name,
+  skin,
+  joiningLabel,
+  onCancel,
+}: {
+  membership: Membership;
+  name: string;
+  skin: JoinControlSkin;
+  joiningLabel: ReactNode;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation("factions");
+  const current = membership.currentFactionSlug;
+  const busy = membership.joining;
+
+  return (
+    <>
+      <p className="content-text" style={skin.proseStyle}>
+        {current && current !== NA_SLUG
+          ? t("detail.join.confirmSwitch", { faction: name, current: factionName(current) })
+          : t("detail.join.confirm", { faction: name })}
+      </p>
+      {membership.joinError && (
+        <p className="content-text" style={skin.errorStyle}>
+          {membership.joinError}
+        </p>
+      )}
+      {/* [Cancel] … [Confirm] — the global footer order (#646). DOM order is
+          visual order here: no kit reverses this row. */}
+      <div style={PAIR_ROW}>
+        <button
+          type="button"
+          data-join="cancel"
+          onClick={onCancel}
+          disabled={busy}
+          style={{ ...skin.cancelStyle, cursor: busy ? "not-allowed" : "pointer" }}
+        >
+          {t("detail.join.cancel")}
+        </button>
+        <button
+          type="button"
+          data-join="confirm"
+          className={skin.className}
+          onClick={() => void membership.join()}
+          disabled={busy}
+          style={{
+            ...skin.confirmStyle,
+            flex: 1,
+            opacity: busy ? 0.6 : 1,
+            cursor: busy ? "not-allowed" : "pointer",
+          }}
+        >
+          {busy ? joiningLabel : t("detail.join.confirmAction")}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
@@ -89,7 +89,7 @@ const OWN_VOICE: Record<string, readonly string[]> = {
 /**
  * Each faction's own Join verb. `albescent` is the fall-through to
  * `DefaultFactionBody`, whose join block is the one lifted out of the retired
- * `DefaultFactionPage` — it keeps that skin's `mobile.join` key. The other
+ * `DefaultFactionPage` — it keeps that skin's generic interpolated verb, moved to `detail.join.joinButton` by #2651. The other
  * seven are `<slug>.join.joinButton` since #2299 gave them one key path.
  */
 const JOIN_BUTTON: Record<string, string> = {
@@ -100,7 +100,7 @@ const JOIN_BUTTON: Record<string, string> = {
   snide: 'snide.join.joinButton',
   ua: 'ua.join.joinButton',
   wow: 'wow.join.joinButton',
-  albescent: 'mobile.join',
+  albescent: 'detail.join.joinButton',
 }
 
 /** The factions that dress this surface, plus the one that still falls through. */

--- a/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
@@ -29,13 +29,12 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
 import { FACTION_MANIFESTS } from '../../../factions'
 import type { FactionDetailState, Membership } from '../useFactionDetail'
 import type { CharacterOut } from '../../../api/auth'
-import { aPraxisCard } from '../../../test/fixtures'
 import { JoinConfirm, type JoinControlSkin } from '../JoinControl'
 
 const mocks = vi.hoisted(() => ({
@@ -92,7 +91,11 @@ function page(slug: string, formFactor: 'desktop' | 'mobile'): string {
     fetchError: null,
     members: [MEMBER],
     tasks: [],
-    recentPraxis: [aPraxisCard({ task_faction_slug: slug })],
+    // EMPTY, deliberately: a card in the gallery would drag the faction's
+    // praxis archetype into this render, and several of those read `useTheme`,
+    // which this harness has no provider for. The join area is what is under
+    // test and it does not read the list.
+    recentPraxis: [],
     viewerFactionSlug: null,
     gameFactions: [],
     onSignup: undefined,

--- a/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * The seam: the join trio's RENDERED BUTTON ORDER, for every faction (#2651).
+ *
+ * #646's ruling — [Cancel] … [Submit], the affirmative on the right, on every
+ * surface — had drifted into seven of the eight faction bodies, each of which
+ * wrote the pair out longhand. The duel sheet holds only because one comment at
+ * `SealActions` reminds people. A comment is not a guard; this is.
+ *
+ * It asserts in three parts, because the order can drift in two different ways:
+ *
+ *   1. THE PAIR ITSELF. `JoinConfirm` is the one place the two buttons are
+ *      written, and cancel is first in its markup. DOM order is visual order —
+ *      no kit reverses this row, and `noRowReverse` below holds that.
+ *   2. EVERY FACTION MOUNTS IT. Per slug from the manifest, so a tenth faction
+ *      is covered the day it registers: the eligible join area is the shared
+ *      control's `data-join="open"` button and nothing else.
+ *   3. NO ARCHETYPE CAN TAKE IT BACK. A body that re-declares `confirming` or
+ *      calls `membership.join()` itself is exactly how this drifted the first
+ *      time, and neither of the two assertions above would see it happen inside
+ *      a branch they do not render.
+ *
+ * Part 2 is where the per-slug claim is made. It cannot be made by clicking:
+ * this harness renders with `renderToStaticMarkup` and has no DOM, so the
+ * confirm step is unreachable through an event. Mounting the one control whose
+ * order part 1 pins is the same statement, and it is the statement that stays
+ * true when a tenth kit arrives.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import { FACTION_MANIFESTS } from '../../../factions'
+import type { FactionDetailState, Membership } from '../useFactionDetail'
+import type { CharacterOut } from '../../../api/auth'
+import { aPraxisCard } from '../../../test/fixtures'
+import { JoinConfirm, type JoinControlSkin } from '../JoinControl'
+
+const mocks = vi.hoisted(() => ({
+  formFactor: 'desktop' as 'mobile' | 'desktop',
+  state: undefined as unknown as FactionDetailState,
+}))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+vi.mock('../useFactionDetail', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useFactionDetail')>()),
+  useFactionDetail: () => mocks.state,
+}))
+
+const FactionDetail = (await import('../../FactionDetail')).default
+
+const MEMBER: CharacterOut = {
+  id: 7,
+  username: 'ada',
+  display_name: 'Ada Reed',
+  bio: '',
+  tagline: '',
+  avatar_url: '',
+  location: '',
+  level: 4,
+  score: 120,
+  all_time_score: 340,
+  faction_slug: 'everymen',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  badges: [],
+  invitations: [],
+}
+
+function membership(overrides: Partial<Membership> = {}): Membership {
+  return {
+    state: 'eligible',
+    currentFactionSlug: null,
+    join: async () => {},
+    joining: false,
+    joinError: null,
+    ...overrides,
+  }
+}
+
+function page(slug: string, formFactor: 'desktop' | 'mobile'): string {
+  mocks.formFactor = formFactor
+  mocks.state = {
+    slug,
+    loading: false,
+    faction: { slug, status: 'visible' },
+    fetchError: null,
+    members: [MEMBER],
+    tasks: [],
+    recentPraxis: [aPraxisCard({ task_faction_slug: slug })],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    onSignup: undefined,
+    signupMsg: null,
+    membership: membership(),
+  }
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FactionDetail slug={slug} />
+    </MemoryRouter>,
+  )
+}
+
+/** A skin that paints nothing — this suite is about order, not pixels. */
+const BARE_SKIN: JoinControlSkin = { openStyle: {}, confirmStyle: {}, cancelStyle: {} }
+
+function confirmStep(overrides: Partial<Membership> = {}): string {
+  return renderToStaticMarkup(
+    <JoinConfirm
+      membership={membership(overrides)}
+      name="The Coven"
+      skin={BARE_SKIN}
+      joiningLabel="Joining…"
+      onCancel={() => {}}
+    />,
+  )
+}
+
+const ARCHETYPES = fileURLToPath(new URL('../archetypes', import.meta.url))
+
+describe('the join pair keeps #646 order on every faction', () => {
+  it('puts cancel before confirm in the markup', () => {
+    const html = confirmStep()
+    const cancel = html.indexOf('data-join="cancel"')
+    const confirm = html.indexOf('data-join="confirm"')
+    expect(cancel, 'a cancel button').toBeGreaterThan(-1)
+    expect(confirm, 'a confirm button').toBeGreaterThan(-1)
+    expect(cancel, 'the affirmative sits on the right (#646)').toBeLessThan(confirm)
+  })
+
+  it('does not reverse the row it just ordered', () => {
+    // A `row-reverse` or an `order:` anywhere in the pair would make DOM order
+    // stop being visual order, which is the one way the assertion above could
+    // pass while the buttons still sat the wrong way round.
+    const html = confirmStep()
+    expect(html).not.toContain('row-reverse')
+    expect(html).not.toMatch(/order:\s*-?\d/)
+  })
+
+  it('keeps the error slot, which only a FAILED join ever draws', () => {
+    expect(confirmStep()).not.toContain('Could not join')
+    expect(confirmStep({ joinError: 'Could not join faction.' })).toContain(
+      'Could not join faction.',
+    )
+  })
+
+  it('shows the pending state and disables both halves while joining', () => {
+    const busy = confirmStep({ joining: true })
+    expect(busy, 'the busy label').toContain('Joining')
+    expect(busy.match(/disabled=""/g), 'cancel and confirm both').toHaveLength(2)
+    expect(busy, 'the pending state is visible, not just disabled').toContain('opacity:0.6')
+  })
+
+  for (const { slug } of FACTION_MANIFESTS) {
+    for (const formFactor of ['desktop', 'mobile'] as const) {
+      it(`${slug} draws its join through the shared control at ${formFactor}`, () => {
+        const html = page(slug, formFactor)
+        expect(
+          [...html.matchAll(/data-join="open"/g)],
+          'exactly one join verb, and it is the shared control',
+        ).toHaveLength(1)
+      })
+    }
+  }
+})
+
+describe('no faction body writes the trio itself', () => {
+  const bodies = readdirSync(ARCHETYPES).filter((name) => name.endsWith('.tsx'))
+
+  it('finds the archetypes it means to scan', () => {
+    expect(bodies.length).toBeGreaterThanOrEqual(9)
+  })
+
+  for (const name of bodies) {
+    it(`${name} owns paint, not behaviour`, () => {
+      const source = readFileSync(join(ARCHETYPES, name), 'utf8')
+      expect(source, 'the confirm step belongs to JoinControl').not.toContain('setConfirming')
+      expect(source, 'the join call belongs to JoinControl').not.toContain('membership.join()')
+      expect(source, 'the cancel label belongs to JoinControl').not.toContain('detail.join.cancel')
+    })
+  }
+})

--- a/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
@@ -156,7 +156,21 @@ describe('the join pair keeps #646 order on every faction', () => {
     expect(busy, 'the pending state is visible, not just disabled').toContain('opacity:0.6')
   })
 
-  for (const { slug } of FACTION_MANIFESTS) {
+  /**
+   * Every faction with a PAGE. Read off the manifest so a tenth kit is covered
+   * the day it registers, minus `na`: it has had a manifest since #2530, but
+   * unaffiliated is a state rather than a faction (`isKnownFaction('na')` is
+   * false, ADR-0039) and there is no na faction page to visit — `factionHero.na`
+   * has no copy at all, so this harness cannot render one. na's SKIN is still
+   * covered here, because `albescent` is the wrapper that mounts it.
+   */
+  const SLUGS = FACTION_MANIFESTS.map(({ slug }) => slug).filter((slug) => slug !== 'na')
+
+  it('walks eight faction pages', () => {
+    expect(SLUGS).toHaveLength(FACTION_MANIFESTS.length - 1)
+  })
+
+  for (const slug of SLUGS) {
     for (const formFactor of ['desktop', 'mobile'] as const) {
       it(`${slug} draws its join through the shared control at ${formFactor}`, () => {
         const html = page(slug, formFactor)

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/taskCard/TaskCard";
@@ -30,6 +30,7 @@ import {
 import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -129,7 +130,6 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
     membership,
   } = state;
   const sections = useFactionSections();
-  const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
@@ -302,105 +302,46 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                 </div>
               )}
 
-              {membership.state === "eligible" && !confirming && (
-                <div style={{ textAlign: "center" }}>
-                  <div
-                    style={{
-                      fontFamily: HAND,
-                      // eslint-disable-next-line local/no-raw-style-values -- ornament: hand-lettered Caveat — the coven's own hand, not typeset copy.
-                      fontSize: 26,
-                      fontWeight: 700,
-                      color: INK,
-                      lineHeight: 1,
-                      marginBottom: "var(--space-sm)",
-                    }}
-                  >
-                    {t("coven.join.eligibleTitle")}
-                  </div>
-                  <div className="content-text" style={{ ...PROSE, marginBottom: "var(--space-lg)" }}>
-                    {t("coven.join.eligibleBody")}
-                  </div>
-                  <button
-                    onClick={() => setConfirming(true)}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      gap: "var(--space-sm)",
-                      width: "100%",
-                      fontFamily: CHROME,
-                      fontSize: "var(--text-lg)",
-                      fontWeight: 700,
-                      letterSpacing: "0.12em",
-                      textTransform: "uppercase",
-                      color: CTA_INK,
-                      background: `linear-gradient(180deg, ${CTA_FROM}, ${CTA_TO})`,
-                      border: `1.5px solid ${CTA_TO}`,
-                      borderRadius: 12,
-                      padding: "var(--space-md)",
-                      boxShadow: `0 8px 18px -8px ${GLOW}`,
-                      cursor: "pointer",
-                    }}
-                  >
-                    <Spark size={12} color={CTA_INK} />
-                    {t("coven.join.joinButton")}
-                  </button>
-                </div>
-              )}
-
-              {membership.state === "eligible" && confirming && (
-                <div>
-                  <div className="content-text" style={{ fontFamily: READING, lineHeight: 1.6, color: INK, marginBottom: "var(--space-lg)" }}>
-                    {membership.currentFactionSlug &&
-                    membership.currentFactionSlug !== "na"
-                      ? t("detail.join.confirmSwitch", {
-                          faction: factionName(faction.slug),
-                          current: factionName(membership.currentFactionSlug),
-                        })
-                      : t("detail.join.confirm", { faction: factionName(faction.slug) })}
-                  </div>
-                  {membership.joinError && (
-                    <div className="content-text" style={{ fontFamily: READING, color: "var(--color-danger)", marginBottom: "var(--space-sm)" }}>{membership.joinError}</div>
-                  )}
-                  <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                    <button
-                      onClick={() => void membership.join()}
-                      disabled={membership.joining}
-                      style={{
-                        flex: 1,
-                        fontFamily: CHROME,
-                        fontSize: "var(--text-md)",
-                        fontWeight: 700,
-                        letterSpacing: "0.12em",
-                        textTransform: "uppercase",
-                        color: CTA_INK,
-                        background: `linear-gradient(180deg, ${CTA_FROM}, ${CTA_TO})`,
-                        border: `1.5px solid ${CTA_TO}`,
-                        borderRadius: 12,
-                        padding: "var(--space-md)",
-                        cursor: membership.joining ? "not-allowed" : "pointer",
-                      }}
-                    >
-                      {membership.joining
-                        ? t("coven.join.joining")
-                        : t("mobile.confirm")}
-                    </button>
-                    <button
-                      onClick={() => setConfirming(false)}
-                      disabled={membership.joining}
-                      style={{
-                        ...CAPTION,
-                        background: "transparent",
-                        border: `1.5px solid ${BORDER}`,
-                        borderRadius: 12,
-                        padding: "var(--space-md) var(--space-lg)",
-                        cursor: membership.joining ? "not-allowed" : "pointer",
-                      }}
-                    >
-                      {t("detail.join.cancel")}
-                    </button>
-                  </div>
-                </div>
+              {membership.state === "eligible" && (
+                <JoinControl
+                  membership={membership}
+                  name={factionName(faction.slug)}
+                  skin={JOIN_SKIN}
+                  // The spark rides IN the label rather than in a slot of its
+                  // own: the label is a node, and one faction's glyph is not a
+                  // reason for every other kit to carry an unused prop (#2651).
+                  openLabel={
+                    <>
+                      <Spark size={12} color={CTA_INK} />
+                      {t("coven.join.joinButton")}
+                    </>
+                  }
+                  joiningLabel={t("coven.join.joining")}
+                  intro={
+                    // The pitch is centred and the question is not — the two
+                    // states parted here before the extraction, so the
+                    // alignment travels with the pitch rather than wrapping
+                    // both.
+                    <div style={{ textAlign: "center" }}>
+                      <div
+                        style={{
+                          fontFamily: HAND,
+                          // eslint-disable-next-line local/no-raw-style-values -- ornament: hand-lettered Caveat — the coven's own hand, not typeset copy.
+                          fontSize: 26,
+                          fontWeight: 700,
+                          color: INK,
+                          lineHeight: 1,
+                          marginBottom: "var(--space-sm)",
+                        }}
+                      >
+                        {t("coven.join.eligibleTitle")}
+                      </div>
+                      <div className="content-text" style={{ ...PROSE, marginBottom: "var(--space-lg)" }}>
+                        {t("coven.join.eligibleBody")}
+                      </div>
+                    </div>
+                  }
+                />
               )}
 
               {(membership.state === "gate" || burned) && (
@@ -542,3 +483,58 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
     </div>
   );
 }
+
+/**
+ * The trio's paint (#2651) — the slip's gradient CTA for both affirmatives and
+ * the caption register for the cancel, which is what these three buttons already
+ * wore. The open pill keeps its glow and its centring flex, because it carries a
+ * glyph; the confirm never had either. `flex`, the busy opacity and the busy
+ * cursor came off all three: the shared control owns the pending state now.
+ */
+const JOIN_SKIN: JoinControlSkin = {
+  openStyle: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "var(--space-sm)",
+    width: "100%",
+    fontFamily: CHROME,
+    fontSize: "var(--text-lg)",
+    fontWeight: 700,
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    color: CTA_INK,
+    background: `linear-gradient(180deg, ${CTA_FROM}, ${CTA_TO})`,
+    border: `1.5px solid ${CTA_TO}`,
+    borderRadius: 12,
+    padding: "var(--space-md)",
+    boxShadow: `0 8px 18px -8px ${GLOW}`,
+    cursor: "pointer",
+  },
+  confirmStyle: {
+    fontFamily: CHROME,
+    fontSize: "var(--text-md)",
+    fontWeight: 700,
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    color: CTA_INK,
+    background: `linear-gradient(180deg, ${CTA_FROM}, ${CTA_TO})`,
+    border: `1.5px solid ${CTA_TO}`,
+    borderRadius: 12,
+    padding: "var(--space-md)",
+  },
+  cancelStyle: {
+    ...CAPTION,
+    background: "transparent",
+    border: `1.5px solid ${BORDER}`,
+    borderRadius: 12,
+    padding: "var(--space-md) var(--space-lg)",
+  },
+  proseStyle: {
+    fontFamily: READING,
+    lineHeight: 1.6,
+    color: INK,
+    marginBottom: "var(--space-lg)",
+  },
+  errorStyle: { fontFamily: READING, color: "var(--color-danger)", marginBottom: "var(--space-sm)" },
+};

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import TaskCard from "../../../components/taskCard/TaskCard";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
@@ -7,11 +7,10 @@ import { factionCssVar, factionName, factionDescription } from "../../../utils/f
 import { computeFactionMultiplier } from "../../../utils/points";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { MobileStickyBar } from "../MobileStickyBar";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
-
-const NA_SLUG = "na";
 
 /**
  * The plate's hairline — the na spectrum, running out from the kicker to the
@@ -143,7 +142,6 @@ export default function DefaultFactionBody({
     onSignup,
     membership,
   } = state;
-  const [confirming, setConfirming] = useState(false);
   const phone = useFormFactor() === "mobile";
   const sections = useFactionSections();
 
@@ -172,9 +170,6 @@ export default function DefaultFactionBody({
     .map((paragraph) => paragraph.trim())
     .filter(Boolean);
 
-  const currentSlug = membership.currentFactionSlug;
-  const switching = currentSlug && currentSlug !== NA_SLUG;
-
   /**
    * The primary verb. Rendered ONCE — inline under the standing line on a
    * laptop, pinned above the tab bar on a phone (#495 / #1566). Only an
@@ -182,52 +177,24 @@ export default function DefaultFactionBody({
    * hidden rather than disabled.
    */
   const joinAction = membership.state === "eligible" && (
-    <>
-      {membership.joinError && (
-        // The phone skin this came from wrote `text-red-600`, and its legacy
-        // exemption died with the file. The token says the same thing and is
-        // what every other body's join error already uses (#1853).
-        <p className="font-body content-text" style={{ color: "var(--color-danger)" }}>
-          {membership.joinError}
-        </p>
-      )}
-      {!confirming ? (
-        <button type="button" onClick={() => setConfirming(true)} style={joinButtonStyle(faction.slug)}>
-          {t("mobile.join", { faction: name })}
-        </button>
-      ) : (
-        <>
-          {/* No `color:` — `body` is `text-ink`, i.e. --color-text-primary, so
-              this prose INHERITS exactly what it used to restate. The inline
-              copy was the defect (#1819): a faction frame that repoints ink on
-              its own root cannot reach past it, and this archetype is the
-              fall-through every unbespoke faction lands on. */}
-          <p className="font-body content-text">
-            {switching
-              ? t("detail.join.confirmSwitch", { faction: name, current: factionName(currentSlug) })
-              : t("detail.join.confirm", { faction: name })}
-          </p>
-          <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-            <button
-              type="button"
-              onClick={() => void membership.join()}
-              disabled={membership.joining}
-              style={{ ...joinButtonStyle(faction.slug), flex: 1, opacity: membership.joining ? 0.6 : 1 }}
-            >
-              {membership.joining ? t("mobile.joining") : t("mobile.confirm")}
-            </button>
-            <button
-              type="button"
-              onClick={() => setConfirming(false)}
-              disabled={membership.joining}
-              style={CANCEL_BUTTON_STYLE}
-            >
-              {t("detail.join.cancel")}
-            </button>
-          </div>
-        </>
-      )}
-    </>
+    <JoinControl
+      membership={membership}
+      name={name}
+      skin={joinSkin(faction.slug)}
+      // NOT a `<slug>.join.*` family like the other seven, and this is the
+      // written reason #2651 asked for. This body is the fall-through for every
+      // faction WITHOUT a kit — `albescent` today, a tenth faction the day it
+      // registers — so a per-slug family here would have to be minted for a slug
+      // that has no voice, and Albescent's would be a tell (ADR-0027, #2409: it
+      // is [REDACTED], not loud). "Join {{faction}}" interpolates the name and
+      // is correct for all of them, which is exactly why it was written that
+      // way. What DID move is the namespace: these were `mobile.join` /
+      // `mobile.joining`, keys that stopped being phone-only when #1314 lifted
+      // this block onto the shared body, and they now sit with the rest of the
+      // trio's shared copy under `detail.join.*`.
+      openLabel={t("detail.join.joinButton", { faction: name })}
+      joiningLabel={t("detail.join.joining")}
+    />
   );
 
   return (
@@ -542,3 +509,27 @@ const CANCEL_BUTTON_STYLE: CSSProperties = {
   padding: "var(--space-md) var(--space-lg)",
   cursor: "pointer",
 };
+
+/**
+ * The trio's paint (#2651). Two of the three slots are the constants that were
+ * already here — `joinButtonStyle` for both affirmatives and
+ * `CANCEL_BUTTON_STYLE` for the quiet half — which is why this body was the
+ * model for the extraction's paint half.
+ *
+ * The prose and the error carried `font-body` as a Tailwind utility and now
+ * carry `var(--font-body)` inline, because the shared control puts
+ * `content-text` on the line and the skin supplies the rest. The two resolve to
+ * the same face: the utility is `"Courier Prime", monospace` and the token is
+ * that plus the `"Courier New"` fallback, so the inline form is the wider of the
+ * two. The prose still sets NO colour — a faction frame that repoints ink on its
+ * own root has to be able to reach it (#1819).
+ */
+function joinSkin(slug: string): JoinControlSkin {
+  return {
+    openStyle: joinButtonStyle(slug),
+    confirmStyle: joinButtonStyle(slug),
+    cancelStyle: CANCEL_BUTTON_STYLE,
+    proseStyle: { fontFamily: "var(--font-body)" },
+    errorStyle: { fontFamily: "var(--font-body)", color: "var(--color-danger)" },
+  };
+}

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/taskCard/TaskCard";
@@ -30,6 +30,7 @@ import {
 import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -173,7 +174,6 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
     membership,
   } = state;
   const sections = useFactionSections();
-  const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
@@ -317,73 +317,34 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                   </div>
                 )}
 
-                {membership.state === "eligible" && !confirming && (
-                  <div>
-                    <div
-                      style={{
-                        fontFamily: CAPS,
-                        fontWeight: 700,
-                        // eslint-disable-next-line local/no-raw-style-values -- ornament: Cinzel codex display title.
-                        fontSize: 23,
-                        lineHeight: 1.02,
-                        color: INK,
-                        marginBottom: "var(--space-md)",
-                      }}
-                    >
-                      {t("ephemerists.join.eligibleTitle")}
-                    </div>
-                    <div className="content-text" style={{ fontFamily: READING, lineHeight: 1.6, color: INK, marginBottom: "var(--space-lg)" }}>
-                      {t("ephemerists.join.eligibleBody")}
-                    </div>
-                    {/* THE ONE PLATE CTA (#2146) — ground, ink and enclosure
-                        from `.eph-cta`, because the enclosure changes width
-                        between the cascades and no inline style has a cascade.
-                        This surface is not one of the three the issue names; it
-                        draws the identical button, which is what decides it. */}
-                    <button
-                      className="eph-cta"
-                      onClick={() => setConfirming(true)}
-                      style={{ width: "100%", ...SMALL_CAPS, fontSize: "var(--text-xl)", letterSpacing: "0.14em", padding: "var(--space-md)", cursor: "pointer" }}
-                    >
-                      {t("ephemerists.join.joinButton")}
-                    </button>
-                  </div>
-                )}
-
-                {membership.state === "eligible" && confirming && (
-                  <div>
-                    <div className="content-text" style={{ fontFamily: READING, lineHeight: 1.6, color: INK, marginBottom: "var(--space-lg)" }}>
-                      {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na"
-                        ? t("detail.join.confirmSwitch", {
-                            faction: factionName(faction.slug),
-                            current: factionName(membership.currentFactionSlug),
-                          })
-                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
-                    </div>
-                    {membership.joinError && (
-                      <div className="content-text" style={{ fontFamily: READING, color: "var(--color-danger)", marginBottom: "var(--space-sm)" }}>{membership.joinError}</div>
-                    )}
-                    <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                      <button
-                        className="eph-cta"
-                        onClick={() => void membership.join()}
-                        disabled={membership.joining}
-                        style={{ flex: 1, ...SMALL_CAPS, fontSize: "var(--text-lg)", letterSpacing: "0.12em", padding: "var(--space-md)", cursor: membership.joining ? "not-allowed" : "pointer" }}
-                      >
-                        {membership.joining
-                          ? t("ephemerists.join.joining")
-                          : t("mobile.confirm")}
-                      </button>
-                      <button
-                        onClick={() => setConfirming(false)}
-                        disabled={membership.joining}
-                        style={{ fontFamily: MARGINALIA, fontStyle: "italic", fontSize: "var(--text-lg)", letterSpacing: "0.06em", color: QUIET, background: "transparent", border: `1px solid ${LINE}`, padding: "var(--space-md) var(--space-lg)", cursor: membership.joining ? "not-allowed" : "pointer" }}
-                      >
-                        {t("detail.join.cancel")}
-                      </button>
-                    </div>
-                  </div>
+                {membership.state === "eligible" && (
+                  <JoinControl
+                    membership={membership}
+                    name={factionName(faction.slug)}
+                    skin={JOIN_SKIN}
+                    openLabel={t("ephemerists.join.joinButton")}
+                    joiningLabel={t("ephemerists.join.joining")}
+                    intro={
+                      <>
+                        <div
+                          style={{
+                            fontFamily: CAPS,
+                            fontWeight: 700,
+                            // eslint-disable-next-line local/no-raw-style-values -- ornament: Cinzel codex display title.
+                            fontSize: 23,
+                            lineHeight: 1.02,
+                            color: INK,
+                            marginBottom: "var(--space-md)",
+                          }}
+                        >
+                          {t("ephemerists.join.eligibleTitle")}
+                        </div>
+                        <div className="content-text" style={{ fontFamily: READING, lineHeight: 1.6, color: INK, marginBottom: "var(--space-lg)" }}>
+                          {t("ephemerists.join.eligibleBody")}
+                        </div>
+                      </>
+                    }
+                  />
                 )}
 
                 {(membership.state === "gate" || burned) && (
@@ -532,3 +493,21 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
     </div>
   );
 }
+
+/**
+ * The trio's paint (#2651).
+ *
+ * THE ONE PLATE CTA (#2146) — ground, ink and enclosure from `.eph-cta`, because
+ * the enclosure changes width between the cascades and no inline style has a
+ * cascade. That class dressed the open verb and the affirmative and never the
+ * cancel, which is exactly what the skin's single `className` slot reaches: the
+ * two affirmatives. The cancel stays a marginal note in the margin's own hand.
+ */
+const JOIN_SKIN: JoinControlSkin = {
+  className: "eph-cta",
+  openStyle: { width: "100%", ...SMALL_CAPS, fontSize: "var(--text-xl)", letterSpacing: "0.14em", padding: "var(--space-md)", cursor: "pointer" },
+  confirmStyle: { ...SMALL_CAPS, fontSize: "var(--text-lg)", letterSpacing: "0.12em", padding: "var(--space-md)" },
+  cancelStyle: { fontFamily: MARGINALIA, fontStyle: "italic", fontSize: "var(--text-lg)", letterSpacing: "0.06em", color: QUIET, background: "transparent", border: `1px solid ${LINE}`, padding: "var(--space-md) var(--space-lg)" },
+  proseStyle: { fontFamily: READING, lineHeight: 1.6, color: INK, marginBottom: "var(--space-lg)" },
+  errorStyle: { fontFamily: READING, color: "var(--color-danger)", marginBottom: "var(--space-sm)" },
+};

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/taskCard/TaskCard";
@@ -8,6 +8,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -230,7 +231,6 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
     membership,
   } = state;
   const sections = useFactionSections();
-  const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
@@ -382,88 +382,33 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                   </div>
                 )}
 
-                {membership.state === "eligible" && !confirming && (
-                  <div>
-                    <div
-                      style={{
-                        fontFamily: BEBAS,
-                        // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas poster headline set tight (lineHeight 0.9).
-                        fontSize: 32,
-                        lineHeight: 0.9,
-                        color: PAPER_TEXT,
-                        marginBottom: "var(--space-sm)",
-                      }}
-                    >
-                      {t("everymen.join.eligibleTitle")}
-                    </div>
-                    <div className="content-text" style={{ fontFamily: MONO, lineHeight: 1.6, color: PAPER_TEXT, marginBottom: "var(--space-lg)" }}>
-                      {t("everymen.join.eligibleBody")}
-                    </div>
-                    <button
-                      onClick={() => setConfirming(true)}
-                      style={{
-                        width: "100%",
-                        fontFamily: BEBAS,
-                        // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas is a condensed poster face — its optical size is not the text scale.
-                        fontSize: 18,
-                        letterSpacing: "0.12em",
-                        color: CREAM,
-                        background: RED,
-                        border: "none",
-                        padding: "var(--space-md)",
-                        boxShadow: `3px 4px 0 ${INK}`,
-                        cursor: "pointer",
-                      }}
-                    >
-                      {t("everymen.join.joinButton")}
-                    </button>
-                  </div>
-                )}
-
-                {membership.state === "eligible" && confirming && (
-                  <div>
-                    <div className="content-text" style={{ fontFamily: MONO, lineHeight: 1.6, color: PAPER_TEXT, marginBottom: "var(--space-lg)" }}>
-                      {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na"
-                        ? t("detail.join.confirmSwitch", {
-                            faction: factionName(faction.slug),
-                            current: factionName(membership.currentFactionSlug),
-                          })
-                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
-                    </div>
-                    {membership.joinError && (
-                      <div className="content-text" style={{ fontFamily: MONO, color: "var(--color-danger)", marginBottom: "var(--space-sm)" }}>{membership.joinError}</div>
-                    )}
-                    <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                      <button
-                        onClick={() => void membership.join()}
-                        disabled={membership.joining}
-                        style={{
-                          flex: 1,
-                          fontFamily: BEBAS,
-                          // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas is a condensed poster face — its optical size is not the text scale.
-                          fontSize: 16,
-                          letterSpacing: "0.1em",
-                          color: CREAM,
-                          background: RED,
-                          border: "none",
-                          padding: "var(--space-md)",
-                          cursor: membership.joining ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {membership.joining
-                          ? t("everymen.join.joining")
-                          : t("mobile.confirm")}
-                      </button>
-                      <button
-                        onClick={() => setConfirming(false)}
-                        disabled={membership.joining}
-                        style={{ fontFamily: MONO, fontSize: "var(--text-md)", fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${PAPER_TEXT} 30%, transparent)`, padding: "var(--space-md) var(--space-lg)", cursor: membership.joining ? "not-allowed" : "pointer" }}
-                      >
-                        {t("detail.join.cancel")}
-                      </button>
-                    </div>
-                  </div>
+                {membership.state === "eligible" && (
+                  <JoinControl
+                    membership={membership}
+                    name={factionName(faction.slug)}
+                    skin={JOIN_SKIN}
+                    openLabel={t("everymen.join.joinButton")}
+                    joiningLabel={t("everymen.join.joining")}
+                    intro={
+                      <>
+                        <div
+                          style={{
+                            fontFamily: BEBAS,
+                            // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas poster headline set tight (lineHeight 0.9).
+                            fontSize: 32,
+                            lineHeight: 0.9,
+                            color: PAPER_TEXT,
+                            marginBottom: "var(--space-sm)",
+                          }}
+                        >
+                          {t("everymen.join.eligibleTitle")}
+                        </div>
+                        <div className="content-text" style={{ fontFamily: MONO, lineHeight: 1.6, color: PAPER_TEXT, marginBottom: "var(--space-lg)" }}>
+                          {t("everymen.join.eligibleBody")}
+                        </div>
+                      </>
+                    }
+                  />
                 )}
 
                 {(membership.state === "gate" || burned) && (
@@ -600,3 +545,38 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
     </div>
   );
 }
+
+/**
+ * The trio's paint (#2651) — the red poster block for both affirmatives, the
+ * mono rule-box for the cancel, all values lifted off the three buttons as they
+ * stood. The offset shadow stays on the OPEN verb alone, which is where it was:
+ * a pressed slab beside a hairline outline is the poster's own hierarchy.
+ */
+const JOIN_SKIN: JoinControlSkin = {
+  openStyle: {
+    width: "100%",
+    fontFamily: BEBAS,
+    // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas is a condensed poster face — its optical size is not the text scale.
+    fontSize: 18,
+    letterSpacing: "0.12em",
+    color: CREAM,
+    background: RED,
+    border: "none",
+    padding: "var(--space-md)",
+    boxShadow: `3px 4px 0 ${INK}`,
+    cursor: "pointer",
+  },
+  confirmStyle: {
+    fontFamily: BEBAS,
+    // eslint-disable-next-line local/no-raw-style-values -- ornament: Bebas is a condensed poster face — its optical size is not the text scale.
+    fontSize: 16,
+    letterSpacing: "0.1em",
+    color: CREAM,
+    background: RED,
+    border: "none",
+    padding: "var(--space-md)",
+  },
+  cancelStyle: { fontFamily: MONO, fontSize: "var(--text-md)", fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${PAPER_TEXT} 30%, transparent)`, padding: "var(--space-md) var(--space-lg)" },
+  proseStyle: { fontFamily: MONO, lineHeight: 1.6, color: PAPER_TEXT, marginBottom: "var(--space-lg)" },
+  errorStyle: { fontFamily: MONO, color: "var(--color-danger)", marginBottom: "var(--space-sm)" },
+};

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/taskCard/TaskCard";
@@ -8,6 +8,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -175,7 +176,6 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
     membership,
   } = state;
   const sections = useFactionSections();
-  const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
@@ -359,101 +359,34 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                   </div>
                 )}
 
-                {membership.state === "eligible" && !confirming && (
-                  <div>
-                    <div
-                      style={{
-                        fontFamily: FONT,
-                        // eslint-disable-next-line local/no-raw-style-values -- ornament: terminal display title.
-                        fontSize: 22,
-                        lineHeight: 1.05,
-                        color: PHOSPHOR,
-                        letterSpacing: "0.03em",
-                        marginBottom: "var(--space-md)",
-                      }}
-                    >
-                      {t("singularity.join.eligibleTitle")}
-                    </div>
-                    <div className="content-text" style={{ fontFamily: FONT, lineHeight: 1.65, color: phosphor(60), marginBottom: "var(--space-lg)" }}>
-                      {t("singularity.join.eligibleBody")}
-                    </div>
-                    <button
-                      onClick={() => setConfirming(true)}
-                      style={{
-                        width: "100%",
-                        fontFamily: FONT,
-                        fontSize: "var(--text-md)",
-                        letterSpacing: "0.14em",
-                        textTransform: "uppercase",
-                        color: VOID,
-                        background: PHOSPHOR,
-                        border: "none",
-                        padding: "var(--space-md)",
-                        boxShadow: `0 0 16px ${phosphor(35)}`,
-                        cursor: "pointer",
-                      }}
-                    >
-                      {t("singularity.join.joinButton")}
-                    </button>
-                  </div>
-                )}
-
-                {membership.state === "eligible" && confirming && (
-                  <div>
-                    <div className="content-text" style={{ fontFamily: FONT, lineHeight: 1.7, color: phosphor(72), marginBottom: "var(--space-lg)" }}>
-                      {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na"
-                        ? t("detail.join.confirmSwitch", {
-                            faction: factionName(faction.slug),
-                            current: factionName(membership.currentFactionSlug),
-                          })
-                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
-                    </div>
-                    {membership.joinError && (
-                      <div className="content-text" style={{ fontFamily: FONT, color: "var(--color-danger)", marginBottom: "var(--space-sm)" }}>
-                        {membership.joinError}
-                      </div>
-                    )}
-                    <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                      <button
-                        onClick={() => void membership.join()}
-                        disabled={membership.joining}
-                        style={{
-                          flex: 1,
-                          fontFamily: FONT,
-                          fontSize: "var(--text-base)",
-                          letterSpacing: "0.12em",
-                          textTransform: "uppercase",
-                          color: VOID,
-                          background: PHOSPHOR,
-                          border: "none",
-                          padding: "var(--space-md)",
-                          cursor: membership.joining ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {membership.joining
-                          ? t("singularity.join.joining")
-                          : t("mobile.confirm")}
-                      </button>
-                      <button
-                        onClick={() => setConfirming(false)}
-                        disabled={membership.joining}
-                        style={{
-                          fontFamily: FONT,
-                          fontSize: "var(--text-md)",
-                          letterSpacing: "0.16em",
-                          textTransform: "uppercase",
-                          color: signal(60),
-                          background: "transparent",
-                          border: `1px solid ${signal(40)}`,
-                          padding: "var(--space-md) var(--space-lg)",
-                          cursor: membership.joining ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {t("detail.join.cancel")}
-                      </button>
-                    </div>
-                  </div>
+                {membership.state === "eligible" && (
+                  <JoinControl
+                    membership={membership}
+                    name={factionName(faction.slug)}
+                    skin={JOIN_SKIN}
+                    openLabel={t("singularity.join.joinButton")}
+                    joiningLabel={t("singularity.join.joining")}
+                    intro={
+                      <>
+                        <div
+                          style={{
+                            fontFamily: FONT,
+                            // eslint-disable-next-line local/no-raw-style-values -- ornament: terminal display title.
+                            fontSize: 22,
+                            lineHeight: 1.05,
+                            color: PHOSPHOR,
+                            letterSpacing: "0.03em",
+                            marginBottom: "var(--space-md)",
+                          }}
+                        >
+                          {t("singularity.join.eligibleTitle")}
+                        </div>
+                        <div className="content-text" style={{ fontFamily: FONT, lineHeight: 1.65, color: phosphor(60), marginBottom: "var(--space-lg)" }}>
+                          {t("singularity.join.eligibleBody")}
+                        </div>
+                      </>
+                    }
+                  />
                 )}
 
                 {(membership.state === "gate" || burned) && (
@@ -581,3 +514,46 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
     </div>
   );
 }
+
+/**
+ * The trio's paint (#2651) — phosphor-on-void for both affirmatives, a signal
+ * hairline for the cancel, exactly as the three buttons stood. The glow stays on
+ * the OPEN verb alone, where it was: the array announces itself once.
+ */
+const JOIN_SKIN: JoinControlSkin = {
+  openStyle: {
+    width: "100%",
+    fontFamily: FONT,
+    fontSize: "var(--text-md)",
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+    color: VOID,
+    background: PHOSPHOR,
+    border: "none",
+    padding: "var(--space-md)",
+    boxShadow: `0 0 16px ${phosphor(35)}`,
+    cursor: "pointer",
+  },
+  confirmStyle: {
+    fontFamily: FONT,
+    fontSize: "var(--text-base)",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    color: VOID,
+    background: PHOSPHOR,
+    border: "none",
+    padding: "var(--space-md)",
+  },
+  cancelStyle: {
+    fontFamily: FONT,
+    fontSize: "var(--text-md)",
+    letterSpacing: "0.16em",
+    textTransform: "uppercase",
+    color: signal(60),
+    background: "transparent",
+    border: `1px solid ${signal(40)}`,
+    padding: "var(--space-md) var(--space-lg)",
+  },
+  proseStyle: { fontFamily: FONT, lineHeight: 1.7, color: phosphor(72), marginBottom: "var(--space-lg)" },
+  errorStyle: { fontFamily: FONT, color: "var(--color-danger)", marginBottom: "var(--space-sm)" },
+};

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/taskCard/TaskCard";
@@ -8,6 +8,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -312,7 +313,6 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
     membership,
   } = state;
   const sections = useFactionSections();
-  const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
@@ -499,116 +499,36 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                   </div>
                 )}
 
-                {membership.state === "eligible" && !confirming && (
-                  <div>
-                    <div
-                      style={{
-                        ...ACID_PLATE,
-                        display: "inline-block",
-                        fontFamily: IMPACT,
-                        // eslint-disable-next-line local/no-raw-style-values -- ornament: Impact stencil headline set tight (lineHeight 0.9) — poster type.
-                        fontSize: 24,
-                        lineHeight: 0.9,
-                        padding: "var(--space-xs) var(--space-sm)",
-                        textTransform: "uppercase",
-                        marginBottom: "var(--space-sm)",
-                      }}
-                    >
-                      {t("snide.join.eligibleTitle")}
-                    </div>
-                    <div className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.5, color: NOTE_MUTED, marginBottom: "var(--space-lg)" }}>
-                      {t("snide.join.eligibleBody")}
-                    </div>
-                    <button
-                      onClick={() => setConfirming(true)}
-                      style={{
-                        width: "100%",
-                        background: PINK,
-                        // #1609: white on `--faction-snide-pink` measures
-                        // 3.50:1 — below AA. The ink that clears it is already
-                        // declared and already measured: 5.38:1.
-                        color: "var(--faction-snide-on-accent)",
-                        fontFamily: BLACK,
-                        fontSize: "var(--text-xl)",
-                        padding: "var(--space-md)",
-                        border: "none",
-                        transform: "rotate(-1deg)",
-                        // The CTA's offset register (#1609) — not lift.
-                        boxShadow: "3px 4px 0 color-mix(in srgb, var(--color-print-offset) 40%, transparent)",
-                        cursor: "pointer",
-                      }}
-                    >
-                      {t("snide.join.joinButton")}
-                    </button>
-                  </div>
-                )}
-
-                {membership.state === "eligible" && confirming && (
-                  <div>
-                    <div className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.6, color: NOTE_MUTED, marginBottom: "var(--space-lg)" }}>
-                      {membership.currentFactionSlug &&
-                      membership.currentFactionSlug !== "na"
-                        ? t("detail.join.confirmSwitch", {
-                            faction: factionName(faction.slug),
-                            current: factionName(membership.currentFactionSlug),
-                          })
-                        : t("detail.join.confirm", { faction: factionName(faction.slug) })}
-                    </div>
-                    {/* The wall's alarm ink, not the global `--color-danger`
-                        (#2343). That token is measured on `--color-bg-page` and
-                        reads 4.08:1 on this wall — it read 3.93:1 on the ink
-                        panel before it, so this is a pre-existing AA miss the
-                        ground move surfaced rather than caused. The faction's
-                        own composer error banner already prints a `-*-alarm`;
-                        `-wall-alarm` is that rung for this ground, at 6.68:1
-                        light / 7.41:1 dark. */}
-                    {membership.joinError && (
-                      <div className="content-text" style={{ fontFamily: MONO, color: WALL_ALARM, marginBottom: "var(--space-sm)" }}>
-                        {membership.joinError}
-                      </div>
-                    )}
-                    <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                      <button
-                        onClick={() => void membership.join()}
-                        disabled={membership.joining}
-                        style={{
-                          flex: 1,
-                          background: PINK,
-                          // #1609: white on `--faction-snide-pink` is 3.50:1,
-                          // below AA; `-on-accent` is the measured 5.38:1 ink.
-                          color: "var(--faction-snide-on-accent)",
-                          fontFamily: BLACK,
-                          fontSize: "var(--text-xl)",
-                          padding: "var(--space-md)",
-                          border: "none",
-                          cursor: membership.joining ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {membership.joining
-                          ? t("snide.join.joining")
-                          : t("mobile.confirm")}
-                      </button>
-                      <button
-                        onClick={() => setConfirming(false)}
-                        disabled={membership.joining}
-                        style={{
-                          fontFamily: COND,
-                          fontSize: "var(--text-xl)",
-                          letterSpacing: "0.12em",
-                          textTransform: "uppercase",
-                          color: NOTE_MUTED,
-                          background: "transparent",
-                          // The dash keeps its 45%; only the ink under it moved,
-                          // onto the tier that flips with this button's ground.
-                          border: `2px dashed color-mix(in srgb, ${NOTE_MUTED} 45%, transparent)`,
-                          padding: "var(--space-md) var(--space-lg)",
-                          cursor: membership.joining ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {t("detail.join.cancel")}
-                      </button>
-                    </div>
-                  </div>
+                {membership.state === "eligible" && (
+                  <JoinControl
+                    membership={membership}
+                    name={factionName(faction.slug)}
+                    skin={JOIN_SKIN}
+                    openLabel={t("snide.join.joinButton")}
+                    joiningLabel={t("snide.join.joining")}
+                    intro={
+                      <>
+                        <div
+                          style={{
+                            ...ACID_PLATE,
+                            display: "inline-block",
+                            fontFamily: IMPACT,
+                            // eslint-disable-next-line local/no-raw-style-values -- ornament: Impact stencil headline set tight (lineHeight 0.9) — poster type.
+                            fontSize: 24,
+                            lineHeight: 0.9,
+                            padding: "var(--space-xs) var(--space-sm)",
+                            textTransform: "uppercase",
+                            marginBottom: "var(--space-sm)",
+                          }}
+                        >
+                          {t("snide.join.eligibleTitle")}
+                        </div>
+                        <div className="content-text" style={{ fontFamily: TYPE, lineHeight: 1.5, color: NOTE_MUTED, marginBottom: "var(--space-lg)" }}>
+                          {t("snide.join.eligibleBody")}
+                        </div>
+                      </>
+                    }
+                  />
                 )}
 
                 {(membership.state === "gate" || burned) && (
@@ -783,3 +703,55 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
     </div>
   );
 }
+
+/**
+ * The trio's paint (#2651) — the pink slab for both affirmatives, the dashed
+ * condensed rule-box for the cancel. Every value stood on one of these three
+ * buttons already; the tilt and the offset shadow stay on the OPEN verb alone,
+ * which is where the wall put them.
+ *
+ * #1609: white on `--faction-snide-pink` measures 3.50:1 — below AA. The ink
+ * that clears it is already declared and already measured: `-on-accent`, 5.38:1.
+ * Both affirmatives read it, which is what having one skin is for.
+ *
+ * The ERROR line is the wall's alarm ink, not the global `--color-danger`
+ * (#2343). That token is measured on `--color-bg-page` and reads 4.08:1 on this
+ * wall; `-wall-alarm` is the rung for this ground, at 6.68:1 light / 7.41:1 dark.
+ */
+const JOIN_SKIN: JoinControlSkin = {
+  openStyle: {
+    width: "100%",
+    background: PINK,
+    color: "var(--faction-snide-on-accent)",
+    fontFamily: BLACK,
+    fontSize: "var(--text-xl)",
+    padding: "var(--space-md)",
+    border: "none",
+    transform: "rotate(-1deg)",
+    // The CTA's offset register (#1609) — not lift.
+    boxShadow: "3px 4px 0 color-mix(in srgb, var(--color-print-offset) 40%, transparent)",
+    cursor: "pointer",
+  },
+  confirmStyle: {
+    background: PINK,
+    color: "var(--faction-snide-on-accent)",
+    fontFamily: BLACK,
+    fontSize: "var(--text-xl)",
+    padding: "var(--space-md)",
+    border: "none",
+  },
+  cancelStyle: {
+    fontFamily: COND,
+    fontSize: "var(--text-xl)",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    color: NOTE_MUTED,
+    background: "transparent",
+    // The dash keeps its 45%; only the ink under it moved, onto the tier that
+    // flips with this button's ground.
+    border: `2px dashed color-mix(in srgb, ${NOTE_MUTED} 45%, transparent)`,
+    padding: "var(--space-md) var(--space-lg)",
+  },
+  proseStyle: { fontFamily: TYPE, lineHeight: 1.6, color: NOTE_MUTED, marginBottom: "var(--space-lg)" },
+  errorStyle: { fontFamily: MONO, color: WALL_ALARM, marginBottom: "var(--space-sm)" },
+};

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import TaskCard from "../../../components/taskCard/TaskCard";
@@ -14,6 +14,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -171,7 +172,6 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
     membership,
   } = state;
   const sections = useFactionSections();
-  const [confirming, setConfirming] = useState(false);
 
   if (!faction) return null;
 
@@ -188,6 +188,31 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
     lineHeight: 1.7,
     color: "var(--faction-ua-card-body)",
     margin: 0,
+  };
+
+  /**
+   * The trio's paint (#2651). Every value below was already on these three
+   * buttons — the solid fill for both affirmatives, the eyebrow for the cancel
+   * — and `flex`, the busy opacity and the busy cursor came off them, because
+   * the shared control owns the pending state now. Built here rather than at
+   * module scope because it reads `prose`, which is.
+   */
+  const joinSkin: JoinControlSkin = {
+    openStyle: { ...SOLID_ACTION, width: "100%", cursor: "pointer" },
+    confirmStyle: SOLID_ACTION,
+    cancelStyle: {
+      ...UA_EYEBROW,
+      background: "transparent",
+      border: "1px solid var(--faction-ua-rule)",
+      borderRadius: "var(--radius-sm)",
+      padding: "var(--space-md) var(--space-lg)",
+    },
+    proseStyle: {
+      ...prose,
+      color: "var(--faction-ua-card-text)",
+      marginBottom: "var(--space-lg)",
+    },
+    errorStyle: { ...prose, color: "var(--color-danger)", marginBottom: "var(--space-sm)" },
   };
 
   return (
@@ -357,97 +382,36 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
               </div>
             )}
 
-            {membership.state === "eligible" && !confirming && (
-              <div>
-                <div
-                  className="content-title"
-                  style={{
-                    fontFamily: UA_DISPLAY,
-                    fontWeight: 600,
-                    lineHeight: 1.05,
-                    color: "var(--faction-ua-card-text)",
-                    margin: "var(--space-xs) 0 var(--space-md)",
-                  }}
-                >
-                  {t("ua.join.eligibleTitle")}
-                </div>
-                <p
-                  className="content-text"
-                  style={{ ...prose, marginBottom: "var(--space-lg)" }}
-                >
-                  {t("ua.join.eligibleBody")}
-                </p>
-                <button
-                  onClick={() => setConfirming(true)}
-                  style={{ ...SOLID_ACTION, width: "100%", cursor: "pointer" }}
-                >
-                  {t("ua.join.joinButton")}
-                </button>
-              </div>
-            )}
-
-            {membership.state === "eligible" && confirming && (
-              <div>
-                <p
-                  className="content-text"
-                  style={{
-                    ...prose,
-                    color: "var(--faction-ua-card-text)",
-                    marginBottom: "var(--space-lg)",
-                  }}
-                >
-                  {membership.currentFactionSlug &&
-                  membership.currentFactionSlug !== "na"
-                    ? t("detail.join.confirmSwitch", {
-                        faction: factionName(faction.slug),
-                        current: factionName(membership.currentFactionSlug),
-                      })
-                    : t("detail.join.confirm", {
-                        faction: factionName(faction.slug),
-                      })}
-                </p>
-                {membership.joinError && (
-                  <p
-                    className="content-text"
-                    style={{
-                      ...prose,
-                      color: "var(--color-danger)",
-                      marginBottom: "var(--space-sm)",
-                    }}
-                  >
-                    {membership.joinError}
-                  </p>
-                )}
-                <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                  <button
-                    onClick={() => void membership.join()}
-                    disabled={membership.joining}
-                    style={{
-                      ...SOLID_ACTION,
-                      flex: 1,
-                      cursor: membership.joining ? "not-allowed" : "pointer",
-                    }}
-                  >
-                    {membership.joining
-                      ? t("ua.join.joining")
-                      : t("mobile.confirm")}
-                  </button>
-                  <button
-                    onClick={() => setConfirming(false)}
-                    disabled={membership.joining}
-                    style={{
-                      ...UA_EYEBROW,
-                      background: "transparent",
-                      border: "1px solid var(--faction-ua-rule)",
-                      borderRadius: "var(--radius-sm)",
-                      padding: "var(--space-md) var(--space-lg)",
-                      cursor: membership.joining ? "not-allowed" : "pointer",
-                    }}
-                  >
-                    {t("detail.join.cancel")}
-                  </button>
-                </div>
-              </div>
+            {membership.state === "eligible" && (
+              <JoinControl
+                membership={membership}
+                name={factionName(faction.slug)}
+                skin={joinSkin}
+                openLabel={t("ua.join.joinButton")}
+                joiningLabel={t("ua.join.joining")}
+                intro={
+                  <>
+                    <div
+                      className="content-title"
+                      style={{
+                        fontFamily: UA_DISPLAY,
+                        fontWeight: 600,
+                        lineHeight: 1.05,
+                        color: "var(--faction-ua-card-text)",
+                        margin: "var(--space-xs) 0 var(--space-md)",
+                      }}
+                    >
+                      {t("ua.join.eligibleTitle")}
+                    </div>
+                    <p
+                      className="content-text"
+                      style={{ ...prose, marginBottom: "var(--space-lg)" }}
+                    >
+                      {t("ua.join.eligibleBody")}
+                    </p>
+                  </>
+                }
+              />
             )}
 
             {membership.state === "gate" && (

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -9,6 +9,7 @@ import { WowSigil } from "../../../components/sigil/WowSigil";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { computeFactionMultiplier } from "../../../utils/points";
 import type { CharacterOut } from "../../../api/auth";
+import { JoinControl, type JoinControlSkin } from "../JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -79,8 +80,6 @@ const PLATE = "var(--faction-wow-plate)";
 const HAIR = "var(--faction-wow-chronicle-rule)";
 const BORDER = "var(--faction-wow-chronicle-border)";
 const SHADOW = "0 18px 40px -20px var(--faction-wow-chronicle-shadow)";
-
-const NA_SLUG = "na";
 
 /** Members shown on the roll before it stops. The rest are on the players page. */
 const ROLL_LIMIT = 8;
@@ -454,12 +453,8 @@ function JoinBlock({
   membership: FactionDetailState["membership"];
 }) {
   const { t } = useTranslation("factions");
-  const [confirming, setConfirming] = useState(false);
 
   if (membership.state === "none") return null;
-
-  const currentSlug = membership.currentFactionSlug;
-  const switching = currentSlug && currentSlug !== NA_SLUG;
 
   return (
     <aside
@@ -509,86 +504,40 @@ function JoinBlock({
           </>
         )}
 
-        {membership.state === "eligible" && !confirming && (
-          <>
-            <div
-              style={{
-                fontFamily: MED,
-                fontSize: "var(--text-title)",
-                lineHeight: 1.15,
-                color: INK,
-                margin: "var(--space-xs) 0 var(--space-sm)",
-              }}
-            >
-              {t("wow.join.eligibleTitle")}
-            </div>
-            <p
-              className="content-text"
-              style={{
-                fontFamily: LORA,
-                fontStyle: "italic",
-                color: MUTED,
-                margin: "0 0 var(--space-lg)",
-              }}
-            >
-              {t("wow.join.eligibleBody")}
-            </p>
-            <button type="button" onClick={() => setConfirming(true)} style={GILT_BUTTON}>
-              {t("wow.join.joinButton")}
-            </button>
-          </>
-        )}
-
-        {membership.state === "eligible" && confirming && (
-          <>
-            <p
-              className="content-text"
-              style={{
-                fontFamily: LORA,
-                lineHeight: 1.6,
-                color: INK,
-                margin: "0 0 var(--space-md)",
-              }}
-            >
-              {switching
-                ? t("detail.join.confirmSwitch", {
-                    faction: name,
-                    current: factionName(currentSlug),
-                  })
-                : t("detail.join.confirm", { faction: name })}
-            </p>
-            {membership.joinError && (
-              <p
-                className="content-text"
-                style={{
-                  fontFamily: LORA,
-                  color: "var(--color-danger)",
-                  margin: "0 0 var(--space-md)",
-                }}
-              >
-                {membership.joinError}
-              </p>
-            )}
-            {/* [Cancel] … [Confirm] — the global footer order (#646). */}
-            <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-              <button
-                type="button"
-                onClick={() => setConfirming(false)}
-                disabled={membership.joining}
-                style={GHOST_BUTTON}
-              >
-                {t("detail.join.cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={() => void membership.join()}
-                disabled={membership.joining}
-                style={{ ...GILT_BUTTON, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
-              >
-                {membership.joining ? t("wow.join.joining") : t("mobile.confirm")}
-              </button>
-            </div>
-          </>
+        {membership.state === "eligible" && (
+          <JoinControl
+            membership={membership}
+            name={name}
+            skin={JOIN_SKIN}
+            openLabel={t("wow.join.joinButton")}
+            joiningLabel={t("wow.join.joining")}
+            intro={
+              <>
+                <div
+                  style={{
+                    fontFamily: MED,
+                    fontSize: "var(--text-title)",
+                    lineHeight: 1.15,
+                    color: INK,
+                    margin: "var(--space-xs) 0 var(--space-sm)",
+                  }}
+                >
+                  {t("wow.join.eligibleTitle")}
+                </div>
+                <p
+                  className="content-text"
+                  style={{
+                    fontFamily: LORA,
+                    fontStyle: "italic",
+                    color: MUTED,
+                    margin: "0 0 var(--space-lg)",
+                  }}
+                >
+                  {t("wow.join.eligibleBody")}
+                </p>
+              </>
+            }
+          />
         )}
 
         {/* The gate and the burn must stay distinguishable: "keep questing" is
@@ -668,4 +617,28 @@ const GHOST_BUTTON: CSSProperties = {
   borderRadius: 999,
   padding: "var(--space-sm) var(--space-lg)",
   cursor: "pointer",
+};
+
+/**
+ * THE ONE KIT ALREADY IN #646 ORDER, and the only one that had named its two
+ * buttons. The skin is those same two constants handed to `JoinControl` — the
+ * gilt pill for both affirmatives, the ghost for the cancel — so nothing on this
+ * page moves except that the pair is now written somewhere the other eight can
+ * read it (#2651).
+ */
+const JOIN_SKIN: JoinControlSkin = {
+  openStyle: GILT_BUTTON,
+  confirmStyle: GILT_BUTTON,
+  cancelStyle: GHOST_BUTTON,
+  proseStyle: {
+    fontFamily: LORA,
+    lineHeight: 1.6,
+    color: INK,
+    margin: "0 0 var(--space-md)",
+  },
+  errorStyle: {
+    fontFamily: LORA,
+    color: "var(--color-danger)",
+    margin: "0 0 var(--space-md)",
+  },
 };


### PR DESCRIPTION
Closes #2651

## The seam

**The join trio's rendered button order, per faction.** The trio was written out
longhand in all eight faction bodies, and seven of them put the affirmative on
the LEFT — a shipped global ruling (#646, stated at `SealActions`) broken in
seven places. The extraction takes the primary button *and* the pair, because
the defect lives in the pair.

## Red first

`frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx` went in
before the migration and failed **26 of 32**: eighteen faction × form-factor
pairs drew no shared control, and eight archetypes wrote the trio themselves.
The order assertion itself was proved to bite by flipping the two buttons in
`JoinConfirm` and watching it go red on its own.

The harness has no DOM (`renderToStaticMarkup`), so the confirm step is not
reachable through a click. The guard therefore asserts in three parts, and part
2 is where the per-slug claim is made:

1. `JoinConfirm` renders cancel before confirm, does not reverse the row, keeps
   the error slot, and shows the busy label + `opacity:0.6` + two `disabled`s.
2. **Every faction with a page** — read off `FACTION_MANIFESTS`, so a tenth kit
   is covered the day it registers — renders exactly one `data-join="open"`, at
   both form factors. `na` is excluded and the reason is written down: it has a
   manifest since #2530 but no faction page (`factionHero.na` has no copy at
   all). Its skin is still exercised, because `albescent` wraps it.
3. No `*FactionBody.tsx` contains `setConfirming`, `membership.join()` or
   `detail.join.cancel`. This is the one that catches a re-inlining inside a
   branch the other two do not render.

## What changed

**New:** `frontend/src/pages/factionDetail/JoinControl.tsx` — `JoinControl`
(owns `confirming`, the three handlers, `disabled`, the busy paint, the labels
and the #646 order) plus the stateless `JoinConfirm` it renders, and the typed
`JoinControlSkin`. The three button slots are **required**, so a kit that
forgets one is a compile error; `className` / `proseStyle` / `errorStyle` are
optional, per the issue's shape.

**Eight bodies** hand it a skin and keep every pixel: `Coven`, `Default`,
`Ephemerists`, `Everymen`, `Singularity`, `Snide`, `Ua`, `Wow`. `Albescent`
draws none of this and still resolves through its Default wrapper (asserted).
The dialog chrome did not move — the plate, the slip and the marginalia are
still each kit's own; only the buttons inside them are shared.

**Three drifts fixed**, because the control now owns the state they describe:

- **#646 order** on all eight. WOW was already right and is the reference.
- **The busy opacity**, uniform. It shipped on WOW and the fall-through only;
  six kits disabled the affirmative and showed nothing.
- **The busy cursor**, uniform. Six set `not-allowed`, two left `pointer` under
  a disabled button.

**Copy.** `mobile.confirm` → `detail.join.confirmAction` (ten call sites,
`InvitationLetterPopup` included), and `mobile.join` / `mobile.joining` →
`detail.join.joinButton` / `detail.join.joining`. The whole trio's shared copy
now sits in one family; `detail.join.confirm` still means the switch *sentence*,
which is why the button is `confirmAction`.

**Default keeps a generic verb, and here is the written reason** the issue asked
for. It is the fall-through for every faction *without* a kit — `albescent`
today, a tenth faction the day it registers — so a `<slug>.join.*` family would
have to be minted for a slug that has no voice, and Albescent's would be a tell
(ADR-0027 / #2409). `Join {{faction}}` interpolates the name and is correct for
all of them. What was stale was the *namespace*, not the string.

## Not touched, deliberately

- **`SealActions`** (`components/duel/shared.tsx`) — grandfathered for the duel
  sheet, per the ruling. Nine measured duel surfaces are untouched.
- **`InvitationLetterPopup` / `FeedCardInvitationLetter` /
  `RelationshipBlockControl`** keep their own `confirming` — different flows,
  out of scope. **One finding worth a follow-up issue:** the popup's own pair is
  *also* confirm-then-cancel, i.e. the same #646 violation, at
  `InvitationLetterPopup.tsx:320-336`. It is out of this issue's scope so I left
  it; it is not covered by the new guard either.
- **Contrast.** No colour moved: every skin value is the one that was on the
  button. `factionContrast.test.ts` is green as part of the full run below. Note
  for the record — that gate is token-and-source based rather than a fixed list
  of "eight grounds", and it also now scans `na` as the ninth manifest (#2530 /
  #2645); nothing in it needed changing.
- **Hit targets.** No padding, font size or box on any of the 24 buttons
  changed, so the 44px floor is exactly where it was.

## One behavioural nuance

On the fall-through body the control is rendered either in the rail or in the
phone sticky bar. `confirming` used to live in the body and survived a resize
across the breakpoint; it now lives in the control, which unmounts on that
crossing, so a resize mid-confirm returns to the pitch. Edge case, stated rather
than hidden.

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit` + e2e project) — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **436 files, 8204 passed, 1 skipped**
- `npm run build` — ok
- `npm run budget` — JS 129.4 KB / CSS 22.1 KB, within budget

`api-schema` is untouched: no route, `response_model` or Pydantic schema in this
diff. **No browser QA was possible from this worktree — visual verification is
outstanding**, which is what the list below is for.

## What to eyeball

Each row is "open the faction page as an eligible viewer, press the join verb,
look at the confirm step".

1. **S.N.I.D.E., light and dark** — the pair is the most repainted: pink slab
   affirmative against a dashed `color-mix` cancel, on the wall ground. Check
   the dashed border still reads at both cascades now that it sits on the left.
2. **Coven, light and dark** — the spark glyph now rides inside the open verb's
   label. Check it still sits before the word and centred, and that the pitch is
   centred while the question below is not (that split is deliberate).
3. **The Ephemerists, light and dark** — the only kit whose buttons are dressed
   by a CSS class (`.eph-cta`), and that enclosure changes width between the
   cascades. It is on the open verb and the affirmative, never the cancel.
4. **The Everymen, light** — the cancel's border is a `color-mix` at 30% on the
   paper ink; it is now the left-hand button against the red slab.
5. **The Singularity, dark** — phosphor on void, and the glow stays on the open
   verb alone. The confirm should have no glow, as before.
6. **WOW, light** — the control group: this one should be **pixel-identical**.
   If anything moved here, the extraction moved it.
7. **UA and Albescent (the fall-through), both themes** — Albescent on the prism
   ground, and check the phone sticky bar as well as the laptop rail.
8. **A FAILED join** — the error slot renders only on a failed join, so nothing
   else can prove it survived. Stop the API (or otherwise make `join()` reject)
   and confirm the error line appears **above** the pair, in the kit's own ink.
   S.N.I.D.E. is the one to check: it alone inks that line with
   `--faction-snide-wall-alarm` rather than `--color-danger`.
9. **The pending state on the six that had none** — Coven, Ephemerists,
   Everymen, Singularity, S.N.I.D.E., UA. While joining, the affirmative should
   now dim to 0.6 and both buttons should take the `not-allowed` cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
