### PR TITLE
The score stamp's outer margin belongs to its host: law 09, four hosts measured, two declarations added (#2655)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -236,21 +236,30 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
 
   /**
    * #2360 — THE ENTRY GETS ITS AIR, THE SEAL KEEPS THE CORNICE.
+   * #2655 — AND THE LEAF, NOT THE TITLE, IS WHERE THE RUNG IS STATED.
    *
    * This was the only praxis card in the kit opening with zero top padding, so
-   * the title butted the cavetto. The obvious repair — a top pad on the leaf —
-   * is the one that must NOT happen: the crown hangs at `top: -13` off the
-   * SCORE STAMP's box, and the stamp's box sits at the leaf's content top, so
-   * padding the leaf moves the crown down out of the 12px cornice and into the
-   * new padding. It still LOOKS right, because the crown only draws on a
-   * crowned praxis — hence this test renders one.
+   * the title butted the cavetto AND the score stamp sat on it. #2360 read the
+   * first half and ruled out a top pad on the leaf, because the crown hangs at
+   * `top: -13` off the SCORE STAMP's box and the box sits at the leaf's content
+   * top — so *24px* of padding drops the crown out of the ~12px cornice.
    *
-   * The air therefore goes on the TITLE, a flex SIBLING of the stamp's column:
-   * a margin there cannot displace the stamp. What is decidable in an SSR
-   * harness with no layout engine is exactly that split, so all three legs are
-   * asserted together — each alone is satisfiable by the wrong fix.
+   * #2655's law 09 reversed WHERE the rung is written, not how big it is. A
+   * travelling piece owns no outer spacing; a per-faction margin standing in for
+   * a gap the host declined to state is the defect wearing a different box. The
+   * leaf states `--space-sm`, the title keeps `--space-lg`, and the arithmetic
+   * is the whole argument:
+   *
+   *   - 8px of leaf padding against a 13px overhang still breaks the crown 5px
+   *     into the cornice, so #2360's stated reason and #2240/#2122 all hold;
+   *   - 8 + 16 = 24, so the entry opens exactly where it did.
+   *
+   * Only the stamp's box moved, which is #2655's named exemption on a frozen
+   * surface. All four legs are asserted together — each alone is satisfiable by
+   * the wrong fix, and the pair of rungs especially: either one on its own would
+   * pass while the sum was wrong.
    */
-  it('gives the title its space without moving the crown off the cornice (#2360)', () => {
+  it('gives the title its space without moving the crown off the cornice (#2360/#2655)', () => {
     const markup = render(
       <EphemeristsPraxisCard praxis={praxis({ is_top_for_task: true })} adminProps={adminProps} />,
     )
@@ -258,24 +267,25 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
     expect(markup, 'the one praxis mark').toContain('var(--fdl-ring)')
     expect(markup, "the crown's overhang, unchanged").toContain('top:-13px')
 
-    // (2) The leaf's top edge has not moved: the first rung of its padding
-    // shorthand is still zero, so the -13 measures from the cavetto's underside.
+    // (2) The leaf opens on the SMALL rung. `--space-xl` here is still the
+    // forbidden value: 24px would swallow the crown's 13px whole.
     const leaf = markup.match(/<div style="position:relative;z-index:\d+;padding:([^ ;"]*)/)
     expect(leaf?.[1], 'the leaf declares a padding').toBeDefined()
-    expect(leaf?.[1], 'a top pad here would pull the crown out of the cornice').toBe('0')
+    expect(leaf?.[1], 'the host states the gap above the stamp (#2655)').toBe('var(--space-sm)')
 
-    // (3) Nor has the heading ROW gained one — it carries the stamp.
+    // (3) The heading ROW states none — it carries the stamp, and a rung here
+    // would double the leaf's. Its `margin-bottom` (#2655) is a different edge.
     const row = markup.match(/<div style="display:flex;justify-content:space-between;[^"]*"/)
     expect(row?.[0], 'the heading row is rendered').toBeDefined()
     expect(row?.[0], 'a pad on the row moves the stamp with the title').not.toMatch(
       /(margin|padding)-(top|block-start)/,
     )
 
-    // (4) And the air is on the title itself, at the kit's rung.
+    // (4) And the title makes up the rest of the kit's rung, not all of it.
     const title = markup.match(/<h2 class="content-title[^"]*" style="([^"]*)"/)
     expect(title?.[1], 'the title is rendered').toBeDefined()
-    expect(title?.[1], "the entry's air, matching its eight fellows").toContain(
-      'margin-top:var(--space-xl)',
+    expect(title?.[1], "the entry's air, less the leaf's rung").toContain(
+      'margin-top:var(--space-lg)',
     )
   })
 })

--- a/frontend/src/components/praxisCard/__tests__/stampOuterMargin.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/stampOuterMargin.test.tsx
@@ -29,11 +29,20 @@
  *    TITLE instead — the piece's own drawing dictating the host's padding,
  *    which is the law read backwards.
  *
- * The other three hosts measured CLEAN and are asserted here so they stay that
- * way: every praxis-detail panel pads `var(--space-lg)` under its centring div
- * and heads it with a `margin-bottom`; every task-detail worth cell is a padded
+ * ### What is NOT asserted here, and why
+ *
+ * The other three hosts measured CLEAN and are deliberately left unasserted:
+ * every praxis-detail panel pads `var(--space-lg)` under its centring div and
+ * heads it with a `margin-bottom`; every task-detail worth cell is a padded
  * `innerBox`; the composer slip wraps with `gap: var(--space-lg)`, which on a
- * wrapped flex row is the row gap too.
+ * wrapped flex row is the row gap too. Each of those is that host's own general
+ * padding rather than a declaration about the stamp, so pinning it here would
+ * freeze three unrelated layouts to catch a defect none of them has.
+ *
+ * The PIECE half of law 09 does cover them: the nine root assertions above hold
+ * wherever a stamp is mounted, so no host can be made flush by the stamp. A host
+ * that later DROPS its own padding is out of this guard's reach, and that is the
+ * known gap — not an oversight.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'

--- a/frontend/src/components/praxisCard/__tests__/stampOuterMargin.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/stampOuterMargin.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * #2655 — LAW 09: A TRAVELLING PIECE OWNS NO OUTER MARGIN. It owns its own box;
+ * the host owns every gap.
+ *
+ * `ScoreStamp` is the worked example: one dispatched surface (ADR-0049) mounted
+ * by the desktop praxis card, the eight praxis-detail archetypes, the eight
+ * task-detail worth cells and the composer's task slip. Four hosts, nine skins.
+ *
+ * ### The seam
+ *
+ * The markup a HOST emits around the stamp, and the ROOT element each skin
+ * emits. Both halves are assertable in this suite's SSR-only harness
+ * (`renderToStaticMarkup`, no layout engine): the law is about which box
+ * DECLARES the spacing, and a declaration survives without a layout pass.
+ *
+ * ### What was actually wrong (measured on `origin/main`, 2026-08-25)
+ *
+ * Not what the plan said. No stamp root declared an outer margin — the defect
+ * was the mirror image: two hosts declared no gap at all.
+ *
+ *  - `PraxisBody`'s heading row states `gap: var(--space-md)`, which on a flex
+ *    ROW is HORIZONTAL only. `MetataskSeal` is the row's immediate next sibling
+ *    with margin 0 on both boxes, so a sealed praxis put its seals hard against
+ *    the bottom edge of the stamp on all nine cards.
+ *  - `EphemeristsPraxisCard` was the one frame in nine opening its body at
+ *    `padding-top: 0`, so the stamp's box sat ON the cornice. #2360 saw the
+ *    symptom, ruled that the frame could not state a top rung (the crown's
+ *    `-13` overhang is measured off the stamp's box) and put the air on the
+ *    TITLE instead — the piece's own drawing dictating the host's padding,
+ *    which is the law read backwards.
+ *
+ * The other three hosts measured CLEAN and are asserted here so they stay that
+ * way: every praxis-detail panel pads `var(--space-lg)` under its centring div
+ * and heads it with a `margin-bottom`; every task-detail worth cell is a padded
+ * `innerBox`; the composer slip wraps with `gap: var(--space-lg)`, which on a
+ * wrapped flex row is the row gap too.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import type { ReactElement } from 'react'
+import '../../../i18n'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { aPraxisCard, aTask } from '../../../test/fixtures'
+import { PraxisBody } from '../desktop/shared'
+import EphemeristsPraxisCard from '../desktop/EphemeristsPraxisCard'
+import AlbescentScoreStamp from '../scoreStamp/AlbescentScoreStamp'
+import CovenScoreStamp from '../scoreStamp/CovenScoreStamp'
+import DefaultScoreStamp from '../scoreStamp/DefaultScoreStamp'
+import EphemeristsScoreStamp from '../scoreStamp/EphemeristsScoreStamp'
+import EverymenScoreStamp from '../scoreStamp/EverymenScoreStamp'
+import SingularityScoreStamp from '../scoreStamp/SingularityScoreStamp'
+import SnideScoreStamp from '../scoreStamp/SnideScoreStamp'
+import UaScoreStamp from '../scoreStamp/UaScoreStamp'
+import WowScoreStamp from '../scoreStamp/WowScoreStamp'
+
+const render = (node: ReactElement) =>
+  renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>)
+
+/** The `style` attribute of the first element matching `pattern`. */
+function styleOf(html: string, pattern: RegExp): string {
+  const tag = html.match(pattern)
+  expect(tag, `no element matched ${pattern}`).toBeTruthy()
+  return tag![0].match(/style="([^"]*)"/)?.[1] ?? ''
+}
+
+/**
+ * Any margin declaration at the START of a property — `margin`, `margin-top`,
+ * `margin-block-start`, the lot. Anchored to a `;` or the string head so
+ * `--wz-margin`-ish custom properties and inner-element markup cannot match.
+ */
+const OUTER_MARGIN = /(^|;)\s*margin/
+
+/**
+ * All nine registered skins. Albescent is a WRAPPER over `DefaultScoreStamp`
+ * (six lines, `class="alb-stamp alb-moves"`) and is included precisely because
+ * a wrapper is the cheapest place to hide an outer margin. `.alb-stamp`
+ * declares nothing in `index.css` and `.alb-moves` is transform/filter only.
+ */
+const STAMPS = {
+  albescent: AlbescentScoreStamp,
+  coven: CovenScoreStamp,
+  default: DefaultScoreStamp,
+  ephemerists: EphemeristsScoreStamp,
+  everymen: EverymenScoreStamp,
+  singularity: SingularityScoreStamp,
+  snide: SnideScoreStamp,
+  ua: UaScoreStamp,
+  wow: WowScoreStamp,
+}
+
+/** A praxis with every term in play, so no skin renders a reduced box. */
+const scored = (over: Partial<PraxisCardOut> = {}): PraxisCardOut =>
+  aPraxisCard({
+    score: 13.6,
+    task_point_value: 12,
+    display_multiplier: 0.8,
+    points_from_votes: 4,
+    ...over,
+  })
+
+describe('the stamp owns no outer margin (#2655, law 09)', () => {
+  // The ROOT element only. Every skin spaces its OWN parts — the Ephemerists
+  // rose's `margin: var(--space-sm) auto 0`, Snide's rule, Coven's plate — and
+  // that is a decision inside a box whose outside edge is the host's business.
+  it.each(Object.entries(STAMPS))('%s declares none on its root', (_slug, Stamp) => {
+    const root = styleOf(render(<Stamp praxis={scored()} />), /^<[a-z]+[^>]*>/)
+    expect(root).not.toMatch(OUTER_MARGIN)
+  })
+
+  // A crowned praxis is the state that tempts one: the crown hangs at
+  // `top: -13` outside the box, and "make room for it" is a margin waiting to
+  // be written. The overhang is the DESIGN (#2122/#2240) and stays a negative
+  // offset on an absolutely-positioned child.
+  it.each(Object.entries(STAMPS))('%s declares none when crowned', (_slug, Stamp) => {
+    const html = render(<Stamp praxis={scored({ is_top_for_task: true })} showCrown />)
+    expect(styleOf(html, /^<[a-z]+[^>]*>/)).not.toMatch(OUTER_MARGIN)
+  })
+})
+
+describe('the praxis card states the gap under the stamp (#2655)', () => {
+  const head = (over: Partial<PraxisCardOut> = {}) =>
+    styleOf(
+      render(<PraxisBody praxis={scored(over)} tint="var(--color-text-primary)" muted="var(--color-text-secondary)" />),
+      /^<div[^>]*>/,
+    )
+
+  it('the heading row declares a vertical gap of its own', () => {
+    // `gap` on this row is horizontal — text column to stamp — and says nothing
+    // about what follows the row. This is the declaration `MetataskSeal` lands
+    // on. It COLLAPSES with `PraxisStats`'s existing `margin-top: var(--space-sm)`
+    // when no seal is between them, so an unsealed card is unmoved.
+    expect(head()).toContain('margin-bottom:var(--space-sm)')
+  })
+
+  it('the gap does not depend on there being a seal to catch it', () => {
+    const sealed = head({ applied_metatasks: [aTask({ metatask_faction_slug: 'coven' })] })
+    expect(sealed).toContain('margin-bottom:var(--space-sm)')
+    expect(sealed).toBe(head())
+  })
+})
+
+/** The steward bar's props, which every frame takes and none of these read. */
+const adminProps = {
+  praxis: aPraxisCard(),
+  showAdminControls: false,
+  onHide: () => {},
+  onDelete: () => {},
+} as unknown as Parameters<typeof EphemeristsPraxisCard>[0]['adminProps']
+
+describe('the Ephemerists frame states the gap above the stamp (#2655)', () => {
+  it('the leaf opens on a rung rather than at zero', () => {
+    const html = render(
+      <EphemeristsPraxisCard
+        praxis={scored({ task_faction_slug: 'ephemerists' })}
+        adminProps={adminProps}
+      />,
+    )
+    // #2360 put this rung on the TITLE because the frame "could not" state it.
+    // It can: `var(--space-sm)` is 8px against the crown's 13px overhang, so
+    // the crown still breaks the cornice (#2240) and the title still opens at
+    // the same 24px — `var(--space-sm)` here plus `var(--space-lg)` there.
+    expect(html).toContain('padding:var(--space-sm) var(--space-xl) var(--space-lg)')
+    expect(html).not.toContain('padding:0 var(--space-xl) var(--space-lg)')
+  })
+})

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -148,22 +148,34 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           `overflow` fix — the frame clips at the card's border box and the
           crown never reaches it. Nothing else in the leaf meets the band.
 
-          SO THE ZERO IS LOAD-BEARING (#2360). This was the only praxis card in
+          THE ZERO WAS LOAD-BEARING UNTIL #2655. This was the only praxis card in
           the kit opening with no top pad — every other frame gives its title
-          `--space-xl` or `--space-lg` — and the owner's report is that the
-          entry reads cramped against the cavetto. The repair may NOT be a top
-          rung here: the crown's `-13` is measured off the STAMP's box, the
-          stamp's box sits at this element's content top, and 24px of padding
-          would drop the crown clear of the 12px cornice and into the padding —
-          undoing #2240 and #2122 on a card that still screenshots correctly,
-          because the crown only draws on a crowned praxis. The air goes on the
-          TITLE instead (`titleStyle` below), which is a flex SIBLING of the
-          stamp's column and so cannot displace it. */}
+          `--space-xl` or `--space-lg` — and the owner's report on #2360 was that
+          the entry read cramped against the cavetto. #2360 ruled that the repair
+          could not be a top rung HERE, because the crown's `-13` is measured off
+          the STAMP's box, the stamp's box sits at this element's content top,
+          and *24px* of padding drops the crown clear of the ~12px cornice and
+          into the padding — undoing #2240 and #2122. So the air went on the
+          TITLE, a flex SIBLING of the stamp's column that cannot displace it.
+
+          THAT PUT A PIECE'S OWN DRAWING IN CHARGE OF ITS HOST'S PADDING, which
+          is law 09 read backwards (#2655): a travelling piece owns no outer
+          spacing, and a per-faction margin standing in for a gap the frame
+          declined to state is the same defect wearing a different box. The
+          frame states its opening rung like its eight fellows now. It is
+          `--space-sm`, not `--space-xl`, and the difference is the whole
+          argument: 8px against a 13px overhang still breaks the crown 5px into
+          the cornice, so #2360's own stated reason survives intact and #2240 and
+          #2122 hold. The title lands where it already did — 8px here plus
+          `--space-lg` on `titleStyle` is the same 24px — so the ONLY thing that
+          moves is the stamp's box, which is this issue's named exemption. (The
+          admin badge is absolutely positioned against this leaf and rides the
+          8px down with it; it is a steward affordance, not chrome.) */}
       <div
         style={{
           position: "relative",
           zIndex: 4,
-          padding: "0 var(--space-xl) var(--space-lg)",
+          padding: "var(--space-sm) var(--space-xl) var(--space-lg)",
         }}
       >
         <AdminOverlay {...adminProps} />
@@ -182,17 +194,19 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           paper={PLATE}
           showCrown={showCrown}
           // THE ENTRY OPENS A RUNG BELOW THE CAVETTO (#2360). `--space-xl` is
-          // the rung five of its eight fellows already give their title, and it
-          // rides on the title rather than on the leaf for the reason the leaf's
-          // comment gives: the seal keeps hanging off the cornice, the entry
-          // starts under it. A praxis with no score renders no stamp at all, so
-          // this is also the whole of the air on an unscored card.
+          // the rung five of its eight fellows already give their title, and the
+          // title still lands on it — but only `--space-lg` of it is stated
+          // here now, because #2655 moved the other `--space-sm` onto the LEAF
+          // where the gap belongs (see its comment). The sum is unchanged and
+          // deliberately so: this is a spacing repair for the stamp, not for the
+          // entry. A praxis with no score renders no stamp at all, and the leaf's
+          // rung covers that case too.
           titleStyle={{
             fontFamily: DECO,
             fontWeight: 400,
             letterSpacing: "0.02em",
             color: INK,
-            marginTop: "var(--space-xl)",
+            marginTop: "var(--space-lg)",
           }}
           // Poiret One for the display line, Spectral for the reading matter.
           fonts={{ display: DECO, body: READING }}

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -169,8 +169,9 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           #2122 hold. The title lands where it already did — 8px here plus
           `--space-lg` on `titleStyle` is the same 24px — so the ONLY thing that
           moves is the stamp's box, which is this issue's named exemption. (The
-          admin badge is absolutely positioned against this leaf and rides the
-          8px down with it; it is a steward affordance, not chrome.) */}
+          admin badge does NOT move: it is `position: absolute; top: 8` against
+          this leaf, and an absolute box resolves against its containing block's
+          PADDING box, which a top rung does not shift.) */}
       <div
         style={{
           position: "relative",

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -223,6 +223,26 @@ export function PraxisBody({
           justifyContent: "space-between",
           alignItems: "flex-start",
           gap: "var(--space-md)",
+          /*
+           * THE HOST STATES THE GAP UNDER THE STAMP (#2655, law 09).
+           *
+           * `gap` above is the row's HORIZONTAL lead — text column to stamp —
+           * and says nothing about what follows the row. `MetataskSeal` is the
+           * row's immediate next sibling and declares margin 0 on purpose (it
+           * travels too: the composer and the detail rails mount it), so a
+           * sealed praxis put its seals hard against the bottom edge of the
+           * stamp on all nine cards. No stamp may answer that with a margin of
+           * its own — it renders the same box wherever it is mounted — so the
+           * declaration belongs here, once, on the box that carries it.
+           *
+           * IT COLLAPSES, AND THAT IS WHY IT IS `margin-bottom` AND NOT PADDING.
+           * The card frames are block containers (no archetype lays this body
+           * out as a flex column — checked), so this adjoins `PraxisStats`'s own
+           * `margin-top: var(--space-sm)` below and the pair collapse to one
+           * rung. An unsealed card is therefore unmoved, which is what a frozen
+           * surface's named exemption is allowed to cost: nothing.
+           */
+          marginBottom: "var(--space-sm)",
         }}
       >
         {/*


### PR DESCRIPTION
Closes #2655

Batch 00 of the rewritten faction-reuse plan. Proves **law 09 — a travelling piece owns no
outer margin. It owns its own box; the host owns every gap.**

## The seam I tested at

**The markup a HOST emits around `<ScoreStamp>`, and the ROOT element each skin emits.** Both
halves are decidable in this repo's SSR-only harness (`renderToStaticMarkup`, no layout engine):
the law is about which box *declares* the spacing, and a declaration survives without a layout
pass. The loop went red on the real defect first — 18 stamp-root assertions passed on the
unchanged tree while both host-edge assertions failed.

New guard: `frontend/src/components/praxisCard/__tests__/stampOuterMargin.test.tsx`.

## 1. The measurement

Re-measured against `origin/main` @ `f5e78fc4`. Where the brief and the code disagreed, the code
won — noted inline.

### The travelling piece

**Confirmed: no `*ScoreStamp.tsx` root declares an outer margin.** All nine roots are
`position: relative` boxes carrying only their own `padding` / `gap` / geometry. The margins that
show up in a grep are all *internal* — the Ephemerists rose's `margin: var(--space-sm) auto 0`,
Snide's and Wow's rules, `DefaultScoreStamp`'s conditional disc margin, UA's `marginTop: 3`
nudges. Every one of them separates a stamp's own parts, and every one of them stays.
`AlbescentScoreStamp` is a six-line wrapper (`class="alb-stamp alb-moves"`, no inline style);
`.alb-stamp` declares nothing in `index.css` and `.alb-moves` is transform/filter only.

**So the plan's phrasing — "nine stamps each declare their own outer spacing" — is false, and the
defect is its mirror image: two edges on one host declare no gap at all.** The symptom the owner
reported is real; the diagnosis was pointing at the wrong box.

### Hosts — the vertical chain above and below the stamp

`ScoreStamp` has exactly four host classes. `grep '<ScoreStamp'` over `src/` (excluding tests)
returns 11 sites, which collapse to these four:

#### A. Desktop praxis card — `components/praxisCard/desktop/shared.tsx` → `PraxisBody`

One shared head row for all nine frames (no faction forks it; `frontend/CLAUDE.md`'s
no-unification rule is untouched). The stamp is the row's second child;
`gap: var(--space-md)` on a flex **row** is horizontal only and says nothing about either
vertical edge.

**Above** = the frame's own padding-top on the box wrapping `PraxisBody`:

| faction | before | after |
|---|---|---|
| na (Default) | `--space-xl` (24) | unchanged |
| albescent (wraps `DefaultPraxisCard`) | `--space-xl` (24) | unchanged |
| coven | `--space-xl` (24) | unchanged |
| **ephemerists** | **`0`** | **`--space-sm` (8)** |
| everymen | `--space-lg` (16) | unchanged |
| singularity | `--space-lg` (16) | unchanged |
| snide | `--space-xl` (24) | unchanged |
| ua | `--space-xl` (24) | unchanged |
| wow | `--space-xl` (24) | unchanged |

**Below** = the head row's bottom edge → `<MetataskSeal>`, the immediate next sibling, margin 0
on both boxes:

| faction | before | after |
|---|---|---|
| all nine | **`0`** | **`--space-sm` (8)** |

That zero is the flush bottom edge in the screenshots. `<PraxisStats>` right after the seal does
declare `marginTop: var(--space-sm)`, so the gap existed everywhere *except* directly under the
stamp.

#### B. Praxis detail — 8 archetypes in `pages/praxisDetail/archetypes/`

Identical shape in all eight: `<section style={panel}>` → `sectionHead(...)` → a bare
`<div style={{ display: "flex", justifyContent: "center" }}>` → the stamp.

- **Above:** `sectionHead`'s own `marginBottom` — `--space-md` (na, coven, everymen, singularity,
  snide, ua, wow) or `--space-lg` (ephemerists).
- **Below:** the panel's `padding` — `var(--space-lg)` on six, `size.panelPad` on wow and ua.

Both edges are non-zero and host-owned. **No defect. Left alone** — forcing `--space-sm` here
would *shrink* eight section heads to fix nothing, and the brief's blanket "space-sm top and
bottom" does not survive contact with a panel that already pads itself. (`AlbescentPraxisDetail`
mounts no stamp of its own; it composes `Default`.)

#### C. Task detail — `TaskWorthStamp` in `pages/taskDetail/archetypes/shared.tsx`, 8 mounts

Every archetype drops it into a padded cell — `innerBox` / `plateBox` / `cell`, all
`var(--space-lg)` desktop / `var(--space-md)` phone, or a `size.*Pad` token. Ephemerists uses a
flex column with `gap: var(--space-md)` inside a padded `cell`. **No defect. Left alone.**
(`AlbescentTaskDetail` substitutes a prism ring through `worthSlot` — the recorded exception,
#2549/#2550.)

#### D. Composer — `TaskSlip` in `pages/editPraxis/archetypes/shared.tsx`

`{mark ?? <ScoreStamp praxis={praxis} />}` is the last item of a `flexWrap: "wrap"` row with
`gap: var(--space-lg)` — which on a *wrapped* flex row is the row gap too, so the stamp gets 16px
above it the moment it drops under the copy. The slip's own chrome pads `var(--space-lg)` all
round. Same slip on `PraxisWaitingSurface`. **No defect. Left alone.**

## 2. The fix

**Two declarations, both on the host, on the one surface that was missing them.**

`components/praxisCard/desktop/shared.tsx` — the head row states its own bottom gap:

```
marginBottom: "var(--space-sm)",
```

It is a **margin and not padding on purpose**: no praxis-card frame lays `PraxisBody` out as a
flex column (checked all nine — zero `flexDirection: "column"` in `desktop/`), so this adjoins
`PraxisStats`'s existing `margin-top: var(--space-sm)` in a block formatting context and the pair
**collapse to one rung**. An unsealed card is therefore pixel-identical; only a sealed one moves,
which is the whole of the reported bug.

`components/praxisCard/desktop/EphemeristsPraxisCard.tsx` — the frame states its opening rung
like its eight fellows: leaf `padding-top` `0` → `var(--space-sm)`, and the title's compensating
`marginTop` drops `--space-xl` → `--space-lg`.

### This overturns half of #2360, deliberately, and here is the arithmetic

#2360 found the same zero, ruled that the repair "may NOT be a top rung here" and put the air on
the **title** instead — because the crown hangs at `top: -13` off the *stamp's* box, the box sits
at the leaf's content top, and *24px* of padding drops the crown clear of the ~12px cornice,
undoing #2240 and #2122.

That is law 09 read backwards: a travelling piece's own drawing was put in charge of its host's
padding, and a per-faction margin was minted to stand in for a gap the frame declined to state.
That margin **is** the "per-faction outer spacing" scope item 3 asks to delete — it is the only
one the measurement found.

#2360's *stated reason* survives at `--space-sm`, and the numbers are the argument:

- **8px of leaf padding against a 13px overhang still breaks the crown 5px into the cornice.**
  #2240 and #2122 hold; the leaf's `z-index` is untouched.
- **8 + 16 = 24.** The entry opens exactly where it did.
- The only thing that moves is the stamp's box — this issue's named exemption on a frozen
  surface. No hue, no typeface, no radius, no size, no internal rhythm.
- One side effect worth naming: `AdminOverlay` is absolutely positioned against that leaf and
  rides the 8px down with it. Steward affordance, not chrome.

#2360's guard in `ephemeristsPlateSurfaces.test.tsx` is **re-expressed for the new split, not
dropped**: `--space-xl` on the leaf is still asserted forbidden (24px would swallow the 13px
overhang whole), the crown's `top:-13px` is still pinned, the heading row is still pinned to no
top rung, and the title's rung is now asserted as the *remainder* rather than the whole. All four
legs still fail on the wrong fix.

## 3. The guard

`frontend/src/components/praxisCard/__tests__/stampOuterMargin.test.tsx` — 21 cases:

- All **nine** skins (Albescent included, precisely because a wrapper is the cheapest place to
  hide a margin), **plain and crowned**, asserting the root's inline style matches no
  `/(^|;)\s*margin/`. Crowned is its own case because "make room for the overhang" is the margin
  most likely to be written next.
- The praxis card's head row declares `margin-bottom: var(--space-sm)`, and declares it whether
  or not a seal is there to catch it.
- The Ephemerists leaf opens on a rung rather than at zero.

It fails if a stamp reintroduces an outer margin **or** if a host drops its gap.

## Verification

Every step named by `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean (incl. the `local/no-raw-style-values` ratchet; every value added is a
  `--space-*` token).
- `npm run typecheck` — clean.
- `npm run typecheck:design-sync` — clean.
- `npm test` — **438 files, 8304 passed, 1 skipped.** No contract changed, so no fixture moved.
- `npm run build` — clean.
- `npm run budget` — JS 129.5 KB, CSS 22.1 KB, within budget (unchanged; no CSS was added).

No backend, route, `response_model` or Pydantic schema was touched, so `api-schema` has nothing
to regenerate.

## What to eyeball

**I have no browser. The gap value is a judgement call, not a measurement — visual QA on this PR
is outstanding and owed before merge.** In priority order:

1. **Ephemerists × desktop praxis card × crowned praxis.** The one place a prior ruling is
   reversed. Check three things at once: the crown still bites into the cavetto (it should clear
   the leaf's top edge by ~5px), the entry title has not moved, and the stamp is no longer sitting
   *on* the cornice. This is the "wrong at the top" screenshot.
2. **Any faction × desktop praxis card × a praxis with an applied metatask seal.** The "wrong at
   the bottom" screenshots. Coven, Snide and Wow are the loudest seals to check it against. The
   seal should now sit a rung under the stamp instead of touching it.
3. **Any faction × desktop praxis card × *no* seal.** The regression check. This should be
   **byte-for-byte where it was** — the margin collapse is what guarantees it, and margin
   collapsing is exactly the kind of thing worth confirming with an eye rather than a test.
4. **Ephemerists × desktop praxis card × *uncrowned*, unscored praxis.** No stamp renders at all
   on an unscored praxis, so this is the case where the leaf's new 8px is the whole of the air.
   It should read as a slightly roomier open, not a gap.
5. **Anything × praxis detail / task detail / composer.** Nothing changed on these three hosts.
   Worth one glance each purely to confirm that "nothing changed" is true, since all four hosts
   mount the same dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
