### PR TITLE
The invitation letter mounts the shared join trio, and the affirmative moves right on two more surfaces (#2656)

### DIFF
--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -5,6 +5,7 @@ import { factionCssVar, factionName } from '../utils/factions'
 import { useAuth } from '../auth/AuthContext'
 import { chooseFaction } from '../api/factions'
 import { extractError } from '../utils/errors'
+import { JoinConfirm, type JoinControlSkin, type JoinTarget } from './JoinControl'
 
 // The per-faction key path (`<slug>.invitation.*`) is runtime-dynamic, so it
 // isn't one of the compile-time key literals the scoped t() expects. Resolve
@@ -78,7 +79,11 @@ export default function InvitationLetterPopup({
   const { t } = useTranslation('factions')
   const { user, applyUser } = useAuth()
   const currentSlug = user?.character?.faction_slug
-  const isSwitch = !!currentSlug && currentSlug !== 'na'
+  // The letter's OWN state, and the only one left here: the open step draws a
+  // second control the trio knows nothing about (see the CTA row below), so the
+  // host has to know which step it is on. Everything past this point — the
+  // switch sentence, the error slot, the pair and its #646 order — is
+  // `JoinConfirm`'s (#2656).
   const [confirming, setConfirming] = useState(false)
   const [joining, setJoining] = useState(false)
   const [joinError, setJoinError] = useState<string | null>(null)
@@ -101,7 +106,7 @@ export default function InvitationLetterPopup({
 
   // The prospectus ENLIST commits the join in place (#493). Joining is one-way
   // (ADR-0019), so ENLIST arms a confirm step before actually joining.
-  async function handleConfirm() {
+  async function join() {
     setJoining(true)
     setJoinError(null)
     try {
@@ -143,6 +148,39 @@ export default function InvitationLetterPopup({
     background: 'transparent',
     color: FAINT,
     cursor: 'pointer',
+  }
+
+  /**
+   * The letter's existing paint, handed to the shared control as a typed skin
+   * (#2656) — the same object literals the buttons above already were. The
+   * letter is not a faction archetype and has no kit; `openStyle` is the ENLIST
+   * the CTA row still draws itself, and the other two are the confirm pair's.
+   */
+  const joinSkin: JoinControlSkin = {
+    openStyle: enlistStyle,
+    confirmStyle: enlistStyle,
+    cancelStyle: dismissStyle,
+    proseStyle: {
+      fontFamily: FONT_BODY,
+      fontSize: 'var(--text-content)',
+      lineHeight: 1.5,
+      color: MUTED,
+      margin: '0 0 var(--space-md)',
+    },
+    errorStyle: {
+      fontFamily: FONT_MONO,
+      fontSize: 'var(--text-content)',
+      color: 'var(--color-danger)',
+      margin: '0 0 var(--space-md)',
+    },
+  }
+
+  /** Five fields on the faction page; the four the trio reads, built here. */
+  const joinTarget: JoinTarget = {
+    currentFactionSlug: currentSlug,
+    join,
+    joining,
+    joinError,
   }
 
   const card = (
@@ -287,14 +325,19 @@ export default function InvitationLetterPopup({
         </ul>
       )}
 
-      {/* CTA row — ENLIST arms a one-way join confirm (#493); dismiss defers. */}
+      {/* CTA row — ENLIST arms a one-way join confirm (#493); dismiss defers.
+          DISMISS IS NOT CANCEL, which is why this row is still the letter's own
+          and only the confirm step is the shared control's: this button closes
+          the letter and leaves the invitation standing, while the cancel one
+          click further in returns to the pitch. Collapsing them would turn
+          "not now" into "never mind" on a letter that survives the dismissal. */}
       {!confirming ? (
         <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'center' }}>
           <button
             type="button"
             autoFocus
             onClick={() => setConfirming(true)}
-            style={enlistStyle}
+            style={joinSkin.openStyle}
             onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.88')}
             onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
           >
@@ -306,35 +349,17 @@ export default function InvitationLetterPopup({
         </div>
       ) : (
         <div>
-          <p style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-content)', lineHeight: 1.5, color: MUTED, margin: '0 0 var(--space-md)' }}>
-            {isSwitch
-              ? t('detail.join.confirmSwitch', { faction: name, current: factionName(currentSlug as string) })
-              : t('detail.join.confirm', { faction: name })}
-          </p>
-          {joinError && (
-            <p style={{ fontFamily: FONT_MONO, fontSize: 'var(--text-content)', color: 'var(--color-danger)', margin: '0 0 var(--space-md)' }}>
-              {joinError}
-            </p>
-          )}
-          <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'center' }}>
-            <button
-              type="button"
-              autoFocus
-              onClick={() => void handleConfirm()}
-              disabled={joining}
-              style={{ ...enlistStyle, cursor: joining ? 'not-allowed' : 'pointer' }}
-            >
-              {t('detail.join.confirmAction')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setConfirming(false)}
-              disabled={joining}
-              style={dismissStyle}
-            >
-              {t('detail.join.cancel')}
-            </button>
-          </div>
+          {/* `autoFocus` because this step is TALLER than the pitch and both
+              live in the one scrim above: focusing the affirmative is what
+              scrolls it into view on a short viewport (#2130). */}
+          <JoinConfirm
+            membership={joinTarget}
+            name={name}
+            skin={joinSkin}
+            joiningLabel={t('detail.join.joining')}
+            onCancel={() => setConfirming(false)}
+            autoFocus
+          />
         </div>
       )}
     </div>

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -79,11 +79,13 @@ export default function InvitationLetterPopup({
   const { t } = useTranslation('factions')
   const { user, applyUser } = useAuth()
   const currentSlug = user?.character?.faction_slug
-  // The letter's OWN state, and the only one left here: the open step draws a
-  // second control the trio knows nothing about (see the CTA row below), so the
-  // host has to know which step it is on. Everything past this point — the
-  // switch sentence, the error slot, the pair and its #646 order — is
-  // `JoinConfirm`'s (#2656).
+  // `confirming` stays with the LETTER because its open step draws a second
+  // control the trio knows nothing about (see the CTA row below), so the host
+  // is the only thing that can know which step it is on. `joining` /
+  // `joinError` stay because the host owns the POST — together with the current
+  // slug they are the `JoinTarget` handed down. What LEFT is the confirm step
+  // itself: the switch sentence, the error slot, the pair and its #646 order
+  // are `JoinConfirm`'s now (#2656).
   const [confirming, setConfirming] = useState(false)
   const [joining, setJoining] = useState(false)
   const [joinError, setJoinError] = useState<string | null>(null)

--- a/frontend/src/components/JoinControl.tsx
+++ b/frontend/src/components/JoinControl.tsx
@@ -1,9 +1,32 @@
 import { useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { factionName } from "../../utils/factions";
-import type { Membership } from "./useFactionDetail";
+import { factionName } from "../utils/factions";
 
 const NA_SLUG = "na";
+
+/**
+ * What the control needs from its host in order to run a join.
+ *
+ * It lives HERE, and the control now lives under `components/`, because of
+ * #2656: the trio's second host is `InvitationLetterPopup`, which is not a
+ * faction page and not an archetype. A shared control parked under `pages/` —
+ * reaching back into that page's hook for its own prop contract — is a
+ * dependency pointing the wrong way the moment anything outside that page
+ * mounts it.
+ *
+ * The faction page's `Membership` extends this and adds `state`, which the trio
+ * never reads: the host decides whether a join block is drawn at all, and by
+ * the time this renders that question is already answered. The popup builds one
+ * of these inline from `useAuth` and its own POST.
+ */
+export interface JoinTarget {
+  /** The faction the viewer would LEAVE by joining; nullish or "na" reads as unaffiliated. */
+  currentFactionSlug: string | null | undefined;
+  /** Run the join. The host owns the call and its failure; this control only reports. */
+  join: () => Promise<void>;
+  joining: boolean;
+  joinError: string | null;
+}
 
 /**
  * The paint every kit hands the join trio (#2651).
@@ -77,8 +100,9 @@ export function JoinControl({
   openLabel,
   joiningLabel,
   intro,
+  autoFocus = false,
 }: {
-  membership: Membership;
+  membership: JoinTarget;
   /** The mounted faction's display name, for the confirm sentence. */
   name: string;
   skin: JoinControlSkin;
@@ -95,6 +119,14 @@ export function JoinControl({
    * only — the confirm step replaces the pitch with the question.
    */
   intro?: ReactNode;
+  /**
+   * For a MODAL host only (#2656). `InvitationLetterPopup`'s confirm step is
+   * taller than its pitch and both steps live in one scrolling scrim, so
+   * focusing the freshly-mounted affirmative is what scrolls it into view on a
+   * short viewport (#2130). Off by default: the eight faction bodies draw this
+   * pair inline on a long page, where grabbing focus would yank the page down.
+   */
+  autoFocus?: boolean;
 }) {
   const [confirming, setConfirming] = useState(false);
 
@@ -105,6 +137,7 @@ export function JoinControl({
         <button
           type="button"
           data-join="open"
+          autoFocus={autoFocus}
           className={skin.className}
           onClick={() => setConfirming(true)}
           style={skin.openStyle}
@@ -122,6 +155,7 @@ export function JoinControl({
       skin={skin}
       joiningLabel={joiningLabel}
       onCancel={() => setConfirming(false)}
+      autoFocus={autoFocus}
     />
   );
 }
@@ -146,12 +180,15 @@ export function JoinConfirm({
   skin,
   joiningLabel,
   onCancel,
+  autoFocus = false,
 }: {
-  membership: Membership;
+  membership: JoinTarget;
   name: string;
   skin: JoinControlSkin;
   joiningLabel: ReactNode;
   onCancel: () => void;
+  /** See {@link JoinControl}. The AFFIRMATIVE takes it, never the cancel. */
+  autoFocus?: boolean;
 }) {
   const { t } = useTranslation("factions");
   const current = membership.currentFactionSlug;
@@ -184,6 +221,7 @@ export function JoinConfirm({
         <button
           type="button"
           data-join="confirm"
+          autoFocus={autoFocus}
           className={skin.className}
           onClick={() => void membership.join()}
           disabled={busy}

--- a/frontend/src/components/__tests__/invitationLetterPopupScroll.test.tsx
+++ b/frontend/src/components/__tests__/invitationLetterPopupScroll.test.tsx
@@ -29,6 +29,8 @@
  * the fix is at the chassis, so it has to hold for a faction nobody reported.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 import '../../i18n'
 import { AuthContext } from '../../auth/AuthContext'
@@ -85,5 +87,33 @@ describe.each(['coven', 'snide'])('invitation prospectus on a short viewport (%s
 
   it('autofocuses the primary action so the browser scrolls it into view', () => {
     expect(render(slug)).toMatch(/<button[^>]*autofocus/i)
+  })
+})
+
+/**
+ * The rendered assertion above only ever reaches the OPEN step, and the step
+ * that actually overflows is the confirm one. That was true before #2656 and it
+ * stayed true after: the confirm markup moved into `JoinConfirm`, so the popup
+ * no longer writes the `autoFocus` this file's whole premise rests on — it
+ * PASSES one, and a moved-out contract nothing checks is a contract that dies
+ * quietly at the next edit.
+ *
+ * So the claim is split, and both halves are checked:
+ *   - the popup asks for it — here, off the source, because this harness fires
+ *     no click and cannot reach the step;
+ *   - the control puts it on the AFFIRMATIVE and not on cancel — in
+ *     `joinControlOrder.test.tsx`, which can render `JoinConfirm` directly.
+ */
+describe('the confirm step keeps the autofocus that scrolls it into view', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../InvitationLetterPopup.tsx', import.meta.url)),
+    'utf8',
+  )
+
+  it('hands the shared confirm step an autoFocus', () => {
+    const at = source.indexOf('<JoinConfirm')
+    expect(at, 'the popup mounts JoinConfirm').toBeGreaterThan(-1)
+    const mount = source.slice(at, source.indexOf('/>', at))
+    expect(mount, 'and asks it to take focus').toContain('autoFocus')
   })
 })

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -252,9 +252,14 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
               flexWrap: "wrap",
             }}
           >
-            <button type="button" className="feed-action" onClick={() => void join()} disabled={joining} style={acceptStyle}>
-              {i18n.t("feed:invitationLetter.confirm.confirm")}
-            </button>
+            {/* [Cancel] … [Confirm] — the global footer order (#646), the same
+                ruling `JoinConfirm` now carries for the faction pages and the
+                invitation letter. This card cannot mount that control: its
+                confirm step is two paragraphs of its own copy, it has a
+                one-click branch for an unaffiliated holder (epic #1419
+                decision 10) and a terminal "joined" state the trio knows
+                nothing about. So it keeps its own pair, and
+                `joinControlOrder.test.tsx` keeps this order honest (#2656). */}
             <button
               type="button"
               className="feed-action"
@@ -263,6 +268,9 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
               style={QUIET}
             >
               {i18n.t("feed:invitationLetter.confirm.cancel")}
+            </button>
+            <button type="button" className="feed-action" onClick={() => void join()} disabled={joining} style={acceptStyle}>
+              {i18n.t("feed:invitationLetter.confirm.confirm")}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
@@ -24,12 +24,26 @@
  * confirm step is unreachable through an event. Mounting the one control whose
  * order part 1 pins is the same statement, and it is the statement that stays
  * true when a tenth kit arrives.
+ *
+ * #2656 WIDENED IT PAST THE ARCHETYPES. Parts 1-3 walked
+ * `pages/factionDetail/archetypes/` and nothing else, so they were blind to
+ * `InvitationLetterPopup` — a host that is not a faction body, that wrote the
+ * whole trio out longhand, and that put the affirmative on the LEFT four days
+ * after the other eight were fixed. A guard that only walks archetypes is why
+ * that survived, so two more parts scan the WHOLE `src` tree:
+ *
+ *   4. THE TRIO'S COPY IS WRITTEN ONCE. `detail.join.{cancel,confirmAction,
+ *      confirmSwitch}` may appear in exactly one source file. Any host that
+ *      re-implements the confirm step needs those words, wherever it lives.
+ *   5. THE JOIN SURFACES ARE A CENSUS. Every file that calls `chooseFaction`
+ *      is listed with how its confirm step is drawn. A new one fails until
+ *      somebody decides which side of the line it is on.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { readFileSync, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
 import { FACTION_MANIFESTS } from '../../../factions'
@@ -112,7 +126,7 @@ function page(slug: string, formFactor: 'desktop' | 'mobile'): string {
 /** A skin that paints nothing — this suite is about order, not pixels. */
 const BARE_SKIN: JoinControlSkin = { openStyle: {}, confirmStyle: {}, cancelStyle: {} }
 
-function confirmStep(overrides: Partial<Membership> = {}): string {
+function confirmStep(overrides: Partial<Membership> = {}, autoFocus = false): string {
   return renderToStaticMarkup(
     <JoinConfirm
       membership={membership(overrides)}
@@ -120,6 +134,7 @@ function confirmStep(overrides: Partial<Membership> = {}): string {
       skin={BARE_SKIN}
       joiningLabel="Joining…"
       onCancel={() => {}}
+      autoFocus={autoFocus}
     />,
   )
 }
@@ -150,6 +165,29 @@ describe('the join pair keeps #646 order on every faction', () => {
     expect(confirmStep({ joinError: 'Could not join faction.' })).toContain(
       'Could not join faction.',
     )
+  })
+
+  it("puts a dialog host's autofocus on the affirmative, never on cancel", () => {
+    // `InvitationLetterPopup` is a modal and its confirm step is TALLER than
+    // its pitch, so the browser scrolling the newly-mounted affirmative into
+    // view is the whole reason #2130's fix works on a phone. The focus has to
+    // land on the affirmative: autofocusing "cancel" inside a scroller would
+    // scroll the same distance and focus the wrong verb.
+    const html = confirmStep({}, true)
+    const confirmAt = html.indexOf('data-join="confirm"')
+    expect(confirmAt, 'a confirm button').toBeGreaterThan(-1)
+    const confirmTag = html.slice(confirmAt, html.indexOf('>', confirmAt))
+    expect(confirmTag, 'the affirmative takes the focus').toContain('autofocus')
+    expect(
+      html.slice(0, confirmAt),
+      'and nothing before it does — that would be the cancel button',
+    ).not.toContain('autofocus')
+  })
+
+  it('autofocuses nothing unless a host asks', () => {
+    // The eight faction bodies draw the pair inline on a long page. A control
+    // that grabbed focus there would yank the page down on every render.
+    expect(confirmStep()).not.toContain('autofocus')
   })
 
   it('shows the pending state and disables both halves while joining', () => {
@@ -201,4 +239,112 @@ describe('no faction body writes the trio itself', () => {
       expect(source, 'the cancel label belongs to JoinControl').not.toContain('detail.join.cancel')
     })
   }
+})
+
+/**
+ * Parts 4 and 5 — the whole `src` tree, not just the archetypes (#2656).
+ *
+ * The scan is SOURCE TEXT, deliberately. A non-archetype host's confirm step
+ * sits behind a click, this harness has no DOM, and so the one thing that can
+ * be asserted about a host nobody has thought of yet is that it does not write
+ * the trio's words for itself.
+ */
+const SRC = fileURLToPath(new URL('../../..', import.meta.url))
+
+/** Every `.ts`/`.tsx` under `src`, src-relative and slash-separated. */
+function sourceFiles(): string[] {
+  return readdirSync(SRC, { recursive: true, encoding: 'utf8' })
+    .map((name) => name.split(sep).join('/'))
+    .filter((name) => /\.tsx?$/.test(name))
+}
+
+function read(name: string): string {
+  return readFileSync(join(SRC, name), 'utf8')
+}
+
+/** The one file allowed to say the confirm step's words. */
+const TRIO_OWNER = 'components/JoinControl.tsx'
+
+/**
+ * The trio's shared copy. `detail.join.confirm` itself is left out on purpose:
+ * it is a prefix of the two below it, so a substring scan for it would match
+ * them and say nothing of its own.
+ */
+const TRIO_COPY = [
+  'detail.join.cancel',
+  'detail.join.confirmAction',
+  'detail.join.confirmSwitch',
+]
+
+/**
+ * Every surface that joins a faction, and how its confirm step is drawn. A new
+ * caller fails this list until somebody decides which line it is on — which is
+ * exactly the decision nobody was asked to make when the invitation popup grew
+ * its own pair.
+ */
+const JOIN_SURFACES: Record<string, string> = {
+  'pages/factionDetail/useFactionDetail.ts':
+    'builds the JoinTarget the shared control consumes; draws no buttons',
+  'components/InvitationLetterPopup.tsx': 'mounts JoinConfirm',
+  'components/feed/FeedCardInvitationLetter.tsx':
+    'its own copy, its own one-click mode — cannot mount the shared control; ordered below',
+  'components/AlbescentInvitation.tsx':
+    'no confirm pair at all: a life picker, then Accept (#2399)',
+}
+
+describe('no host writes the join trio itself, archetype or not', () => {
+  it('scans a tree it can actually see', () => {
+    const files = sourceFiles()
+    expect(files.length).toBeGreaterThan(200)
+    expect(files).toContain(TRIO_OWNER)
+  })
+
+  it('writes the trio copy in exactly one file', () => {
+    const offenders = sourceFiles().filter(
+      (name) =>
+        name !== TRIO_OWNER &&
+        !name.includes('__tests__/') &&
+        TRIO_COPY.some((key) => read(name).includes(key)),
+    )
+    expect(offenders, `the confirm step's words belong to ${TRIO_OWNER}`).toEqual([])
+  })
+
+  it('knows every surface that joins a faction', () => {
+    // `api/` is the client and `hooks/` the caches; neither draws a control.
+    const callers = sourceFiles().filter(
+      (name) =>
+        !name.startsWith('api/') &&
+        !name.startsWith('hooks/') &&
+        !name.includes('__tests__/') &&
+        read(name).includes('chooseFaction('),
+    )
+    expect(callers.sort()).toEqual(Object.keys(JOIN_SURFACES).sort())
+  })
+})
+
+describe('the feed letter, the one join surface that keeps its own pair', () => {
+  /**
+   * It cannot mount the shared control without changing its words: its confirm
+   * step is two paragraphs of `feed:invitationLetter.confirm.*`, it has a
+   * one-click branch for an unaffiliated holder (epic #1419 decision 10) and a
+   * terminal "joined" state the trio has no idea about. So #646 is asserted
+   * against its own markup instead — source order, because the confirm step is
+   * one click past a state this harness cannot reach.
+   */
+  const source = readFileSync(
+    join(SRC, 'components/feed/FeedCardInvitationLetter.tsx'),
+    'utf8',
+  )
+
+  it('puts cancel before confirm', () => {
+    const cancel = source.indexOf('invitationLetter.confirm.cancel')
+    const confirm = source.indexOf('invitationLetter.confirm.confirm')
+    expect(cancel, 'a cancel button').toBeGreaterThan(-1)
+    expect(confirm, 'a confirm button').toBeGreaterThan(-1)
+    expect(cancel, 'the affirmative sits on the right (#646)').toBeLessThan(confirm)
+  })
+
+  it('does not reverse the row it just ordered', () => {
+    expect(source).not.toContain('row-reverse')
+  })
 })

--- a/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
@@ -49,7 +49,7 @@ import '../../../i18n'
 import { FACTION_MANIFESTS } from '../../../factions'
 import type { FactionDetailState, Membership } from '../useFactionDetail'
 import type { CharacterOut } from '../../../api/auth'
-import { JoinConfirm, type JoinControlSkin } from '../JoinControl'
+import { JoinConfirm, type JoinControlSkin } from '../../../components/JoinControl'
 
 const mocks = vi.hoisted(() => ({
   formFactor: 'desktop' as 'mobile' | 'desktop',

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -30,7 +30,7 @@ import {
 import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -7,7 +7,7 @@ import { factionCssVar, factionName, factionDescription } from "../../../utils/f
 import { computeFactionMultiplier } from "../../../utils/points";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { MobileStickyBar } from "../MobileStickyBar";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -30,7 +30,7 @@ import {
 import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -8,7 +8,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -8,7 +8,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -8,7 +8,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -14,7 +14,7 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -9,7 +9,7 @@ import { WowSigil } from "../../../components/sigil/WowSigil";
 import { factionName, factionDescription } from "../../../utils/factions";
 import { computeFactionMultiplier } from "../../../utils/points";
 import type { CharacterOut } from "../../../api/auth";
-import { JoinControl, type JoinControlSkin } from "../JoinControl";
+import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
 import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -26,6 +26,7 @@ import { useTaskSignup } from "../../hooks/useTaskSignup";
 import { useGameConfig } from "../../hooks/useGameConfig";
 import { extractError } from "../../utils/errors";
 import { useFactionBackdrop } from "../../components/backdrop/BackdropContext";
+import type { JoinTarget } from "../../components/JoinControl";
 import type { FactionConfigOut } from "../../api/gameConfig";
 
 /**
@@ -84,13 +85,17 @@ export function resolveMembershipState(
   return "gate";
 }
 
-export interface Membership {
+/**
+ * This page's viewer relationship: the four fields the shared join trio reads
+ * ({@link JoinTarget}) plus the one it does not, which decides whether a join
+ * block is drawn at all.
+ *
+ * The four moved to `components/JoinControl` in #2656 rather than being copied:
+ * the popup is a second host for the same control, and a contract owned by one
+ * page's hook is not one a second host can honestly implement.
+ */
+export interface Membership extends JoinTarget {
   state: MembershipState;
-  /** Display name of the faction the viewer would leave by joining (for the confirm copy); null if unaffiliated. */
-  currentFactionSlug: string | null | undefined;
-  join: () => Promise<void>;
-  joining: boolean;
-  joinError: string | null;
 }
 
 export interface FactionDetailState {


### PR DESCRIPTION
Closes #2656

## The seam

**The rendered order of the join confirm pair, at every mount of the trio — including hosts that
are not faction archetypes.**

The failing test came first and went red on four things at once: `InvitationLetterPopup` writing
the trio's copy for itself, the tree scan finding no shared owner outside `pages/`, the missing
dialog-autofocus contract, and `FeedCardInvitationLetter`'s pair. Then green.

## What changed

- **`InvitationLetterPopup` mounts `JoinConfirm`.** Its copy of the switch sentence, the error
  slot and the button pair — the pair that put the affirmative on the **left** — is deleted. Its
  existing paint (`enlistStyle`, `dismissStyle`, the prose and error typography) goes in as the
  `JoinControlSkin`.
- **`JoinControl` moved to `frontend/src/components/JoinControl.tsx`** and now owns its own prop
  contract, `JoinTarget` (the four fields the trio reads). `Membership` in `useFactionDetail.ts`
  `extends JoinTarget` and keeps the fifth, `state`, which the trio never reads. Eight archetypes
  take a one-line import-path change.
- **The order guard is widened past the archetypes** (parts 4 and 5, whole `src` tree).
- **`FeedCardInvitationLetter` puts its affirmative on the right.** Same #646 defect, guarded.

## Decision: where `JoinControl` lives — moved, and the type moved with it

Moved. A shared control under `pages/factionDetail/` was already a component importing a page
hook for its own prop contract, and the moment a second, non-page host mounts it that dependency
points the wrong way in both directions at once.

Moving the file **while leaving `Membership` behind would have moved nothing** — `components/`
would still import from `pages/`, just type-only. So the four fields the control actually reads
became `JoinTarget`, exported beside it; the page's `Membership` extends it. The archetypes pass
a `Membership` where a `JoinTarget` is expected and TypeScript's structural typing means not one
of them changed beyond its import path. Direction is now pages → components, everywhere.

## The finding this issue exists to produce

**Does a typed skin survive a host that is not a faction archetype? Yes — the skin does. The
stateful wrapper does not, and it should not.**

1. **`JoinControlSkin` needed no new slot for paint.** All three required button styles already
   existed in the letter as inline objects. The letter is not a kit, has no faction archetype and
   no CSS class of its own, and the skin took it unmodified.
2. **`JoinControl` (stateful) could not be mounted; `JoinConfirm` (stateless) could.** `JoinControl`
   renders `intro` + *one* button in its open state and owns `confirming` privately. The letter's
   open state has a **second** control beside the verb — dismiss, which defers the letter and is
   emphatically not the confirm step's cancel — and a host cannot lay that out without knowing
   which step it is on. So the letter keeps a one-line `confirming` and mounts the stateless half.
   **Phase 2 should plan on that split**: `JoinConfirm` is the reusable unit (it carries the copy,
   the error slot, the disabled/busy states and the #646 order); `JoinControl` is a convenience for
   hosts whose open state is a lone button, which is all eight archetypes and not the popup.
3. **One BEHAVIOURAL prop was missing, and it is not paint.** A modal host needs the freshly-mounted
   affirmative focused, because that is what scrolls the taller confirm step into view on a short
   viewport (#2130). An inline faction body must not grab focus. That is `autoFocus`, off by
   default — the kind of thing a skin cannot express, and worth knowing before nine lanes assume
   the skin is the whole interface.
4. **The skin has no slot for the pair's ROW, and I did not add one.** See the delta below.
5. **The guard was the root cause, not the popup.** A guard that walks `archetypes/` cannot see a
   host that is not one. Parts 4 and 5 scan the whole `src` tree: the trio's copy may appear in
   exactly one file, and every `chooseFaction` caller is a named census entry, so the *next*
   non-archetype join surface fails the suite until somebody decides which side of the line it is on.

## `FeedCardInvitationLetter` — the same defect, not the same duplication

Checked, as asked. It had the identical #646 inversion and it is fixed here (one root cause, both
symptoms). It is **not** the same duplication, and mounting the shared control there would change
its words: its confirm step is two paragraphs of `feed:invitationLetter.confirm.*`, it has a
one-click branch for an unaffiliated holder (epic #1419 decision 10) and a terminal "joined" state
the trio knows nothing about. So it keeps its own pair, and part 5's census plus a dedicated order
assertion keep it honest.

`components/AlbescentInvitation.tsx` is the third `chooseFaction` host. It has **no confirm pair at
all** — a life picker, then Accept (#2399) — so there was nothing to invert. It is in the census so
it cannot grow one quietly.

## Where the code disagreed with the brief

- The brief said the popup carries `confirming`/`joining`/`joinError` and should delete the state
  machine. `joining` and `joinError` **cannot** leave: they are two of the four fields of the
  `JoinTarget` the host hands down, and there is no shared join hook (the faction page gets them
  from `useFactionDetail`, which is a whole page hook). `confirming` cannot leave either, for
  reason 2 above. What left is the confirm step's *markup and copy*, which is what actually carried
  the bug.
- The popup's confirm pair was at lines ~320–336 as described, and the affirmative was indeed on
  the left.

## Appearance deltas (small, deliberate, and I could not see any of them)

The letter's chrome, masthead, headline, pitch, perks box and open CTA row are byte-identical. The
confirm step has three:

1. **Pair gap `--space-md` (12px) → `--space-sm` (8px)**, and `align-items: center` → default
   stretch. `PAIR_ROW` belongs to the control and is uniform across all nine kits by design; adding
   a fourth skin slot for 4px would be config for a value that should not vary. Called out rather
   than papered over — this is finding 4.
2. **The busy affirmative now dims to `opacity: 0.6`** and its label reads `detail.join.joining`
   ("Joining…") while the POST is in flight. Before, the popup left it reading "Confirm" and merely
   disabled. This is the uniform busy state #2651 introduced.
3. The prose and error lines pick up `class="content-text"`, which sets `font-size` only — and the
   skin passes the same size inline, so it is inert here.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **437 files, 8291 passed**, 1 skipped |
| `npm run build` | ok |
| `npm run budget` | within budget (JS 129.8 KB, CSS 22.1 KB) |

No backend, route, `response_model` or Pydantic change, so `api-schema` and the pytest job are
untouched.

`invitationLetterPopupScroll.test.tsx` still passes **and still means something**: its autofocus
premise would have gone vacuous the moment the confirm markup moved out (it only ever renders the
*open* step), so the claim is split in two and both halves are checked — the popup asks for
`autoFocus` (source, since this harness fires no click), and `joinControlOrder` renders
`JoinConfirm` directly to prove the focus lands on the **affirmative** and not on cancel.

## What to eyeball

**Visual QA is outstanding. I have no browser and no dev stack — nothing below has been looked at
by anything but a static renderer.**

- **The Coven's invitation letter** (the faction reported in #2130), and one more with a different
  accent, e.g. **S.N.I.D.E.** or **the Ephemerists**:
  - **pitch / open** — ENLIST and the dismiss word beside it should be pixel-identical to `main`,
    and dismiss must still *close the letter* (not return to the pitch).
  - **confirm** — the pair should now read **[Cancel] [Confirm]**, affirmative on the right,
    Confirm full-width-ish with `flex: 1`. Check the 12px → 8px gap looks deliberate rather than
    cramped, and that Cancel's baseline still sits right now that it stretches instead of centring.
  - **joining** — Confirm reads "Joining…", dimmed to 0.6, both halves disabled, `not-allowed`
    cursor. This is new; before it just froze.
  - **join-failed** — the red mono error line above the pair. Easiest way in is a slug the viewer
    cannot join (a burned faction 403s).
  - As a **switcher** (viewer already in a real faction) so the `confirmSwitch` sentence renders,
    and as **unaffiliated** for the plain `confirm` one.
  - **Short viewport / phone**: opening the confirm step must still scroll it into view. That is the
    `autoFocus` path and it is the one thing no test in this repo can actually observe.
- **`/updates`, the feed invitation letter**, as a holder already in another faction (that is the
  only mode with a confirm step): the pair should now read **[Cancel] [Accept]**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
