### PR TITLE
The labyrinth and favicon SVGs parse again, so Albescent's sigil paints (#2683)

### DIFF
--- a/backend/tests/test_shipped_svgs_are_well_formed.py
+++ b/backend/tests/test_shipped_svgs_are_well_formed.py
@@ -1,0 +1,57 @@
+"""Guard: every SVG this repo commits parses as well-formed XML.
+
+An SVG is an XML document, and a browser that cannot parse one does not fall
+back to anything - it decodes nothing. When that SVG is a CSS `mask-image`,
+"decodes nothing" means the masked element is masked out entirely: it keeps its
+box, its background and its computed style, and paints zero ink.
+
+That is what happened to Albescent's sigil (#2683). `labyrinth.svg` carried a
+`--` as an em dash inside its explanatory comment, which XML forbids, so
+`AlbescentSigil` painted nothing on every surface in both themes. `favicon.svg`
+had the identical defect and the tab icon was dead with it.
+
+Nothing else in the repo could see it. The files are served `200
+image/svg+xml` with the right bytes - they are *served* fine, just unparseable;
+`getComputedStyle` reports the mask URL happily, because CSS accepts the URL
+and the decode fails later; layout is unchanged, because the box survives; the
+bundle wires the component up correctly. Every green check stayed green while
+the mark was invisible for weeks.
+
+So the check belongs at the only seam that can catch it: the bytes on disk, fed
+to a real XML parser. `git ls-files` is the file list rather than a hardcoded
+set of directories, so an SVG added anywhere is covered the day it lands.
+"""
+import subprocess
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _committed_svgs() -> list[Path]:
+    listing = subprocess.run(
+        ["git", "ls-files", "-z", "*.svg"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [_REPO_ROOT / name for name in listing.stdout.split("\0") if name]
+
+
+def test_every_committed_svg_parses_as_xml() -> None:
+    paths = _committed_svgs()
+    assert paths, "no committed .svg files found - has the glob or the repo root moved?"
+
+    broken: list[str] = []
+    for path in paths:
+        try:
+            ElementTree.parse(path)
+        except ElementTree.ParseError as error:
+            broken.append(f"{path.relative_to(_REPO_ROOT).as_posix()}: {error}")
+
+    assert not broken, (
+        "these SVGs are not well-formed XML, so no browser can decode them "
+        "(a `--` inside a comment is the classic cause - XML forbids it; use an "
+        "em dash or a single hyphen): " + "; ".join(broken)
+    )

--- a/frontend/public/factionMarks/labyrinth.svg
+++ b/frontend/public/factionMarks/labyrinth.svg
@@ -5,15 +5,24 @@
      BAND-TO-GAP RATIO, because the previous cut could not survive a small mount:
      its walls were 16% of the radius with 8% gaps over a 26-90% span, which at
      22px put the gaps at 0.9 device pixels and antialiased them into a solid
-     ring -- i.e. into na DefaultSigil silhouette, the one thing this mark must
+     ring — i.e. into na DefaultSigil silhouette, the one thing this mark must
      not converge on.
      This cut spends more of the radius (15-97%) and splits it 20% wall / 11%
      gap, and widens each entrance from 42 to 54 degrees about its ORIGINAL
-     centre (270 deg outer and inner, 90 deg middle), so nothing moves -- the
+     centre (270 deg outer and inner, 90 deg middle), so nothing moves — the
      openings only get wide enough to read.
      Arcs, not the polyline the 84px clip-path port produced: exact at every
      scale and a tenth of the bytes.
      It is an ALPHA STENCIL. The fill is discarded and the ink comes from a
-     token, the way enso.webp works -- see AlbescentSigil. -->
+     token, the way enso.webp works — see AlbescentSigil.
+
+     KEEP THIS COMMENT XML-LEGAL. It is a mask-image, so a parse error is not a
+     degraded render, it is no ink at all on every surface in both themes (and
+     nothing else in the repo notices — the file still serves 200, the CSS is
+     still valid, the box still measures). A double hyphen anywhere in here is
+     fatal and XML gives you no way to escape one, so write an em dash.
+     backend/tests/test_shipped_svgs_are_well_formed.py (#2683) catches it
+     now — including in this very sentence, which is why it spells the pair
+     out in words. -->
 <path fill="#000" d="M60.5 5.7A40.74 40.74 0 1 1 23.5 5.7L27.32 13.18A32.34 32.34 0 1 0 56.68 13.18ZM29.42 66.7A27.72 27.72 0 1 1 54.58 66.7L50.77 59.21A19.32 19.32 0 1 0 33.23 59.21ZM48.67 28.9A14.7 14.7 0 1 1 35.33 28.9L39.14 36.39A6.3 6.3 0 1 0 44.86 36.39Z"/>
 </svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -7,12 +7,16 @@
     under a dark color scheme so the icon always contrasts the tab bar.
 
     EVERY COLOUR IN THIS FILE IS A HAND-COPY OF THE LIGHT (`:root`) BLOCK OF
-    frontend/src/index.css:
+    frontend/src/index.css. Custom properties are named below WITHOUT their
+    leading double hyphen, because XML forbids that pair anywhere inside a
+    comment and a comment is not escapable — putting it back makes this file
+    unparseable and the tab icon blank (#2683). Restore the two hyphens in
+    front of each name when you go looking for it in index.css:
 
-      glyph ramp  --faction-default-stop-1 .. -stop-7  (the na spectrum,
-                  ADR-0039), at the offsets --faction-default-rainbow uses
-      .tile       --color-text-primary   (the light theme's ink)
-      dark .tile  --color-bg-page        (the light theme's paper)
+      glyph ramp  faction-default-stop-1 .. -stop-7  (the na spectrum,
+                  ADR-0039), at the offsets faction-default-rainbow uses
+      .tile       color-text-primary   (the light theme's ink)
+      dark .tile  color-bg-page        (the light theme's paper)
 
     The copy is not laziness and not drift: this file is served from `public/`,
     outside the bundle and outside the cascade. A favicon is a standalone
@@ -22,8 +26,8 @@
     (#1215) behind a comment that merely claimed they were the spectrum.
 
     It tracks the LIGHT stops on BOTH tiles, deliberately. Browser chrome
-    gives us no theme signal -- the `prefers-color-scheme` query below reads
-    the OS scheme, not the site's `[data-theme]` -- and this asset's flip runs
+    gives us no theme signal — the `prefers-color-scheme` query below reads
+    the OS scheme, not the site's `[data-theme]` — and this asset's flip runs
     *opposite* to the site's, since an OS dark scheme swaps in the LIGHT tile.
     Borrowing the `[data-theme="dark"]` stops would therefore lay colours
     brightened for dark grounds onto the pale tile. The dark block is a


### PR DESCRIPTION
`frontend/public/factionMarks/labyrinth.svg` and `frontend/public/favicon.svg` were not well-formed XML, so no browser could decode either. `AlbescentSigil` paints through `mask-image: url(/factionMarks/labyrinth.svg)`, and an undecodable mask image masks the element **out entirely** — the span keeps its 72px box and shows zero ink, on every surface, in both themes. That is the owner's "the sigil is missing in all kinds of places".

Closes #2683

## The seam I tested at

**The asset file as a document** — "do these committed bytes parse as XML?" Not the component, not the CSS, not the manifest. Every one of those is correct and every one of them stayed green while the mark was invisible, which is exactly why the bug survived review, CI and a prior investigation.

I wrote the guard first and it went red on the real defect before I touched either asset:

```
frontend/public/factionMarks/labyrinth.svg: not well-formed (invalid token): line 8, column 12
frontend/public/favicon.svg: not well-formed (invalid token): line 12, column 20
```

Those are the same two positions #2683 measured against production with libxml2 (it reports the column one lower). Independent confirmation of the diagnosis, from a different parser.

## What changed

**Comment-only, in both files.** Nothing outside a comment moves: no path, no stop, no fill, no offset. The #2509 re-cut is fine and the arcs are correct.

- `labyrinth.svg` — three `--` used as em dashes became `—`.
- `favicon.svg` — needed more than an em-dash swap, and this is the one thing the issue under-specifies. It had **six** offenders, not one. Two were em dashes; the other four were CSS custom-property names in its documentation table (`--faction-default-stop-1`, `--faction-default-rainbow`, `--color-text-primary`, `--color-bg-page`). XML has no escape for that pair inside a comment — entities are not recognised there — so those four are named without their leading hyphens, and the comment says so and says how to restore them when you go looking in `index.css`. `faviconSpectrum.test.ts` hardcodes the token names in TypeScript rather than reading them out of the comment, so it is unaffected (5/5 still pass).
- Both files gained a short note about the constraint, because the failure is silent in every direction.

## Verification (runnable)

**Both files parse.** `backend/tests/test_shipped_svgs_are_well_formed.py` walks `git ls-files '*.svg'` and feeds each to a real XML parser. Red before the fix (above), green after.

**The guard fails if you reintroduce a `--`.** Not a thought experiment — I did it by accident. My first draft of the warning notes quoted the forbidden pair literally, and the guard caught it at the exact new lines:

```
frontend/public/factionMarks/labyrinth.svg: ... line 22, column 48
frontend/public/favicon.svg: ... line 13, column 68
```

That is why both notes now spell "double hyphen" out in words. The guard earned its keep before it was merged.

**The labyrinth inks > 0 pixels.** I have no browser, so I did not re-measure this — I proved the stronger thing instead. A script stripped the comments from the pre-fix and post-fix bytes, parsed both, and canonicalised: the non-comment documents are **identical** for both files. #2683 measured "same paths, the double hyphen replaced" at **2637 inked pixels** at 72×72 (50.9% coverage) versus **0** for the shipped file. This PR ships exactly that document, so the measurement carries. The stencil is also non-degenerate on inspection: 1 path, 3 closed subpaths, 6 arcs — the three concentric walls.

**CI, run locally against `.github/workflows/test.yml`.** `npm run lint`, `npm run typecheck` (both configs), `npm run typecheck:design-sync`, `npm run build`, `npm run budget` (within budget — `public/` assets are not blocking, JS 130.0 KB / CSS 22.1 KB), and the full `npm test`: **445 files, 8730 passed, 1 skipped, 0 failed**. `ruff check` clean on the new test. `api-schema` is unaffected — no route, `response_model` or Pydantic schema is touched.

The backend suite could not run in full here: this worktree has no `.env`, so 11 unrelated test files fail to import on `DATABASE_URL`/`SECRET_KEY`/`MEDIA_BASE_URL`. That is pre-existing and environmental. The new guard is stdlib-only and needs no DB and no env — it passes in that same shell where those 11 cannot even import.

## Out of scope

`AlbescentSigil.tsx` is correct and untouched. `factionFacet.tsx` is untouched — #2528 is a separate defect on the same mark (the facet passes `factionCssVar(slug)`, flat grey for Albescent) and is being fixed in parallel. Fixing this one makes that grey observable rather than invisible.

## What to eyeball

**Visual QA is outstanding — I have no browser and no dev stack.** Nothing below was seen on screen; the evidence above is parser- and pixel-arithmetic, not eyes. Hard-refresh first, both themes: the old favicon and the old mask are very likely cached.

- The **Albescent faction page hero** — the sigil should be present at full size, the three concentric walls readable with their entrances open.
- The **filter facet** — expect the mark to appear here for the first time; if it is flat grey, that is #2528 and not this PR.
- The **players roster** — sigils on Albescent members' rows.
- The **sidebar activity rail**.
- The **credential card footer**.
- The **browser tab's favicon** — the rainbow WØ tile, and it should flip with the OS colour scheme (dark OS shows the pale tile, deliberately opposite to the site).
- Both themes on each, and one small mount (~22px) to confirm the #2509 re-cut still reads as a labyrinth rather than a solid ring.
