### PR TITLE
Lane 06: fifteen S.N.I.D.E. and Everymen surfaces read roles, not tokens (32 sites, 0 values changed)

### DIFF
--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -54,6 +54,7 @@ import {
   useOwnerReveal,
 } from '../OwnerControls'
 import { CommentFlagControl, canFlagComment } from '../FlagControl'
+import { factionRoleVars } from '../../../utils/factionRoles'
 
 /** The composer's accent: red as a RULE (the field's edge) and a FILL (the
  *  Post button), never as type. Its AA ink is the one #924 measured on it. */
@@ -78,7 +79,7 @@ const DATELINE = {
 
 /** The author's name, set as the slip's byline: the poster face, on the band. */
 const BYLINE = {
-  fontFamily: 'var(--faction-everymen-card-font)',
+  fontFamily: 'var(--ev-voice-face, var(--faction-everymen-card-font))',
   // Content tier, not the label tier the kind label on the feed card uses: a
   // person's name is identity, and Bebas is narrow enough that 18px reads about
   // as large as 14 of a normal face.
@@ -113,7 +114,16 @@ function Slip({
 }) {
   const mobile = useFormFactor() === 'mobile'
   return (
-    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+    <div
+      style={{
+        // `Slip` is the surface root for BOTH modes — the row and the composer
+        // both render through it — so the role map is declared once here.
+        ...factionRoleVars('everymen', 'ev-voice'),
+        display: 'flex',
+        gap: 'var(--space-md)',
+        alignItems: 'flex-start',
+      }}
+    >
       {avatar}
       <div
         {...containerProps}

--- a/frontend/src/components/duel/SnideDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideDuelSealConfirm.tsx
@@ -41,6 +41,7 @@
  */
 import type { CSSProperties } from 'react'
 import { factionCssVar } from '../../utils/factions'
+import { factionRoleVars } from '../../utils/factionRoles'
 import {
   duelSides,
   RaceRoster,
@@ -56,7 +57,7 @@ const INK = 'var(--faction-snide-ink)'
 const ACID = 'var(--faction-snide-acid)'
 const PINK = 'var(--faction-snide-pink)'
 const PAPER = 'var(--faction-snide-paper)'
-const MUTED = 'var(--faction-snide-card-muted)'
+const MUTED = 'var(--snd-duel-quiet, var(--faction-snide-card-muted))'
 /**
  * The sheet-measured "sealed / positive" ink (#694). `--color-success` is the
  * shared slots' default and reads **2.07:1** on this photocopier ink in the
@@ -141,6 +142,11 @@ export default function SnideDuelSealConfirm({
       label={copy.heading}
       scrim={SCRIM}
       ground={{
+        /* `ground` IS this surface's root style — `DuelSealSheet` spreads it on
+           the phone sheet and on the desktop card, both of which contain every
+           child — so the role map is declared here rather than on a wrapper
+           this component does not own (#2676). */
+        ...factionRoleVars('snide', 'snd-duel'),
         ...HALFTONE,
         borderLeft: `7px solid ${accent}`,
         color: PAPER,

--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -1,6 +1,7 @@
 import type { FactionHeroProps } from "../../pages/FactionDetail";
 import { SnideSigil } from "../sigil/SnideSigil";
 import i18n from "../../i18n";
+import { factionRoleVars } from "../../utils/factionRoles";
 
 /**
  * S.N.I.D.E. faction-page hero — a flyposted wall (NOT a tidy poster): faint
@@ -47,7 +48,7 @@ const PLATE = "var(--faction-snide-ink)";
  * because the disc is frozen on `PLATE` and BOTH of its ends were measured
  * there: 6.93:1 by day, 15.55:1 by night.
  */
-const CHROME = "var(--faction-snide)";
+const CHROME = "var(--snd-hero-fill, var(--faction-snide))";
 /** The stock the disc gave up, kept as the raster that reads on it. Invariant. */
 const STOCK = "var(--faction-snide-paper)";
 
@@ -76,6 +77,7 @@ export default function SnideFactionHero({
   return (
     <header
       style={{
+        ...factionRoleVars("snide", "snd-hero"),
         position: "relative",
         overflow: "hidden",
         marginBottom: "var(--space-xl)",
@@ -440,7 +442,7 @@ export default function SnideFactionHero({
                   // The CARD's tier is the right one HERE and only here on this
                   // hero: the chit is a slab, not the wall. 12.96:1 light /
                   // 11.85:1 dark on the plate.
-                  color: "var(--faction-snide-card-muted)",
+                  color: "var(--snd-hero-quiet, var(--faction-snide-card-muted))",
                 }}
               >
                 {s.label}

--- a/frontend/src/components/feed/EverymenFeedFrame.tsx
+++ b/frontend/src/components/feed/EverymenFeedFrame.tsx
@@ -59,6 +59,7 @@
 import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
+import { factionRoleVars } from '../../utils/factionRoles'
 
 const ROW_SKIN: FeedRowSkin = { ink: { actor: 'var(--everymen-paper-accent)' } }
 
@@ -74,6 +75,7 @@ export default function EverymenFeedFrame({
   return (
     <article
       style={{
+        ...factionRoleVars('everymen', 'ev-feed'),
         position: 'relative',
         background: 'var(--everymen-paper)',
         color: 'var(--everymen-paper-text)',
@@ -160,7 +162,7 @@ export default function EverymenFeedFrame({
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              fontFamily: 'var(--faction-everymen-card-font)',
+              fontFamily: 'var(--ev-feed-face, var(--faction-everymen-card-font))',
               fontSize: mobile ? 'var(--text-lg)' : 'var(--text-xl)',
               letterSpacing: mobile ? '0.12em' : '0.18em',
               textTransform: 'uppercase',

--- a/frontend/src/components/metataskSeal/skins/EverymenSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/EverymenSeal.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { EverymenBand } from '../../cardMasthead/factionBands'
 import type { SealSkinProps } from '../types'
+import { factionRoleVars } from '../../../utils/factionRoles'
 
 /**
  * Everymen seal — a union-broadsheet dispatch stamped onto the host praxis.
@@ -26,6 +27,7 @@ export default function EverymenSeal({ metatask, removable, onRemove }: SealSkin
     <div
       className="relative"
       style={{
+        ...factionRoleVars('everymen', 'ev-seal'),
         background: 'var(--everymen-paper)',
         color: 'var(--everymen-paper-text)',
         border: '1.5px solid var(--everymen-ink)',
@@ -82,7 +84,7 @@ export default function EverymenSeal({ metatask, removable, onRemove }: SealSkin
           <span
             className="font-body block"
             style={{
-              fontFamily: 'var(--faction-everymen-card-font)',
+              fontFamily: 'var(--ev-seal-face, var(--faction-everymen-card-font))',
               fontSize: 'var(--text-content)',
               letterSpacing: '0.01em',
             }}
@@ -106,7 +108,7 @@ export default function EverymenSeal({ metatask, removable, onRemove }: SealSkin
             textAlign: 'center',
             transform: 'rotate(-8deg)',
             mixBlendMode: 'multiply',
-            fontFamily: 'var(--faction-everymen-card-font)',
+            fontFamily: 'var(--ev-seal-face, var(--faction-everymen-card-font))',
             fontSize: 'var(--text-lg)',
             lineHeight: 1.05,
             padding: 'var(--space-xs)',

--- a/frontend/src/components/metataskSeal/skins/SnideSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/SnideSeal.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { SnideBand } from '../../cardMasthead/factionBands'
 import type { SealSkinProps } from '../types'
+import { factionRoleVars } from '../../../utils/factionRoles'
 
 /**
  * S.N.I.D.E. seal — a photocopier-ink ransom note slapped on the host praxis.
@@ -84,8 +85,9 @@ export default function SnideSeal({ metatask, removable, onRemove }: SealSkinPro
     <div
       className="relative"
       style={{
-        background: 'var(--faction-snide-card-bg)',
-        color: 'var(--faction-snide-card-text)',
+        ...factionRoleVars('snide', 'snd-seal'),
+        background: 'var(--snd-seal-paper, var(--faction-snide-card-bg))',
+        color: 'var(--snd-seal-ink, var(--faction-snide-card-text))',
         border: '2px solid var(--faction-snide-pink)',
         borderRadius: 2,
         transform: 'rotate(-1deg)',

--- a/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { factionCssVar } from "../../../utils/factions";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { EverymenBand } from "../../cardMasthead/factionBands";
 import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { AdminOverlay } from "../shared";
@@ -39,6 +39,10 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * single left-edge line and it stays.
  */
 
+/** The sheet, named once: it is both the frame's ground and the value
+ *  `PraxisBody` needs to knock its own boxes back out of. */
+const PAPER = "var(--ev-praxis-paper, var(--faction-everymen-card-bg))";
+
 /** The red margin rule down the sheet. Static (#586). */
 const everymenMarginRule: CSSProperties = {
   position: "absolute",
@@ -55,14 +59,15 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
     <div
       style={{
         ...frameBase,
+        ...factionRoleVars("everymen", "ev-praxis"),
         borderRadius: 2, // broadsheet — near-square
         overflow: "hidden",
-        background: factionCssVar("everymen", "card-bg"),
+        background: PAPER,
         border: "1px solid var(--everymen-frame)",
         boxShadow: "0 3px 14px var(--color-cast-shadow-soft)",
         position: "relative",
         fontFamily: "var(--font-faction-typewriter)",
-        color: factionCssVar("everymen", "card-text"),
+        color: "var(--ev-praxis-ink, var(--faction-everymen-card-text))",
         transition: "background 150ms, color 150ms",
       }}
     >
@@ -94,15 +99,15 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
-          tint={factionCssVar("everymen", "card-accent")}
-          muted={factionCssVar("everymen", "card-muted")}
-          paper={factionCssVar("everymen", "card-bg")}
+          tint="var(--ev-praxis-accent, var(--faction-everymen-card-accent))"
+          muted="var(--ev-praxis-quiet, var(--faction-everymen-card-muted))"
+          paper={PAPER}
           showCrown={showCrown}
           // Bebas Neue is Everymen's declared card font and, until #888, reached
           // task and faction cards but never a praxis card. The broadsheet's own
           // Special Elite stays on the reading matter.
           fonts={{
-            display: "var(--faction-everymen-card-font)",
+            display: "var(--ev-praxis-face, var(--faction-everymen-card-font))",
             body: "var(--font-faction-typewriter)",
           }}
         />

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -3,6 +3,7 @@ import { WALL, WALL_PLAIN } from "../../factionMarks/snideAtoms";
 import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
+import { factionRoleVars } from "../../../utils/factionRoles";
 
 /**
  * S.N.I.D.E. — THE EVIDENCE SLAB (#842), REPOSTED ON THE WALL (#2177).
@@ -100,6 +101,12 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
       className="snd-praxis-frame"
       style={{
         ...frameBase,
+        /* THE ROLE MAP UNDER ITS OWN PREFIX, NOT `--snd-praxis-*` (#2676). That
+           channel is the HOST's — the task-detail row sets it to repoint this
+           card's ground and inks — and declaring it here would overwrite the
+           host from inside the child. `--snd-pcard-*` is this card's own name
+           for the vocabulary, so the two never meet. */
+        ...factionRoleVars("snide", "snd-pcard"),
         // No borderRadius: the evidence slab has hard corners in the prototype.
         position: "relative",
         background: ground(groundIsBusy),
@@ -134,7 +141,7 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           // identity belongs. A two-line excerpt set in it is unreadable, so the
           // body stays on the slab's Special Elite.
           fonts={{
-            display: "var(--faction-snide-card-font)",
+            display: "var(--snd-pcard-face, var(--faction-snide-card-font))",
             body: "var(--faction-snide-font-type)",
           }}
           titleStyle={{

--- a/frontend/src/components/selectCard/EverymenSelectCard.tsx
+++ b/frontend/src/components/selectCard/EverymenSelectCard.tsx
@@ -4,6 +4,7 @@ import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { EverymenSigil } from "../sigil/EverymenSigil";
 import { EverymenCog } from "../factionMarks/everymenCogs";
 import { CARD_CTA } from "../taskCard/cardCta";
+import { factionRoleVars } from "../../utils/factionRoles";
 
 /**
  * The Everymen — the faction-DIRECTORY tile (#2327, a child of #2321). The HELP
@@ -146,7 +147,7 @@ import { CARD_CTA } from "../taskCard/cardCta";
  * the grid.
  */
 
-const POSTER = "var(--faction-everymen-card-font)"; /* Bebas Neue */
+const POSTER = "var(--ev-select-face, var(--faction-everymen-card-font))"; /* Bebas Neue */
 const TYPED = "var(--font-body)"; /* Courier Prime */
 
 /** The sheet's ink — the paper's own text colour, which FLIPS with the paper. */
@@ -170,6 +171,7 @@ export default function EverymenSelectCard({ state = "locked", members, onVisit 
   const status = i18n.t(`feed:factionSelect.everymen.status.${state}` as const);
   return (
     <div style={{
+      ...factionRoleVars("everymen", "ev-select"),
       width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
       background: "var(--everymen-paper)", color: INK, fontFamily: TYPED,
       border: `2px solid ${INK}`, borderRadius: 2, padding: "var(--space-xs)",

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -11,6 +11,7 @@ import { useGroundIsBusy } from "../backdrop/BackdropContext";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
+import { factionRoleVars } from "../../utils/factionRoles";
 
 /**
  * Everymen — THE HELP WANTED BILL (task card v2, #1023).
@@ -49,7 +50,7 @@ import { useFormFactor } from "../../hooks/useFormFactor";
  * `[data-theme="dark"]` cascade, never a ternary.
  */
 
-const POSTER = "var(--faction-everymen-card-font)"; /* Bebas Neue */
+const POSTER = "var(--ev-task-face, var(--faction-everymen-card-font))"; /* Bebas Neue */
 const TYPED = "var(--font-body)"; /* Courier Prime */
 
 /**
@@ -260,7 +261,12 @@ export default function EverymenTaskCard({
   return (
     <div
       data-form-factor={formFactor}
-      style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}
+      style={{
+        ...factionRoleVars("everymen", "ev-task"),
+        width: size.cardWidth,
+        maxWidth: "100%",
+        boxSizing: "border-box",
+      }}
     >
       <article
         style={{

--- a/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
@@ -138,6 +138,7 @@ import {
   useComposerSizes,
 } from '../../editPraxis/archetypes/shared'
 import { EverymenCog } from '../../../components/factionMarks/everymenCogs'
+import { factionRoleVars } from '../../../utils/factionRoles'
 
 const SLUG = 'everymen'
 
@@ -169,7 +170,7 @@ const SHADOW = 'var(--faction-everymen-bill-shadow)'
 /** #1449's alarm rung, measured on this paper. Not the neutral `--color-danger`. */
 const ALARM = 'var(--faction-everymen-card-alarm)'
 
-const BEBAS = 'var(--faction-everymen-card-font)' /* Bebas Neue */
+const BEBAS = 'var(--ev-path-face, var(--faction-everymen-card-font))' /* Bebas Neue */
 const COURIER = 'var(--font-body)' /* Courier Prime */
 
 /** The cogs' period, the work order's own 22s. Ornament timing. */
@@ -320,7 +321,10 @@ export default function EverymenCreateCharacter({ state }: { state: CreateCharac
   )
 
   return (
-    <ComposerPage sizes={sizes} style={{ fontFamily: COURIER, color: INK }}>
+    <ComposerPage
+      sizes={sizes}
+      style={{ ...factionRoleVars('everymen', 'ev-path'), fontFamily: COURIER, color: INK }}
+    >
       {/* A REAL `<form>`, not a bare button with an onClick. The Default skin
           submits through one and so must this: it is what makes Enter commit
           from a text field. `handleSubmit` calls `preventDefault()` itself. */}

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -123,6 +123,7 @@ import { EverymenCog } from "../../../components/factionMarks/everymenCogs";
 import { MetataskSealStack } from "../../../components/metataskSeal/MetataskSealStack";
 import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 import Breadcrumb from "../../../components/nav/Breadcrumb";
+import { factionRoleVars } from "../../../utils/factionRoles";
 
 interface Props {
   state: EditPraxisState;
@@ -174,7 +175,7 @@ const BAR_INK = "var(--faction-everymen-bill-cta-ink)";
 const PAPER_DEEP = "var(--everymen-paper-deep)";
 const SHADOW = "var(--faction-everymen-bill-shadow)";
 
-const BEBAS = "var(--faction-everymen-card-font)"; /* Bebas Neue */
+const BEBAS = "var(--ev-compose-face, var(--faction-everymen-card-font))"; /* Bebas Neue */
 const COURIER = "var(--font-body)"; /* Courier Prime */
 
 /** The cogs' period, the design's own 22s. It had drifted to 26 (#1830). The
@@ -353,7 +354,14 @@ export default function EverymenEditPraxis({ state }: Props) {
   const dress: ComposerDress = {
     accent: ACCENT,
     alarm: ALARM,
-    pageStyle: { fontFamily: COURIER, color: INK },
+    // `pageStyle` is the root of BOTH stages — the composer page here and the
+    // shared waiting surface the dress is handed to — so declaring the role map
+    // in it reaches everything this archetype draws (#2676).
+    pageStyle: {
+      ...factionRoleVars("everymen", "ev-compose"),
+      fontFamily: COURIER,
+      color: INK,
+    },
     sheetStyle,
     masthead,
     ground,

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -11,6 +11,7 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 import { WALL } from '../../../components/factionMarks/snideAtoms'
+import { factionRoleVars } from '../../../utils/factionRoles'
 
 /**
  * S.N.I.D.E. MOBILE FieldDesk home (#530) — the operative's file on a phone.
@@ -35,11 +36,11 @@ import { WALL } from '../../../components/factionMarks/snideAtoms'
  *  five-layer {@link WALL} still reads as something pasted ON it. */
 const DESK = 'var(--faction-snide-wall)'
 const WALL_TEXT = 'var(--faction-snide-wall-text)'
-const INK = 'var(--faction-snide-card-bg)'
-const TEXT = 'var(--faction-snide-card-text)'
-const MUTED = 'var(--faction-snide-card-muted)'
-const ACID = 'var(--faction-snide-card-accent)'
-const ACCENT_WALL = 'var(--faction-snide)'
+const INK = 'var(--snd-desk-paper, var(--faction-snide-card-bg))'
+const TEXT = 'var(--snd-desk-ink, var(--faction-snide-card-text))'
+const MUTED = 'var(--snd-desk-quiet, var(--faction-snide-card-muted))'
+const ACID = 'var(--snd-desk-accent, var(--faction-snide-card-accent))'
+const ACCENT_WALL = 'var(--snd-desk-fill, var(--faction-snide))'
 const PINK = 'var(--faction-snide-pink)'
 const LINE = 'var(--faction-snide-border)'
 const COND = 'var(--faction-snide-font-cond)'
@@ -204,7 +205,15 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
     <div
       data-skin="snide"
       className="page"
-      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)', fontFamily: TYPE, color: WALL_TEXT, background: DESK }}
+      style={{
+        ...factionRoleVars('snide', 'snd-desk'),
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-lg)',
+        fontFamily: TYPE,
+        color: WALL_TEXT,
+        background: DESK,
+      }}
     >
       {/* Masthead — the ransom cut over an acid rule */}
       <header>

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -141,6 +141,7 @@ import {
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import Breadcrumb from "../../../components/nav/Breadcrumb";
+import { factionRoleVars } from "../../../utils/factionRoles";
 
 const IMPACT = "var(--faction-snide-font-impact)"; /* Anton */
 const BLACK = "var(--faction-snide-font-black)"; /* Archivo Black */
@@ -168,11 +169,11 @@ const STOCK = "var(--faction-snide-paper)";
  * The SLAB — the page's one ground, black in both themes, with the ink family it
  * was measured against. Everything pasted on the wall is one of these.
  */
-const PLATE = "var(--faction-snide-card-bg)";
-const PLATE_TEXT = "var(--faction-snide-card-text)";
-const PLATE_MUTED = "var(--faction-snide-card-muted)";
+const PLATE = "var(--snd-read-paper, var(--faction-snide-card-bg))";
+const PLATE_TEXT = "var(--snd-read-ink, var(--faction-snide-card-text))";
+const PLATE_MUTED = "var(--snd-read-quiet, var(--faction-snide-card-muted))";
 /** Acid as the plate's INK, which is the one ground that admits it as type. */
-const PLATE_ACCENT = "var(--faction-snide-card-accent)";
+const PLATE_ACCENT = "var(--snd-read-accent, var(--faction-snide-card-accent))";
 /** Acid as a drawn RULE or ring. Same pigment, and never type on paper. */
 const ACID = "var(--faction-snide-acid)";
 
@@ -816,7 +817,15 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   );
 
   return (
-    <div className="py-8" style={{ position: "relative", fontFamily: TYPE, color: INK }}>
+    <div
+      className="py-8"
+      style={{
+        ...factionRoleVars("snide", "snd-read"),
+        position: "relative",
+        fontFamily: TYPE,
+        color: INK,
+      }}
+    >
       {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
           same trail at every width - see components/nav/Breadcrumb. */}
       <Breadcrumb

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionFill, factionName } from "../../../utils/factions";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { mediaUrl } from "../../../utils/media";
 import {
   actionColumnSize,
@@ -114,10 +115,10 @@ const PINK_INK = "var(--faction-snide-note-pink-ink)";
  * The SLAB — every sheet pasted on the wall, black in BOTH themes, with the ink
  * family it was measured against. Acid carries type only here.
  */
-const PLATE = "var(--faction-snide-card-bg)";
-const PLATE_TEXT = "var(--faction-snide-card-text)";
-const PLATE_MUTED = "var(--faction-snide-card-muted)";
-const PLATE_ACCENT = "var(--faction-snide-card-accent)";
+const PLATE = "var(--snd-task-paper, var(--faction-snide-card-bg))";
+const PLATE_TEXT = "var(--snd-task-ink, var(--faction-snide-card-text))";
+const PLATE_MUTED = "var(--snd-task-quiet, var(--faction-snide-card-muted))";
+const PLATE_ACCENT = "var(--snd-task-accent, var(--faction-snide-card-accent))";
 /** The pink that is a DRAWN LINE — pen circle, strike-out cross. Invariant. */
 const PINK = "var(--faction-snide-pink)";
 /** Photocopier black that does NOT flip: borders and shadows printed on acid. */
@@ -529,7 +530,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
             // cream, which on the slab prints black-on-black in light. Newsprint
             // grey is the slab's own quiet pigment and is light in both themes.
             backgroundImage:
-              "radial-gradient(var(--faction-snide-card-muted) 22%, transparent 23%), radial-gradient(var(--faction-snide-card-muted) 22%, transparent 23%)",
+              `radial-gradient(${PLATE_MUTED} 22%, transparent 23%), radial-gradient(${PLATE_MUTED} 22%, transparent 23%)`,
             backgroundSize: "6px 6px, 6px 6px",
             backgroundPosition: "0 0, 3px 3px",
           }}
@@ -906,7 +907,15 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
   );
 
   return (
-    <div className="py-8" style={{ position: "relative", fontFamily: TYPE, color: INK }}>
+    <div
+      className="py-8"
+      style={{
+        ...factionRoleVars("snide", "snd-task"),
+        position: "relative",
+        fontFamily: TYPE,
+        color: INK,
+      }}
+    >
       {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
           same trail on every page — see components/nav/Breadcrumb. */}
       <Breadcrumb taskId={task.id} taskTitle={task.title} />

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2492,6 +2492,31 @@ function sourceOf(relative: string): string {
 }
 
 /**
+ * A ROLE READ, as a regex fragment wrapping the token a source guard is hunting.
+ *
+ * The faction lanes (#2649) rewrite `var(--faction-snide-card-bg)` into
+ * `var(--snd-desk-paper, var(--faction-snide-card-bg))` — same value, new
+ * spelling — and every guard in this file that reads a token off the SOURCE
+ * rather than out of `index.css` matches on the spelling. Lane 06 broke two of
+ * them, and it broke them the dangerous way round: `pressGrounds` stopped
+ * resolving four of `SnideFieldDesk`'s aliases and reported the file CLEANER
+ * than it is. A guard that silently narrows is worse than one that fails.
+ *
+ * WHY THE FALLBACK IS THE VALUE TO MEASURE. The surfaces these guards read are
+ * all on the `sheet` ground, where the role map points at exactly the token
+ * each site already named — so the declared property and the fallback carry one
+ * value and reading either is the same measurement. That is not an assumption
+ * left in prose: `factionRoleMigration.test.ts` re-derives every fallback in
+ * every migrated file from the resolver and fails if one drifts. A surface that
+ * ever takes `chrome` breaks the equality, which is why that file records each
+ * surface's ground and this comment names the dependency.
+ */
+const ROLE_READ = String.raw`(?:var\(\s*--[\w-]+\s*,\s*)?`;
+
+/** Closes {@link ROLE_READ}. Separate because the token sits between them. */
+const ROLE_READ_END = String.raw`\)?`;
+
+/**
  * `dress.pageStyle` out of `EphemeristsEditPraxis` — THE SECOND EPHEMERISTS
  * ROOT, and the one two separate seams (#1636's links, #1800's labels) have now
  * had to be declared on. One reader, so the third seam does not re-derive the
@@ -4141,7 +4166,9 @@ describe("the S.N.I.D.E. hero's black medallion and its subhead (#2368)", () => 
       expect(
         source,
         `${HERO} no longer binds \`${alias}\` to ${token}; retarget this guard at whatever it is called there now.`,
-      ).toMatch(new RegExp(`const ${alias} = ["']var\\(${token}\\)["']`));
+      ).toMatch(
+        new RegExp(`const ${alias} = ["']${ROLE_READ}var\\(${token}\\)${ROLE_READ_END}["']`),
+      );
     }
     return source;
   }
@@ -4151,7 +4178,9 @@ describe("the S.N.I.D.E. hero's black medallion and its subhead (#2368)", () => 
     const trimmed = expression.replace(/[`"'${}]/g, "").replace(/[,;]$/, "").trim();
     const alias = ALIASES.find(([name]) => name === trimmed);
     if (alias) return alias[1];
-    const bare = trimmed.match(/^var\((--[a-z-]+)\)$/);
+    // `CHROME` is a role read since #2676, and it also reaches `tokenOf`
+    // directly at the medallion's ink. Both spellings resolve to one token.
+    const bare = trimmed.match(new RegExp(`^${ROLE_READ}var\\((--[a-z-]+)\\)${ROLE_READ_END}$`));
     expect(bare, `${role} paints \`${trimmed}\`, which is neither an alias this guard knows nor a var()`).not.toBeNull();
     return bare![1];
   }
@@ -4729,15 +4758,27 @@ describe("S.N.I.D.E. is not an always-dark faction (#2631)", () => {
    */
   function pressGrounds(file: string): string[] {
     const source = stripComments(sourceOf(file));
+    // Both readers below tolerate a {@link ROLE_READ} wrapper, and this is the
+    // guard where that MATTERS: lane 06 turned four of `SnideFieldDesk`'s
+    // ground aliases into role reads, and an alias map that cannot see them
+    // does not fail — it reports the file cleaner than it is.
+    const SNIDE_TOKEN = String.raw`var\((--faction-snide-[\w-]+)\)`;
     const aliases = new Map(
-      [...source.matchAll(/const ([A-Z_][A-Z_0-9]*) = ["']var\((--faction-snide-[\w-]+)\)["']/g)].map(
-        (match) => [match[1], match[2]] as const,
-      ),
+      [
+        ...source.matchAll(
+          new RegExp(
+            `const ([A-Z_][A-Z_0-9]*) = ["']${ROLE_READ}${SNIDE_TOKEN}${ROLE_READ_END}["']`,
+            "g",
+          ),
+        ),
+      ].map((match) => [match[1], match[2]] as const),
     );
     return [...source.matchAll(/(?:background(?:Color)?|pageBackground|barTrack):\s*([^,;\n}]+)/g)]
       .map((match) => match[1].trim())
       .filter((value) => {
-        const token = aliases.get(value) ?? value.match(/^var\((--faction-snide-[\w-]+)\)$/)?.[1];
+        const token =
+          aliases.get(value) ??
+          value.match(new RegExp(`^${ROLE_READ}${SNIDE_TOKEN}${ROLE_READ_END}$`))?.[1];
         return token === "--faction-snide-ink" || token === "--faction-snide-card-bg";
       });
   }

--- a/frontend/src/utils/__tests__/factionRoleMigration.test.ts
+++ b/frontend/src/utils/__tests__/factionRoleMigration.test.ts
@@ -141,7 +141,10 @@ const SURFACES: Surface[] = [
     slug: "everymen",
     prefix: "ev-praxis",
     ground: "sheet",
-    sites: 6,
+    // 6 token reads removed, 5 written: `card-bg` was named twice — as the
+    // frame's own ground and again as `PraxisBody`'s `paper` — and both are now
+    // the one `PAPER` const.
+    sites: 5,
   },
   {
     file: "components/metataskSeal/skins/EverymenSeal.tsx",

--- a/frontend/src/utils/__tests__/factionRoleMigration.test.ts
+++ b/frontend/src/utils/__tests__/factionRoleMigration.test.ts
@@ -1,0 +1,299 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  FACTION_ROLES,
+  factionRoleVar,
+  type FactionGround,
+  type FactionRole,
+} from "../factionRoles";
+import { stripComments } from "./cssVars";
+
+/**
+ * THE MERGE GATE FOR A FACTION LANE, AS A RUNNABLE CHECK (#2676, decision 12 of
+ * "Nine Kits, One Vocabulary" on #2649).
+ *
+ * A lane moves a surface from naming a faction token directly —
+ * `var(--faction-snide-card-bg)` — to naming a ROLE with that token carried as
+ * the fallback: `var(--snd-task-paper, var(--faction-snide-card-bg))`, with
+ * `factionRoleVars(slug, prefix, ground)` spread on the surface's root. Every
+ * such move is supposed to be value-preserving, and "supposed to be" is the
+ * whole problem: a migration that changes a pixel is a redesign wearing a
+ * refactor's clothes, and NOTHING ELSE WE RUN CAN SEE IT. tsc sees two strings.
+ * eslint sees two strings. `factionTokensDeclared` sees a declared name. The
+ * bundle budget sees the same bytes. A fallback pointing one token sideways —
+ * `-card-muted` where the role resolves to `-card-accent` — compiles, lints,
+ * renders, and is simply the wrong colour.
+ *
+ * THE SEAM IS THE FALLBACK ARM, and it is the only place the old value and the
+ * new name are written down together. So this file re-derives, from the
+ * resolver, what each fallback must be, and compares it to what the source
+ * actually says. That comparison IS the "computed-value diff" the epic asks
+ * every lane to publish for review — expressed once, here, instead of once per
+ * PR description where nothing re-checks it after the merge.
+ *
+ * WHY A SOURCE SCAN AND NOT A RENDER. The failure is per-SITE and the sites are
+ * inside style objects, module constants and props threaded into shared
+ * components; mounting each surface would need a fixture per archetype and
+ * would still only reach the branches that fixture happens to hit. The source
+ * has every site in it exactly once.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO: it does not check that a role is used on
+ * the RIGHT declaration — `paper` in a `color:` is a contrast bug, and that is
+ * `factionContrast.test.ts`'s job (#2661) — and it does not police surfaces
+ * absent from the table below. Adding a surface to a lane means adding its row.
+ */
+
+const SRC_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+
+interface Surface {
+  /** Path under `frontend/src`. */
+  file: string;
+  /** The faction the surface is compile-time bound to. */
+  slug: string;
+  /** The surface's OWN prefix. Never shared — see `factionRoleVars`. */
+  prefix: string;
+  ground: FactionGround;
+  /**
+   * How many role reads the file WRITES. Pinned, because a read quietly dropped
+   * in a later edit is a site that went back to naming the faction directly and
+   * a read quietly added is one nobody measured.
+   *
+   * It is not always the number of old token reads the lane removed. Where a
+   * file already had a module constant for the value, a second literal copy of
+   * the same token collapses into it: `SnideTaskDetail` named
+   * `--faction-snide-card-muted` twice inside one `radial-gradient()` beside a
+   * `PLATE_MUTED` const that held exactly that string, so six removals became
+   * four reads. Fewer reads than removals is the shape of a deletion; MORE
+   * would be a repaint, and the straggler test below is what makes the
+   * difference checkable rather than asserted.
+   */
+  sites: number;
+}
+
+/**
+ * Lane 06's contact sheet, in the one place a machine can read it.
+ *
+ * S.N.I.D.E. owns the repo's only ground override (`chrome.snide`), so its
+ * ground is a real choice here rather than a formality. Every surface below is
+ * a CONTENT SHEET — a task/praxis detail column, a card, a comment, a stamp, a
+ * mobile home for one faction's own pages — so all seven take `sheet`. `chrome`
+ * is the app's own furniture wearing a faction, which in this repo is the rail
+ * and nothing in this lane. Choosing `chrome` for any of these would repoint
+ * `paper` to `--faction-snide-wall` and repaint the surface, which is exactly
+ * what a lane may not do.
+ */
+const SURFACES: Surface[] = [
+  {
+    file: "pages/taskDetail/archetypes/SnideTaskDetail.tsx",
+    slug: "snide",
+    prefix: "snd-task",
+    ground: "sheet",
+    // 6 token reads removed, 4 written — see `sites`.
+    sites: 4,
+  },
+  {
+    file: "pages/praxisDetail/archetypes/SnidePraxisDetail.tsx",
+    slug: "snide",
+    prefix: "snd-read",
+    ground: "sheet",
+    sites: 4,
+  },
+  {
+    file: "pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx",
+    slug: "snide",
+    prefix: "snd-desk",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    file: "components/factionHero/SnideFactionHero.tsx",
+    slug: "snide",
+    prefix: "snd-hero",
+    ground: "sheet",
+    sites: 2,
+  },
+  {
+    file: "components/metataskSeal/skins/SnideSeal.tsx",
+    slug: "snide",
+    prefix: "snd-seal",
+    ground: "sheet",
+    sites: 2,
+  },
+  {
+    file: "components/praxisCard/desktop/SnidePraxisCard.tsx",
+    slug: "snide",
+    prefix: "snd-pcard",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "components/duel/SnideDuelSealConfirm.tsx",
+    slug: "snide",
+    prefix: "snd-duel",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "components/praxisCard/desktop/EverymenPraxisCard.tsx",
+    slug: "everymen",
+    prefix: "ev-praxis",
+    ground: "sheet",
+    sites: 6,
+  },
+  {
+    file: "components/metataskSeal/skins/EverymenSeal.tsx",
+    slug: "everymen",
+    prefix: "ev-seal",
+    ground: "sheet",
+    sites: 2,
+  },
+  {
+    file: "components/taskCard/EverymenTaskCard.tsx",
+    slug: "everymen",
+    prefix: "ev-task",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "components/selectCard/EverymenSelectCard.tsx",
+    slug: "everymen",
+    prefix: "ev-select",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "components/comments/voices/EverymenComment.tsx",
+    slug: "everymen",
+    prefix: "ev-voice",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "components/feed/EverymenFeedFrame.tsx",
+    slug: "everymen",
+    prefix: "ev-feed",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "pages/characterPaths/archetypes/EverymenCreateCharacter.tsx",
+    slug: "everymen",
+    prefix: "ev-path",
+    ground: "sheet",
+    sites: 1,
+  },
+  {
+    file: "pages/editPraxis/archetypes/EverymenEditPraxis.tsx",
+    slug: "everymen",
+    prefix: "ev-compose",
+    ground: "sheet",
+    sites: 1,
+  },
+];
+
+/**
+ * `stripComments` is the CSS stripper, so it takes `/* … *​/` and leaves `//`.
+ * Both matter: these files quote token names in prose constantly, and a
+ * mention is not a read. The line form is stripped here, with `://` spared so
+ * a `url(https://…)` survives — the same carve-out `factionTokensDeclared`
+ * documents from the other side.
+ */
+function readSource(file: string): string {
+  const text = readFileSync(join(SRC_DIR, ...file.split("/")), "utf-8");
+  return stripComments(text).replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/**
+ * A role read: `var(--<prefix>-<role>, var(--faction-…))`.
+ *
+ * The fallback arm is required to be a single bare `var()` — no `color-mix`, no
+ * second fallback — because that is the only shape whose value this file can
+ * compare against the resolver. A lane that needs a composed fallback is
+ * composing, which decision 07 says belongs to the surface as a NAMED extra
+ * rather than hidden inside a core role's fallback.
+ */
+function roleReads(source: string, prefix: string): [FactionRole, string][] {
+  return FACTION_ROLES.flatMap((role) => {
+    const property = `--${prefix}-${role.replace(/[A-Z]/g, (l) => `-${l.toLowerCase()}`)}`;
+    const pattern = new RegExp(
+      `var\\(\\s*${property}\\s*,\\s*(var\\(\\s*--[\\w-]+\\s*\\))\\s*\\)`,
+      "g",
+    );
+    return [...source.matchAll(pattern)].map(
+      (match) => [role, match[1].replace(/\s+/g, "")] as [FactionRole, string],
+    );
+  });
+}
+
+describe("lane 06 — every migrated site keeps the value it shipped with", () => {
+  it.each(SURFACES)(
+    "$file declares $prefix once, on the $ground ground",
+    ({ file, slug, prefix, ground }) => {
+      const source = readSource(file);
+      const declarations = [
+        ...source.matchAll(
+          /factionRoleVars\(\s*["'`]([\w-]+)["'`]\s*,\s*["'`]([\w-]+)["'`]\s*(?:,\s*["'`](\w+)["'`]\s*)?\)/g,
+        ),
+      ];
+
+      expect(
+        declarations.map((match) => [match[1], match[2], match[3] ?? "sheet"]),
+        "the root spreads its own prefix, exactly once",
+      ).toEqual([[slug, prefix, ground]]);
+    },
+  );
+
+  it.each(SURFACES)(
+    "$file: every $prefix read falls back to the token its role resolves to",
+    ({ file, slug, prefix, ground, sites }) => {
+      const reads = roleReads(readSource(file), prefix);
+
+      expect(reads.length, `role reads in ${file}`).toBe(sites);
+      expect(
+        reads.map(([role, fallback]) => `${role} -> ${fallback}`),
+        "old var -> new var -> SAME declared value",
+      ).toEqual(
+        reads.map(
+          ([role]) => `${role} -> ${factionRoleVar(slug, role, ground)}`,
+        ),
+      );
+    },
+  );
+
+  it("gives every surface a prefix of its own (#2659 — a prefix may not be shared)", () => {
+    const prefixes = SURFACES.map((surface) => surface.prefix);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+
+  it("leaves no core-role token named directly in a migrated file", () => {
+    const CORE = String.raw`card-bg|card-text|card-muted|card-border|card-accent|on-fill|card-radius|card-font`;
+    const stragglers = SURFACES.flatMap(({ file, slug, prefix }) => {
+      const source = readSource(file);
+      // A bare read is any `--faction-<slug>[-<core suffix>]` NOT sitting in the
+      // fallback arm of one of this surface's own role reads. Blanking the
+      // fallbacks first is what makes "not preceded by" expressible without a
+      // lookbehind whose width varies with the role name.
+      const withoutFallbacks = source.replace(
+        new RegExp(String.raw`var\(\s*--${prefix}-[\w-]+\s*,\s*var\(\s*--[\w-]+\s*\)\s*\)`, "g"),
+        "",
+      );
+      const bare = [
+        ...withoutFallbacks.matchAll(
+          new RegExp(String.raw`var\(\s*--faction-${slug}(?:-(?:${CORE}))?\s*\)`, "g"),
+        ),
+        ...withoutFallbacks.matchAll(
+          new RegExp(
+            String.raw`factionCssVar\(\s*["'\`]${slug}["'\`]\s*(?:,\s*["'\`](?:${CORE})["'\`]\s*)?\)`,
+            "g",
+          ),
+        ),
+      ];
+      return bare.map((match) => `${file}: ${match[0]}`);
+    });
+
+    expect(stragglers).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2676

Lane 06 of "Nine Kits, One Vocabulary" (#2649). Fifteen surfaces spread
`factionRoleVars(slug, prefix, 'sheet')` on the root they own and read
`var(--<prefix>-<role>, <today's token>)` below, per `WORLD_ZERO_STYLE.md:1179`.
**35 direct token reads removed, 32 role reads written, 0 values changed.**
`index.css` is untouched, and so are the three files carved out of every lane.

## The seam I tested at, and the failing test that came first

**The seam is the fallback arm** — the one place the old value and the new name
are written down together. Everything else we run reads two strings: `tsc`,
`eslint`, `no-raw-style-values`, `factionTokensDeclared` (which sees a declared
name and stops) and the byte budget all pass a fallback pointing one token
sideways. `var(--snd-task-quiet, var(--faction-snide-card-accent))` compiles,
lints, renders, and is simply the wrong colour.

`frontend/src/utils/__tests__/factionRoleMigration.test.ts` re-derives every
fallback from the resolver and compares it to what the source says. Written
first; it went red on all 36 sites and the straggler list it printed *is* the
census below. It is the computed-value diff as a runnable check, not a paragraph
nobody re-runs after the merge.

## 1. Computed-value diff — the merge gate

Every row generated from the resolver, not typed by hand.

| file | faction | prefix | ground | role | old var | new var | same value |
|---|---|---|---|---|---|---|---|
| `pages/taskDetail/archetypes/SnideTaskDetail.tsx` | snide | `--snd-task-*` | sheet | `paper` | `var(--faction-snide-card-bg)` | `--snd-task-paper` | yes |
|  |  |  |  | `ink` | `var(--faction-snide-card-text)` | `--snd-task-ink` | yes |
|  |  |  |  | `quiet` | `var(--faction-snide-card-muted)` | `--snd-task-quiet` | yes |
|  |  |  |  | `accent` | `var(--faction-snide-card-accent)` | `--snd-task-accent` | yes |
| `pages/praxisDetail/archetypes/SnidePraxisDetail.tsx` | snide | `--snd-read-*` | sheet | `paper` | `var(--faction-snide-card-bg)` | `--snd-read-paper` | yes |
|  |  |  |  | `ink` | `var(--faction-snide-card-text)` | `--snd-read-ink` | yes |
|  |  |  |  | `quiet` | `var(--faction-snide-card-muted)` | `--snd-read-quiet` | yes |
|  |  |  |  | `accent` | `var(--faction-snide-card-accent)` | `--snd-read-accent` | yes |
| `pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx` | snide | `--snd-desk-*` | sheet | `paper` | `var(--faction-snide-card-bg)` | `--snd-desk-paper` | yes |
|  |  |  |  | `ink` | `var(--faction-snide-card-text)` | `--snd-desk-ink` | yes |
|  |  |  |  | `quiet` | `var(--faction-snide-card-muted)` | `--snd-desk-quiet` | yes |
|  |  |  |  | `accent` | `var(--faction-snide-card-accent)` | `--snd-desk-accent` | yes |
|  |  |  |  | `fill` | `var(--faction-snide)` | `--snd-desk-fill` | yes |
| `components/factionHero/SnideFactionHero.tsx` | snide | `--snd-hero-*` | sheet | `quiet` | `var(--faction-snide-card-muted)` | `--snd-hero-quiet` | yes |
|  |  |  |  | `fill` | `var(--faction-snide)` | `--snd-hero-fill` | yes |
| `components/metataskSeal/skins/SnideSeal.tsx` | snide | `--snd-seal-*` | sheet | `paper` | `var(--faction-snide-card-bg)` | `--snd-seal-paper` | yes |
|  |  |  |  | `ink` | `var(--faction-snide-card-text)` | `--snd-seal-ink` | yes |
| `components/praxisCard/desktop/SnidePraxisCard.tsx` | snide | `--snd-pcard-*` | sheet | `face` | `var(--faction-snide-card-font)` | `--snd-pcard-face` | yes |
| `components/duel/SnideDuelSealConfirm.tsx` | snide | `--snd-duel-*` | sheet | `quiet` | `var(--faction-snide-card-muted)` | `--snd-duel-quiet` | yes |
| `components/praxisCard/desktop/EverymenPraxisCard.tsx` | everymen | `--ev-praxis-*` | sheet | `paper` | `var(--faction-everymen-card-bg)` | `--ev-praxis-paper` | yes |
|  |  |  |  | `ink` | `var(--faction-everymen-card-text)` | `--ev-praxis-ink` | yes |
|  |  |  |  | `quiet` | `var(--faction-everymen-card-muted)` | `--ev-praxis-quiet` | yes |
|  |  |  |  | `accent` | `var(--faction-everymen-card-accent)` | `--ev-praxis-accent` | yes |
|  |  |  |  | `face` | `var(--faction-everymen-card-font)` | `--ev-praxis-face` | yes |
| `components/metataskSeal/skins/EverymenSeal.tsx` | everymen | `--ev-seal-*` | sheet | `face` ×2 | `var(--faction-everymen-card-font)` | `--ev-seal-face` | yes |
| `components/taskCard/EverymenTaskCard.tsx` | everymen | `--ev-task-*` | sheet | `face` | `var(--faction-everymen-card-font)` | `--ev-task-face` | yes |
| `components/selectCard/EverymenSelectCard.tsx` | everymen | `--ev-select-*` | sheet | `face` | `var(--faction-everymen-card-font)` | `--ev-select-face` | yes |
| `components/comments/voices/EverymenComment.tsx` | everymen | `--ev-voice-*` | sheet | `face` | `var(--faction-everymen-card-font)` | `--ev-voice-face` | yes |
| `components/feed/EverymenFeedFrame.tsx` | everymen | `--ev-feed-*` | sheet | `face` | `var(--faction-everymen-card-font)` | `--ev-feed-face` | yes |
| `pages/characterPaths/archetypes/EverymenCreateCharacter.tsx` | everymen | `--ev-path-*` | sheet | `face` | `var(--faction-everymen-card-font)` | `--ev-path-face` | yes |
| `pages/editPraxis/archetypes/EverymenEditPraxis.tsx` | everymen | `--ev-compose-*` | sheet | `face` | `var(--faction-everymen-card-font)` | `--ev-compose-face` | yes |

**32 rows, 32 `yes`, zero repaints.** Every fallback is byte-identical to what
`factionRoleVar(slug, role, 'sheet')` returns, and the surfaces resolve to a
declared property carrying that same value, so the two arms agree by
construction rather than by measurement.

**35 old reads → 32 new reads.** Three were duplicates that collapsed into a
const the file already had: `SnideTaskDetail` named `-card-muted` twice inside
one `radial-gradient()` beside a `PLATE_MUTED` holding exactly that string, and
`EverymenPraxisCard` named `-card-bg` as the frame's ground and again as
`PraxisBody`'s `paper`. Fewer reads than removals is a deletion; more would be
a repaint.

### The frozen four

| surface | in this lane | rows that CHANGED |
|---|---|---|
| task card | `EverymenTaskCard.tsx` (1 site) | **0** |
| praxis card | `SnidePraxisCard.tsx`, `EverymenPraxisCard.tsx` (6 sites) | **0** |
| vote | `VoteShell.tsx` — **carved out, not touched** | **0** |
| score stamp | `SnideSeal.tsx`, `EverymenSeal.tsx` (4 sites) | **0** |

## 2. Contact sheet

| # | surface | faction | prefix | ground | root the map is declared on |
|---|---|---|---|---|---|
| 1 | task detail | S.N.I.D.E. | `--snd-task-*` | sheet | the page `<div className="py-8">` |
| 2 | praxis (read) detail | S.N.I.D.E. | `--snd-read-*` | sheet | the page `<div className="py-8">` |
| 3 | field desk (mobile home) | S.N.I.D.E. | `--snd-desk-*` | sheet | the `<div className="page">` |
| 4 | faction hero | S.N.I.D.E. | `--snd-hero-*` | sheet | the `<header>` |
| 5 | metatask seal | S.N.I.D.E. | `--snd-seal-*` | sheet | the seal's own `<div>` |
| 6 | praxis card | S.N.I.D.E. | `--snd-pcard-*` | sheet | `.snd-praxis-frame` |
| 7 | duel seal confirm | S.N.I.D.E. | `--snd-duel-*` | sheet | `DuelSealSheet`'s `ground` prop |
| 8 | praxis card | Everymen | `--ev-praxis-*` | sheet | the broadsheet frame `<div>` |
| 9 | metatask seal | Everymen | `--ev-seal-*` | sheet | the seal's own `<div>` |
| 10 | task card | Everymen | `--ev-task-*` | sheet | the card's outer `<div>` |
| 11 | faction select card | Everymen | `--ev-select-*` | sheet | the tile's outer `<div>` |
| 12 | comment voice | Everymen | `--ev-voice-*` | sheet | `Slip`'s wrapper (both modes) |
| 13 | feed frame | Everymen | `--ev-feed-*` | sheet | the `<article>` |
| 14 | create character | Everymen | `--ev-path-*` | sheet | `ComposerPage`'s `style` |
| 15 | edit praxis | Everymen | `--ev-compose-*` | sheet | `dress.pageStyle` |

### Ground: `sheet` for all fifteen, and it was checked rather than assumed

S.N.I.D.E. owns the repo's only ground override, so this is a real choice.
Every surface here is a **content sheet**; `chrome` is the app's own furniture
wearing a faction, which in this repo is the rail and nothing else. Picking
`chrome` for any of these would repoint `paper` from `-card-bg` to
`--faction-snide-wall` and repaint the surface — the thing a lane may not do.

The one that needed arguing is **the faction hero (#4)**: its `<header>` already
*stands on* the wall (#2343), which looks like a `chrome` case. It is not — its
two core reads are both measured against the **slab**, not the wall: the
medallion's `CHROME` is legal only because the disc is frozen on `PLATE`
(6.93:1 / 15.55:1), and the stat chit's `-card-muted` is annotated in-file as
"the CARD's tier is the right one HERE and only here… the chit is a slab, not
the wall". Moving those two to `chrome` would have moved the inks off the ground
they were measured on.

**#2669 is not touched.** That bug is `accent` on the `chrome` ground reading
1.03:1 on the light wall. Nothing in this lane requests `chrome`, and
`--snd-*-accent` on `sheet` resolves to `--faction-snide-card-accent`, the acid
measured for the near-black slab — unchanged. The fix stays with #2669.

### Two prefixes that are not the obvious name, and why

- **`--snd-pcard-*`, not `--snd-praxis-*`**, on the S.N.I.D.E. praxis card.
  `--snd-praxis-*` already exists and is the **host's** channel: the task-detail
  row sets it (`index.css` `.snd-detail-praxis`) to repoint that card's ground
  and inks, and `snideOneGround.test.tsx` asserts it. Declaring it on the card's
  own root would have overwritten the parent from inside the child — a silent
  repaint on exactly one surface.
- **`--ev-voice-*`** is declared on `Slip`, the local wrapper both the row and
  the composer render through, rather than on either mode's return.

## 3. What to eyeball (visual QA is outstanding)

I have no browser and no dev stack; nothing below has been rendered. The
migration is value-preserving by construction and by the generated table above,
so the realistic risk is not "wrong colour" but "property declared on a node
that is not an ancestor of the read" — which would silently fall back to the
same value and therefore look right. That makes eyeballing cheap: **anything
that looks different is a real bug.**

Both cascades for every row.

1. **S.N.I.D.E. task detail** and **praxis detail** — the black slab, the acid
   plate, the halftone dot screen behind the worth stamp (the one gradient that
   changed shape, from two literals to one const).
2. **S.N.I.D.E. field desk** (mobile) — the credential panel on the wall vs the
   `RansomCard` clipping pasted on it. This is the surface whose ground guard
   was failing open, so it is the highest-value look.
3. **S.N.I.D.E. faction hero** — the medallion disc and the three stat chits.
4. **S.N.I.D.E. praxis card in two hosts** — in the feed (its own ground) and in
   the task-detail gallery row, which sets `--snd-praxis-*`. If the prefix
   collision I avoided were real, this is where it would show.
5. **S.N.I.D.E. duel seal confirm**, phone and laptop — `ground` is spread on a
   different element at each width.
6. **Everymen praxis card, task card and select tile** — Bebas on the headline,
   and the broadsheet's cream/ink pair.
7. **Everymen comment voice**, both modes — a thread row and the composer.
8. **Everymen create-character and edit-praxis**, including the composer's
   **waiting stage**, which shares `dress.pageStyle`.
9. **Metatask seals** for both factions, on a praxis detail and in the stack.

## Census corrections (the issue's table was measured, and it rotted)

- **The Ephemerists have zero in-scope sites.** Both of their two core-role
  reads are in `VoteShell.tsx`, which is carved out of every lane. Nothing to do.
- **Coven has five, and none of them can take the map.** `ActivityTicker` is
  app chrome borrowing the Coven pink as a fill and is not a Coven surface at
  all; `CovenSigil` and `covenSlip`'s `Spark` are leaf marks whose ink is a
  caller-supplied **prop** with the token as a default; `CovenAvatar` hands
  `badgeBg` straight into `BadgedAvatar` and renders no element of its own.
  Giving any of them a role map needs a wrapper node, and `factionRoles.ts` says
  in writing that a role "cannot move a node, add a node, or cross a component
  prop". Left exactly as they are.
- **Two of the issue's 36 were comment mentions**, not reads:
  `EverymenSigil.tsx:14` (a docblock quoting the design's `var()`) and
  `roomPresence.ts:229` (a note about a library bug). `EverymenSigil` defaults to
  `--everymen-red`, a legacy token, not a core role.
- **`EverymenPraxisCard` had five reads nobody had counted.** They go through
  `factionCssVar("everymen", "card-bg" | "card-text" | "card-muted" |
  "card-accent")`, so both census greps — mine and the issue's — matched only the
  literal `var()` spelling and reported the file as a single `card-font` site.
  Same failure class as the `style={{` count that sank the epic's body.

Net: 36 claimed → **35 real, 32 migratable, 3 collapsed as duplicates**.

## One guard was failing open, and it is fixed here

`factionContrast.test.ts` reads some tokens off the **source** and matches on
the spelling, which this lane changes.

- `heroSource`'s alias check failed **loudly** ("retarget this guard") — the
  good case.
- `pressGrounds` did not. Its alias map stopped resolving four of
  `SnideFieldDesk`'s ground constants, so the surface that grounds hardest on
  the slab reported **two grounds instead of six** and went green. A guard that
  silently narrows is worse than one that breaks.

`ROLE_READ` is a shared regex fragment that still pins the token exactly and
only tolerates the `var(--prefix-role, …)` wrapper. Reading the fallback is the
right measurement **only because every surface here is on `sheet`**; that
dependency is named in the comment and the per-surface ground is recorded in
`factionRoleMigration.test.ts`. The file's two other alias guards cover surfaces
this lane did not touch and are deliberately left alone — they fail loudly, so
lanes 02–05 will be told rather than narrowed.

## Not in this lane

No new colour, no `index.css` edit, no archetype unified, no new prefix
registered (`factionTokensDeclared.test.ts` harvests them by regex — verified:
all fifteen resolve). Bespoke vocabularies (`-slip-*`, `-note-*`, `-wall*`,
`-acid`, `-plate-*`, `-frame`) untouched, per decision 07.
`VoteShell.tsx`, `cardMasthead/factionBands.tsx` and `utils/factions.ts` are
not in the diff.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally:
`lint` ✓ · `typecheck` ✓ · `typecheck:design-sync` ✓ · `test` ✓ (441 files,
8539 passed) · `build` ✓ · `budget` ✓ (JS 130.0 KB, CSS 22.1 KB — unchanged,
the map declares at runtime and ships no CSS). No backend files touched, so
`api-schema` and `test` are unaffected.

**Visual QA is outstanding** — see the list above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
