### PR TITLE
The filter facet inks only the seven themed marks, so na and Albescent keep their spectrum (#2528)

### DIFF
--- a/frontend/src/components/sigil/FactionSigil.tsx
+++ b/frontend/src/components/sigil/FactionSigil.tsx
@@ -114,8 +114,22 @@ export function factionSigilRing(slug: string | null | undefined): string | unde
  * re-deriving the fallback and proving its own copy instead.
  */
 export function DefaultSigilAdapter({ size }: SigilVariantProps) {
-  // The default ring has no color prop — it draws
-  // --faction-default-rainbow-conic.
+  /* NOT FORWARDED, AND THAT IS THE POINT (#2528). The note here used to say
+     "the default ring has no color prop", which stopped being true at #1892 —
+     `DefaultSigil` takes one now, for the sidebar's activity rail, which samples
+     a window of --faction-default-rainbow per row. That is the same stale-comment
+     shape that cost UA its ink at #2635, so it is corrected rather than left to
+     be read as a fact.
+
+     The behaviour is deliberately unchanged. `na` owns the spectrum (ADR-0039)
+     and it must not be repainted a solid; dropping the prop here is what kept
+     the filter facet's `factionCssVar('na')` — a flat --faction-default grey —
+     off the ring while it was still being passed, which is why the report
+     (#2528) named only Albescent's labyrinth, whose adapter DOES forward. With
+     the facet's guard in place nothing hands this a `color` at all, so
+     forwarding would be inert churn that only becomes visible the day someone
+     passes na a grey. The rail reaches `DefaultSigil` directly, not through the
+     dispatcher. */
   return <DefaultSigil size={size} />;
 }
 

--- a/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
@@ -27,6 +27,7 @@
  * only a click sets. The option list they render is what `factionFacet` and
  * `FilterOption` say it is, and that is what these tests pin.
  */
+import type { ReactElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect, vi } from 'vitest'
 
@@ -47,6 +48,8 @@ import {
   type SegmentBox,
 } from '../filterState'
 import type { FactionOut } from '../../../../api/factions'
+import type { FactionSigilProps } from '../../../sigil/FactionSigil'
+import { isKnownFaction } from '../../../../utils/factions'
 // The catalog itself, not a hardcoded string: the assertion has to fail if the
 // key is missing, not merely if the words drift.
 import common from '../../../../locales/en/common.json'
@@ -356,6 +359,40 @@ describe('factionFacet — the faction axis as one configuration of the widget',
     for (const place of ['row', 'trigger', 'chip'] as const) {
       expect(facet.renderOrnament?.('ua', place)).toBeTruthy()
     }
+  })
+
+  /**
+   * #2528. This facet is the only sigil mount in the tree that passes a `color`,
+   * and the ink it passes is `factionCssVar(slug)` — the faction's one solid hue.
+   * That is the point for the seven themed slugs: the mark has to read as that
+   * faction at the trigger's 13px, and #2635 is what made UA's actually land.
+   *
+   * `na` and `albescent` both map to CSS_KEY `default`, and `--faction-default`
+   * is a flat grey — so a solid handed to either paints over the spectrum they
+   * own (ADR-0039 for na, #783 for the labyrinth's deliberate absence of livery).
+   * The guard is on the SEAM, i.e. the element this facet builds, because that is
+   * where the decision is taken; what each mark does with a `color` it is given
+   * is the mark's own business and has already drifted once per adapter.
+   */
+  it('hands a solid ink only to a slug that owns one (#2528)', () => {
+    const facet = factionFacet(VISIBLE, [], () => {})
+    const inkFor = (slug: string) =>
+      (facet.renderOrnament?.(slug, 'trigger') as ReactElement<FactionSigilProps>)
+        .props.color
+
+    // The seven themed marks keep their hue, at every size.
+    expect(inkFor('ua')).toBe('var(--faction-ua)')
+    expect(inkFor('singularity')).toBe('var(--faction-singularity)')
+
+    // The two that own a spectrum get NO ink, and fall through to it.
+    for (const slug of ['na', 'albescent']) {
+      expect(isKnownFaction(slug)).toBe(false)
+      expect(inkFor(slug)).toBeUndefined()
+    }
+
+    // And the rule is the predicate, not a two-name denylist: an unregistered
+    // slug resolves to `default` too, so it must not be inked grey either.
+    expect(inkFor('not-a-faction')).toBeUndefined()
   })
 })
 

--- a/frontend/src/components/ui/FilterBar/factionFacet.tsx
+++ b/frontend/src/components/ui/FilterBar/factionFacet.tsx
@@ -20,6 +20,7 @@ import {
   factionCssVar,
   factionName,
   isFactionHiddenFromChoosers,
+  isKnownFaction,
   sortFactionsByRainbowOrder,
   UNAFFILIATED_FACTION_SLUG,
 } from '../../../utils/factions'
@@ -98,11 +99,25 @@ export function factionFacet(
     })),
     selected,
     onChange,
+    // A SOLID ONLY FOR A SLUG THAT OWNS ONE (#2528). This facet is the only
+    // sigil mount in the tree that passes a `color`, and it exists so a themed
+    // faction's mark reads as that faction at the trigger's 13px — #2635 is
+    // where that stopped being aspirational for UA. But `na` and `albescent`
+    // both resolve to CSS_KEY `default`, and `--faction-default` is a flat grey:
+    // handing it to them painted over the very spectrum they own — the
+    // unaffiliated rainbow (ADR-0039) and the labyrinth's deliberate lack of any
+    // livery of its own (#783) — so beside seven coloured marks they read as
+    // absent, which is the report. Unthemed means NO ink, and the mark falls
+    // through to its own default like every other mount in the app already does.
+    //
+    // `isKnownFaction` and not a two-name check: it tests the MAPPED value, so
+    // an unregistered slug — a deep-linked `?factions=whatever` — is unthemed by
+    // the same rule rather than inked grey by omission.
     renderOrnament: (slug, place) => (
       <FactionSigil
         slug={slug}
         size={SIGIL_SIZE[place]}
-        color={factionCssVar(slug)}
+        color={isKnownFaction(slug) ? factionCssVar(slug) : undefined}
       />
     ),
   }


### PR DESCRIPTION
Closes #2528

The filter facet is the only sigil mount in the tree that passes a `color`, and it
passed `factionCssVar(slug)` unconditionally. Both unthemed slugs resolve to
`CSS_KEY` value `default`, and `--faction-default` is a flat grey, so the facet
handed grey to the two marks that own a spectrum.

**The fix is a guard, not a dropped prop.** The owner has answered the question in
the issue body: the facet *should* pass a solid, but only for the seven themed
factions — that solid is why a themed mark reads as that faction at the trigger's
13px, and #2635 is where it stopped being aspirational for UA. So the ink is now
gated on `isKnownFaction(slug)`, and an unthemed slug gets no `color` and falls
through to the spectrum its own component draws.

`isKnownFaction` is reused, not reinvented — `utils/factions.ts` already documents
it as the way ornament surfaces reach the spectrum, and it tests the *mapped*
value, so a deep-linked unregistered slug is unthemed by the same rule rather than
inked grey by omission.

## The seam under test

`factionFacet(...).renderOrnament(slug, place)` — the element the facet builds, and
its `color` prop. That is where the decision is taken. The guard asserts the two
themed slugs still carry `var(--faction-ua)` / `var(--faction-singularity)`, that
`na`, `albescent` and an unregistered slug carry no ink at all, and it pins
`isKnownFaction(slug) === false` for the two so it fails loudly if that predicate's
meaning ever shifts.

Deliberately *not* asserted on rendered markup: what each mark does with an ink it
is handed is the mark's own business, and it has already drifted once per adapter —
which is the correction below.

Red first: `expected 'var(--faction-default)' to be undefined`.

## One correction to the issue body — na was never grey

The issue says na and Albescent both paint grey. **Only Albescent does.** Verified
against `origin/main`:

- `DefaultSigilAdapter({ size })` destructures `size` only and drops `color` on the
  floor, so `na` already fell through to `--faction-default-rainbow-conic`.
- `AlbescentSigilAdapter({ size, color })` forwards it, so the labyrinth alone
  landed on `--faction-default` (`#6b6a7a` light / `#8b8aa0` dark).

`DefaultSigilAdapter` carried a comment claiming "the default ring has no color
prop". That stopped being true at #1892 — `DefaultSigil` takes one now, for the
sidebar activity rail, which samples a window of the rainbow per row and reaches
`DefaultSigil` directly rather than through the dispatcher. **The comment is
corrected; the behaviour is not touched.** With the facet's guard in place nothing
hands that adapter a `color`, so forwarding it would be inert churn whose only
effect would be to repaint `na` grey the day someone passed one — the exact bug
this issue is about. This is the same stale-comment shape that cost UA its ink at
#2635, which is why it is worth correcting rather than leaving to be read as fact.

## Scope

The facet is the *only* offender. `CardMasthead`'s `markColor` is the one other
mount that passes an ink, and `factionBands.tsx` sets it only for themed bands
while `sealBands.tsx` already documents that na and Albescent are handed none.

Not touched, and not mine: `labyrinth.svg` / `favicon.svg` (the issue's "other
places", filed as #2683 and being fixed in parallel), and `SIGIL_SIZE` — the 13px
discussion in the issue is context, not scope.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 445 files, 8731 passed, 1 skipped |
| `npm run build` | built |
| `npm run budget` | JS 130.0 KB, CSS 22.1 KB — within budget, unmoved |

`api-schema` is untouched — no backend, route or Pydantic change.

**Visual QA is outstanding.** I have no browser and no dev stack, so everything
above is a code-seam proof. It is doubly outstanding here: until #2683 lands,
`labyrinth.svg` is not well-formed XML and Albescent's mark decodes nowhere, so the
grey this PR removes is currently *invisible* rather than wrong on screen. Eyeball
this after #2683 merges.

## What to eyeball

The filter facet, on any page that mounts one (Tasks, Praxes, Players, Updates), in
**both light and dark**:

- **the trigger** (13px, always on screen) — for a themed faction, for `na`, and for
  Albescent
- **the panel rows** (18px) — same three
- **the selected chips** (14px) — same three

Looking for: the seven themed marks still read as their own faction's hue at 13px,
and the unaffiliated ring and the labyrinth carry the rainbow rather than a flat
grey — the same spectrum they already wear on the players roster and the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
