### PR TITLE
Two one-line cleanups: a dead constant and a kit name that stopped resolving (#2665, #2625)

### DIFF
--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -80,7 +80,7 @@ internally and stacks single-column on a phone):
 the phone skins. Character profile went the same way in #1319 (`*ProfileBody`).
 
 **Mobile-only screens**: `DefaultFieldDesk` / `WowFieldDesk` / `UaFieldDesk` / `SnideFieldDesk` …
-(`fielddesk`), plus the singletons `DefaultTasks`, `DefaultSettings`,
+(`fielddesk`), plus the singletons `DefaultTasks`,
 `DefaultCreateCharacter`, `DefaultEditCharacter`, `DefaultFactionsDirectory`.
 Players is the one surface still split by form factor: `MobilePlayers` and
 `DesktopPlayers`, each taking the same `playersProps` shape.

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -16,8 +16,6 @@ from models.task import Task
 from services.character import ALBESCENT_FACTION_SLUG, can_start_as_albescent
 from services.era import get_current_era_row, get_or_create_stats
 
-UA_FACTION_SLUG: str = "ua"
-
 # UNAFFILIATED_FACTION_SLUG is imported above from faction_slugs, which owns it
 # (#1559). It used to be re-declared here and again in services/scoring.py.
 


### PR DESCRIPTION
Two unrelated one-line cleanups, kept as two commits so the diff reads cleanly.

Closes #2665
Closes #2625

## The seams

Neither change has a runtime seam, so neither gets a test — YAGNI. What each one *does* have is a
correspondence that can be checked by grep, and that is the seam I verified at:

- **#2665 — the reference surface of the symbol.** The question is "does anything read this name?",
  which lives in the repo's symbol graph, not in behaviour. A test asserting a deleted constant stays
  deleted would be a test of the grep.
- **#2625 — doc-name ↔ kit-registration correspondence.** The question is "does every component name
  in `.design-sync/conventions.md` still resolve to an export in `frontend/.ds-kit/index.tsx`?" That
  seam has no compiler behind it: `conventions.md` is prose, so `tsc` cannot catch a name that stopped
  resolving. Grep is the check.

## `UA_FACTION_SLUG` (#2665)

`backend/services/faction_service.py:19` declared `UA_FACTION_SLUG: str = "ua"` and nothing read it.

The issue carried an escape hatch — if the grep says otherwise by the time it is picked up, the code
wins. **I re-ran it against current `origin/main` (d3f98246) rather than trusting the issue**, and
widened it from `backend/` to the whole repo:

```
grep -rn "UA_FACTION_SLUG" backend/        -> 1 hit
git grep -n "UA_FACTION_SLUG" origin/main  -> 1 hit
```

Both return only `backend/services/faction_service.py:19`, the declaration itself. The hatch does not
trigger, so the deletion stands.

The commit also collapses the blank line the deletion orphaned. Without that, the import block was
followed by two blank lines and ruff raised a **new** `I001`. With it, the only finding left on the
file is the pre-existing `F401` for `CharacterStats`, which is unrelated and out of scope.

## `DefaultSettings` in the kit conventions (#2625)

`.design-sync/conventions.md:83` listed `DefaultSettings` as a kit singleton. #2154 deleted that
component (`frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx`, gone as of `6ddde148`)
along with its test, its `.ds-kit` registration, its preview and its `config.json` entry. Settings is
now one responsive `pages/Settings.tsx` with sections under `pages/settings/sections/`.

That file is a live conventions document telling a builder what the kit contains, so a name that no
longer resolves is a wrong instruction rather than a stale note.

Before editing the line I checked the rest of it, so as not to fix one dead name and leave another:

| Name on line 83-84 | Still exported from `frontend/.ds-kit/index.tsx`? |
|---|---|
| `DefaultTasks` | yes (line 69) |
| `DefaultCreateCharacter` | yes (line 52) |
| `DefaultEditCharacter` | yes (line 53) |
| `DefaultFactionsDirectory` | yes (line 56) |
| `DefaultSettings` | **no — removed** |

`frontend/src/pages/settings/mobileArchetypes/` no longer exists, and neither `.ds-kit/index.tsx` nor
`.design-sync/config.json` registers a Settings surface any more.

### What I deliberately did not touch

- **`docs/adr/0084-...md:173`** also names `DefaultSettings`. #2600 ruled on 2026-08-24 that ADRs are
  records of decisions taken and are not rewritten — rewriting their prose would falsify the log.
  0084 says *"today's"* and was accurate when accepted. Verified untouched in the diff.
- **The bigger question the issue floats** — whether 0084's argument still holds now that Settings is
  a non-dispatched page. Out of scope; it should not block or expand a one-line fix. If it needs
  settling, the remedy is a new ADR or an amendment note, not an edit to 0084's body.
- **`frontend/src/pages/settings/sections/AccountSection.tsx`** mentions `DefaultSettings` three
  times. Those are historical provenance notes about where the code was lifted from and are correct
  as written.

## Verification

- Re-verified the #2665 grep against current `origin/main` before deleting, and grepped each file on
  disk after editing to confirm the write landed.
- `ruff check` on `faction_service.py`: no new findings; the one remaining (`F401 CharacterStats`) is
  pre-existing on pristine `main`.
- `ruff format` reports a would-reformat hunk at `faction_service.py:198` — **pre-existing**, confirmed
  by running it against pristine `origin/main`, which produces the identical hunk. Left alone rather
  than bloating a one-line diff. Note CI runs no ruff step at all; `.github/workflows/test.yml` names
  only `test`, `api-schema` and `frontend`.
- Full suite: see the CI run on this head SHA, which runs all three jobs for real.

**Visual QA is outstanding** — I had no browser and no dev stack in this worktree. There is nothing
visual in this PR: one deleted Python constant with no readers, and one word removed from a markdown
document. No component, no CSS, no token, no copy a user can see.

## What to eyeball

1. The `.design-sync/conventions.md` line still reads as a sentence with `DefaultSettings` gone —
   `plus the singletons` now runs straight into `DefaultTasks`, then the four survivors on the
   next line.
2. `docs/adr/0084-...md` is genuinely absent from the diff (`git show --stat` is two files, not three).
3. The three `DefaultSettings` mentions in `AccountSection.tsx` are still there — they are meant to be.
4. `backend/services/faction_service.py` keeps exactly one blank line between the import block and the
   `# UNAFFILIATED_FACTION_SLUG is imported above` comment.
5. You agree the ADR-0084 question is a separate issue and not something this PR should have answered.
