### PR TITLE
Lane 04: fifteen WOW surfaces read roles, not tokens (97 sites, 18 files, 0 values changed)

### DIFF
--- a/frontend/src/components/__tests__/frameRadiusReadsTheToken.test.tsx
+++ b/frontend/src/components/__tests__/frameRadiusReadsTheToken.test.tsx
@@ -99,7 +99,18 @@ const render = (node: ReactElement) =>
 const frameStyle = (html: string): string => {
   const match = /style="([^"]*border-radius[^"]*)"/.exec(html);
   expect(match, "nothing in this card declares a border-radius").not.toBeNull();
-  return (match as RegExpExecArray)[1];
+  // Fold a ROLE READ back to its fallback (#2649's faction lanes, #2674 here).
+  // A migrated frame asks its faction for the `radius` role and carries today's
+  // token as the fallback — `var(--wow-feed-radius,
+  // var(--faction-wow-card-radius))` — which is the same value under a new
+  // spelling. Folding it keeps every row below pinned to its exact token
+  // instead of each lane restating its prefix in this cross-faction table; that
+  // the fallback IS the resolver's token is gated in
+  // `utils/__tests__/factionRoleMigration.test.ts`.
+  return (match as RegExpExecArray)[1].replace(
+    /var\(--[\w-]+,\s*(var\(--[\w-]+\))\)/g,
+    "$1",
+  );
 };
 
 const CASES = [

--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -105,7 +105,11 @@ describe('the four chrome slots (the contract every frame owes)', () => {
   it('tints the archive by INHERITANCE — the head is plum, the ✕ paints in currentColor', () => {
     // Rule 3 of the seam: the control arrives finished and is tinted by setting
     // `color` on what it sits in, never by rebuilding it.
-    expect(frame()).toContain('color:var(--faction-wow-card-accent)')
+    // The head's plum is the `accent` ROLE now (#2674), carrying today's
+    // token as its fallback — the same value, asked for by role.
+    expect(frame()).toContain(
+      'color:var(--wow-feed-accent, var(--faction-wow-card-accent))',
+    )
   })
 })
 
@@ -146,9 +150,13 @@ describe('the proclamation chrome', () => {
     // asks that the frame reads it — restating the pixel is the thing the token
     // exists to stop.
     const html = frame()
-    expect(html).toContain('border-radius:var(--faction-wow-card-radius)')
+    expect(html).toContain(
+      'border-radius:var(--wow-feed-radius, var(--faction-wow-card-radius))',
+    )
     expect(html).toContain('2px solid var(--faction-wow-chronicle-gold)')
-    expect(html).toContain('background:var(--faction-wow-card-bg)')
+    expect(html).toContain(
+      'background:var(--wow-feed-paper, var(--faction-wow-card-bg))',
+    )
   })
 
   it('never lays the muted date ink on the parchment plate (#1221)', () => {

--- a/frontend/src/components/avatar/WowAvatar.tsx
+++ b/frontend/src/components/avatar/WowAvatar.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { factionRoleVars } from "../../utils/factionRoles";
 import { WowSigil } from "../sigil/WowSigil";
 import { AVATAR_ROOT, BadgedAvatar, avatarDim, type FactionAvatarProps } from "./FactionAvatar";
 
@@ -78,7 +79,18 @@ export default function WowAvatar({ character, size, badge }: FactionAvatarProps
   const pillFont = Math.max(RANK_PILL_MIN_FONT_PX, Math.round(dim * 0.102));
 
   return (
-    <span style={{ ...AVATAR_ROOT, width: dim, height: dim }}>
+    <span
+      style={{
+        // THE ROLE MAP (#2674). Declared on the plate's own root, because the
+        // two reads below are handed to `BadgedAvatar` as PROPS — a shared,
+        // faction-blind component that must keep taking a plain string. A
+        // custom property crosses that boundary where a prefix could not.
+        ...factionRoleVars("wow", "wow-avatar"),
+        ...AVATAR_ROOT,
+        width: dim,
+        height: dim,
+      }}
+    >
       <span
         style={{
           display: "flex",
@@ -100,8 +112,8 @@ export default function WowAvatar({ character, size, badge }: FactionAvatarProps
           circle={{
             borderColor: "var(--faction-wow-crest-field-rim)",
             bg: "var(--faction-wow-avatar-field)",
-            textColor: "var(--faction-wow-card-text)",
-            fontFamily: "var(--faction-wow-card-font)",
+            textColor: "var(--wow-avatar-ink, var(--faction-wow-card-text))",
+            fontFamily: "var(--wow-avatar-face, var(--faction-wow-card-font))",
           }}
           badgeBg="var(--faction-wow-crest-field)"
           badgeRing="var(--faction-wow-chronicle-gold)"
@@ -118,7 +130,7 @@ export default function WowAvatar({ character, size, badge }: FactionAvatarProps
             bottom: -Math.round(dim * 0.034),
             left: "50%",
             transform: "translateX(-50%)",
-            fontFamily: "var(--faction-wow-card-font)",
+            fontFamily: "var(--wow-avatar-face, var(--faction-wow-card-font))",
             fontSize: pillFont,
             letterSpacing: "0.04em",
             lineHeight: 1.2,

--- a/frontend/src/components/comments/__tests__/wowComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/wowComment.test.tsx
@@ -89,7 +89,9 @@ describe('the comment wears the proclamation chrome', () => {
     expect(html).toContain('height:6px')
     expect(html).toContain('border-radius:9px')
     expect(html).toContain('2px solid var(--faction-wow-chronicle-gold)')
-    expect(html).toContain('background:var(--faction-wow-card-bg)')
+    // The sheet asks the faction for its `paper` ROLE (#2674) and carries
+    // today's token as the fallback, so the cream is the cream it always was.
+    expect(html).toContain('background:var(--wow-comment-paper, var(--faction-wow-card-bg))')
   })
 
   it('letters the name in MedievalSharp and the quiet register in Lora italic', () => {

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { useAuth } from '../../../auth/AuthContext'
+import { factionRoleVars } from '../../../utils/factionRoles'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
 import {
@@ -68,14 +69,14 @@ import { CommentFlagControl, canFlagComment } from '../FlagControl'
  * ink is `-card-text` at 13:1 — uses the parchment plate.
  */
 
-const MED = 'var(--faction-wow-card-font)' /* MedievalSharp */
+const MED = 'var(--wow-comment-face, var(--faction-wow-card-font))' /* MedievalSharp */
 const LORA = 'var(--faction-wow-body-font)' /* Lora */
 const GOLD = 'var(--faction-wow-chronicle-gold)'
 /* `--faction-wow-stamp-total` inked the composer's ✦ prompt line; #1911 took
    the line, and the token has no other slot on this card. */
-const INK = 'var(--faction-wow-card-text)'
-const MUTED = 'var(--faction-wow-card-muted)'
-const PLUM = 'var(--faction-wow-card-accent)'
+const INK = 'var(--wow-comment-ink, var(--faction-wow-card-text))'
+const MUTED = 'var(--wow-comment-quiet, var(--faction-wow-card-muted))'
+const PLUM = 'var(--wow-comment-accent, var(--faction-wow-card-accent))'
 const RIBBON = 'var(--faction-wow-quest-ribbon)'
 
 /**
@@ -122,6 +123,12 @@ function Sheet({
       <div
         {...containerProps}
         style={{
+          // THE ROLE MAP (#2674). Declared on the SHEET, not on the flex row
+          // above it: the crest beside the sheet is a sibling, and a prefix
+          // belongs to the surface that reads it. Every read carries today's
+          // token as its fallback, so the shared `ComposerControls` this hands
+          // strings to is unaware anything moved.
+          ...factionRoleVars('wow', 'wow-comment'),
           flex: 1,
           minWidth: 0,
           borderRadius: SHEET_RADIUS,
@@ -129,7 +136,7 @@ function Sheet({
           // the @mention listbox, an absolutely positioned child, and a
           // clipping ancestor cuts it off. The crown below rounds its own ends
           // instead, which is all the clip was ever doing.
-          background: 'var(--faction-wow-card-bg)',
+          background: 'var(--wow-comment-paper, var(--faction-wow-card-bg))',
           color: INK,
           border: `2px solid ${GOLD}`,
           boxShadow: 'var(--faction-wow-quest-shadow)',

--- a/frontend/src/components/duel/wowLists.tsx
+++ b/frontend/src/components/duel/wowLists.tsx
@@ -28,6 +28,8 @@
  */
 import type { CSSProperties } from 'react'
 
+import { factionRoleVar } from '../../utils/factionRoles'
+
 /* -------------------------------------------------------------------------- */
 /* Tokens                                                                     */
 /* -------------------------------------------------------------------------- */
@@ -43,10 +45,22 @@ export const RIBBON = 'var(--faction-wow-duel-ribbon)'
 /** The modal wash behind the seal. */
 export const SCRIM = 'var(--faction-wow-duel-scrim)'
 
-/** The chronicle's own inks, reused so the lists read as the same faction. */
-export const INK = 'var(--faction-wow-card-text)'
-export const MUTED = 'var(--faction-wow-card-muted)'
-export const PLUM = 'var(--faction-wow-card-accent)'
+/**
+ * The chronicle's own inks, reused so the lists read as the same faction.
+ *
+ * THE ROLES, ASKED FOR DIRECTLY, BECAUSE THIS MODULE HAS NO ROOT (#2674). Lane
+ * 04's surfaces spread `factionRoleVars(slug, '<their own prefix>')` on a root
+ * and read `var(--<prefix>-ink, …)` below it. This file is the tourney
+ * vocabulary, mounted under `WowDuelSealConfirm` and its two form factors —
+ * consumers outside this lane — so there is no one root here to declare a
+ * prefix on, and a prefix shared between the vocabulary and every host would BE
+ * the `--kit-*` namespace the law declines. `factionRoleVar` answers one role
+ * with no all-or-nothing seam to protect, and returns the identical strings
+ * these constants held before.
+ */
+export const INK = factionRoleVar('wow', 'ink')
+export const MUTED = factionRoleVar('wow', 'quiet')
+export const PLUM = factionRoleVar('wow', 'accent')
 export const EYEBROW_INK = 'var(--faction-wow-accent-deep)'
 export const PANEL = 'var(--faction-wow-chronicle-panel)'
 /**
@@ -74,7 +88,7 @@ export const ON_RIBBON = 'var(--faction-wow-stamp-chip-text)'
  */
 export const NOTICE = 'var(--faction-wow-card-notice)'
 
-export const DISPLAY_FONT = 'var(--faction-wow-card-font)' // MedievalSharp
+export const DISPLAY_FONT = factionRoleVar('wow', 'face') // MedievalSharp
 export const BODY_FONT = 'var(--faction-wow-body-font)' // Lora
 
 /**

--- a/frontend/src/components/factionHero/WowFactionHero.tsx
+++ b/frontend/src/components/factionHero/WowFactionHero.tsx
@@ -1,5 +1,6 @@
 import type { FactionHeroProps } from "../../pages/FactionDetail";
 import i18n from "../../i18n";
+import { factionRoleVars } from "../../utils/factionRoles";
 import { WowSigil } from "../sigil/WowSigil";
 
 /**
@@ -37,6 +38,10 @@ export default function WowFactionHero({
     <header style={{ marginBottom: "var(--space-2xl)" }}>
       <div
         style={{
+          // THE ROLE MAP (#2674), on the banner plate. It goes on the PLATE and
+          // not on the <header> above it: the header is only a margin, and a
+          // prefix belongs to the surface that reads it.
+          ...factionRoleVars("wow", "wow-hero"),
           position: "relative",
           overflow: "hidden",
           borderRadius: "var(--radius-xl)",
@@ -83,7 +88,7 @@ export default function WowFactionHero({
           <div
             className="label-heading"
             style={{
-              fontFamily: "var(--faction-wow-card-font)",
+              fontFamily: "var(--wow-hero-face, var(--faction-wow-card-font))",
               color: "var(--faction-wow-accent-deep)",
             }}
           >
@@ -92,10 +97,10 @@ export default function WowFactionHero({
 
           <h1
             style={{
-              fontFamily: "var(--faction-wow-card-font)",
+              fontFamily: "var(--wow-hero-face, var(--faction-wow-card-font))",
               fontSize: "var(--text-heading)",
               lineHeight: 1.05,
-              color: "var(--faction-wow-card-text)",
+              color: "var(--wow-hero-ink, var(--faction-wow-card-text))",
               margin: "var(--space-sm) 0 var(--space-xs)",
               // No overflow-wrap: a wordmark never breaks mid-word (#2000). The
               // banner is full-width and centred, and "Warriors of Whimsy" sets
@@ -110,7 +115,7 @@ export default function WowFactionHero({
             style={{
               fontFamily: "var(--faction-wow-body-font)",
               fontStyle: "italic",
-              color: "var(--faction-wow-card-accent)",
+              color: "var(--wow-hero-accent, var(--faction-wow-card-accent))",
               margin: "0 0 var(--space-lg)",
             }}
           >
@@ -143,7 +148,7 @@ export default function WowFactionHero({
                   <div
                     className="content-title"
                     style={{
-                      fontFamily: "var(--faction-wow-card-font)",
+                      fontFamily: "var(--wow-hero-face, var(--faction-wow-card-font))",
                       lineHeight: 1,
                       color: "var(--faction-wow-figure)",
                     }}

--- a/frontend/src/components/factionMarks/wowMobile.tsx
+++ b/frontend/src/components/factionMarks/wowMobile.tsx
@@ -38,19 +38,36 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 
+import { factionRoleVar } from "../../utils/factionRoles";
 import { WowSigil } from "../sigil/WowSigil";
 
-export const WOW_INK = "var(--faction-wow-card-text)";
-export const WOW_MUTED = "var(--faction-wow-card-muted)";
+/**
+ * THE FIVE CORE ROLES ARE ASKED FOR DIRECTLY, BECAUSE THIS MODULE HAS NO ROOT
+ * (#2674). Lane 04's surfaces spread `factionRoleVars(slug, '<their own
+ * prefix>')` on a root and read `var(--<prefix>-ink, …)` below it. This file is
+ * shared vocabulary: six mobile skins import these constants and mount them
+ * under six different roots, `WowFieldDesk`'s among them, which is outside this
+ * lane. There is no one root to declare a prefix on, and one prefix shared
+ * between the pavilion and every skin that composes it would BE the `--kit-*`
+ * namespace the law declines. `factionRoleVar` answers one role with no
+ * all-or-nothing seam to protect and returns the identical strings these
+ * constants held before.
+ *
+ * The five that are NOT roles stay exactly as they are: the gilt, the figure
+ * gold, the parchment plate and the chronicle rule are WOW's own vocabulary and
+ * decision 07 leaves a surface's extras to the surface.
+ */
+export const WOW_INK = factionRoleVar("wow", "ink");
+export const WOW_MUTED = factionRoleVar("wow", "quiet");
 /** The header byline's ink — see the measured deviation in index.css. */
 export const WOW_DEEP = "var(--faction-wow-accent-deep)";
-export const WOW_PLUM = "var(--faction-wow-card-accent)";
+export const WOW_PLUM = factionRoleVar("wow", "accent");
 export const WOW_GOLD = "var(--faction-wow-chronicle-gold)";
 export const WOW_FIGURE = "var(--faction-wow-stamp-total)";
-export const WOW_CARD = "var(--faction-wow-card-bg)";
+export const WOW_CARD = factionRoleVar("wow", "paper");
 export const WOW_PLATE = "var(--faction-wow-plate)";
 export const WOW_RULE = "var(--faction-wow-chronicle-rule)";
-export const WOW_DISPLAY = "var(--faction-wow-card-font)"; // MedievalSharp
+export const WOW_DISPLAY = factionRoleVar("wow", "face"); // MedievalSharp
 export const WOW_BODY = "var(--faction-wow-body-font)"; // Lora
 
 /**

--- a/frontend/src/components/factionMarks/wowOrnament.tsx
+++ b/frontend/src/components/factionMarks/wowOrnament.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 
+import { factionRoleVar } from "../../utils/factionRoles";
+
 /**
  * Warriors of Whimsy — THE SHARED ORNAMENT VOCABULARY (#1121).
  *
@@ -38,8 +40,20 @@ import type { CSSProperties, ReactNode } from "react";
 
 /** Frame + rule gold. Theme-invariant, and never an ink: 2.24:1 on the cream. */
 const GOLD = "var(--faction-wow-chronicle-gold)";
-/** Plum as INK — this one DOES flip with the theme. */
-const PLUM = "var(--faction-wow-card-accent)";
+/**
+ * Plum as INK — this one DOES flip with the theme.
+ *
+ * A ROLE, ASKED FOR DIRECTLY, BECAUSE THIS MODULE HAS NO ROOT (#2674). The
+ * surfaces in lane 04 spread `factionRoleVars(slug, '<their own prefix>')` and
+ * read `var(--<prefix>-accent, …)` below it. This file is shared vocabulary
+ * mounted under six different roots — including `WowTaskDetail`'s and
+ * `WowCreateCharacter`'s — so it has no prefix of its own to declare, and one
+ * prefix shared between the ornament and its six hosts would BE the `--kit-*`
+ * namespace the law declines. `factionRoleVar` is the resolver's answer for a
+ * single role with no all-or-nothing seam to protect; it returns the identical
+ * string this constant held before.
+ */
+const PLUM = factionRoleVar("wow", "accent");
 /**
  * Plum as ORNAMENT (#1830).
  *

--- a/frontend/src/components/feed/WowFeedFrame.tsx
+++ b/frontend/src/components/feed/WowFeedFrame.tsx
@@ -1,4 +1,5 @@
 import { useFormFactor } from '../../hooks/useFormFactor'
+import { factionRoleVars } from '../../utils/factionRoles'
 import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 import type { FeedFrameProps } from './feedFrameProps'
 
@@ -78,11 +79,23 @@ import type { FeedFrameProps } from './feedFrameProps'
  * Both themes come from the `[data-theme="dark"]` cascade.
  */
 
-const MED = 'var(--faction-wow-card-font)' /* MedievalSharp */
+/**
+ * THE FOUR CORE ROLES ARE ASKED FOR BY NAME (#2674). The `<article>` below
+ * spreads `factionRoleVars('wow', 'wow-feed')`, so `--wow-feed-face` and its
+ * kin are declared on this card's own root and read nowhere else. The prefix is
+ * this SURFACE's — a shared `--kit-*` namespace is declined by the law, because
+ * a page wrapper declaring it would repaint every descendant including a card
+ * belonging to a different faction than the page.
+ *
+ * Each read carries today's token as its fallback, so the card is byte-identical
+ * whether the vars are declared or not — which is also what keeps the shared,
+ * faction-blind payload this chassis wraps unaffected.
+ */
+const MED = 'var(--wow-feed-face, var(--faction-wow-card-font))' /* MedievalSharp */
 const LORA = 'var(--faction-wow-body-font)' /* Lora */
 const GOLD = 'var(--faction-wow-chronicle-gold)'
 const GILT = 'var(--faction-wow-stamp-total)'
-const PLUM = 'var(--faction-wow-card-accent)'
+const PLUM = 'var(--wow-feed-accent, var(--faction-wow-card-accent))'
 const RIBBON = 'var(--faction-wow-quest-ribbon)'
 
 /** The barber ribbon's two weights: the 6px crown and the 3px section rule.
@@ -127,11 +140,12 @@ export default function WowFeedFrame({
     <article
       data-form-factor={formFactor}
       style={{
+        ...factionRoleVars('wow', 'wow-feed'),
         // The chronicle's shape, said once (#2361/#2403).
-        borderRadius: 'var(--faction-wow-card-radius)',
+        borderRadius: 'var(--wow-feed-radius, var(--faction-wow-card-radius))',
         overflow: 'hidden',
-        background: 'var(--faction-wow-card-bg)',
-        color: 'var(--faction-wow-card-text)',
+        background: 'var(--wow-feed-paper, var(--faction-wow-card-bg))',
+        color: 'var(--wow-feed-ink, var(--faction-wow-card-text))',
         border: `2px solid ${GOLD}`,
         boxShadow: 'var(--faction-wow-quest-shadow)',
         fontFamily: LORA,
@@ -216,7 +230,7 @@ export default function WowFeedFrame({
               fontStyle: 'italic',
               fontSize: 'var(--text-lg)',
               // The cream-only ink, on the cream sheet it was measured against.
-              color: 'var(--faction-wow-card-muted)',
+              color: 'var(--wow-feed-quiet, var(--faction-wow-card-muted))',
               whiteSpace: 'nowrap',
             }}
           >

--- a/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
@@ -199,6 +199,20 @@ describe('the shared dismiss control', () => {
   })
 })
 
+/**
+ * Fold `var(--<surface-prefix>-<role>, <today's token>)` back to the token
+ * (#2674). A chassis migrated onto `utils/factionRoles.ts` asks its faction for
+ * a ROLE and carries today's token as the fallback, so what this row measures —
+ * the value the control's slot resolves to — has not moved; only the spelling
+ * has. `factions/__tests__/wowRoleMap.test.ts` is the gate that each fallback is
+ * the token the site named before, which is what makes folding it away sound
+ * rather than lenient. Restating each surface's prefix in this table would make
+ * a shared, nine-faction row edited by every faction lane for a value nobody
+ * changed.
+ */
+const foldRoleReads = (html: string) =>
+  html.replace(/var\(--[\w-]+,\s*(var\(--[\w-]+\))\)/g, '$1')
+
 describe.each(Object.entries(CASES))('%s: the band it is placed on', (name, { ink, ground, Frame }) => {
   if (Frame) {
     it('publishes the measured ink to the slot that holds the control', () => {
@@ -209,7 +223,7 @@ describe.each(Object.entries(CASES))('%s: the band it is placed on', (name, { in
           </Frame>
         </MemoryRouter>,
       )
-      expect(html).toContain(`color:var(${ink})`)
+      expect(foldRoleReads(html)).toContain(`color:var(${ink})`)
       expect(html).toContain('<span id="x"')
     })
   }

--- a/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
@@ -204,9 +204,11 @@ describe('the shared dismiss control', () => {
  * (#2674). A chassis migrated onto `utils/factionRoles.ts` asks its faction for
  * a ROLE and carries today's token as the fallback, so what this row measures —
  * the value the control's slot resolves to — has not moved; only the spelling
- * has. `factions/__tests__/wowRoleMap.test.ts` is the gate that each fallback is
- * the token the site named before, which is what makes folding it away sound
- * rather than lenient. Restating each surface's prefix in this table would make
+ * has. `utils/__tests__/factionRoleMigration.test.ts` is the gate that each
+ * fallback is the token the site named before — it re-derives every one from
+ * the resolver — which is what makes folding it away sound rather than lenient.
+ * (`factions/__tests__/wowRoleMap.test.ts` is a different guard: the rootless
+ * kit modules and the carve-outs.) Restating each surface's prefix in this table would make
  * a shared, nine-faction row edited by every faction lane for a value nobody
  * changed.
  */

--- a/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
@@ -131,9 +131,10 @@ const CASES = [
  * (#2674). A chassis migrated onto `utils/factionRoles.ts` asks its faction for
  * a ROLE and carries today's token as the fallback, so the ink this row
  * measures has not moved; only its spelling has. The gate on that claim is
- * `factions/__tests__/wowRoleMap.test.ts`, which asserts every fallback IS the
- * token the site named before — without it, folding here would be lenient
- * rather than sound. Naming each surface's prefix in this nine-faction table
+ * `utils/__tests__/factionRoleMigration.test.ts`, which re-derives every
+ * fallback from the resolver and fails if one drifts — without it, folding here
+ * would be lenient rather than sound. (`factions/__tests__/wowRoleMap.test.ts`
+ * is a different guard: the rootless kit modules and the carve-outs.) Naming each surface's prefix in this nine-faction table
  * would instead make it a file every faction lane has to edit.
  */
 const foldRoleReads = (html: string) =>

--- a/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
@@ -126,6 +126,19 @@ const CASES = [
   },
 ] as const
 
+/**
+ * Fold `var(--<surface-prefix>-<role>, <today's token>)` back to the token
+ * (#2674). A chassis migrated onto `utils/factionRoles.ts` asks its faction for
+ * a ROLE and carries today's token as the fallback, so the ink this row
+ * measures has not moved; only its spelling has. The gate on that claim is
+ * `factions/__tests__/wowRoleMap.test.ts`, which asserts every fallback IS the
+ * token the site named before — without it, folding here would be lenient
+ * rather than sound. Naming each surface's prefix in this nine-faction table
+ * would instead make it a file every faction lane has to edit.
+ */
+const foldRoleReads = (html: string) =>
+  html.replace(/var\(--[\w-]+,\s*(var\(--[\w-]+\))\)/g, '$1')
+
 describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Frame, ink, ground, veil }) => {
   it('reaches the actor name inside children it did not mount', () => {
     const html = renderToStaticMarkup(
@@ -135,7 +148,7 @@ describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Fram
         </Frame>
       </MemoryRouter>,
     )
-    expect(html).toContain(`color:var(${ink})`)
+    expect(foldRoleReads(html)).toContain(`color:var(${ink})`)
     // The row's default hue is gone from the NAME. It stays on the fills — the
     // headline rule and the monogram disc — which are ADR-0039's, not this seam's.
     expect(html).toContain(`background:var(--faction-${slug})`)

--- a/frontend/src/components/metataskSeal/skins/WowSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/WowSeal.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
+import { factionRoleVars } from '../../../utils/factionRoles'
 import { WowBand } from '../../cardMasthead/factionBands'
 import type { SealSkinProps } from '../types'
 
@@ -32,8 +33,13 @@ export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps
     <div
       className="relative"
       style={{
+        // THE ROLE MAP (#2674), on the writ's own root. `WowBand` inside it is
+        // the shared cross-faction masthead, carved out of every lane; every
+        // read below carries today's token as its fallback, so the band and the
+        // writ resolve exactly as they did.
+        ...factionRoleVars('wow', 'wow-seal'),
         background: 'var(--faction-wow-chronicle-bg)',
-        color: 'var(--faction-wow-card-text)',
+        color: 'var(--wow-seal-ink, var(--faction-wow-card-text))',
         border: '2px solid var(--faction-wow-chronicle-border)',
         borderRadius: 6,
         overflow: 'hidden',
@@ -50,7 +56,7 @@ export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps
         style={{
           height: 5,
           background:
-            'repeating-linear-gradient(90deg, var(--faction-wow-chronicle-gold) 0 10px, var(--faction-wow-card-accent) 10px 20px)',
+            'repeating-linear-gradient(90deg, var(--faction-wow-chronicle-gold) 0 10px, var(--wow-seal-accent, var(--faction-wow-card-accent)) 10px 20px)',
         }}
       />
 
@@ -82,7 +88,7 @@ export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps
               zIndex: 2,
               background: 'transparent',
               border: 'none',
-              color: 'var(--faction-wow-card-accent)',
+              color: 'var(--wow-seal-accent, var(--faction-wow-card-accent))',
               fontSize: 'var(--text-xl)',
               cursor: 'pointer',
             }}
@@ -96,11 +102,11 @@ export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps
         <span
           className="block"
           style={{
-            fontFamily: 'var(--faction-wow-card-font)',
+            fontFamily: 'var(--wow-seal-face, var(--faction-wow-card-font))',
             fontSize: 'var(--text-md)',
             textTransform: 'uppercase',
             letterSpacing: '0.14em',
-            color: 'var(--faction-wow-card-accent)',
+            color: 'var(--wow-seal-accent, var(--faction-wow-card-accent))',
             marginBottom: 'var(--space-xs)',
           }}
         >
@@ -114,7 +120,7 @@ export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps
             fontStyle: 'italic',
             fontSize: 'var(--text-content)',
             lineHeight: 1.3,
-            color: 'var(--faction-wow-card-text)',
+            color: 'var(--wow-seal-ink, var(--faction-wow-card-text))',
           }}
         >
           {metatask.title}
@@ -123,7 +129,7 @@ export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps
         <span
           className="block"
           style={{
-            fontFamily: 'var(--faction-wow-card-font)',
+            fontFamily: 'var(--wow-seal-face, var(--faction-wow-card-font))',
             fontSize: 'var(--text-title)',
             letterSpacing: '0.03em',
             color: 'var(--faction-wow-stamp-total)',

--- a/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { WowBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
@@ -50,12 +51,20 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
     <div
       style={{
         ...frameBase,
+        // THE ROLE MAP (#2674). `--wow-praxis-card-*` is declared here, on the
+        // chronicle's own sheet, and read nowhere else: the prefix belongs to
+        // this SURFACE, not to the app. Every read below carries today's token
+        // as its fallback, which is what leaves `WowBand` — the shared
+        // cross-faction masthead, carved out of every lane — untouched inside
+        // this root, and the shared `PraxisBody` it hands values to unaware
+        // that anything moved.
+        ...factionRoleVars("wow", "wow-praxis-card"),
         // The chronicle parchment's shape, said once (#2361/#2403).
-        borderRadius: "var(--faction-wow-card-radius)",
+        borderRadius: "var(--wow-praxis-card-radius, var(--faction-wow-card-radius))",
         position: "relative",
         overflow: "hidden",
         background: "var(--faction-wow-chronicle-bg)",
-        color: "var(--faction-wow-card-text)",
+        color: "var(--wow-praxis-card-ink, var(--faction-wow-card-text))",
         border: "2px solid var(--faction-wow-chronicle-border)",
         boxShadow: "0 6px 22px -10px var(--faction-wow-chronicle-shadow)",
         fontFamily: "var(--faction-wow-body-font)",
@@ -76,7 +85,7 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
         style={{
           height: 6,
           background:
-            "repeating-linear-gradient(90deg, var(--faction-wow-chronicle-gold) 0 11px, var(--faction-wow-card-accent) 11px 22px)",
+            "repeating-linear-gradient(90deg, var(--faction-wow-chronicle-gold) 0 11px, var(--wow-praxis-card-accent, var(--faction-wow-card-accent)) 11px 22px)",
         }}
       />
       <div style={{ padding: "var(--space-xl)" }}>
@@ -84,17 +93,17 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
         <PraxisBody
           praxis={praxis}
           tint="var(--faction-wow-chronicle-gold)"
-          muted="var(--faction-wow-card-muted)"
+          muted="var(--wow-praxis-card-quiet, var(--faction-wow-card-muted))"
           paper="var(--faction-wow-chronicle-bg)"
           titleStyle={{
-            fontFamily: "var(--faction-wow-card-font)",
-            color: "var(--faction-wow-card-text)",
+            fontFamily: "var(--wow-praxis-card-face, var(--faction-wow-card-font))",
+            color: "var(--wow-praxis-card-ink, var(--faction-wow-card-text))",
           }}
           showCrown={showCrown}
           // MedievalSharp illuminates, Lora reads — the chronicle's own pair,
           // matching the WOW mobile card (#888).
           fonts={{
-            display: "var(--faction-wow-card-font)",
+            display: "var(--wow-praxis-card-face, var(--faction-wow-card-font))",
             body: "var(--faction-wow-body-font)",
           }}
           mediaEmptyStyle={{
@@ -102,7 +111,7 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
             borderRadius: 6,
             border: "2px dashed var(--faction-wow-chronicle-gold)",
             background: "transparent",
-            color: "var(--faction-wow-card-muted)",
+            color: "var(--wow-praxis-card-quiet, var(--faction-wow-card-muted))",
             textTransform: "none",
             letterSpacing: "0.06em",
             fontSize: "var(--text-content)",
@@ -116,7 +125,7 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
                   fontFamily: "var(--faction-wow-body-font)",
                   fontStyle: "italic",
                   fontSize: "var(--text-content)",
-                  color: "var(--faction-wow-card-muted)",
+                  color: "var(--wow-praxis-card-quiet, var(--faction-wow-card-muted))",
                   marginTop: "var(--space-sm)",
                 }}
               >

--- a/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
@@ -63,13 +64,20 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
     fontFamily: "var(--faction-wow-body-font)",
     fontStyle: "italic" as const,
     fontSize: "var(--text-md)",
-    color: "var(--faction-wow-card-accent)",
+    color: "var(--wow-score-stamp-accent, var(--faction-wow-card-accent))",
     marginTop: "var(--space-xs)",
   };
 
   return (
     <div
       style={{
+        // THE ROLE MAP (#2674). `--wow-score-stamp-*` is declared on the plate
+        // itself and read nowhere else — the prefix belongs to this SURFACE,
+        // not to the app, and the stamp is mounted inside four different hosts
+        // whose own prefixes it must not borrow or leak into. Every read below
+        // carries today's token as its fallback, so not a pixel of the plate
+        // moves.
+        ...factionRoleVars("wow", "wow-score-stamp"),
         position: "relative",
         minWidth: 116,
         boxSizing: "border-box",
@@ -109,18 +117,18 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
               fontFamily: "var(--faction-wow-body-font)",
               fontStyle: "italic",
               fontSize: "var(--text-base)",
-              color: "var(--faction-wow-card-muted)",
+              color: "var(--wow-score-stamp-quiet, var(--faction-wow-card-muted))",
             }}
           >
             {t("card.stamp.base")}
           </span>
           <span
             style={{
-              fontFamily: "var(--faction-wow-card-font)",
+              fontFamily: "var(--wow-score-stamp-face, var(--faction-wow-card-font))",
               // eslint-disable-next-line local/no-raw-style-values -- ornament: the chronicle's base numeral, the design's 25 (§4a)
               fontSize: 25,
               lineHeight: 0.8,
-              color: "var(--faction-wow-card-text)",
+              color: "var(--wow-score-stamp-ink, var(--faction-wow-card-text))",
             }}
           >
             {base}
@@ -129,7 +137,7 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
             <span
               style={{
                 marginLeft: "auto",
-                fontFamily: "var(--faction-wow-card-font)",
+                fontFamily: "var(--wow-score-stamp-face, var(--faction-wow-card-font))",
                 fontSize: "var(--text-lg)",
                 color: "var(--faction-wow-stamp-chip-text)",
                 background: "var(--faction-wow-stamp-chip-bg)",
@@ -180,7 +188,7 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
           style={{
             height: 2,
             background:
-              "linear-gradient(90deg, var(--faction-wow-chronicle-gold), var(--faction-wow-card-accent))",
+              "linear-gradient(90deg, var(--faction-wow-chronicle-gold), var(--wow-score-stamp-accent, var(--faction-wow-card-accent)))",
             opacity: 0.8,
             margin: "var(--space-sm) 0 var(--space-xs)",
           }}
@@ -189,7 +197,7 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
       <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-xs)" }}>
         <span
           style={{
-            fontFamily: "var(--faction-wow-card-font)",
+            fontFamily: "var(--wow-score-stamp-face, var(--faction-wow-card-font))",
             // eslint-disable-next-line local/no-raw-style-values -- ornament: the bottom-line total, the design's 29 (§4a)
             fontSize: 29,
             lineHeight: 0.8,
@@ -204,7 +212,7 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
         <span
           aria-hidden
           style={{
-            fontFamily: "var(--faction-wow-card-font)",
+            fontFamily: "var(--wow-score-stamp-face, var(--faction-wow-card-font))",
             // eslint-disable-next-line local/no-raw-style-values -- ornament: the ✦ device sized as a glyph, the design's 13 (§4a)
             fontSize: 13,
             color: "var(--faction-wow-chronicle-gold)",

--- a/frontend/src/components/selectCard/WowSelectCard.tsx
+++ b/frontend/src/components/selectCard/WowSelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { factionRoleVars } from "../../utils/factionRoles";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { WowSigil } from "../sigil/WowSigil";
 
@@ -120,8 +121,13 @@ export default function WowSelectCard({ state = "locked", members, onVisit }: Om
   const tags = i18n.t("feed:factionSelect.wow.tags", { returnObjects: true }) as string[];
   return (
     <div style={{
+      // THE ROLE MAP (#2674), declared on the placard's own root. The prefix
+      // belongs to this SURFACE: a select card sits in a grid beside eight
+      // other factions' cards, which is precisely the leak a shared namespace
+      // would cause.
+      ...factionRoleVars("wow", "wow-select-card"),
       width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: "var(--faction-wow-card-bg)", color: "var(--faction-wow-card-text)", fontFamily: "var(--faction-wow-body-font)",
+      background: "var(--wow-select-card-paper, var(--faction-wow-card-bg))", color: "var(--wow-select-card-ink, var(--faction-wow-card-text))", fontFamily: "var(--faction-wow-body-font)",
       border: "2px solid var(--faction-wow-chronicle-gold)", borderRadius: "var(--radius-xl)",
       boxShadow: chosen
         ? "0 0 0 3px var(--faction-wow-chronicle-gold), var(--faction-wow-quest-shadow)"
@@ -132,7 +138,7 @@ export default function WowSelectCard({ state = "locked", members, onVisit }: Om
         <div style={{
           position: "absolute", zIndex: 2, top: 14, right: -32, transform: "rotate(38deg)",
           background: "var(--faction-wow-plum-surface)", color: "var(--faction-wow-on-plum)",
-          fontFamily: "var(--faction-wow-card-font)", letterSpacing: "0.1em",
+          fontFamily: "var(--wow-select-card-face, var(--faction-wow-card-font))", letterSpacing: "0.1em",
           // eslint-disable-next-line local/no-raw-style-values -- ornament: the CHOSEN sash is a drawn banner; its lettering is struck to the ribbon, and its inset IS the ribbon's width (rounding reflows the sash off the corner).
           fontSize: 11, padding: "3px 36px",
           boxShadow: "0 2px 5px var(--faction-wow-stamp-shadow)",
@@ -151,16 +157,16 @@ export default function WowSelectCard({ state = "locked", members, onVisit }: Om
           {/* above the 56px motto floor, so the seal keeps its Pig-Latin band */}
           <WowSigil size={88} />
         </div>
-        <div style={{ fontFamily: "var(--faction-wow-card-font)", fontSize: "var(--text-title)", lineHeight: 1.1, color: "var(--faction-wow-card-text)" }}>
+        <div style={{ fontFamily: "var(--wow-select-card-face, var(--faction-wow-card-font))", fontSize: "var(--text-title)", lineHeight: 1.1, color: "var(--wow-select-card-ink, var(--faction-wow-card-text))" }}>
           {i18n.t("feed:factionSelect.wow.name")}
         </div>
-        <p className="content-text" style={{ fontStyle: "italic", color: "var(--faction-wow-card-accent)", margin: "var(--space-xs) 0 var(--space-md)", lineHeight: 1.4 }}>
+        <p className="content-text" style={{ fontStyle: "italic", color: "var(--wow-select-card-accent, var(--faction-wow-card-accent))", margin: "var(--space-xs) 0 var(--space-md)", lineHeight: 1.4 }}>
           {i18n.t("feed:factionSelect.wow.tagline")}
         </p>
         <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: "var(--space-xs)" }}>
           {tags.map((tag) => (
             <span key={tag} style={{
-              fontSize: "var(--text-md)", color: "var(--faction-wow-card-accent)",
+              fontSize: "var(--text-md)", color: "var(--wow-select-card-accent, var(--faction-wow-card-accent))",
               background: "var(--faction-wow-chronicle-panel)", border: "1px solid var(--faction-wow-chronicle-gold)",
               borderRadius: 20, padding: "var(--space-xs) var(--space-md)",
             }}>{tag}</span>
@@ -168,12 +174,12 @@ export default function WowSelectCard({ state = "locked", members, onVisit }: Om
         </div>
       </div>
       <div style={{ padding: "var(--space-lg) var(--space-xl)", textAlign: "center" }}>
-        <div style={{ fontSize: "var(--text-content)", color: "var(--faction-wow-card-muted)", marginBottom: "var(--space-md)" }}>
+        <div style={{ fontSize: "var(--text-content)", color: "var(--wow-select-card-quiet, var(--faction-wow-card-muted))", marginBottom: "var(--space-md)" }}>
           {status}{members != null && <> · {i18n.t("feed:factionSelect.wow.members", { count: members })}</>}
         </div>
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer",
-          fontFamily: "var(--faction-wow-card-font)", fontSize: "var(--text-content)", letterSpacing: "0.04em",
+          fontFamily: "var(--wow-select-card-face, var(--faction-wow-card-font))", fontSize: "var(--text-content)", letterSpacing: "0.04em",
           color: "var(--faction-wow-on-plum)",
           background: "var(--faction-wow-plum-surface)",
           border: "2px solid var(--faction-wow-plum-surface)", borderRadius: "var(--radius-md)",

--- a/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
@@ -65,6 +65,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 
+import { FACTION_ROLES, factionRoleVar } from "../../../utils/factionRoles";
 import { readThemes, resolveVar, stripComments } from "../../../utils/__tests__/cssVars";
 
 const read = (relative: string): string =>
@@ -114,13 +115,32 @@ function propsBehind(
   return found;
 }
 
+/**
+ * Rider 2's one genuine case: `utils/factionRoles` DOES hand a file paint, and
+ * a text scan cannot see it (#2674).
+ *
+ * `factionRoleVars('wow', <prefix>)` declares WOW's nine core roles on a root
+ * by INTERPOLATION, so `--faction-wow-card-bg` never appears in the source as a
+ * name. Resolving it is exact rather than approximate, which is what keeps this
+ * sweep the transitive answer: the resolver can emit this faction's nine core
+ * roles and nothing else — not another family, not another faction — so a tile
+ * that adopts it cannot smuggle an off-register name in behind it.
+ */
+const ROLE_MAP_PROPS = FACTION_ROLES.map((role) =>
+  factionRoleVar("wow", role).replace(/^var\(|\)$/g, ""),
+);
+
 /** Faction paint. House tokens — spacing, the type ramp, radii — are everyone's. */
 const isFactionPaint = (prop: string): boolean =>
   prop.startsWith("--faction-") || prop.startsWith("--font-faction-");
 
 function tokensPainting(relative: string): Set<string> {
+  const source = code(relative);
   const props = new Set<string>();
-  for (const [, prop] of code(relative).matchAll(/(--[a-z0-9-]+)/g)) props.add(prop);
+  for (const [, prop] of source.matchAll(/(--[a-z0-9-]+)/g)) props.add(prop);
+  if (/factionRoleVars\(\s*["']wow["']/.test(source)) {
+    for (const prop of ROLE_MAP_PROPS) props.add(prop);
+  }
   return new Set([...props].filter(isFactionPaint));
 }
 
@@ -185,6 +205,9 @@ answer — not by widening this test.`,
     const imports = [...code(TILE).matchAll(/^import .*?from "([^"]+)";$/gm)].map((m) => m[1]);
     expect(imports.sort(), "a new import here needs `propsBehind` resolving it, the way #2325 resolves `covenSlip`").toEqual([
       "../../i18n",
+      // Resolved, not waived: `ROLE_MAP_PROPS` above adds the nine names this
+      // one declares by interpolation to every scan (#2674).
+      "../../utils/factionRoles",
       "../sigil/WowSigil",
       "./FactionSelectCard",
     ]);
@@ -198,8 +221,8 @@ answer — not by widening this test.`,
 
   it("sets the call in the decree's own face and size", () => {
     const source = code(TILE);
-    expect(source, "MedievalSharp, from `--faction-wow-card-font`").toContain(
-      'fontFamily: "var(--faction-wow-card-font)", fontSize: "var(--text-content)"',
+    expect(source, "MedievalSharp, asked for as the `face` ROLE (#2674)").toContain(
+      'fontFamily: "var(--wow-select-card-face, var(--faction-wow-card-font))", fontSize: "var(--text-content)"',
     );
     expect(
       source,

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -5,6 +5,7 @@ import { CARD_CTA } from "./cardCta";
 import { CardCtaControl } from "./CardCtaControl";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
+import { factionRoleVars } from "../../utils/factionRoles";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 import { BalloonBunch, Bunting, Zig } from "../factionMarks/wowOrnament";
@@ -82,12 +83,24 @@ import { BalloonBunch, Bunting, Zig } from "../factionMarks/wowOrnament";
  * tokens and the fourth became `--faction-wow-quest-blade`.
  */
 
-const MED = "var(--faction-wow-card-font)"; /* MedievalSharp */
+/**
+ * THE FOUR CORE ROLES ARE ASKED FOR BY NAME (#2674). The `<article>` below
+ * spreads `factionRoleVars('wow', 'wow-task-card')`, so these four are declared
+ * on the decree's own sheet and read nowhere else — the prefix belongs to this
+ * SURFACE, not to the app, because a shared namespace on a page wrapper would
+ * repaint every descendant including a card of another faction.
+ *
+ * Every read carries today's token as its fallback, so a decree renders
+ * byte-identically whether or not the vars are declared. That is what keeps
+ * `WowBand` — the shared cross-faction masthead, carved out of every lane —
+ * unaffected while it sits inside this root.
+ */
+const MED = "var(--wow-task-card-face, var(--faction-wow-card-font))"; /* MedievalSharp */
 const LORA = "var(--faction-wow-body-font)"; /* Lora */
 
-const INK = "var(--faction-wow-card-text)";
-const MUTED = "var(--faction-wow-card-muted)";
-const PLUM = "var(--faction-wow-card-accent)";
+const INK = "var(--wow-task-card-ink, var(--faction-wow-card-text))";
+const MUTED = "var(--wow-task-card-quiet, var(--faction-wow-card-muted))";
+const PLUM = "var(--wow-task-card-accent, var(--faction-wow-card-accent))";
 const GOLD = "var(--faction-wow-chronicle-gold)";
 const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
 const GILT = "var(--faction-wow-stamp-total)";
@@ -180,14 +193,15 @@ export default function WowTaskCard({
     >
       <article
         style={{
+          ...factionRoleVars("wow", "wow-task-card"),
           position: "relative",
           overflow: "hidden",
           boxSizing: "border-box",
           width: "100%",
-          background: "var(--faction-wow-card-bg)",
+          background: "var(--wow-task-card-paper, var(--faction-wow-card-bg))",
           border: `2px solid ${GOLD}`,
           // The decree's shape, said once (#2361/#2403).
-          borderRadius: "var(--faction-wow-card-radius)",
+          borderRadius: "var(--wow-task-card-radius, var(--faction-wow-card-radius))",
           boxShadow: "var(--faction-wow-quest-shadow)",
           color: INK,
         }}

--- a/frontend/src/factions/__tests__/wowRoleMap.test.ts
+++ b/frontend/src/factions/__tests__/wowRoleMap.test.ts
@@ -1,204 +1,91 @@
 /**
- * WOW ASKS THE FACTION FOR A ROLE, NOT FOR A TOKEN (#2674, lane 04 of "Nine
- * Kits, One Vocabulary" — the re-cut recorded on #2649).
+ * THE TWO HALVES OF LANE 04 THAT `factionRoleMigration.test.ts` CANNOT HOLD
+ * (#2674, lane 04 of "Nine Kits, One Vocabulary" — the re-cut on #2649).
  *
- * THE SEAM UNDER TEST is the read: `var(--<surface-prefix>-<role>, <today's
- * token>)`, the one place a WOW surface meets `utils/factionRoles.ts`. Both
- * halves of that expression can be wrong in a way nothing else in CI can see.
+ * That file is the merge gate for a migrated SURFACE: one prefix declared on
+ * one root, every read's fallback re-derived from the resolver. Fifteen of this
+ * lane's eighteen files are rows in it. The other three are not surfaces at all,
+ * and the two files this lane must NOT have touched are not in any lane's
+ * table by construction. Both are census work, and a census NAMES its members
+ * rather than counting them (#1998 → #2090) — a new WOW kit module has to add
+ * its own line here instead of fitting inside a total.
  *
- *  - A MISSPELLED PREFIX (`--wow-fed-paper`) renders as the fallback and looks
- *    perfect. `factionTokensDeclared.test.ts` catches the orphan only because it
- *    reconstructs the resolver's exact cross-product; it cannot check that the
- *    prefix a file READS is the prefix that file DECLARES, which is the failure
- *    a copy-pasted surface actually makes.
- *  - A WRONG FALLBACK (`var(--wow-feed-paper, var(--faction-wow-plate))`) is a
- *    REPAINT hiding inside a refactor, and it is invisible today and forever
- *    after: WOW declares no ground override, so the declared value and the
- *    fallback are the same string, and the wrong fallback never renders. It
- *    would surface years later, on the first ground override, as a colour
- *    nobody changed.
+ * THE ROOTLESS THREE. A prefix is declared on a root and read below it.
+ * `wowMobile`, `wowLists` and `wowOrnament` have no root: they are the shared
+ * vocabulary six mobile skins, six ornament consumers and the duel seal compose
+ * from, mounted under many different roots — `WowFieldDesk`'s and
+ * `WowDuelSealConfirm`'s among them, both outside this lane. One prefix shared
+ * between the vocabulary and every host would BE the `--kit-*` namespace the law
+ * declines, and handing each host's prefix down is a component prop, which is
+ * tree work. `factionRoleVar` is the resolver's own answer for a single role
+ * with no all-or-nothing seam to protect: it returns the identical string these
+ * constants held before, so the value cannot move.
  *
- * So this file is the lane's COMPUTED-VALUE DIFF, mechanised: every migrated
- * read's fallback must be exactly the token `factionRoleVar('wow', role)`
- * resolves to, which is the token that site named before the migration. A green
- * run is the proof that not one pixel moved.
- *
- * IT NAMES ITS SURFACES RATHER THAN COUNTING THEM (#1998 → #2090). A total is
- * what lets a wrong mount pass; a new WOW surface has to add its own line here
- * rather than quietly fit inside a number. The three rootless entries are the
- * other half of the same census — see {@link KIT_MODULES}.
+ * THE CARVED-OUT TWO. `VoteShell` and `factionBands` read core roles for MORE
+ * THAN ONE faction, which is slot ownership — a column, not a row — and belongs
+ * to batches 11+. Carving them out is what makes the five lanes strictly
+ * disjoint, so a lane that helpfully "tidied" one would break the parallel
+ * build for everyone. Asserting the carve-out from INSIDE the lane is what
+ * makes an accidental sweep loud instead of silent.
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import {
-  FACTION_ROLES,
-  factionRoleProperty,
-  factionRoleVar,
-  type FactionRole,
-} from "../../utils/factionRoles";
-
 const SRC = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
 
-/**
- * The surfaces, and the prefix each one picked.
- *
- * THE PREFIX BELONGS TO THE SURFACE, NOT TO THE APP — one shared `--kit-*`
- * namespace is explicitly declined by the law, because a page wrapper declaring
- * it repaints every descendant including a card belonging to a different
- * faction than the page. Each name here is qualified with `wow` for the same
- * reason at one level down: nine parallel lanes are migrating nine task cards,
- * and a bare `--task-card-paper` would be nine files claiming one name.
- */
-const SURFACES: Record<string, string> = {
-  "components/avatar/WowAvatar.tsx": "wow-avatar",
-  "components/comments/voices/WowComment.tsx": "wow-comment",
-  "components/factionHero/WowFactionHero.tsx": "wow-hero",
-  "components/feed/WowFeedFrame.tsx": "wow-feed",
-  "components/metataskSeal/skins/WowSeal.tsx": "wow-seal",
-  "components/praxisCard/desktop/WowPraxisCard.tsx": "wow-praxis-card",
-  "components/praxisCard/scoreStamp/WowScoreStamp.tsx": "wow-score-stamp",
-  "components/selectCard/WowSelectCard.tsx": "wow-select-card",
-  "components/taskCard/WowTaskCard.tsx": "wow-task-card",
-  "pages/characterPaths/archetypes/WowCreateCharacter.tsx": "wow-create",
-  "pages/characterProfile/archetypes/WowProfileBody.tsx": "wow-profile",
-  "pages/editPraxis/archetypes/WowEditPraxis.tsx": "wow-edit-praxis",
-  "pages/factionDetail/archetypes/WowFactionBody.tsx": "wow-faction-page",
-  "pages/praxisDetail/archetypes/WowPraxisDetail.tsx": "wow-praxis-page",
-  "pages/taskDetail/archetypes/WowTaskDetail.tsx": "wow-task-page",
-};
-
-/**
- * The three files in the lane that are NOT surfaces, and so cannot pick a
- * prefix.
- *
- * A prefix is declared on a root and read below it. These three have no root:
- * they are the shared vocabulary six mobile skins, six ornament consumers and
- * the duel seal compose from, mounted under many different roots — including
- * `WowFieldDesk` and `WowDuelSealConfirm`, which are outside this lane. Giving
- * them one prefix between them would BE the `--kit-*` namespace the law
- * declines; giving them their consumers' prefixes is tree work, not paint.
- *
- * `factionRoleVar` is the answer the resolver already ships for exactly this:
- * one role, as a `var()` reference, with no all-or-nothing seam to protect
- * because the slug is a literal. It returns the identical string the constant
- * held before, so these files move onto the vocabulary at zero risk.
- */
+/** The shared WOW vocabulary modules, which have no root to hang a prefix on. */
 const KIT_MODULES = [
-  "components/duel/wowLists.tsx",
   "components/factionMarks/wowMobile.tsx",
+  "components/duel/wowLists.tsx",
   "components/factionMarks/wowOrnament.tsx",
 ];
 
-/**
- * Carved out of every lane (#2649): shared cross-faction renderers that dispatch
- * on slug internally. That is slot ownership — a column, not a row — and it
- * belongs to batches 11+. They must still name WOW's tokens directly.
- */
+/** Shared cross-faction renderers, carved out of every lane (#2649). */
 const CARVED_OUT = [
   "components/vote/VoteShell.tsx",
   "components/cardMasthead/factionBands.tsx",
 ];
 
-/** The nine core-role suffixes, as `index.css` spells them. */
-const CORE_SUFFIX = new RegExp(
-  "--faction-wow(?:-card-(?:bg|text|muted|border|accent|radius|font)|-on-fill)?(?![a-z0-9-])",
-  "g",
-);
+/** A read of one of WOW's nine core roles, spelt as the token. */
+const CORE_TOKEN =
+  /--faction-wow(?:-card-(?:bg|text|muted|border|accent|radius|font)|-on-fill)?(?![a-z0-9-])/g;
 
-/** Comments quote token names as prose; a mention is not a read. */
-function stripComments(text: string): string {
-  return text
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/^[^\n"'`]*\/\/.*$/gm, "");
-}
-
+/** Comments quote token names as prose constantly; a mention is not a read. */
 function source(relative: string): string {
-  return stripComments(readFileSync(join(SRC, relative), "utf-8"));
+  return readFileSync(join(SRC, ...relative.split("/")), "utf-8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
 }
 
-/** Every `var(--prefix-role, …)` read in `text`, with its fallback. */
-function roleReads(
-  text: string,
-  prefix: string,
-): { role: FactionRole; fallback: string }[] {
-  return FACTION_ROLES.flatMap((role) => {
-    const property = factionRoleProperty(prefix, role);
-    const pattern = new RegExp(
-      `var\\(\\s*${property}\\s*,\\s*(var\\(--[\\w-]+\\))\\s*\\)`,
-      "g",
-    );
-    return [...text.matchAll(pattern)].map((match) => ({
-      role,
-      fallback: match[1],
-    }));
+describe("WOW's rootless kit modules ask for a role, not a token (#2674)", () => {
+  it.each(KIT_MODULES)("%s composes from factionRoleVar", (path) => {
+    expect(source(path)).toMatch(/factionRoleVar\(\s*['"]wow['"]/);
   });
-}
 
-describe("WOW reads the role map", () => {
-  it.each(Object.entries(SURFACES))(
-    "%s declares its own prefix on its root",
-    (path, prefix) => {
-      // The prefix a surface READS has to be the prefix it DECLARES. Nothing
-      // else in CI compares the two, and a copy-pasted surface gets this wrong.
-      // Quote-agnostic: this repo has no prettier config and each archetype
-      // keeps its own house style.
-      expect(source(path)).toMatch(
-        new RegExp(`factionRoleVars\\(\\s*['"]wow['"],\\s*['"]${prefix}['"]`),
-      );
-    },
-  );
+  it.each(KIT_MODULES)("%s names no core-role token directly", (path) => {
+    // These files declare no prefix, so there is no fallback arm to exempt:
+    // every core-role name left in one would be a straggler.
+    expect(source(path).match(CORE_TOKEN) ?? []).toEqual([]);
+  });
 
-  it.each(Object.entries(SURFACES))(
-    "%s reads at least one role, so the census cannot pass vacuously",
-    (path, prefix) => {
-      expect(roleReads(source(path), prefix).length).toBeGreaterThan(0);
-    },
-  );
+  it.each(KIT_MODULES)("%s spreads no prefix, having no root", (path) => {
+    // The negative half. `factionRoleVars` here would mean this module had
+    // claimed a root it does not own — and would repaint every descendant of
+    // whichever host mounted it, including a card of a different faction.
+    expect(source(path)).not.toContain("factionRoleVars");
+  });
+});
 
-  it.each(Object.entries(SURFACES))(
-    "%s carries today's token as every fallback — the computed-value diff",
-    (path, prefix) => {
-      for (const { role, fallback } of roleReads(source(path), prefix)) {
-        expect(fallback).toBe(factionRoleVar("wow", role));
-      }
-    },
-  );
-
-  it.each([...Object.keys(SURFACES), ...KIT_MODULES])(
-    "%s names no core-role token outside a role fallback",
-    (path) => {
-      const prefix = SURFACES[path];
-      let text = source(path);
-      if (prefix) {
-        for (const role of FACTION_ROLES) {
-          const property = factionRoleProperty(prefix, role);
-          text = text.replace(
-            new RegExp(
-              `var\\(\\s*${property}\\s*,\\s*var\\(--[\\w-]+\\)\\s*\\)`,
-              "g",
-            ),
-            "«role»",
-          );
-        }
-      }
-      expect(text.match(CORE_SUFFIX) ?? []).toEqual([]);
-    },
-  );
-
-  it.each(KIT_MODULES)(
-    "%s composes from factionRoleVar, having no root",
-    (path) => {
-      expect(source(path)).toMatch(/factionRoleVar\(\s*['"]wow['"]/);
-    },
-  );
-
-  it.each(CARVED_OUT)("%s is carved out and still names WOW directly", (path) => {
-    // A lane that "tidied" one of these would break the disjointness the five
-    // parallel lanes were cut for. Asserting the carve-out from inside the lane
-    // is what makes an accidental sweep loud.
-    expect((source(path).match(CORE_SUFFIX) ?? []).length).toBeGreaterThan(0);
+describe("the files carved out of every lane still name WOW directly", () => {
+  it.each(CARVED_OUT)("%s is untouched by this lane", (path) => {
+    expect(
+      (source(path).match(CORE_TOKEN) ?? []).length,
+      `${path} dispatches on slug for MORE than one faction, so its core-role
+reads belong to batches 11+ (slot ownership — a column, not a row). If this is
+newly empty, a lane swept a file the five-way parallel build depends on being
+disjoint.`,
+    ).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/factions/__tests__/wowRoleMap.test.ts
+++ b/frontend/src/factions/__tests__/wowRoleMap.test.ts
@@ -1,0 +1,204 @@
+/**
+ * WOW ASKS THE FACTION FOR A ROLE, NOT FOR A TOKEN (#2674, lane 04 of "Nine
+ * Kits, One Vocabulary" — the re-cut recorded on #2649).
+ *
+ * THE SEAM UNDER TEST is the read: `var(--<surface-prefix>-<role>, <today's
+ * token>)`, the one place a WOW surface meets `utils/factionRoles.ts`. Both
+ * halves of that expression can be wrong in a way nothing else in CI can see.
+ *
+ *  - A MISSPELLED PREFIX (`--wow-fed-paper`) renders as the fallback and looks
+ *    perfect. `factionTokensDeclared.test.ts` catches the orphan only because it
+ *    reconstructs the resolver's exact cross-product; it cannot check that the
+ *    prefix a file READS is the prefix that file DECLARES, which is the failure
+ *    a copy-pasted surface actually makes.
+ *  - A WRONG FALLBACK (`var(--wow-feed-paper, var(--faction-wow-plate))`) is a
+ *    REPAINT hiding inside a refactor, and it is invisible today and forever
+ *    after: WOW declares no ground override, so the declared value and the
+ *    fallback are the same string, and the wrong fallback never renders. It
+ *    would surface years later, on the first ground override, as a colour
+ *    nobody changed.
+ *
+ * So this file is the lane's COMPUTED-VALUE DIFF, mechanised: every migrated
+ * read's fallback must be exactly the token `factionRoleVar('wow', role)`
+ * resolves to, which is the token that site named before the migration. A green
+ * run is the proof that not one pixel moved.
+ *
+ * IT NAMES ITS SURFACES RATHER THAN COUNTING THEM (#1998 → #2090). A total is
+ * what lets a wrong mount pass; a new WOW surface has to add its own line here
+ * rather than quietly fit inside a number. The three rootless entries are the
+ * other half of the same census — see {@link KIT_MODULES}.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  FACTION_ROLES,
+  factionRoleProperty,
+  factionRoleVar,
+  type FactionRole,
+} from "../../utils/factionRoles";
+
+const SRC = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+
+/**
+ * The surfaces, and the prefix each one picked.
+ *
+ * THE PREFIX BELONGS TO THE SURFACE, NOT TO THE APP — one shared `--kit-*`
+ * namespace is explicitly declined by the law, because a page wrapper declaring
+ * it repaints every descendant including a card belonging to a different
+ * faction than the page. Each name here is qualified with `wow` for the same
+ * reason at one level down: nine parallel lanes are migrating nine task cards,
+ * and a bare `--task-card-paper` would be nine files claiming one name.
+ */
+const SURFACES: Record<string, string> = {
+  "components/avatar/WowAvatar.tsx": "wow-avatar",
+  "components/comments/voices/WowComment.tsx": "wow-comment",
+  "components/factionHero/WowFactionHero.tsx": "wow-hero",
+  "components/feed/WowFeedFrame.tsx": "wow-feed",
+  "components/metataskSeal/skins/WowSeal.tsx": "wow-seal",
+  "components/praxisCard/desktop/WowPraxisCard.tsx": "wow-praxis-card",
+  "components/praxisCard/scoreStamp/WowScoreStamp.tsx": "wow-score-stamp",
+  "components/selectCard/WowSelectCard.tsx": "wow-select-card",
+  "components/taskCard/WowTaskCard.tsx": "wow-task-card",
+  "pages/characterPaths/archetypes/WowCreateCharacter.tsx": "wow-create",
+  "pages/characterProfile/archetypes/WowProfileBody.tsx": "wow-profile",
+  "pages/editPraxis/archetypes/WowEditPraxis.tsx": "wow-edit-praxis",
+  "pages/factionDetail/archetypes/WowFactionBody.tsx": "wow-faction-page",
+  "pages/praxisDetail/archetypes/WowPraxisDetail.tsx": "wow-praxis-page",
+  "pages/taskDetail/archetypes/WowTaskDetail.tsx": "wow-task-page",
+};
+
+/**
+ * The three files in the lane that are NOT surfaces, and so cannot pick a
+ * prefix.
+ *
+ * A prefix is declared on a root and read below it. These three have no root:
+ * they are the shared vocabulary six mobile skins, six ornament consumers and
+ * the duel seal compose from, mounted under many different roots — including
+ * `WowFieldDesk` and `WowDuelSealConfirm`, which are outside this lane. Giving
+ * them one prefix between them would BE the `--kit-*` namespace the law
+ * declines; giving them their consumers' prefixes is tree work, not paint.
+ *
+ * `factionRoleVar` is the answer the resolver already ships for exactly this:
+ * one role, as a `var()` reference, with no all-or-nothing seam to protect
+ * because the slug is a literal. It returns the identical string the constant
+ * held before, so these files move onto the vocabulary at zero risk.
+ */
+const KIT_MODULES = [
+  "components/duel/wowLists.tsx",
+  "components/factionMarks/wowMobile.tsx",
+  "components/factionMarks/wowOrnament.tsx",
+];
+
+/**
+ * Carved out of every lane (#2649): shared cross-faction renderers that dispatch
+ * on slug internally. That is slot ownership — a column, not a row — and it
+ * belongs to batches 11+. They must still name WOW's tokens directly.
+ */
+const CARVED_OUT = [
+  "components/vote/VoteShell.tsx",
+  "components/cardMasthead/factionBands.tsx",
+];
+
+/** The nine core-role suffixes, as `index.css` spells them. */
+const CORE_SUFFIX = new RegExp(
+  "--faction-wow(?:-card-(?:bg|text|muted|border|accent|radius|font)|-on-fill)?(?![a-z0-9-])",
+  "g",
+);
+
+/** Comments quote token names as prose; a mention is not a read. */
+function stripComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[^\n"'`]*\/\/.*$/gm, "");
+}
+
+function source(relative: string): string {
+  return stripComments(readFileSync(join(SRC, relative), "utf-8"));
+}
+
+/** Every `var(--prefix-role, …)` read in `text`, with its fallback. */
+function roleReads(
+  text: string,
+  prefix: string,
+): { role: FactionRole; fallback: string }[] {
+  return FACTION_ROLES.flatMap((role) => {
+    const property = factionRoleProperty(prefix, role);
+    const pattern = new RegExp(
+      `var\\(\\s*${property}\\s*,\\s*(var\\(--[\\w-]+\\))\\s*\\)`,
+      "g",
+    );
+    return [...text.matchAll(pattern)].map((match) => ({
+      role,
+      fallback: match[1],
+    }));
+  });
+}
+
+describe("WOW reads the role map", () => {
+  it.each(Object.entries(SURFACES))(
+    "%s declares its own prefix on its root",
+    (path, prefix) => {
+      // The prefix a surface READS has to be the prefix it DECLARES. Nothing
+      // else in CI compares the two, and a copy-pasted surface gets this wrong.
+      // Quote-agnostic: this repo has no prettier config and each archetype
+      // keeps its own house style.
+      expect(source(path)).toMatch(
+        new RegExp(`factionRoleVars\\(\\s*['"]wow['"],\\s*['"]${prefix}['"]`),
+      );
+    },
+  );
+
+  it.each(Object.entries(SURFACES))(
+    "%s reads at least one role, so the census cannot pass vacuously",
+    (path, prefix) => {
+      expect(roleReads(source(path), prefix).length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(Object.entries(SURFACES))(
+    "%s carries today's token as every fallback — the computed-value diff",
+    (path, prefix) => {
+      for (const { role, fallback } of roleReads(source(path), prefix)) {
+        expect(fallback).toBe(factionRoleVar("wow", role));
+      }
+    },
+  );
+
+  it.each([...Object.keys(SURFACES), ...KIT_MODULES])(
+    "%s names no core-role token outside a role fallback",
+    (path) => {
+      const prefix = SURFACES[path];
+      let text = source(path);
+      if (prefix) {
+        for (const role of FACTION_ROLES) {
+          const property = factionRoleProperty(prefix, role);
+          text = text.replace(
+            new RegExp(
+              `var\\(\\s*${property}\\s*,\\s*var\\(--[\\w-]+\\)\\s*\\)`,
+              "g",
+            ),
+            "«role»",
+          );
+        }
+      }
+      expect(text.match(CORE_SUFFIX) ?? []).toEqual([]);
+    },
+  );
+
+  it.each(KIT_MODULES)(
+    "%s composes from factionRoleVar, having no root",
+    (path) => {
+      expect(source(path)).toMatch(/factionRoleVar\(\s*['"]wow['"]/);
+    },
+  );
+
+  it.each(CARVED_OUT)("%s is carved out and still names WOW directly", (path) => {
+    // A lane that "tidied" one of these would break the disjointness the five
+    // parallel lanes were cut for. Asserting the carve-out from inside the lane
+    // is what makes an accidental sweep loud.
+    expect((source(path).match(CORE_SUFFIX) ?? []).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
@@ -118,6 +118,7 @@ import { useId, useRef, type CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionCssVar, factionName } from '../../../utils/factions'
+import { factionRoleVars } from '../../../utils/factionRoles'
 import CredentialCard from '../../../components/CredentialCard'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
@@ -146,21 +147,33 @@ import {
 const SLUG = 'wow'
 
 /* ── WOW's two faces (§3) ── */
-/** MedievalSharp — the chronicle's display hand. */
-const MED = 'var(--faction-wow-card-font)'
+/**
+ * MedievalSharp — the chronicle's display hand.
+ *
+ * THE FOUR CORE ROLES ARE ASKED FOR BY NAME (#2674). `ComposerPage` below puts
+ * the style object it is handed straight on its root element, so
+ * `factionRoleVars('wow', 'wow-create')` declares the prefix on the page this
+ * file dresses without a prop being threaded through a shared block — that
+ * would be tree work, and this is paint.
+ *
+ * Every read carries today's token as its fallback. The names below that are
+ * NOT roles stay put: the inset plate, the label olive, the plum FILL and its
+ * ink, the gold and its quiet rung are this surface's own extras (decision 07).
+ */
+const MED = 'var(--wow-create-face, var(--faction-wow-card-font))'
 /** Lora — body AND label on the writ, per that design's type row. */
 const LORA = 'var(--faction-wow-body-font)'
 
 /* ── The chronicle palette. Every one a shipped --faction-wow-* token, and
    every pairing below already measured in `factionContrast.test.ts`. ── */
 /** The sheet: cream parchment by day, the deep ground by night. */
-const SHEET = 'var(--faction-wow-card-bg)'
+const SHEET = 'var(--wow-create-paper, var(--faction-wow-card-bg))'
 /** The inset parchment plate every editable field is set on. */
 const FIELD = 'var(--faction-wow-chronicle-panel)'
 /** Body ink. 14:1 on the cream, and measured on the plate too. */
-const INK = 'var(--faction-wow-card-text)'
+const INK = 'var(--wow-create-ink, var(--faction-wow-card-text))'
 /** Quiet ink — CREAM ONLY (4.77:1 there, 4.25:1 on the plate). */
-const MUTED = 'var(--faction-wow-card-muted)'
+const MUTED = 'var(--wow-create-quiet, var(--faction-wow-card-muted))'
 /** The label/eyebrow ink, the one measured on BOTH chronicle grounds. */
 const LABEL = 'var(--faction-wow-accent-deep)'
 /** Plum as a SURFACE. Theme-invariant, with its own AA ink beside it. */
@@ -271,7 +284,10 @@ export default function WowCreateCharacter({ state }: { state: CreateCharacterSt
   )
 
   return (
-    <ComposerPage sizes={sizes} style={{ fontFamily: LORA, color: INK }}>
+    <ComposerPage
+      sizes={sizes}
+      style={{ ...factionRoleVars('wow', 'wow-create'), fontFamily: LORA, color: INK }}
+    >
       {/* A REAL `<form>`, not a bare button with an onClick. The Default skin
           submits through one and so must this: it is what makes Enter commit
           from a text field, and what gives the browser's own required-field

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -66,6 +66,7 @@ import {
 } from '../../../components/factionMarks/wowMobile'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { factionName } from '../../../utils/factions'
+import { factionRoleVars } from '../../../utils/factionRoles'
 import { mediaUrl } from '../../../utils/media'
 import { useTranslation } from 'react-i18next'
 import type { ProfileBodyProps } from '../FactionProfileBody'
@@ -80,15 +81,29 @@ import {
 
 type Segment = 'praxis' | 'tasks'
 
-const INK = 'var(--faction-wow-card-text)'
-const MUTED = 'var(--faction-wow-card-muted)'
-const PLUM = 'var(--faction-wow-card-accent)'
+/**
+ * THE FIVE CORE ROLES ARE ASKED FOR BY NAME (#2674), AND THIS FILE OWNS ONLY
+ * ONE OF ITS TWO ROOTS.
+ *
+ * `MobileProfile` below spreads `factionRoleVars('wow', 'wow-profile')` on the
+ * pavilion page it draws. The DESKTOP half has no root here: it hands `dress`
+ * to the shared `ProfileSkin`, which owns the page element all nine factions
+ * mount on, so declaring the prefix for that half means giving `ProfileDress` a
+ * root-vars slot — a component prop, which is TREE work and not a paint lane's
+ * to do (the axis #2650 established). Until then the desktop reads resolve
+ * through their fallbacks, which is byte-for-byte what shipped: the fallback is
+ * per-SITE by design, and an undeclared prefix is the neutral case the law
+ * builds pixel-identity out of.
+ */
+const INK = 'var(--wow-profile-ink, var(--faction-wow-card-text))'
+const MUTED = 'var(--wow-profile-quiet, var(--faction-wow-card-muted))'
+const PLUM = 'var(--wow-profile-accent, var(--faction-wow-card-accent))'
 const GOLD = 'var(--faction-wow-chronicle-gold)'
 const FIGURE = 'var(--faction-wow-figure)'
-const SURFACE = 'var(--faction-wow-card-bg)'
+const SURFACE = 'var(--wow-profile-paper, var(--faction-wow-card-bg))'
 const PLATE = 'var(--faction-wow-plate)'
 const PLATE_BORDER = 'var(--faction-wow-plate-border)'
-const DISPLAY = 'var(--faction-wow-card-font)'
+const DISPLAY = 'var(--wow-profile-face, var(--faction-wow-card-font))'
 const BODY = 'var(--faction-wow-body-font)'
 
 function heading(title: string, eyebrow: string): ReactNode {
@@ -307,6 +322,7 @@ function MobileProfile({
       data-skin="wow"
       data-testid="mobile-profile"
       style={{
+        ...factionRoleVars('wow', 'wow-profile'),
         ...wowMobilePage,
         display: 'flex',
         flexDirection: 'column',

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -116,6 +116,7 @@
 import { useState } from "react";
 import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
@@ -162,14 +163,28 @@ interface Props {
 }
 
 /* ── WOW's two faces (§3) ── */
-/** MedievalSharp — the chronicle's display hand. */
-const MED = "var(--faction-wow-card-font)";
+/**
+ * MedievalSharp — the chronicle's display hand.
+ *
+ * THE FIVE CORE ROLES ARE ASKED FOR BY NAME (#2674). `dress.pageStyle` below
+ * spreads `factionRoleVars('wow', 'wow-edit-praxis')`, and `ComposerPage` puts
+ * that object straight on its root element — so the prefix is declared on the
+ * page this file dresses without a prop being added to a shared block, which
+ * would be tree work rather than paint.
+ *
+ * Every read carries today's token as its fallback. The palette below that is
+ * NOT a role stays exactly where it is: the alarm rung, the inset parchment
+ * plate, the plate's own quiet register, the label olive, the plum FILL and its
+ * ink are this surface's extras, each one measured against a ground the core
+ * vocabulary does not name (decision 07).
+ */
+const MED = "var(--wow-edit-praxis-face, var(--faction-wow-card-font))";
 /** Lora — body AND label on this surface, per the design's type row. */
 const LORA = "var(--faction-wow-body-font)";
 
 /* ── The chronicle palette. Every one a shipped --faction-wow-* token. ── */
 /** The sheet: cream parchment by day, the deep ground by night. */
-const SHEET = "var(--faction-wow-card-bg)";
+const SHEET = "var(--wow-edit-praxis-paper, var(--faction-wow-card-bg))";
 /* The error banner's ink (#1231). The banner sits straight on the sheet, and
  * the neutral `--color-danger` under its own veil misses AA there in light
  * (4.08:1 on this ground); this is #1449's alarm rung, already measured
@@ -178,9 +193,9 @@ const ALARM = "var(--faction-wow-card-alarm)";
 /** The inset parchment plate every editable field is set on. */
 const FIELD = "var(--faction-wow-chronicle-panel)";
 /** Body ink. 14:1 on both grounds. */
-const INK = "var(--faction-wow-card-text)";
+const INK = "var(--wow-edit-praxis-ink, var(--faction-wow-card-text))";
 /** Quiet ink — CREAM ONLY. See the pairing note in the header. */
-const MUTED = "var(--faction-wow-card-muted)";
+const MUTED = "var(--wow-edit-praxis-quiet, var(--faction-wow-card-muted))";
 /**
  * The same quiet register on the PLATE. `--faction-wow-card-muted` is measured
  * against the cream card and is 4.24:1 on the inset parchment — which is why
@@ -193,7 +208,7 @@ const PANEL_QUIET = "var(--faction-wow-chronicle-quiet)";
 /** The label/eyebrow ink, the one measured on BOTH chronicle grounds. */
 const LABEL = "var(--faction-wow-accent-deep)";
 /** Plum as INK — the one member of this palette that flips with the theme. */
-const PLUM = "var(--faction-wow-card-accent)";
+const PLUM = "var(--wow-edit-praxis-accent, var(--faction-wow-card-accent))";
 /** Plum as a SURFACE. Theme-invariant, with its own AA ink below. */
 const PLUM_FILL = "var(--faction-wow-plum-surface)";
 const ON_PLUM = "var(--faction-wow-on-plum)";
@@ -354,7 +369,11 @@ export default function WowEditPraxis({ state }: Props) {
   const dress: ComposerDress = {
     accent: PLUM,
     alarm: ALARM,
-    pageStyle: { fontFamily: LORA, color: INK },
+    pageStyle: {
+      ...factionRoleVars("wow", "wow-edit-praxis"),
+      fontFamily: LORA,
+      color: INK,
+    },
     sheetStyle,
     masthead,
     ground,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
@@ -237,7 +237,12 @@ describe("the last two archetype seams of #1706", () => {
     "%s left-rules the task slip in its accent",
     (slug) => {
       const markup = render(slug);
-      expect(markup).toMatch(/border-left:2px solid var\(--[a-z-]+\)/);
+      // `[,)]` rather than `)`: a skin migrated onto `utils/factionRoles.ts`
+      // asks its faction for the `accent` ROLE and carries today's token as the
+      // fallback (#2674), so the rule reads `var(--<prefix>-accent, var(--…))`.
+      // What this asserts is unchanged — a token, never a literal — and the
+      // fallback itself is gated per faction (`factions/__tests__/*RoleMap`).
+      expect(markup).toMatch(/border-left:2px solid var\(--[a-z-]+[,)]/);
     },
   );
 });

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
@@ -241,7 +241,8 @@ describe("the last two archetype seams of #1706", () => {
       // asks its faction for the `accent` ROLE and carries today's token as the
       // fallback (#2674), so the rule reads `var(--<prefix>-accent, var(--…))`.
       // What this asserts is unchanged — a token, never a literal — and the
-      // fallback itself is gated per faction (`factions/__tests__/*RoleMap`).
+      // fallback itself is gated per surface, by
+      // `utils/__tests__/factionRoleMigration.test.ts`.
       expect(markup).toMatch(/border-left:2px solid var\(--[a-z-]+[,)]/);
     },
   );

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -7,6 +7,7 @@ import PraxisCard from "../../../components/praxisCard/PraxisCard";
 import { BalloonBunch, Bunting, Zig } from "../../../components/factionMarks/wowOrnament";
 import { WowSigil } from "../../../components/sigil/WowSigil";
 import { factionName, factionDescription } from "../../../utils/factions";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { computeFactionMultiplier } from "../../../utils/points";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
@@ -61,21 +62,33 @@ import type { FactionDetailState } from "../useFactionDetail";
  * contract below are the final ones.
  */
 
-const MED = "var(--faction-wow-card-font)"; /* MedievalSharp */
+/**
+ * THE FIVE CORE ROLES ARE ASKED FOR BY NAME (#2674). The `.wz-faction-grid`
+ * frame below spreads `factionRoleVars('wow', 'wow-faction-page')` beside the
+ * `--label-ink` repoint it already carries — the same seam, one level up: a
+ * custom property set once on the frame rather than a colour written at each
+ * site.
+ *
+ * Every read carries today's token as its fallback, so an unset prefix renders
+ * exactly what shipped. The names below that are NOT roles stay put — the olive
+ * label ink, the plum fill and its ink, the gold, the gilt, the plate, the
+ * hairline and the lift are this surface's own extras (decision 07).
+ */
+const MED = "var(--wow-faction-page-face, var(--faction-wow-card-font))"; /* MedievalSharp */
 const LORA = "var(--faction-wow-body-font)"; /* Lora */
 
-const INK = "var(--faction-wow-card-text)";
-const MUTED = "var(--faction-wow-card-muted)";
+const INK = "var(--wow-faction-page-ink, var(--faction-wow-card-text))";
+const MUTED = "var(--wow-faction-page-quiet, var(--faction-wow-card-muted))";
 /** Label ink. Olive-gold, the one measured to clear AA on the parchment field. */
 const LABEL = "var(--faction-wow-accent-deep)";
-const PLUM = "var(--faction-wow-card-accent)";
+const PLUM = "var(--wow-faction-page-accent, var(--faction-wow-card-accent))";
 const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
 const ON_PLUM = "var(--faction-wow-on-plum)";
 /** Frame + rule gold. Never an ink: 2.24:1 on the cream (§3). */
 const GOLD = "var(--faction-wow-chronicle-gold)";
 /** The burnt gold reserved for figures. */
 const GILT = "var(--faction-wow-stamp-total)";
-const CARD = "var(--faction-wow-card-bg)";
+const CARD = "var(--wow-faction-page-paper, var(--faction-wow-card-bg))";
 const PLATE = "var(--faction-wow-plate)";
 const HAIR = "var(--faction-wow-chronicle-rule)";
 const BORDER = "var(--faction-wow-chronicle-border)";
@@ -135,7 +148,12 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
     <div
       className="wz-faction-grid"
       data-skin="wow"
-      style={{ ["--label-ink" as string]: "var(--faction-wow-accent-deep)" } as CSSProperties}
+      style={
+        {
+          ...factionRoleVars("wow", "wow-faction-page"),
+          ["--label-ink" as string]: "var(--faction-wow-accent-deep)",
+        } as CSSProperties
+      }
     >
       {/* ── MAIN COLUMN ── */}
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -11,6 +11,7 @@ import { BalloonBunch, Bunting, Zig } from '../../../components/factionMarks/wow
 import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
+import { factionRoleVars } from '../../../utils/factionRoles'
 import { mediaUrl } from '../../../utils/media'
 import {
   bylineFaces,
@@ -125,22 +126,33 @@ import Breadcrumb from "../../../components/nav/Breadcrumb";
  * heading suppressed so one list carries one heading (#1029).
  */
 
-const MED = 'var(--faction-wow-card-font)' /* MedievalSharp */
+/**
+ * THE FIVE CORE ROLES ARE ASKED FOR BY NAME (#2674). The parchment field below
+ * (`.wow-detail-field`) spreads `factionRoleVars('wow', 'wow-praxis-page')`,
+ * and the prefix is declared THERE rather than on the outer wrapper, which also
+ * holds the neutral shared `Breadcrumb` above the surface (#2102).
+ *
+ * Every read carries today's token as its fallback. The names below that are
+ * NOT roles stay put: the scribe's hand, the olive label ink measured on BOTH
+ * grounds, the gold, the inset and the hairline are this surface's own extras,
+ * which decision 07 leaves to the surface.
+ */
+const MED = 'var(--wow-praxis-page-face, var(--faction-wow-card-font))' /* MedievalSharp */
 const LORA = 'var(--faction-wow-body-font)' /* Lora */
 /** The scribe's marginal hand. A SURFACE face (§4), not Coven's card font. */
 const HAND = 'var(--font-faction-script)' /* Caveat */
 
-const INK = 'var(--faction-wow-card-text)'
+const INK = 'var(--wow-praxis-page-ink, var(--faction-wow-card-text))'
 /** Metadata ink. 4.52:1 inside a cream plate — NOT legible enough on the field. */
-const MUTED = 'var(--faction-wow-card-muted)'
+const MUTED = 'var(--wow-praxis-page-quiet, var(--faction-wow-card-muted))'
 /** Label ink, the one measured on BOTH grounds: 5.32:1 on the cream plate and
  *  5.06:1 on the darker parchment field this page lays its headers straight on. */
 const LABEL = 'var(--faction-wow-accent-deep)'
 /** Plum as INK — this one flips with the theme. 5.11:1 on the field. */
-const PLUM = 'var(--faction-wow-card-accent)'
+const PLUM = 'var(--wow-praxis-page-accent, var(--faction-wow-card-accent))'
 /** Frame + rule gold. Theme-invariant, and never an ink: 2.24:1 on the cream. */
 const GOLD = 'var(--faction-wow-chronicle-gold)'
-const CARD = 'var(--faction-wow-card-bg)'
+const CARD = 'var(--wow-praxis-page-paper, var(--faction-wow-card-bg))'
 const INSET = 'var(--faction-wow-detail-inset)'
 const HAIR = 'var(--faction-wow-chronicle-rule)'
 
@@ -731,6 +743,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
       <div
         className="wow-detail-field"
         style={{
+          ...factionRoleVars('wow', 'wow-praxis-page'),
           position: 'relative',
           zIndex: 1,
           maxWidth: 1200,

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -5,6 +5,7 @@ import PraxisCard from "../../../components/praxisCard/PraxisCard";
 import { BalloonBunch, Bunting, Zig } from "../../../components/factionMarks/wowOrnament";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionFill, factionName } from "../../../utils/factions";
+import { factionRoleVars } from "../../../utils/factionRoles";
 import { mediaUrl } from "../../../utils/media";
 import {
   actionColumnSize,
@@ -75,17 +76,30 @@ import Breadcrumb from "../../../components/nav/Breadcrumb";
  * forbids. Nothing about how they render changed.
  */
 
-const MED = "var(--faction-wow-card-font)"; /* MedievalSharp */
+/**
+ * THE FIVE CORE ROLES ARE ASKED FOR BY NAME (#2674). The parchment field below
+ * (`.wow-detail-field`) spreads `factionRoleVars('wow', 'wow-task-page')`, and
+ * the prefix is declared THERE rather than on the outer wrapper: the wrapper
+ * also holds `Breadcrumb`, which is neutral site chrome above the surface
+ * (#2102) and has no business inheriting a faction's roles.
+ *
+ * Every read carries today's token as its fallback. The nine names that are NOT
+ * roles below — the olive label ink, the plum fill and its edge, the gilt, the
+ * inset, the hairline — stay exactly as they are: decision 07 leaves a surface's
+ * extras to the surface, and several of them exist precisely because they were
+ * measured against a ground the core map does not describe.
+ */
+const MED = "var(--wow-task-page-face, var(--faction-wow-card-font))"; /* MedievalSharp */
 const LORA = "var(--faction-wow-body-font)"; /* Lora */
 
-const INK = "var(--faction-wow-card-text)";
-const MUTED = "var(--faction-wow-card-muted)";
+const INK = "var(--wow-task-page-ink, var(--faction-wow-card-text))";
+const MUTED = "var(--wow-task-page-quiet, var(--faction-wow-card-muted))";
 /** Label ink. Olive-gold, the one measured to clear AA on BOTH grounds — the
  *  cream card (5.32:1) and, unlike `--faction-wow-card-muted` (4.20:1), the
  *  darker parchment field this page lays its headers straight onto. */
 const LABEL = "var(--faction-wow-accent-deep)";
 /** Plum as INK/ornament — flips with the theme. */
-const PLUM = "var(--faction-wow-card-accent)";
+const PLUM = "var(--wow-task-page-accent, var(--faction-wow-card-accent))";
 /** Plum as a FILL — theme-invariant, 5.16:1 under `--faction-wow-on-plum`. */
 const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
 const PLUM_EDGE = "var(--faction-wow-plum-edge)";
@@ -94,7 +108,7 @@ const ON_PLUM = "var(--faction-wow-on-plum)";
 const GOLD = "var(--faction-wow-chronicle-gold)";
 /** The burnt gold reserved for the total. 4.80:1 on the plaque. */
 const GILT = "var(--faction-wow-stamp-total)";
-const CARD = "var(--faction-wow-card-bg)";
+const CARD = "var(--wow-task-page-paper, var(--faction-wow-card-bg))";
 const INSET = "var(--faction-wow-detail-inset)";
 const HAIR = "var(--faction-wow-chronicle-rule)";
 
@@ -796,6 +810,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
       <div
         className="wow-detail-field"
         style={{
+          ...factionRoleVars("wow", "wow-task-page"),
           position: "relative",
           zIndex: 1,
           maxWidth: 1200,

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -4504,7 +4504,15 @@ describe("the collab block takes its dress from the skin (#2269, #2267)", () => 
    */
   function tokenOfConst(name: string, sources: string[]): string | null {
     for (const source of sources) {
-      const found = new RegExp(`\\b${name} = "var\\((--[a-z-]+)\\)"`).exec(source);
+      // {@link ROLE_READ}: since #2674 WOW's `MUTED` is
+      // `var(--wow-edit-praxis-quiet, var(--faction-wow-card-muted))`. The
+      // token stays pinned exactly — only the wrapper is optional — so this
+      // widens the SPELLING and not the measurement. It is also the direction
+      // that cannot narrow: an unresolved const returns null here and the
+      // caller's `.toBe(skin.quiet)` goes red, so this guard fails closed.
+      const found = new RegExp(
+        `\\b${name} = ["']${ROLE_READ}var\\((--[a-z-]+)\\)${ROLE_READ_END}["']`,
+      ).exec(source);
       if (found) return found[1];
     }
     return null;

--- a/frontend/src/utils/__tests__/factionRoleMigration.test.ts
+++ b/frontend/src/utils/__tests__/factionRoleMigration.test.ts
@@ -74,7 +74,7 @@ interface Surface {
 }
 
 /**
- * Lane 06's contact sheet, in the one place a machine can read it.
+ * The lanes' contact sheets, in the one place a machine can read it.
  *
  * S.N.I.D.E. owns the repo's only ground override (`chrome.snide`), so its
  * ground is a real choice here rather than a formality. Every surface below is
@@ -195,6 +195,140 @@ const SURFACES: Surface[] = [
     ground: "sheet",
     sites: 1,
   },
+
+  /* ── Lane 04 (#2674): Warriors of Whimsy, 15 surfaces ────────────────────
+   *
+   * 97 core-role sites over 18 files. Three of the eighteen are absent here on
+   * purpose: `factionMarks/wowMobile`, `duel/wowLists` and
+   * `factionMarks/wowOrnament` are shared vocabulary with NO ROOT — six mobile
+   * skins and six ornament consumers mount them, several outside this lane — so
+   * they have no prefix to declare and take `factionRoleVar` instead. Their
+   * guard is `factions/__tests__/wowRoleMap.test.ts`, which also pins the three
+   * files carved out of every lane.
+   *
+   * Ten of the 97 sites were in those three modules, so 87 role reads is the
+   * whole of the rest: no site collapsed and none was added.
+   *
+   * EVERY ONE IS `sheet`. WOW declares no ground override at all, and none of
+   * these is app furniture — `chrome` in this repo is the rail. */
+  {
+    file: "components/taskCard/WowTaskCard.tsx",
+    slug: "wow",
+    prefix: "wow-task-card",
+    ground: "sheet",
+    sites: 6,
+  },
+  {
+    file: "components/praxisCard/desktop/WowPraxisCard.tsx",
+    slug: "wow",
+    prefix: "wow-praxis-card",
+    ground: "sheet",
+    sites: 9,
+  },
+  {
+    // One of the frozen four, and mounted inside four different hosts — which
+    // is exactly why the prefix is the STAMP's rather than borrowed from
+    // whichever surface it lands on.
+    file: "components/praxisCard/scoreStamp/WowScoreStamp.tsx",
+    slug: "wow",
+    prefix: "wow-score-stamp",
+    ground: "sheet",
+    sites: 8,
+  },
+  {
+    file: "components/feed/WowFeedFrame.tsx",
+    slug: "wow",
+    prefix: "wow-feed",
+    ground: "sheet",
+    sites: 6,
+  },
+  {
+    file: "components/selectCard/WowSelectCard.tsx",
+    slug: "wow",
+    prefix: "wow-select-card",
+    ground: "sheet",
+    sites: 9,
+  },
+  {
+    file: "components/metataskSeal/skins/WowSeal.tsx",
+    slug: "wow",
+    prefix: "wow-seal",
+    ground: "sheet",
+    sites: 7,
+  },
+  {
+    file: "components/comments/voices/WowComment.tsx",
+    slug: "wow",
+    prefix: "wow-comment",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    file: "components/factionHero/WowFactionHero.tsx",
+    slug: "wow",
+    prefix: "wow-hero",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    // 3 reads from 3 removals, two of which cross into the shared, faction-blind
+    // `BadgedAvatar` as PROPS — a custom property crosses that boundary where a
+    // prefix could not, which is why the declaration sits on the plate root.
+    file: "components/avatar/WowAvatar.tsx",
+    slug: "wow",
+    prefix: "wow-avatar",
+    ground: "sheet",
+    sites: 3,
+  },
+  {
+    file: "pages/taskDetail/archetypes/WowTaskDetail.tsx",
+    slug: "wow",
+    prefix: "wow-task-page",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    file: "pages/praxisDetail/archetypes/WowPraxisDetail.tsx",
+    slug: "wow",
+    prefix: "wow-praxis-page",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    file: "pages/factionDetail/archetypes/WowFactionBody.tsx",
+    slug: "wow",
+    prefix: "wow-faction-page",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    // The one surface in this lane whose prefix is declared on ONE of its two
+    // roots. The mobile pavilion is this file's own element; the desktop half
+    // hands a dress to the shared `ProfileSkin`, which owns the page element all
+    // nine factions mount on. Giving `ProfileDress` a root-vars slot is a
+    // component prop — tree work, not a paint lane's. Until then the desktop
+    // reads resolve through their fallbacks, which is byte-for-byte what
+    // shipped, and the rows below are what prove it.
+    file: "pages/characterProfile/archetypes/WowProfileBody.tsx",
+    slug: "wow",
+    prefix: "wow-profile",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    file: "pages/editPraxis/archetypes/WowEditPraxis.tsx",
+    slug: "wow",
+    prefix: "wow-edit-praxis",
+    ground: "sheet",
+    sites: 5,
+  },
+  {
+    file: "pages/characterPaths/archetypes/WowCreateCharacter.tsx",
+    slug: "wow",
+    prefix: "wow-create",
+    ground: "sheet",
+    sites: 4,
+  },
 ];
 
 /**
@@ -231,7 +365,7 @@ function roleReads(source: string, prefix: string): [FactionRole, string][] {
   });
 }
 
-describe("lane 06 — every migrated site keeps the value it shipped with", () => {
+describe("every migrated site keeps the value it shipped with", () => {
   it.each(SURFACES)(
     "$file declares $prefix once, on the $ground ground",
     ({ file, slug, prefix, ground }) => {


### PR DESCRIPTION
Closes #2674

Lane 04 of "Nine Kits, One Vocabulary" (#2649). Fifteen WOW surfaces and three
rootless kit modules stop naming `--faction-wow-*` and ask the faction for a
ROLE instead. **No colour, no radius, no face changes.**

## The seam I tested at, and the failing test first

**The seam is the read: `var(--<surface-prefix>-<role>, <today's token>)`** —
the one place a surface meets `utils/factionRoles.ts`. Both halves can be wrong
invisibly:

- a **misspelled prefix** renders as the fallback and looks perfect;
- a **wrong fallback** is a repaint hiding in a refactor, and WOW declares no
  ground override, so the declared value and the fallback are the same string
  and the wrong one **never renders** — it would surface years later, on the
  first ground override, as a colour nobody changed.

The loop went red on that defect before any source moved (`aa27a47d`, 51
failures). It is now green, and the gate lives in
`utils/__tests__/factionRoleMigration.test.ts` — lane 06's file, extended rather
than duplicated.

## 1. Computed-value diff — the merge gate

**Zero rows changed, and it is proven mechanically rather than asserted here.**
`factionRoleMigration.test.ts` re-derives every fallback in every migrated file
from the resolver and fails if one drifts; 62 tests, 30 surfaces.

The proof is one line of arithmetic. WOW appears in **no** `GROUND_OVERRIDES`
entry, so `rolesFor('wow', 'sheet') === SHEET_ROLES`, and therefore for every
role `factionRoleVars('wow', p)[--p-<role>] === factionRoleVar('wow', <role>)`
=== the exact token the site named before. **Declared value and fallback are the
same string at every one of the 87 sites**, so the read resolves identically
whether the prefix is declared or not.

| role | old var | new var | declared value |
|---|---|---|---|
| `paper` | `var(--faction-wow-card-bg)` | `var(--<p>-paper, …)` | `var(--faction-wow-card-bg)` |
| `ink` | `var(--faction-wow-card-text)` | `var(--<p>-ink, …)` | `var(--faction-wow-card-text)` |
| `quiet` | `var(--faction-wow-card-muted)` | `var(--<p>-quiet, …)` | `var(--faction-wow-card-muted)` |
| `accent` | `var(--faction-wow-card-accent)` | `var(--<p>-accent, …)` | `var(--faction-wow-card-accent)` |
| `radius` | `var(--faction-wow-card-radius)` | `var(--<p>-radius, …)` | `var(--faction-wow-card-radius)` |
| `face` | `var(--faction-wow-card-font)` | `var(--<p>-face, …)` | `var(--faction-wow-card-font)` |

`line`, `fill` and `onFill` are **declared and read by nothing** — WOW's TSX has
zero reads of `-card-border` or `-on-fill`, and its bare fill only in files
outside this lane. That is the rail's declares-nine-reads-seven ruling, inherited.

### The frozen four

| surface | rows changed |
|---|---|
| `WowTaskCard.tsx` | **0** |
| `WowPraxisCard.tsx` | **0** |
| `WowScoreStamp.tsx` | **0** |
| `vote` (`VoteShell.tsx`) | **0 — not touched at all** |

## 2. Contact sheet

Prefixes are qualified with `wow-` on purpose. The prefix belongs to the
SURFACE, but nine parallel lanes are migrating nine task cards, and a bare
`--task-card-paper` would be nine files claiming one name.

| surface | prefix | ground | reads | declared on |
|---|---|---|---|---|
| `components/taskCard/WowTaskCard.tsx` | `wow-task-card` | sheet | 6 | the `<article>` sheet |
| `components/praxisCard/desktop/WowPraxisCard.tsx` | `wow-praxis-card` | sheet | 9 | the chronicle sheet |
| `components/praxisCard/scoreStamp/WowScoreStamp.tsx` | `wow-score-stamp` | sheet | 8 | the plate itself |
| `components/selectCard/WowSelectCard.tsx` | `wow-select-card` | sheet | 9 | the placard root |
| `components/metataskSeal/skins/WowSeal.tsx` | `wow-seal` | sheet | 7 | the writ root |
| `components/feed/WowFeedFrame.tsx` | `wow-feed` | sheet | 6 | the `<article>` |
| `components/comments/voices/WowComment.tsx` | `wow-comment` | sheet | 5 | the SHEET, not the flex row |
| `components/factionHero/WowFactionHero.tsx` | `wow-hero` | sheet | 5 | the banner PLATE, not the `<header>` |
| `components/avatar/WowAvatar.tsx` | `wow-avatar` | sheet | 3 | the plate root |
| `pages/taskDetail/archetypes/WowTaskDetail.tsx` | `wow-task-page` | sheet | 5 | `.wow-detail-field` |
| `pages/praxisDetail/archetypes/WowPraxisDetail.tsx` | `wow-praxis-page` | sheet | 5 | `.wow-detail-field` |
| `pages/factionDetail/archetypes/WowFactionBody.tsx` | `wow-faction-page` | sheet | 5 | `.wz-faction-grid` |
| `pages/characterProfile/archetypes/WowProfileBody.tsx` | `wow-profile` | sheet | 5 | the mobile pavilion — see caveat |
| `pages/editPraxis/archetypes/WowEditPraxis.tsx` | `wow-edit-praxis` | sheet | 5 | `dress.pageStyle` |
| `pages/characterPaths/archetypes/WowCreateCharacter.tsx` | `wow-create` | sheet | 4 | `ComposerPage`'s `style` |
| `components/factionMarks/wowMobile.tsx` | **none** — `factionRoleVar` | — | 5 | rootless |
| `components/duel/wowLists.tsx` | **none** — `factionRoleVar` | — | 4 | rootless |
| `components/factionMarks/wowOrnament.tsx` | **none** — `factionRoleVar` | — | 1 | rootless |

**Every surface is `sheet`.** None of these is app furniture — `chrome` in this
repo is the rail — and WOW declares no ground override at all, so `chrome` would
have been a formality even where it was arguable. **No surface here asks for
`chrome`.**

### Three files could not pick a prefix, and that is the shape, not a shortcut

A prefix is declared on a root and read below it. `wowMobile`, `wowLists` and
`wowOrnament` have **no root**: they are the shared vocabulary six mobile skins,
six ornament consumers and the duel seal compose from, mounted under many
different roots — `WowFieldDesk`'s and `WowDuelSealConfirm`'s among them, both
**outside this lane**. One prefix shared between the vocabulary and every host
would BE the `--kit-*` namespace the law declines; handing each host's prefix
down is a component prop, which is tree work. So they take `factionRoleVar`, the
resolver's own answer for a single role with no all-or-nothing seam to protect.
It returns the identical string the constants held before.

### One caveat: `WowProfileBody` owns only one of its two roots

The mobile pavilion is this file's own element and declares the prefix. The
**desktop** half hands a `ProfileDress` to the shared `ProfileSkin`, which owns
the page element all nine factions mount on — so its reads resolve through their
fallbacks, byte-for-byte what shipped. Giving `ProfileDress` a root-vars slot is
a component prop, i.e. tree work, and I did not do it in a paint lane. Flagging
it rather than burying it. (The two composers did **not** need this:
`ComposerPage` already spreads the style object it is handed onto its root.)

## 3. What to eyeball — visual QA is outstanding

I have no browser and no dev stack. Every claim above is static or test-backed.
The combinations worth a human's eyes, cheapest first:

- **A WOW task card and a WOW praxis card, side by side, both cascades.** Two of
  the frozen four, and both mount `WowBand` — the carved-out shared masthead —
  *inside* a root that now declares nine new custom properties. What would be
  visible if the fallback logic were wrong: the plum banner or its gilt
  lettering shifting.
- **The score stamp in all four of its hosts** (praxis card, praxis detail,
  edit-praxis task slip, task detail), crowned and uncrowned. It is the one
  surface whose prefix is its own rather than its host's.
- **The character profile, DESKTOP and MOBILE, side by side.** This is the
  caveat above: the two halves now reach their inks by different paths, and they
  must look identical. If anything in this PR moved a pixel, it is most likely
  here.
- **The faction directory grid** with WOW's placard among the other eight —
  the leak a shared namespace would cause is exactly a neighbouring card
  repainting.
- **A WOW comment thread** (row and composer), because the crest is a *sibling*
  of the sheet that declares the prefix, not a descendant.
- **A WOW avatar at 24px and at 54px** — the rank pill and the monogram both
  read the prefix through props into the shared `BadgedAvatar`.
- **Both detail pages and the faction page**, dark mode, for the parchment field
  and the `--label-ink` repoint that now sits beside the role map.

## Verification

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` ·
`npm test` (**442 files, 8580 passed, 1 skipped**) · `npm run build` ·
`npm run budget` (JS 130.0 KB, CSS 22.1 KB — within budget, **unchanged**).

## Notes for review

**The site counts were verified, not obeyed.** The issue's table is exactly
right once comments are excluded: **100 core-role sites in 20 files**, less the
2 carved-out files (3 sites) = **97 in 18**, matching the epic. My first census
counted comment mentions and reported 122; the corrected one reproduces the
issue's per-file numbers exactly.

**Censused with BOTH spellings.** `factionCssVar("wow", …)` appears **nowhere**
outside tests. Two `factionCssVar(slug, …)` reads in `WowCreateCharacter` and
one `factionFill(…)` in `WowTaskDetail` take a **dynamic** slug for a
*different* faction — that is slot ownership, a column not a row, so batches
11+. No uncounted WOW core-role read exists.

**Carve-outs respected.** `VoteShell.tsx`, `factionBands.tsx` and
`utils/factions.ts` are untouched, and `factions/__tests__/wowRoleMap.test.ts`
now asserts the first two still name WOW directly — so a later lane that
helpfully tidies one breaks loudly instead of silently.

**`index.css` is untouched.**

### Guard hygiene (both findings from lane 06, verified here)

1. **`factionContrast.test.ts`'s `tokenOfConst` narrowed.** It greps
   `const X = "var(--token)"`, so WOW's `MUTED` stopped resolving the moment it
   became a role read. It fails **closed** — an unresolved const returns `null`
   and `.toBe(skin.quiet)` goes red, which is how it was caught — but the fix is
   lane 06's `ROLE_READ`/`ROLE_READ_END` fragment **reused**, not a second one.
   Count checked, not just colour: **1088 tests, unchanged**.
2. **I swept every other guard that reads these files' source** —
   `labelTierSweep`, `wowSealAccent`, `wowTaskCardV3`, `disabledControlContrast`,
   `roomPresenceContrast`, `duelCardOpponentInk`,
   `wowWearsTheDecreeRegister`. None enumerates rows from a token spelling I
   changed; `wowTaskCardV3`'s `toHaveLength(3)` counts `-gilt-mid` inside the
   carved-out `WowBand`. `WowFactionBody.tsx` **is** in my scope, and no contrast
   guard reads it — checked.
3. **`wowWearsTheDecreeRegister`'s rider 2 is resolved, not waived.** That sweep
   pins the tile's import list because an import can carry paint a text scan
   cannot see — and `factionRoleVars` builds its names by *interpolation*, so it
   is the first import that genuinely does. The scan now adds the nine names the
   resolver can emit, which is exact rather than approximate: it can emit this
   faction's nine core roles and nothing else.
4. **Three cross-faction tests fold the role read instead of restating prefixes**
   (`feedRowInk`, `feedArchiveControl`, `frameRadiusReadsTheToken`). One line
   each, in one place, so lanes 02/03/05 do not each have to add rows to a
   nine-faction table for a value nobody changed. `composerRule`'s regex widens
   from `)` to `[,)]` — still a token, never a literal.

### Follow-ups, not done here

- `ProfileDress` wants a root-vars slot so the desktop profile can declare its
  prefix (tree work, batches 11+).
- The three folded-read helpers are three copies of one two-line function.
  Deliberately not extracted to a shared test helper **while five lanes are in
  flight** — a new shared file is exactly the contended-file problem the lanes
  were cut to avoid. Worth one sweep once they have all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
