### PR TITLE
A UA member's standing was invisible: the Trans span was child 2, the catalog says <1>

### DIFF
--- a/frontend/src/pages/factionDetail/__tests__/uaJoinBlock.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/uaJoinBlock.test.tsx
@@ -66,6 +66,13 @@ describe('UA draws a join block like any other faction', () => {
     const out = render('member')
     expect(out).toContain(REGISTRY_HEADING)
     expect(out).toContain('You practise here')
+    // The standing VALUE. `ua.join.memberStanding` interpolates the accent word
+    // as `<1>`, and UA alone split the separator out as `{" "}` — which made
+    // the whitespace node child 1 and the span child 2, so i18next dropped it
+    // and every UA member read a bare "Standing ·". Assert the WHOLE line:
+    // `render()` strips tags and the eyebrow above is "Those practising", so
+    // `toContain('practising')` passes vacuously against this exact defect.
+    expect(out).toContain('Standing · practising')
   })
 
   it('offers an invited viewer the practice', () => {

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -373,11 +373,13 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                     marginTop: "var(--space-md)",
                   }}
                 >
+                  {/* The element must be the FIRST child after the text, or
+                      the catalog's `<1>` indexes the whitespace node instead
+                      and i18next drops the span: UA was the only one of seven
+                      bodies that split the separator out as `{" "}`, and it
+                      rendered a bare "Standing ·" with no standing. */}
                   <Trans t={t} i18nKey="ua.join.memberStanding">
-                    Standing ·{" "}
-                    <span style={{ color: "var(--faction-ua-card-accent)" }}>
-                      practising
-                    </span>
+                    Standing · <span style={{ color: "var(--faction-ua-card-accent)" }}>practising</span>
                   </Trans>
                 </div>
               </div>


### PR DESCRIPTION
Closes #2670

A UA member's registry panel rendered `Standing ·` and nothing else — the accent-coloured
`practising` was never in the DOM.

`ua.join.memberStanding` is `"Standing · <1>practising</1>"`. UA alone split the separator out
as an explicit `{" "}` across three JSX lines, making the children `"Standing ·"`, `" "`,
`<span>` — so `<1>` indexed the whitespace node and i18next dropped the element. The other six
faction bodies (Coven, Ephemerists, Everymen, Singularity, S.N.I.D.E., WOW) put the element
directly after the text, so their `<1>` is correct; this one now matches them.

**Seam:** `UaFactionBody`'s registry panel, SSR-rendered — the seam `uaJoinBlock.test.tsx`
already tests at.

**Why nothing caught it.** The member case asserted only `'You practise here'`. Its `render()`
helper strips every tag and the panel's own eyebrow is *"Those practising"*, so even
`toContain('practising')` passes **vacuously** against this exact defect. The assertion now
carries the whole line. Verified red on the old component, green on the new.

## What to eyeball

`/factions/ua` as a **UA member**, both themes: the standing line under "You practise here"
should read `Standing · practising` with the second word in UA orange.

Measured live during the QA that found this — contrast of the restored word on
`--faction-ua-card-bg`: **light 5.18:1, dark 6.58:1** at 18px, both AA.

The other four membership states were verified in the same pass and are unchanged by this PR:
`none` draws no panel; `eligible` draws the join block and its confirm step with CANCEL left /
CONFIRM right (#646); `gate` draws the soft gate; `burned` draws the closed-for-the-era notice.
Every string in all five panels measured ≥ 4.5:1 in both cascades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
