### PR TITLE
Guards resolve a role read instead of matching how it is spelled

### DIFF
--- a/frontend/src/components/__tests__/frameRadiusReadsTheToken.test.tsx
+++ b/frontend/src/components/__tests__/frameRadiusReadsTheToken.test.tsx
@@ -48,6 +48,7 @@ import EphemeristsPraxisCard from "../praxisCard/desktop/EphemeristsPraxisCard";
 import UaTaskCard from "../taskCard/UaTaskCard";
 import WowTaskCard from "../taskCard/WowTaskCard";
 import WowFeedFrame from "../feed/WowFeedFrame";
+import { resolveRoleReads } from "../../test/sourceScan";
 
 // `useTheme()` throws outside a `ThemeProvider` by design (#701) and the score
 // stamps reach for it. Nothing here depends on which half it gets.
@@ -99,18 +100,13 @@ const render = (node: ReactElement) =>
 const frameStyle = (html: string): string => {
   const match = /style="([^"]*border-radius[^"]*)"/.exec(html);
   expect(match, "nothing in this card declares a border-radius").not.toBeNull();
-  // Fold a ROLE READ back to its fallback (#2649's faction lanes, #2674 here).
-  // A migrated frame asks its faction for the `radius` role and carries today's
-  // token as the fallback — `var(--wow-feed-radius,
-  // var(--faction-wow-card-radius))` — which is the same value under a new
-  // spelling. Folding it keeps every row below pinned to its exact token
-  // instead of each lane restating its prefix in this cross-faction table; that
-  // the fallback IS the resolver's token is gated in
-  // `utils/__tests__/factionRoleMigration.test.ts`.
-  return (match as RegExpExecArray)[1].replace(
-    /var\(--[\w-]+,\s*(var\(--[\w-]+\))\)/g,
-    "$1",
-  );
+  // Fold a ROLE READ down to the token the map names (#2649's faction lanes,
+  // #2674 here). A migrated frame asks its faction for the `radius` role, so the
+  // attribute reads `border-radius:var(--leaf-task-card-radius)` and carries the
+  // map's declaration alongside it. `resolveRoleReads` resolves the one from the
+  // other, which keeps every row below pinned to its exact token instead of each
+  // lane restating its prefix in this cross-faction table.
+  return resolveRoleReads((match as RegExpExecArray)[1]);
 };
 
 const CASES = [
@@ -138,27 +134,19 @@ const CASES = [
 ] as const;
 
 /**
- * The frame's radius read from `token` — bare, or through one role read that
- * falls back to it.
+ * The frame's radius read from `token`, after any role read has been resolved.
  *
  * A #2659 lane moves a surface onto `factionRoleVars`, so the card emits
- * `border-radius:var(--leaf-task-card-radius, var(--faction-ua-card-radius))`. Same
- * computed value; the wrapper is allowed exactly one level deep and must fall
- * back to THIS token, so a card that copies the number still fails.
+ * `border-radius:var(--leaf-task-card-radius)` and the map supplies the token.
+ * `frameStyle` has already folded that, so a card that copies the NUMBER still
+ * fails — which is the whole point of #2403.
  */
-const radiusRead = (token: string) =>
-  new RegExp(
-    "border-radius:var\\(" +
-      token +
-      "\\)|border-radius:var\\(--[\\w-]+,\\s*var\\(" +
-      token +
-      "\\)\\)",
-  );
+const radiusRead = (token: string) => `border-radius:var(${token})`;
 
 describe("the frame radius is the token, not a copy of it (#2403)", () => {
   for (const { name, key, node } of CASES) {
     it(`${name} reads --faction-${key}-card-radius`, () => {
-      expect(frameStyle(render(node()))).toMatch(radiusRead(`--faction-${key}-card-radius`));
+      expect(frameStyle(render(node()))).toContain(radiusRead(`--faction-${key}-card-radius`));
     });
   }
 

--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -20,6 +20,7 @@ import FactionFeedFrame from '../feed/FactionFeedFrame'
 import FeedCardRouter from '../feed/FeedCardRouter'
 import { feedKicker } from '../feed/feedItemLabels'
 import type { ActivityFeedItem } from '../../api/activityFeed'
+import { resolveRoleReads } from "../../test/sourceScan";
 
 /** The chassis, exercised through the dispatcher the way the feed reaches it. */
 function frame(tag: string | null = null): string {
@@ -107,8 +108,8 @@ describe('the four chrome slots (the contract every frame owes)', () => {
     // `color` on what it sits in, never by rebuilding it.
     // The head's plum is the `accent` ROLE now (#2674), carrying today's
     // token as its fallback — the same value, asked for by role.
-    expect(frame()).toContain(
-      'color:var(--wow-feed-accent, var(--faction-wow-card-accent))',
+    expect(resolveRoleReads(frame())).toContain(
+      'color:var(--faction-wow-card-accent)',
     )
   })
 })
@@ -150,12 +151,12 @@ describe('the proclamation chrome', () => {
     // asks that the frame reads it — restating the pixel is the thing the token
     // exists to stop.
     const html = frame()
-    expect(html).toContain(
-      'border-radius:var(--wow-feed-radius, var(--faction-wow-card-radius))',
+    expect(resolveRoleReads(html)).toContain(
+      'border-radius:var(--faction-wow-card-radius)',
     )
     expect(html).toContain('2px solid var(--faction-wow-chronicle-gold)')
-    expect(html).toContain(
-      'background:var(--wow-feed-paper, var(--faction-wow-card-bg))',
+    expect(resolveRoleReads(html)).toContain(
+      'background:var(--faction-wow-card-bg)',
     )
   })
 

--- a/frontend/src/components/comments/__tests__/wowComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/wowComment.test.tsx
@@ -20,6 +20,7 @@ import i18n from '../../../i18n'
 import type { CommentOut } from '../../../api/comments'
 import type { CharacterOut } from '../../../api/auth'
 import WowComment from '../voices/WowComment'
+import { resolveRoleReads } from '../../../test/sourceScan'
 
 const COMMENT: CommentOut = {
   id: 7,
@@ -91,7 +92,7 @@ describe('the comment wears the proclamation chrome', () => {
     expect(html).toContain('2px solid var(--faction-wow-chronicle-gold)')
     // The sheet asks the faction for its `paper` ROLE (#2674) and carries
     // today's token as the fallback, so the cream is the cream it always was.
-    expect(html).toContain('background:var(--wow-comment-paper, var(--faction-wow-card-bg))')
+    expect(resolveRoleReads(html)).toContain('background:var(--faction-wow-card-bg)')
   })
 
   it('letters the name in MedievalSharp and the quiet register in Lora italic', () => {

--- a/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
@@ -46,6 +46,7 @@ import type { FeedFrameProps } from '../feedFrameProps'
 import { AA_LARGE, compositeOver, contrastRatio, formatRatio, parseColor, type Rgba } from '../../../utils/contrast'
 import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
 import '../../../i18n'
+import { resolveRoleReads } from '../../../test/sourceScan'
 
 const THEMES = readThemes(readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8'))
 
@@ -212,8 +213,7 @@ describe('the shared dismiss control', () => {
  * a shared, nine-faction row edited by every faction lane for a value nobody
  * changed.
  */
-const foldRoleReads = (html: string) =>
-  html.replace(/var\(--[\w-]+,\s*(var\(--[\w-]+\))\)/g, '$1')
+const foldRoleReads = resolveRoleReads
 
 describe.each(Object.entries(CASES))('%s: the band it is placed on', (name, { ink, ground, Frame }) => {
   if (Frame) {

--- a/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
@@ -38,6 +38,7 @@ import { normalizeFeedItem } from '../normalizeFeedItem'
 import { AA_NORMAL, compositeOver, contrastRatio, formatRatio, parseColor } from '../../../utils/contrast'
 import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
 import '../../../i18n'
+import { resolveRoleReads } from '../../../test/sourceScan'
 
 const THEMES = readThemes(readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8'))
 
@@ -137,8 +138,7 @@ const CASES = [
  * is a different guard: the rootless kit modules and the carve-outs.) Naming each surface's prefix in this nine-faction table
  * would instead make it a file every faction lane has to edit.
  */
-const foldRoleReads = (html: string) =>
-  html.replace(/var\(--[\w-]+,\s*(var\(--[\w-]+\))\)/g, '$1')
+const foldRoleReads = resolveRoleReads
 
 describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Frame, ink, ground, veil }) => {
   it('reaches the actor name inside children it did not mount', () => {

--- a/frontend/src/components/selectCard/__tests__/everymenWearsTheBillRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/everymenWearsTheBillRegister.test.ts
@@ -50,6 +50,7 @@ import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 
 import { readThemes, resolveVar, stripComments } from "../../../utils/__tests__/cssVars";
+import { resolveRoleReads } from '../../../test/sourceScan'
 
 const read = (relative: string): string =>
   readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
@@ -187,7 +188,9 @@ answer — not by widening this test.`,
         `the bill's poster face is no longer Bebas in ${theme}`,
       ).toBe('"Bebas Neue", Impact, sans-serif');
     }
-    const source = code(TILE);
+    // The tile asks for the `face` ROLE; `resolveRoleReads` folds that back to
+    // the token the map names, so this still pins the family and not a spelling.
+    const source = resolveRoleReads(code(TILE));
     expect(source, "the card names the faction's ROLE token").toContain("--faction-everymen-card-font");
     expect(source, "--font-faction-poster is retired, not merely unused here").not.toContain(
       'var(--font-faction-poster)',

--- a/frontend/src/components/selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 
 import { stripComments } from "../../../utils/__tests__/cssVars";
+import { resolveRoleReads } from '../../../test/sourceScan'
 
 const read = (relative: string): string =>
   readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
@@ -105,7 +106,9 @@ same question, not by widening this test.`,
     // directly and the unread global alias was retired. Here
     // `--faction-singularity-card-font` IS an alias to `--font-faction-terminal`,
     // so the family token keeps a reader and only the tile moves.
-    const source = code(TILE);
+    // The tile asks for the `face` ROLE; `resolveRoleReads` folds that back to
+    // the token the map names, so this still pins the alias and not a spelling.
+    const source = resolveRoleReads(code(TILE));
     expect(source, "--font-faction-terminal is the raw family").not.toContain("--font-faction-terminal");
     expect(source).toContain("--faction-singularity-card-font");
   });

--- a/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
@@ -67,6 +67,7 @@ import { describe, it, expect } from "vitest";
 
 import { FACTION_ROLES, factionRoleVar } from "../../../utils/factionRoles";
 import { readThemes, resolveVar, stripComments } from "../../../utils/__tests__/cssVars";
+import { resolveRoleReads } from '../../../test/sourceScan'
 
 const read = (relative: string): string =>
   readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
@@ -220,9 +221,9 @@ answer — not by widening this test.`,
   });
 
   it("sets the call in the decree's own face and size", () => {
-    const source = code(TILE);
+    const source = resolveRoleReads(code(TILE));
     expect(source, "MedievalSharp, asked for as the `face` ROLE (#2674)").toContain(
-      'fontFamily: "var(--wow-select-card-face, var(--faction-wow-card-font))", fontSize: "var(--text-content)"',
+      'fontFamily: "var(--faction-wow-card-font)", fontSize: "var(--text-content)"',
     );
     expect(
       source,

--- a/frontend/src/pages/editPraxis/__tests__/roomPresenceContrast.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/roomPresenceContrast.test.ts
@@ -41,6 +41,7 @@ import {
 import { readThemes, resolveVar, type Theme } from "../../../utils/__tests__/cssVars";
 import { paintedAwareness, type AwarenessLike } from "../roomPresence";
 import { BODY_EDITOR_BASE_THEME } from "../archetypes/bodyEditorTheme";
+import { resolveRoleReads } from "../../../test/sourceScan";
 
 const THEMES = readThemes(
   readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8"),
@@ -295,7 +296,12 @@ describe("the ground manifest above still matches the skins (#2267)", () => {
   // module that dresses that skin's body field.
   for (const ground of COMPOSER_GROUNDS) {
     it(`${ground.key} still dresses its body field with ${ground.ground}`, () => {
-      const source = readFileSync(fileURLToPath(new URL(ground.source, import.meta.url)), "utf8");
+      // The ink is the `ink` ROLE on a migrated composer, so the token is
+      // computed rather than written. `resolveRoleReads` folds it back, which
+      // keeps this pinned to the token and not to how it is spelled.
+      const source = resolveRoleReads(
+        readFileSync(fileURLToPath(new URL(ground.source, import.meta.url)), "utf8"),
+      );
       expect(source).toContain(ground.ground);
       expect(source).toContain(ground.ink);
     });

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -37,6 +37,7 @@ import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
 import type { CurrentUser } from "../../../api/auth";
 import { aMember, aPraxis } from '../../../test/fixtures'
+import { resolveRoleReads } from "../../../test/sourceScan";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -411,12 +412,11 @@ describe("UA praxis detail — the dress", () => {
     // to that same token so the figure reads as an aperture. A plate painted in
     // `-lift` or `-panel` breaks both.
     const { html } = render(state());
-    // Either the bare token or one role read that falls back to it: #2673 put
-    // this page on `factionRoleVars`, so the plate emits
-    // `background:var(--leaf-praxis-detail-paper, var(--faction-ua-card-bg))`. Same
-    // computed value, and a repoint to `-lift` or `-panel` still fails.
-    expect(html, "the rail plates are the sheet").toMatch(
-      /background:var\(--faction-ua-card-bg\)|background:var\(--[\w-]+,\s*var\(--faction-ua-card-bg\)\)/,
+    // #2673 put this page on `factionRoleVars`, so the plate reads the `paper`
+    // ROLE and the map supplies the token. `resolveRoleReads` folds the one into
+    // the other, so a repoint to `-lift` or `-panel` still fails.
+    expect(resolveRoleReads(html), "the rail plates are the sheet").toMatch(
+      /background:var\(--faction-ua-card-bg\)/,
     );
   });
 

--- a/frontend/src/test/sourceScan.ts
+++ b/frontend/src/test/sourceScan.ts
@@ -21,6 +21,13 @@ import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import {
+  FACTION_ROLES,
+  factionRoleProperty,
+  factionRoleVar,
+  type FactionGround,
+} from '../utils/factionRoles'
+
 /** `frontend/src`, the root every scan walks and every path is reported against. */
 export const SRC_DIR = fileURLToPath(new URL('..', import.meta.url))
 
@@ -73,3 +80,105 @@ export const toRelative = (path: string): string =>
 /** Read a scanned file with its comments already gone. */
 export const readStripped = (path: string): string =>
   stripComments(readFileSync(path, 'utf8'))
+
+/* -------------------------------------------------------------------------- */
+/* Role reads                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Fold every role read in `text` down to the token the role map names.
+ *
+ * A guard that asks "does this surface paint itself in the faction's own ink?"
+ * used to answer by looking for `--faction-ua-card-text` in the source or in the
+ * rendered markup. Since #2659 the surface spreads a map and reads
+ * `var(--leaf-task-detail-ink)` instead, so the token name is no longer written
+ * anywhere the guard can see it — it is computed. Twelve guards were widened
+ * one at a time to accept the transitional `var(--x-ink, var(--faction-…))`
+ * shape, and two of them grew a private `foldRoleReads` to do it; both copies
+ * broke the moment the fallback came off (#2689).
+ *
+ * So the fold lives here, and it resolves rather than pattern-matches. It reads
+ * the declarations out of the same text it is folding — either the
+ * `factionRoleVars("ua", "leaf-task-detail")` call in a source file, or the
+ * `--leaf-task-detail-ink:var(--faction-ua-card-text)` React renders into a
+ * style attribute — so a guard gets the token whether or not a fallback is
+ * still there, and keeps asserting the thing it was written to assert.
+ *
+ * It deliberately does NOT know the role vocabulary's tokens itself. Everything
+ * comes back through `factionRoleVar`, so a repointed role moves this on the
+ * same commit and no second table exists to drift.
+ */
+export function resolveRoleReads(text: string): string {
+  const tokens = roleDeclarations(text)
+  if (tokens.size === 0) return text
+
+  let out = ''
+  let cursor = 0
+  for (let i = text.indexOf('var('); i !== -1; i = text.indexOf('var(', i + 1)) {
+    if (i < cursor) continue
+    const closed = balancedEnd(text, i + 3)
+    if (closed === null) continue
+    const [property] = splitOnTopLevelComma(text.slice(i + 4, closed))
+    const token = tokens.get(property)
+    if (token === undefined) continue
+    out += text.slice(cursor, i) + token
+    cursor = closed + 1
+  }
+  return out + text.slice(cursor)
+}
+
+/**
+ * `--<prefix>-<role>` → the token it resolves to, harvested from whichever of
+ * the two shapes the text is in. A CSS declaration wins over a call, because a
+ * rendered style attribute is what the browser actually got.
+ */
+function roleDeclarations(text: string): Map<string, string> {
+  const tokens = new Map<string, string>()
+
+  const call = new RegExp(
+    String.raw`factionRoleVars\(\s*["'\`]([\w-]+)["'\`]\s*,\s*["'\`]([\w-]+)["'\`]\s*(?:,\s*["'\`](\w+)["'\`]\s*)?\)`,
+    'g',
+  )
+  for (const [, slug, prefix, ground] of text.matchAll(call)) {
+    for (const role of FACTION_ROLES) {
+      tokens.set(
+        factionRoleProperty(prefix, role),
+        factionRoleVar(slug, role, (ground ?? 'sheet') as FactionGround),
+      )
+    }
+  }
+
+  for (const [, property, token] of text.matchAll(
+    /(--[\w-]+)\s*:\s*(var\(--faction-[\w-]+\))/g,
+  )) {
+    tokens.set(property, token)
+  }
+
+  return tokens
+}
+
+/** Index of the `)` closing the `(` at `open`, or null. */
+function balancedEnd(text: string, open: number): number | null {
+  let depth = 0
+  for (let i = open; i < text.length; i += 1) {
+    if (text[i] === '(') depth += 1
+    else if (text[i] === ')') {
+      depth -= 1
+      if (depth === 0) return i
+    }
+  }
+  return null
+}
+
+/** `--x-ink, var(--y)` → `["--x-ink", "var(--y)"]`; no comma → one element. */
+function splitOnTopLevelComma(body: string): [string, string | null] {
+  let depth = 0
+  for (let i = 0; i < body.length; i += 1) {
+    if (body[i] === '(') depth += 1
+    else if (body[i] === ')') depth -= 1
+    else if (body[i] === ',' && depth === 0) {
+      return [body.slice(0, i).trim(), body.slice(i + 1).trim()]
+    }
+  }
+  return [body.trim(), null]
+}

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -94,7 +94,7 @@ import {
   type FactionGround,
   type FactionRole,
 } from "../factionRoles";
-import { readStripped, sourceFiles, toRelative } from "../../test/sourceScan";
+import { readStripped, resolveRoleReads, sourceFiles, toRelative } from "../../test/sourceScan";
 import { readThemes, resolveVar, stripComments, type Theme } from "./cssVars";
 
 const CSS_PATH = fileURLToPath(new URL("../../index.css", import.meta.url));
@@ -2479,9 +2479,21 @@ function ruleBody(selector: string): string {
   return CSS_TEXT.slice(at, CSS_TEXT.indexOf("}", at));
 }
 
-/** A component's source, for the same reason `ruleBody` exists. */
+/**
+ * A component's source, for the same reason `ruleBody` exists — with every role
+ * read folded down to the token the map names.
+ *
+ * The guards below hunt tokens in SOURCE rather than in `index.css`, and since
+ * #2659 a migrated surface no longer writes the token: it asks for a role and
+ * the map answers. Folding here rather than at each call site is what stopped
+ * this file needing a `roleRead()` regex wrapper around every hunted token —
+ * and it removes the failure mode that wrapper was written for, where a guard
+ * silently stops resolving and reports a file CLEANER than it is.
+ */
 function sourceOf(relative: string): string {
-  return readFileSync(fileURLToPath(new URL(`../../${relative}`, import.meta.url)), "utf8");
+  return resolveRoleReads(
+    readFileSync(fileURLToPath(new URL(`../../${relative}`, import.meta.url)), "utf8"),
+  );
 }
 
 /**

--- a/frontend/src/utils/__tests__/fontsLoaded.test.ts
+++ b/frontend/src/utils/__tests__/fontsLoaded.test.ts
@@ -8,6 +8,7 @@ import {
   type FactionGround,
   type FactionRole,
 } from "../factionRoles";
+import { resolveRoleReads } from "../../test/sourceScan";
 
 /**
  * Guard for the silently-unloaded font family (#839).
@@ -797,7 +798,11 @@ describe("an inherited page face is not asked to fake a bold (#2487)", () => {
 
   /** The families a composer's `pageStyle` puts on everything below it. */
   function pageFamilies(file: string): string[] {
-    const source = readSource(file);
+    // A composer that asks for the `face` ROLE writes `var(--x-face)`, which is
+    // no token any stylesheet declares — the map supplies it at render. Fold the
+    // role reads first so the reference below is a real token again, resolved
+    // through `factionRoleVar` rather than restated here (#2689).
+    const source = resolveRoleReads(readSource(file));
     const anchor = source.indexOf("pageStyle:");
     if (anchor === -1) return [];
     const offset = source.slice(anchor).search(/font-?[fF]amily\s*[:=]/);


### PR DESCRIPTION
Twelve guards answer *"does this surface paint itself in the faction's own
ink?"* by looking for `--faction-ua-card-text` in source or rendered markup.
Since #2659 a migrated surface does not write that token — it spreads a map and
reads `var(--leaf-task-detail-ink)`, so the name is computed.

Each guard was widened separately to accept the transitional
`var(--x-ink, var(--faction-…))` shape, and two grew a private `foldRoleReads`
to do it (`feedRowInk`, `feedArchiveControl` — byte-identical copies). Every one
of those widenings pins a **spelling**, which is the thing these guards exist to
stop being pinned to.

## The resolver

`resolveRoleReads` in `test/sourceScan.ts` folds a role read down to the token
the map names. It **resolves rather than pattern-matches**: it reads the
declarations out of the same text it is folding — either the
`factionRoleVars("ua", "leaf-task-detail")` call in a source file, or the
`--leaf-task-detail-ink:var(--faction-ua-card-text)` React renders into a style
attribute — so it works on source and on markup, with or without a fallback.

It knows no tokens of its own. Everything comes back through `factionRoleVar`,
so a repointed role moves it on the same commit and there is no second table.

`sourceScan.ts` is the right home: it already exists because nine guards each
carried their own tree walk and comment stripper — *"nine copies that drifted in
three directions"*.

## Guard by guard

| guard | what changed |
|---|---|
| `feedRowInk`, `feedArchiveControl` | the two private `foldRoleReads` copies deleted |
| `frameRadiusReadsTheToken` | a regex alternation accepting either shape collapses to the token |
| `factionContrast` | folded once in `sourceOf` — **12 failures, one edit** |
| `fontsLoaded` | `pageFamilies` resolves `var(--x-face)` to a real family again |
| `wowFeedChassis`, `wowComment`, `uaPraxisDetail`, `roomPresenceContrast`, 3 × selectCard register | arm literals become the token |

## Why this is worth doing on its own

Not that they pass — they pass today. That they now fail for the **right
reason**. `factionContrast`'s own header records Lane 06 breaking `pressGrounds`
the dangerous way round: it stopped resolving four of `SnideFieldDesk`'s aliases
and reported the file **cleaner than it is**. A guard that silently narrows is
worse than one that fails, and resolving cannot silently narrow.

## Verification

Green as committed: `npm run test` 9,374 passed, `lint` and `typecheck` clean.

Green with all 277 fallbacks stripped locally too — the only remaining failures
were the role gate's own REQUIRE clause, which is exactly what the next change
turns into its BAN clause. That is the real proof this PR works: it is the one
that makes the sweep possible.

No production source changed, so no pixel moves.

Refs #2689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
