### PR TITLE
Four docs said the coverage gate was 80; CI has been failing under 92

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Python conventions live in `backend/CLAUDE.md`; frontend conventions in
 - Backend: `uvicorn main:app --reload` from `/backend`
 - Frontend: `npm run dev` from `/frontend`
 - DB: `docker-compose up -d`; `alembic upgrade head` after pulling
-- Tests: `pytest --cov=. --cov-fail-under=80` from `/backend`
+- Tests: `pytest --cov=. --cov-fail-under=92` from `/backend`
 
 Every backend command above needs `backend/.venv` activated, and the backend
 preview does **not** work from a worktree — worktrees carry no venv. Read

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -11,7 +11,7 @@ asyncio_default_test_loop_scope = session
 # Both pytest-timeout defaults are taken deliberately and must stay unset:
 #   - timeout_method: `signal` raises pytest.fail, so the session continues and
 #     fixtures finalise. `thread` calls os._exit(1), which would kill coverage
-#     reporting and the --cov-fail-under=80 gate with it.
+#     reporting and the --cov-fail-under=92 gate with it.
 #   - timeout_func_only: false, so the clock covers fixture setup and teardown.
 #     Load-bearing — the observed wedge named no test, i.e. it was at a file
 #     boundary, and func-only would sail straight past it.

--- a/docs/spec/SPEC-testing.md
+++ b/docs/spec/SPEC-testing.md
@@ -82,7 +82,7 @@ artifact. It is deliberately not on the PR-blocking path.
 The PR-blocking suite is `.github/workflows/test.yml`, and it is **three jobs**, all
 three of them required checks on `main`:
 
-- `test` — a Postgres service, `alembic upgrade head`, then `pytest --cov --cov-fail-under=80`
+- `test` — a Postgres service, `alembic upgrade head`, then `pytest --cov --cov-fail-under=92`
 - `frontend` — lint, `tsc --noEmit`, the `/design-sync` typecheck, vitest, `vite build`,
   and the initial-load byte budget
 - `api-schema` — regenerate `backend/openapi.json` and the generated TS types, then
@@ -90,7 +90,7 @@ three of them required checks on `main`:
 
 That workflow is the authoritative config (don't mirror its YAML here) — this list names
 the jobs because agents need to know how many gates exist, not what is inside them. Read
-the workflow for the steps. The coverage floor is 80% and should rise over time.
+the workflow for the steps. The coverage floor is 92% and should rise over time.
 
 Note `npm test` alone is only vitest, i.e. one of `frontend`'s six steps; it is not the
 frontend gate.


### PR DESCRIPTION
`.github/workflows/test.yml:60` runs `pytest --cov=. --cov-report=term-missing --cov-fail-under=92`. **Four places told a reader 80**, so a backend run that passed locally could still fail the required `test` check — the exact gap a "running locally" line exists to close.

| file | what it said |
|---|---|
| `CLAUDE.md:80` | the copy-pasteable local command |
| `backend/pytest.ini:14` | names the gate while arguing `timeout_method` |
| `docs/spec/SPEC-testing.md:85` | restates the `test` job's command |
| `docs/spec/SPEC-testing.md:93` | "The coverage floor is 80%" |

The ask was the `CLAUDE.md` line. I grepped before editing and found the same stale number in three more places; fixing only the one named would have left three docs still saying 80.

**Numbers only.** No gate moves, no behaviour changes — `test.yml` was already the authority and is untouched.

## How it surfaced

Found during `/builder-bot` while verifying a subagent's claim that CI ran no ruff step. That claim was a misreading — ruff *is* gated, by `backend/tests/unit/test_ruff_clean.py` inside the `test` job, deliberately, because `.github/workflows/**` is owner-only. But reading the workflow to check it surfaced this.

## One thing worth noting

`SPEC-testing.md` says *"That workflow is the authoritative config (don't mirror its YAML here)"* two lines above a mirrored value that had rotted. I left line 85 as a number rather than de-mirroring it, because that list names what the three jobs are and a bare `pytest --cov` would stop naming the gate at all. If you'd rather these stop restating the workflow, that's a different (and slightly larger) edit — say so.

A guard could prevent recurrence — assert every `--cov-fail-under=NN` in tracked files matches the workflow's. I did **not** build one: three of the four sites use that literal token but line 93's prose ("80%") wouldn't be caught, so it would be a partial guard for a number that moves rarely. Offered, not assumed.

## What to eyeball

Nothing on screen — documentation and one `.ini` comment. Worth confirming you're happy with 92 being stated as the floor in `SPEC-testing.md`, since that file frames it as a number that "should rise over time" and it has now risen.
