### PR TITLE
S.N.I.D.E.'s chrome accent takes the wall's own marker: 1.03:1 becomes 7.71:1

### DIFF
--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2442,22 +2442,15 @@ const BASELINE: Record<string, { ratio: number; issue: number }> = {
   //       un-composited it would read clear — which is #594's mistake exactly.
   "dark | snide/chrome line on paper": { ratio: 2.77, issue: 2668 },
   //
-  //   (b) THE ONE THAT IS A DEFECT IN A GROUND OVERRIDE, NOT AN OLD DEBT.
-  //       S.N.I.D.E.'s `chrome` map (#2631/#2659) moves six roles onto the wall
-  //       family and leaves `accent` inheriting the sheet's
-  //       `--faction-snide-card-accent` — the acid, measured for the near-black
-  //       photocopier SLAB. The wall flips; in light it is #efece3, and the
-  //       acid reads 1.03:1 on it. That is the same shape as the `onFill` pair
-  //       #2659's review caught by eye and #2663 then made unrepresentable in
-  //       the type — a role left behind when its ground moved — and it is the
-  //       first thing this loop found that a human review had not.
-  //
-  //       Filed as #2669. It is almost certainly SATISFIABLE rather than a colour nobody
-  //       has: #2173 already ruled that `--faction-snide-acid` never touches
-  //       paper, and `-wall-credit` (6.28:1 light / 9.22:1 dark) is the rung of
-  //       the same hue the fill already moved to. Choosing it is a design call
-  //       with an owner, so it is filed rather than taken here.
-  "light | snide/chrome accent on paper": { ratio: 1.03, issue: 2669 },
+  //   (b) WAS THE ONE THAT IS A DEFECT IN A GROUND OVERRIDE, NOT AN OLD DEBT —
+  //       AND IT IS FIXED, SO ITS LINE IS GONE (#2669). S.N.I.D.E.'s `chrome`
+  //       map moved six roles onto the wall family and left `accent` inheriting
+  //       the sheet's `--faction-snide-card-accent`: the acid, measured for the
+  //       near-black photocopier SLAB, reading 1.03:1 on the light wall. The
+  //       owner took the candidate this loop's own note named — `-wall-credit`,
+  //       the rung of the same hue `fill` already moved to — so the entry was
+  //       DELETED rather than re-measured, which is the only lawful way a line
+  //       leaves this list.
 };
 
 function key(theme: Theme, pair: Pair): string {

--- a/frontend/src/utils/__tests__/factionRoles.test.ts
+++ b/frontend/src/utils/__tests__/factionRoles.test.ts
@@ -140,12 +140,17 @@ describe("a faction overrides for a ground its card sheet cannot serve (#2631, A
     ["ink", "var(--faction-snide-note-ink)"],
     ["quiet", "var(--faction-snide-note-muted)"],
     ["line", "var(--faction-snide-note-wall-edge)"],
+    // The acid was measured for the near-black slab and reads 1.03:1 on the
+    // light wall (#2669). `-wall-credit` is the rung of the hue `fill` already
+    // took here — 7.71:1 / 11.36:1, gated bare on this ground by
+    // `SNIDE_WALL_INKS` since #2343.
+    ["accent", "var(--faction-snide-wall-credit)"],
     ["fill", "var(--faction-snide-wall-credit)"],
-    // The pair, not a sixth independent choice — see the block below.
+    // The pair, not a seventh independent choice — see the block below.
     ["onFill", "var(--faction-snide-wall)"],
   ];
 
-  it("moves exactly the six roles the wall re-grounds", () => {
+  it("moves exactly the seven roles the wall re-grounds", () => {
     const chrome = factionRoleVars("snide", "rail", "chrome");
     const sheet = factionRoleVars("snide", "rail", "sheet");
     // `factionRoleProperty`, not `--rail-${role}`. Spelled the second way this

--- a/frontend/src/utils/factionRoles.ts
+++ b/frontend/src/utils/factionRoles.ts
@@ -153,13 +153,18 @@ const SHEET_ROLES: FactionRoleMap = {
  * This is the STRUCTURE half, and it is only half. #2661 landed the other one:
  * `factionContrast.test.ts` now loops over this resolver rather than a
  * hand-curated pair list, so a ground override's `onFill`/`fill` pair is
- * MEASURED and not merely present. It found the sibling this type cannot
- * express, on this very entry — the chrome ground moves `paper` to the wall
- * and leaves `accent` on `-card-accent`, which is the acid measured for the
- * near-black slab and reads 1.03:1 on the light wall. The type can force a
- * fill's ink to travel with it because they are one pair; it cannot know that
- * every OTHER ink must be re-measured when `paper` moves, which is a ratio and
- * so belongs to the loop.
+ * MEASURED and not merely present.
+ *
+ * MOVING `paper` RE-OPENS EVERY INK ON IT — THE RULE THIS TYPE CANNOT HOLD.
+ * The loop found the sibling on this very entry: the chrome ground moved
+ * `paper` to the wall and left `accent` on `-card-accent`, the acid measured
+ * for the near-black slab, reading 1.03:1 on the light wall (#2669, fixed
+ * below). So an override that names `paper` is re-measuring `ink`, `quiet`,
+ * `line` and `accent` whether it repoints them or not — inheriting one is a
+ * claim about a ratio, not a default. The type can force a fill's ink to travel
+ * with it because they are ONE PAIR and that is expressible; it cannot express
+ * "legible on", which is a number. Do not try to build it here — that is the
+ * contrast loop's job, and it is already doing it.
  */
 export type GroundOverride = Partial<Omit<FactionRoleMap, "fill" | "onFill">> &
   ({ fill: string | null; onFill: string } | { fill?: never; onFill?: string });
@@ -199,6 +204,23 @@ export type GroundOverride = Partial<Omit<FactionRoleMap, "fill" | "onFill">> &
  * 11.36:1 dark. Adding a second row would be a second name for one measurement,
  * which that file spends a paragraph warning against.
  *
+ * AND `accent` MOVES FOR THE THIRD TIME FOR THE SAME REASON: THE PAPER MOVED
+ * (#2669). It was the one ink this entry left on the card family, and the card
+ * family's accent is `--faction-snide-card-accent` — the acid, #b6ff2e, pinned
+ * invariant in both cascades because the slab it was measured on is near-black
+ * in both. On the wall that flips it reads 1.03:1 by day: invisible, and the
+ * first thing #2661's loop caught that a human review had not. #2173 had
+ * already ruled the acid never touches paper, which points the same way.
+ *
+ * It lands on `-wall-credit`, the rung of this hue the fill already moved to on
+ * this ground — no token minted, none repointed, and not a new measurement:
+ * `SNIDE_WALL_INKS` already gates it as a BARE ink on `-wall` (#2343, "the
+ * marker scrawl, bare"). 7.71:1 by day, 11.36:1 by night, against `accent`'s
+ * 4.5 text floor. It reads as an accent and not merely as a pass: the role is
+ * "decorative / meta ink — not `ink` at a lower alpha", and this is a hue of
+ * its own next to the neutral `-note-ink` / `-note-muted` tiers, the same
+ * marker the faction page scrawls its credits in.
+ *
  * `radius` and `face` stay on the card family on purpose.
  */
 const GROUND_OVERRIDES: Record<FactionGround, Record<string, GroundOverride>> = {
@@ -209,6 +231,7 @@ const GROUND_OVERRIDES: Record<FactionGround, Record<string, GroundOverride>> = 
       ink: "note-ink",
       quiet: "note-muted",
       line: "note-wall-edge",
+      accent: "wall-credit",
       fill: "wall-credit",
       onFill: "wall",
     },


### PR DESCRIPTION
Closes #2669

S.N.I.D.E.'s `chrome` ground moved six roles onto the wall family and left `accent`
inheriting the sheet's `--faction-snide-card-accent`. That token is the acid, `#b6ff2e`,
declared invariant in **both** cascades because the photocopier slab it was measured on is
near-black in both. The wall flips: by day it is `#efece3`, and the acid reads **1.03:1**
on it.

`accent` now reads `--faction-snide-wall-credit` — the owner's call, and the rung of the
same hue `fill` already moved to on this ground.

## The seam, and the red

The seam is the resolver, not a component: `factionRoleVar('snide', 'accent', 'chrome')`
feeding `factionContrast.test.ts`'s enumerated loop. Nothing renders `--rail-accent` today,
so there is no rendered seam to test at — which is the point of #2661 measuring the
resolver instead of the screen.

The failing test was the ratchet itself. Deleting the `"light | snide/chrome accent on
paper"` BASELINE line (commit 1) put the loop red on the real defect, one failure, before
any fix existed:

```
light | snide/chrome accent on paper: --faction-snide-card-accent (#b6ff2e)
  on --faction-snide-wall (#efece3) = 1.03:1, needs 4.5:1.
```

Commit 2 makes it green.

## The measurement is mine, and the issue's numbers had rotted

Measured against the real ground with the spec's own `resolveVar` / `parseColor` /
`contrastRatio`, not taken from the issue body:

| pair | light | dark | floor |
|---|---|---|---|
| `-wall-credit` on `-wall` (the new `accent`) | **7.71:1** | **11.36:1** | 4.5 (text) |
| `-card-accent` on `-wall` (what it replaces) | 1.03:1 | 16.33:1 | 4.5 |

The issue body says 6.28:1 / 9.22:1 for this pair. Those are stale — `#14532d` on `#efece3`
is 7.71:1 and `#4ade80` on `#0a0a0b` is 11.36:1 today. Clears either way; the direction of
the call is unchanged. (6.70:1 is the reading on `-wall-deep`, which is not this ground's
`paper`.)

This is not a new measurement, only a new reader of one: `SNIDE_WALL_INKS` has gated
`-wall-credit` bare on `-wall` since #2343 ("the marker scrawl, bare").

## It reads as an accent, not merely as a pass

`accent` is "decorative / meta ink — not `ink` at a lower alpha: several families give it a
hue of its own." `-wall-credit` is a hue of its own beside the neutral `-note-ink` /
`-note-muted` tiers, and it is the same marker the faction page already scrawls its credits
in. #2173's rule that the acid never touches paper pointed the same way.

## Constraints held

- **No new colour, no repointing.** `index.css` is untouched — 0 lines. `npm run budget`
  still reports CSS at 22.1 KB against the 22.2 KB warn line, unchanged.
- The BASELINE line was **deleted**, never re-measured. The `(b)` paragraph above it now
  records why it went, since the ratchet's own rule is that a line only ever leaves by
  being fixed.

## Scope item 3 — the note, not a mechanism

The `GroundOverride` docblock already argued the `fill`/`onFill` case. It now also states
the rule the type cannot hold: **naming `paper` re-opens every ink on it** — inheriting one
is a claim about a ratio, not a default. `fill`/`onFill` is expressible because it is one
pair; "legible on" is a number. No type-level mechanism was built, and the docblock says
why not.

`factionRoles.test.ts`'s "moves exactly the **six** roles" guard is now seven — the count
is the kind of thing that encodes a bug if left alone.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, run locally: `lint`,
`typecheck`, `typecheck:design-sync`, `test` (445 files / 8730 passed), `build`, `budget`.
Backend and `api-schema` are untouched — no route, schema or Pydantic model in the diff.

**Visual QA is outstanding: I have no browser and no dev stack.** Note that there may be
nothing on screen to look at — `--rail-accent` has no reader in the app today, so this is
latent. It is fixed anyway because the nine faction lanes are written against this
vocabulary, and the first lane to paint chrome meta-ink would have inherited an invisible
one.

## What to eyeball

- **The S.N.I.D.E. rail, light theme, once anything reads `--rail-accent`.** Meta ink should
  be the dark marker green `#14532d` on the flyposted wall, not acid.
- **The same in dark**, where it becomes mint `#4ade80` on near-black. The acid passed here
  (16.33:1), so dark is the cascade where this change is a *choice* rather than a repair —
  check the mint still reads as a decorative tier and does not compete with `-note-ink`.
- **`accent` beside `fill` on the same chrome surface.** Both now resolve `-wall-credit`, so
  a meta ink sitting on or next to a faction fill will be same-on-same. Nothing paints both
  today; the first lane that does needs to look.
- **The wall's corner washes.** The chrome `paper` is measured flat, but the wall carries an
  acid wash top-left and a pink one bottom-right (`SNIDE_WALL_GROUNDS`). `-wall-credit` is
  already gated in all four, so this is a look-not-measure check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
