### PR TITLE
Era 2 is not a config flip: ADR-0087 and the rollover findings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,6 +63,44 @@ _Avoid_: "the letter", "the prospectus", "the invitation" as a bare noun. It is 
 letter**, for all nine, and the words in prose do not follow whichever key family a given
 faction happens to use.
 
+**Structural slug** vs **roster faction** *(ADR-0087)*:
+The two populations a faction slug can belong to. **Structural** slugs carry a role the game
+cannot run without and are present in **every** era: `na` (the neutral faction — the
+born-unaffiliated state and the cross-faction task marker) and `albescent` (the endgame).
+`EraConfig.__post_init__` requires both, and `starting_faction_slug` / `reset_faction_slug`
+are pinned to `na`. Everything else is **roster** — the era's to choose, along with every
+perk on it. A perk may vanish between eras or move to a different faction; `ua` held the
+habit bonus, `coven` the collab bonus, `ephemerists` Task Vision, and none of the three
+exists in Era 2.
+_Avoid_: "the default faction" for `na` when you mean the structural role — `default` ≡ `na`
+≡ Unaffiliated is the *visual* identity (see **Default archetype**), which is a different
+question from which slugs an era must define.
+_Avoid also_: treating any Era 1 perk assignment as permanent. Ask the era which faction
+holds a perk; never name the faction.
+
+**Retired faction** *(ADR-0087; `FactionStatus.retired`)*:
+A faction that was in some past era and is not in the live one. Its row stays — never
+deleted, because `character.faction_slug` and `task.primary_faction_slug` are FKs onto it —
+but it leaves the faction registry and the join options. **Its task history stays in the
+archive**: retirement removes a faction from the *registry*, not from the *record*.
+Distinct from `hidden`, which means a system row (`na`, `aged_out`) no player may ever act
+on, and which is the only status `hidden_faction_slugs` returns.
+_Avoid_: "deleted", "removed" — a retired faction's members, tasks and praxes all still
+point at it. _Avoid also_: using `hidden` for retirement; that conflation would take Era 1's
+board out of the archive.
+
+**Per-era rules module** *(`backend/tests/eras/test_era_<key>_rules.py`)*:
+The one place an era's own rules are tested, passing that era's `EraConfig` explicitly rather
+than reading `CURRENT_ERA`. Every era in `_ERA_ATTRIBUTE_BY_CONFIG_KEY` must have one, and a
+guard requires the module to name every perk that era grants (walked from `_MAX_PERK_FIELDS`
+/ `_ANY_PERK_FIELDS` / `_DUEL_PERK_FIELDS`). It is what makes "which tests does this era
+need?" answerable — Era 2 was authored in #1618 granting four perks and none was exercised
+until the era went live. Its counterpart is the **era-agnostic** test, which asserts a
+mechanic that holds in every era and therefore may never name a faction: it reads the
+modifier off whichever slug the fixture actually got.
+_Avoid_: pinning a general mechanic to one era's config to make it pass — if it only holds
+for that era, it is that era's rule and belongs in its module.
+
 **Dispatcher**:
 The per-surface map (`Record<slug, Component>`) plus the `pickVariant` call that turns a
 faction slug into its archetype, falling back to the default. One dispatcher per surface.

--- a/docs/adr/0030-default-faction-behaviour-ua-is-ordinary-grid-is-a-directory.md
+++ b/docs/adr/0030-default-faction-behaviour-ua-is-ordinary-grid-is-a-directory.md
@@ -1,7 +1,21 @@
 # Default faction behaviour: UA is an ordinary faction; the grid is a directory, not a join surface
 
-**Status:** Accepted
+**Status:** Amended by ADR-0087
 **Date:** 2026-07-03
+
+## Amendment
+
+**Amended 2026-08-25 by [ADR-0087](0087-structural-faction-slugs-are-not-era-owned.md)** — the grid's hidden set is no longer
+`HIDDEN_SLUGS = {na, aged_out}`. A faction the **live era does not list** is `retired` and
+also absent from the directory, so the set is now "the sentinels, plus everything this era
+dropped". Era 2 retires four (`ua`, `coven`, `ephemerists`, `singularity`).
+
+This also retires the first bullet's subject as a standing fact: UA is an ordinary faction
+*in Era 1*. Faction-specific behaviour is per-era (ADR-0087), so UA's ordinariness — like
+Coven's collab bonus and Ephemerists' Task Vision — is an Era 1 statement, not a permanent one.
+
+The rest stands: the grid is a directory, not a join surface, and joining still happens on the
+faction detail page.
 
 Building on [ADR-0019](0019-characters-start-unaffiliated-invite-gated-factions.md)
 (characters are born unaffiliated `na`; faction membership is invite-gated), this

--- a/docs/adr/0042-era-as-ruleset-config-owns-rules-db-owns-history.md
+++ b/docs/adr/0042-era-as-ruleset-config-owns-rules-db-owns-history.md
@@ -1,12 +1,24 @@
 # ADR-0042 — Era-as-ruleset: `game_config` owns the rules, the DB owns only history
 
-**Status:** Accepted
+**Status:** Amended by ADR-0087
 **Date:** 2026-07-17
 
 **Relates to:** CLAUDE.md "Config architecture", `backend/game_config.py`, `backend/eras/`
 
 > Harvested from the retired `SPEC-architecture.md §4` during the 2026-07-17 docs
 > consolidation.
+
+## Amendment
+
+**Partly amended 2026-08-25 by [ADR-0087](0087-structural-faction-slugs-are-not-era-owned.md)** — the "era doc wins" posture below
+still governs every game rule, with **two named exceptions**. `EraConfig.starting_faction_slug`
+and `reset_faction_slug` are no longer era-overridable: both are pinned to `na`, validated in
+`EraConfig.__post_init__`. An era also may no longer omit `na` or `albescent` from its roster —
+those two slugs carry structural roles (neutral, and endgame) that are fixed across eras.
+
+Nothing else here moves. "Config owns the rules, the DB owns history" is reinforced by
+ADR-0087, not weakened: the reason the two fields are pinned is that they were never really
+*rules*, they were the names of structural slugs.
 
 ## Context
 

--- a/docs/adr/0087-structural-faction-slugs-are-not-era-owned.md
+++ b/docs/adr/0087-structural-faction-slugs-are-not-era-owned.md
@@ -1,0 +1,139 @@
+# ADR-0087 — Structural faction slugs are not era-owned; a dropped faction is retired, not deleted
+
+**Status:** Accepted
+**Date:** 2026-08-25
+
+**Amends:** [ADR-0042](0042-era-as-ruleset-config-owns-rules-db-owns-history.md) — the
+"era doc wins" clause, *as applied to two fields only*. `starting_faction_slug` and
+`reset_faction_slug` stop being era-overridable. Every other rule stays era-owned;
+the ADR's posture is otherwise untouched and is in fact reinforced below.
+**Amends:** [ADR-0030](0030-default-faction-behaviour-ua-is-ordinary-grid-is-a-directory.md) —
+the clause "hides only the non-destination sentinel slugs `na` and `aged_out`,
+implemented as `HIDDEN_SLUGS = {na, aged_out}`". The directory now also omits
+factions the live era does not list.
+
+**Relates to:** [ADR-0019](0019-characters-start-unaffiliated-invite-gated-factions.md)
+(born unaffiliated — reinforced, not changed), [ADR-0038](0038-faction-identity-is-config-canonical.md)
+(the `Faction` row is slug + status only), [ADR-0080](0080-one-life-earns-albescent-its-siblings-take-it-and-the-earner-never-can.md)
+and [ADR-0082](0082-albescent-is-redacted-not-hidden.md) (Albescent's eligibility and
+redaction — untouched), #1559 (which opened the seam this closes), #1618 (Era 2 authored).
+
+## Context
+
+Era 1 was the only era the code had ever run. Pointing `CURRENT_ERA` at Era 2 for the
+first time surfaced that "the roster is era-owned" had been applied too widely: the
+era config was treated as the authority on *every* faction slug, including the two
+that carry structural roles the game cannot function without.
+
+Two specific things went wrong, and neither is a bug in Era 2's config:
+
+1. **`na` and `albescent` were era-owned by omission.** Nothing required either to be
+   present. `faction_slugs.py` asserted that only `na` is structurally required and said
+   nothing about `albescent`; `EraConfig` checked neither. An era file could have dropped
+   `na` — the FK target for the born-unaffiliated state and for cross-faction tasks — and
+   the failure would have been a foreign-key violation at the first character creation.
+
+2. **Dropping a faction from the config did nothing to its row.** `seed.upsert_era_factions`
+   only ever added. `models.faction.FactionStatus` already documented the intended
+   behaviour — "retiring a faction means dropping it from the era config, which leaves its
+   row `hidden`" — but nothing implemented it, because until a second era went live no era
+   had ever dropped one. Era 2 drops four (`ua`, `coven`, `ephemerists`, `singularity`), so
+   `GET /factions` would have kept offering all four to join while `can_join_faction`, which
+   reads the era config, refused every one of them.
+
+The second is also where the existing two-value `FactionStatus` runs out. `hidden` was
+minted for *system* rows — `na`, `aged_out` — that no player should ever act on, and the
+one place that reads it (`services.task.list_tasks`, via `hidden_faction_slugs`) uses it to
+drop those factions' tasks from every listing. That filter has never excluded a row in
+production: `hidden_faction_slugs` subtracts `na` from its own result, leaving only
+`aged_out`, which no task carries. Retiring four real factions through the same flag would
+have activated a dormant filter and taken most of Era 1's task history out of the archive —
+including the retired archive `level_to_see_retired_tasks` unlocks at level 2 — while the
+praxes written against those tasks stayed visible, linking to tasks that appeared in no list.
+
+## Decision
+
+**Faction slugs fall into two populations, and only one of them is era-owned.**
+
+### Structural — fixed in every era
+
+- **`na` is the neutral faction in every era.** It must be present in `era.factions`. It is
+  the FK target for the born-unaffiliated state and for cross-faction tasks, and those two
+  meanings stay distinct (`UNAFFILIATED_FACTION_SLUG` / `CROSS_FACTION_SLUG` are not aliases).
+- **`albescent` is the endgame faction in every era.** It must be present in `era.factions`.
+  *Its gate is still era-tunable* — `albescent_level_required` and the coverage rule remain
+  ordinary era fields. What is fixed is that it exists and that it is the endgame.
+- **`starting_faction_slug` and `reset_faction_slug` are pinned to `na`.** Both stay as
+  `EraConfig` fields, validated in `__post_init__` rather than deleted, so a future era
+  author gets an instructive failure instead of a missing word. This closes the pre-sort
+  seam #1559 opened.
+- Enforcement is in `EraConfig.__post_init__`, so a malformed era file fails at import
+  rather than at the first request.
+
+### Roster — era-owned, as before
+
+Every other faction is the era's to choose, and so is every perk. A perk may vanish between
+eras or move to a different faction; nothing may assume Era 1's assignment. `ua` held the
+habit bonus, `coven` the collab bonus, `ephemerists` Task Vision — all three are absent from
+Era 2, and that is a design choice, not a regression.
+
+### A faction the live era does not list is *retired*
+
+`FactionStatus` gains a third value. The three now mean:
+
+| Status | Meaning |
+|---|---|
+| `visible` | In the live era. Listed in the registry, joinable subject to the ordinary gates |
+| `retired` | Was in some past era, not in the live one. Out of the registry and out of the join options; **its task history stays in the archive** |
+| `hidden` | A system row (`na`, `aged_out`) no player should ever act on. Never listed anywhere |
+
+`seed.upsert_era_factions` becomes a two-way mirror: it adds a row for every slug the live
+era lists, and marks `retired` every row the live era does not. **Rows are never deleted** —
+`character.faction_slug` and `task.primary_faction_slug` are FKs onto this table, and a
+closed era's characters and tasks are the history those columns point at.
+
+`hidden_faction_slugs` keeps returning `hidden` only. That is the whole point of the third
+value: retirement removes a faction from the *registry*, not from the *record*.
+
+## Consequences
+
+- **`FactionStatus` regains a third value that #1398 deliberately removed.** That deletion's
+  stated reason was "nothing else ever writes this column... no writer could produce it".
+  Retirement is exactly the writer that was missing, so the reason is void — but this ADR
+  exists partly so the next reader does not re-delete it on the old argument.
+- **The Factions grid loses four tiles at the Era 2 rollover** and gains them back only if a
+  later era lists those slugs again. Their kits (#1632 and others) stay in
+  `frontend/src/utils/factions.ts` and degrade to `default`; the work is dormant, not lost.
+- **Era 1's task archive survives the rollover**, which it would not have under a single
+  `hidden` flag.
+- **A character can hold a retired slug.** Between a deploy and the rollover, and in any era
+  that sets `reset_faction=False`, a character sits in a faction the live era has no config
+  for. `scoring.compute_faction_multiplier` already answers `1.0` for an unknown slug, and
+  the name still resolves from the copy catalog, so this degrades rather than breaks.
+- **Tests may not name a faction to get one.** A fixture may know only that it got *some*
+  faction; a test that asserts a score reads the modifier off the slug the fixture actually
+  used. A test whose subject is a specific perk finds the holder by the perk, or lives in
+  that era's own rules module.
+
+## Considered and rejected
+
+**Delete `starting_faction_slug` and `reset_faction_slug`.** With both pinned to `na` they
+are config for a value that never changes, and four call sites would inline
+`UNAFFILIATED_FACTION_SLUG` instead. Rejected because the fields are the vocabulary an era
+author would need to *express* the intent; a validated field explains the rule at the point
+someone tries to break it, a missing field explains nothing. Reopening the seam is deleting
+one validation line.
+
+**Require every era to declare a perk-free "baseline" faction** so fixtures have a neutral
+vehicle. Rejected: it makes game design serve the test suite. Era 2 gives all five of its
+factions something on purpose, and an era should stay free to do that.
+
+**One flag: retire through `hidden`.** Simplest, and it is what the `FactionStatus` docstring
+literally said. Rejected because it conflates "a system row nobody may act on" with "a real
+faction people were in", and the observable cost is Era 1's task archive disappearing.
+
+**Stop filtering tasks by faction status at all**, deleting the dormant filter instead of
+teaching it a third state. Genuinely the smaller change, and it would also have preserved the
+archive. Rejected because the filter is a live seam for a rule we may want (hiding a faction
+mid-era *should* be able to pull its tasks), and losing it to solve a different problem is a
+trade we would have to undo.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,7 +4,7 @@
      script instead. backend/tests/test_adr_index.py fails if this file
      is out of step with docs/adr/. -->
 
-86 records, of which **79 still state a rule**.
+87 records, of which **80 still state a rule**.
 
 | Status | Meaning |
 |---|---|
@@ -44,7 +44,7 @@
 | [0027](0027-albescent-is-a-secret-society.md) | Albescent is a secret society, revealed by a sticky per-account flag | Amended | [ADR-0080](0080-one-life-earns-albescent-its-siblings-take-it-and-the-earner-never-can.md), [ADR-0082](0082-albescent-is-redacted-not-hidden.md) |
 | [0028](0028-task-crown-replaces-faction-distinction-laurel.md) | The Task Crown replaces the Faction Distinction Laurel | Amended | [ADR-0054](0054-one-theme-aware-task-crown.md) |
 | [0029](0029-faction-permits-is-the-single-faction-rules-seam.md) | `faction_permits` is the single faction-rules seam | Accepted | — |
-| [0030](0030-default-faction-behaviour-ua-is-ordinary-grid-is-a-directory.md) | Default faction behaviour: UA is an ordinary faction; the grid is a directory, not a join surface | Accepted | — |
+| [0030](0030-default-faction-behaviour-ua-is-ordinary-grid-is-a-directory.md) | Default faction behaviour: UA is an ordinary faction; the grid is a directory, not a join surface | Amended | [ADR-0087](0087-structural-faction-slugs-are-not-era-owned.md) |
 | [0031](0031-backend-emits-keys-frontend-catalog-resolves.md) | Backend emits copy keys; the frontend catalog resolves them | Accepted | — |
 | [0032](0032-react-i18next-copy-catalog.md) | UI copy lives in react-i18next JSON catalogs | Accepted | — |
 | [0033](0033-player-profile-contract-and-badge-registry.md) | Player profile: one faction-agnostic contract; badges are a code registry evaluated on read | Accepted | — |
@@ -56,7 +56,7 @@
 | [0039](0039-unaffiliated-fill-is-a-gradient-not-a-hue.md) | Unaffiliated's fill is a gradient, not a hue | Accepted | — |
 | [0040](0040-feed-controls-are-neutral-chrome.md) | Feed controls are neutral chrome; faction skinning stops at the card boundary | Accepted | — |
 | [0041](0041-two-layer-identity-account-vs-character.md) | Two-layer identity: Account (private anchor) vs Character (public persona) | Accepted | — |
-| [0042](0042-era-as-ruleset-config-owns-rules-db-owns-history.md) | Era-as-ruleset: `game_config` owns the rules, the DB owns only history | Accepted | — |
+| [0042](0042-era-as-ruleset-config-owns-rules-db-owns-history.md) | Era-as-ruleset: `game_config` owns the rules, the DB owns only history | Amended | [ADR-0087](0087-structural-faction-slugs-are-not-era-owned.md) |
 | [0043](0043-vote-budget-is-recomputed-on-read.md) | Vote budget is recomputed on read; only `votes_spent_this_era` is stored | Accepted | — |
 | [0044](0044-characterstats-is-a-per-era-star-schema-split.md) | `CharacterStats` is a per-era star-schema split off `Character` | Accepted | — |
 | [0045](0045-pragmatic-ddd-posture.md) | Pragmatic DDD: implicit aggregates, anemic models, no repository layer, HTTPException in services | Accepted | — |
@@ -101,3 +101,4 @@
 | [0084](0084-a-page-wears-a-faction-when-it-has-exactly-one-faction-to-wear.md) | A page wears a faction when it has exactly one faction to wear | Accepted | — |
 | [0085](0085-snide-is-not-an-always-dark-faction.md) | S.N.I.D.E. is not an always-dark faction; it has three registers | Accepted | — |
 | [0086](0086-only-the-base-multiplies-a-metatask-is-flat.md) | Only the base multiplies; a metatask is flat | Accepted | — |
+| [0087](0087-structural-faction-slugs-are-not-era-owned.md) | Structural faction slugs are not era-owned; a dropped faction is retired, not deleted | Accepted | — |

--- a/docs/agents/era-rollover-findings.md
+++ b/docs/agents/era-rollover-findings.md
@@ -9,8 +9,13 @@ fixes tried during the investigation were reverted after the grill settled that 
 flip lands **last** — see Outcome at the bottom. Everything below is the evidence,
 recorded as it was found; nothing here is fixed on this branch.
 
-Result of the flip alone: **unit 442/442 green; integration 36 failed, 1061
-passed, plus 3 modules that fail at import.**
+Result of the flip alone: **unit 442/442 green; integration 35 failed, plus 3
+modules that fail at import.**
+
+(An earlier draft said 36. That count included one failure caused by a
+`services/era.py` change made during the investigation and since reverted —
+`test_praxis_feed_scope::test_era_scope_falls_through_when_the_era_is_unseeded`,
+which belongs to F1 rather than to the flip.)
 
 ---
 
@@ -152,7 +157,7 @@ no-ops when the row is absent — so it degrades quietly rather than crashing.
 
 ## F5. The test suite is written against Era 1's roster
 
-All 39 integration failures, by cause:
+All 38 integration failures, by cause:
 
 | # | Cause | Where |
 |---|---|---|
@@ -161,7 +166,7 @@ All 39 integration failures, by cause:
 | 9 | **Scoring assertions** that only hold under Coven's 1.1 collab modifier | `test_score_rounds_half_up::test_coven_collab_banks_half_up` |
 | 7 | **Level-jump fixture errors** | `test_level_jump_signup` |
 | 4 | **Route rejections** (400/422/404/403) — correct behaviour: the faction does not exist | `test_dev_login`, `test_admin_edit_task_faction`, `test_characters` |
-| 1 | Ephemerists' retired-task carve-out | `test_praxes`, `test_task_can_sign_up_filter`, `test_task_visibility_gates` |
+| 3 | Ephemerists' retired-task carve-out | `test_praxes`, `test_task_can_sign_up_filter`, `test_task_visibility_gates` |
 
 The shared fixture is the single biggest lever: `conftest.faction_ua` seeds exactly
 two literal rows (`ua` visible, `na` hidden) and `factories.py` defaults every
@@ -276,3 +281,21 @@ reverted to docs only for that reason.
 - **Structural vs roster** (new, from the owner): `na` is the neutral faction and `albescent`
   the endgame **in every era**; everything else is roster, and any perk may vanish or move
   between eras. A faction not in the live era is retired.
+
+### Two couplings outside the backend suite
+
+- **`CLAUDE.md`'s routing table names `era_1.py` as the live era in three places** (lines 20,
+  21, 31). It is the first thing every agent reads, so a stale pointer misroutes work for
+  everyone. Added to #2711.
+- **The e2e duel fixture fails silently.** `seed.py`'s `DUEL_FIXTURE_TASK_FACTION_SLUG = "ua"`
+  is guarded, so under Era 2 it no-ops and the task is never seeded; `frontend/e2e/duel.helpers.ts`
+  then selects on `primary_faction_slug === 'ua'` and finds nothing. The guard turns a loud
+  backend crash into a misleading e2e failure three files away — the opposite of what F4's
+  "degrades quietly rather than crashing" implied. Added to #2710.
+
+### Checked and clear
+
+The frontend's ~193 tests touching `coven` / `ephemerists` / `singularity` all keep passing:
+it never reads the era config, taking slugs from `GET /factions` at runtime and `CSS_KEY`
+statically. `docs/spec/*` and `WORLD_ZERO_STYLE.md` say "seven / eight / nine factions" in
+several places, but that counts *built archetypes*, not the era roster, and stays true.

--- a/docs/agents/era-rollover-findings.md
+++ b/docs/agents/era-rollover-findings.md
@@ -1,0 +1,278 @@
+# Era rollover: what breaks when `CURRENT_ERA` moves
+
+Findings from pointing `CURRENT_ERA` at `ERA_2` (Metamorphosis) and running the
+backend suite against it, 2026-08-25. Era 2 had been authored-but-dormant since
+#1618; this is the first time anything actually ran under it.
+
+**Status of the branch this was found on:** docs only. The flip and the two code
+fixes tried during the investigation were reverted after the grill settled that the
+flip lands **last** — see Outcome at the bottom. Everything below is the evidence,
+recorded as it was found; nothing here is fixed on this branch.
+
+Result of the flip alone: **unit 442/442 green; integration 36 failed, 1061
+passed, plus 3 modules that fail at import.**
+
+---
+
+## The headline
+
+Era 1 is not "the current era" in this codebase — it is **the only era the code
+has ever had**, and a lot of things quietly encode its roster rather than reading
+the era. Nothing here is a bug in Era 2's config. Every failure is a place that
+named an Era 1 faction instead of asking the era a question.
+
+Era 2 drops four slugs — `ua`, `coven`, `ephemerists`, `singularity` — and keeps
+five: `snide`, `wow`, `everymen`, `albescent`, `na`.
+
+---
+
+## F1. The rollover script cannot perform a rollover
+
+`scripts/era_reset.py` is the documented way to close one era and open the next.
+It cannot do it, and the reason is circular:
+
+```python
+current_era_row = await get_current_era_row_safe(session)   # era_reset.py:99
+if current_era_row is None:
+    print("ERROR: no era row for the current config - run seed.py before a rollover.")
+    return 1
+```
+
+`get_current_era_row_safe` (`services/era.py`) resolves the live era as *the
+latest `Era` row whose `config_key == CURRENT_ERA.config_key`*. The instant
+`CURRENT_ERA` becomes Era 2, **no row carries `era_2` yet** — creating it is the
+job of the very script that just refused to run. The script's own `print_plan`
+proves the intent: it prints `current_era_row` as the era being **closed**, so it
+wants the *old* row and looks it up by the *new* key.
+
+Worse, the same lookup backs the whole app. Between the deploy and the rollover,
+`get_current_era_row` raises:
+
+```
+500 "No active era configured. Run the initial seed before creating characters."
+```
+
+...on every path that resolves a character's stats. So the deploy window is an
+outage that only the rollover can end, and the rollover is what the outage blocks.
+
+**This has never been exercised.** `tests/integration/test_era_reset_script.py`
+builds its era row from `CURRENT_ERA.config_key` (via the `era` fixture in
+`conftest.py`), so every test rolls Era N into Era N — a config-key *change* has
+no coverage at all.
+
+### Options (needs a decision, they are not equivalent)
+
+- **(a) Fix the script only.** Look the closing era up as *the latest `Era` row*,
+  regardless of key. Smallest change; leaves the deploy-window 500s.
+- **(b) Redefine "the live era" as the latest row** in `get_current_era_row_safe`,
+  dropping the `config_key` filter. This is what the append-only invariant already
+  says — `get_closing_era_id` and `get_next_era_row` both document "rows are only
+  ever appended, one per reset". Closes the window *and* fixes the script in one
+  line. **Cost:** "the era is unseeded" stops meaning "no row for this key" and
+  starts meaning "no rows at all", so a deployed-but-not-rolled-over app serves
+  the *new* rules against the *old* era row instead of failing loudly. It also
+  breaks exactly one test, which mutates `era.config_key = "era_not_seeded"` to
+  simulate the unseeded state (`test_praxis_feed_scope.py:153`).
+  *(Tried on this branch, then reverted — it is a judgement call, not a cleanup.)*
+- **(c) Let `seed.py` open the row.** The seeder already runs on every deploy
+  (`start.sh`) and already owns "make the DB match the era config" for factions and
+  tasks. Having it insert the `Era` row for an unseen `config_key` removes the
+  window entirely — but it collides with the rollover, which *creates* that row
+  itself to stamp `started_by`. Bigger redesign; probably the honest end state.
+
+---
+
+## F2. Dropping a faction from the config leaves its row visible
+
+`models/faction.py` states the design outright:
+
+> "Retiring a faction means dropping it from the era config, which leaves its row
+> `hidden`."
+
+Nothing implemented the second half. `seed.upsert_era_factions` only ever *added*
+rows, and `GET /factions` serves `visible` rows straight from the table — so after
+the flip the registry would still have offered `ua`, `coven`, `ephemerists` and
+`singularity` to join, while `can_join_faction` (which reads the era config) refused
+every one of them. Four factions you can see and cannot join.
+
+It went unnoticed because until now no era had ever dropped one.
+
+**Ruled**: not `hidden` — a third status, `retired` (ADR-0087, issue #2706). Rows are
+never deleted; `character.faction_slug` and `task.primary_faction_slug` are FKs onto
+this table and a closed era's rows are the history they point at.
+
+**The knock-on that forced the third status:** `hidden` factions' *tasks* drop out of
+every listing (`services/task.py` filters on `hidden_faction_slugs`), and that filter
+has never excluded a row in production — `hidden_faction_slugs` subtracts `na` from its
+own result, leaving only `aged_out`, which no task carries. Retiring four real factions
+through `hidden` would have activated a dormant filter and taken most of Era 1's task
+history out of the archive.
+
+---
+
+## F3. Seeding a fresh DB and rolling over an existing one are different paths
+
+This matters directly for "delete the database and test again".
+
+`bootstrap_admin` creates the `Era` row **only when Pixie's account is absent** —
+i.e. only on a genuinely un-bootstrapped database.
+
+- **Fresh DB**: the seeder writes an `era_2` row. No rollover needed, no F1 at all.
+  This path works today.
+- **Existing DB**: the seeder never writes the row, so `era_2` never appears unless
+  `era_reset.py` writes it — and F1 says it will not.
+
+So wiping the DB *routes around* F1 rather than testing it. If the rollover is
+meant to be a supported operation, it needs its own test against a config-key
+change, not just a fresh-seed run.
+
+---
+
+## F4. Dev seeding breaks on a fresh Era 2 database
+
+`scripts/seed_demo_praxes.py` hardcodes Era 1 slugs:
+
+```python
+METATASK_FACTION_SLUG = "ua"       # line 100  — not in Era 2
+DUEL_TASK_FACTION_SLUG = "snide"   # line 125  — fine
+COLLAB_TASK_FACTION_SLUG = "coven" # line 145  — not in Era 2
+```
+
+and line 516 does `era.factions[COLLAB_TASK_FACTION_SLUG].collab_own_modifier`
+— an unguarded `KeyError` under Era 2.
+
+Phase 5 is **dev-only** (`if env == "dev"` in `seed.py`), so production is safe.
+But it will fire the moment anyone seeds a fresh dev database on this branch,
+which is exactly the plan. Fix before re-testing.
+
+`seed.py:305`'s `DUEL_FIXTURE_TASK_FACTION_SLUG = "ua"` is already guarded — it
+no-ops when the row is absent — so it degrades quietly rather than crashing.
+
+---
+
+## F5. The test suite is written against Era 1's roster
+
+All 39 integration failures, by cause:
+
+| # | Cause | Where |
+|---|---|---|
+| 10 | **FK violation** — a fixture seeds a `Task`/`Character` into a slug with no `Faction` row, because the seeder no longer creates it | `test_seed_score_fixtures`, `test_score_rounds_half_up`, `test_backfill_metatask_multiplier` |
+| 8 | **`KeyError`** on `CURRENT_ERA.factions["ua" / "coven" / "singularity"]` | 3 of these are *module-level* constants, so the file fails at import: `test_collab_vote_recalc:33`, `test_era_scoped_recalc:42`, `test_habit_bonus:37` |
+| 9 | **Scoring assertions** that only hold under Coven's 1.1 collab modifier | `test_score_rounds_half_up::test_coven_collab_banks_half_up` |
+| 7 | **Level-jump fixture errors** | `test_level_jump_signup` |
+| 4 | **Route rejections** (400/422/404/403) — correct behaviour: the faction does not exist | `test_dev_login`, `test_admin_edit_task_faction`, `test_characters` |
+| 1 | Ephemerists' retired-task carve-out | `test_praxes`, `test_task_can_sign_up_filter`, `test_task_visibility_gates` |
+
+The shared fixture is the single biggest lever: `conftest.faction_ua` seeds exactly
+two literal rows (`ua` visible, `na` hidden) and `factories.py` defaults every
+character, task and duel side to `faction_slug="ua"` — **257 `"ua"` literals across
+82 files.** Its own docstring admits the slug is arbitrary:
+
+> "`ua` is the default slug because it is the only faction the shared fixtures seed
+> a row for, and most callers do not read the slug at all."
+
+### Two traps found while attempting the migration (both cost a full test run)
+
+1. **Seeding only the live era's factions makes it worse, not better** —
+   197 failures instead of 36. The ~250 sites that seat a character in `ua` need
+   that row to *exist*; production keeps it too (hidden, never deleted). The fixture
+   should seed every slug any era ever configured and let the live era decide
+   `visible` vs `hidden` — that is production's actual shape.
+2. **`era.starting_faction_slug` is the wrong default.** It is `na`, and `na` is a
+   sentinel two rules treat specially: `faction_slugs.faction_filter_slugs` folds it
+   together with `albescent` for every faceted list, and
+   `scoring.compute_faction_multiplier` reads a cross-faction task as own-faction.
+   Defaulting to it silently changed the answer to ~25 task-listing tests.
+
+### And the trap under both of them
+
+**Metamorphosis has no ordinary faction.** Era 1's `ua` was a plain vehicle —
+baseline modifiers everywhere, one small perk. Every Era 2 faction carries
+something: `snide` the duel gamble (2.0/0.0), `wow` the level jump, `everymen`
+Double Dipper, `albescent` inherits all of them, `na` is a sentinel. There is no
+neutral slug to default a fixture to, so the fixture needs to *declare* what it
+wants ("a faction with no duel modifier") rather than name one.
+
+---
+
+## F6. Rules that lose their subject entirely
+
+These are not test bugs. The rule still exists and is still era-driven; Era 2 just
+grants it to nobody, so the guard silently stops guarding. Each needs a decision:
+**skip loudly**, or **pin the test to `ERA_1`** (services all take
+`era: EraConfig = CURRENT_ERA`, so a test can name its era — that seam already exists).
+
+| Rule | Held by | In Era 2 |
+|---|---|---|
+| `habit_bonus_points` (+5 on a praxis sealed inside the window) | `ua` only | **nobody** — Era 2 has no habit bonus at all |
+| Collab bonus (1.1x) | `coven` only | **nobody** — era_2.py says so: "the first era with no non-1.0 collab modifier at all" |
+| Task Vision (praxis on a retired task) | `ephemerists` | `allow_praxis_on_retired_task_factions` is empty by design |
+
+The half-up rounding tests are the sharpest case: Coven's 1.1 was the *only* thing
+producing a fractional score to round. With every modifier at 1.0 there is nothing
+to round, so `test_coven_collab_banks_half_up` cannot fail no matter what the
+rounding code does. A vacuous pass is worse than a red test.
+
+---
+
+## F7. Consequences of Era 2 that are correct but worth saying out loud
+
+Not bugs — design consequences the rollover makes real:
+
+- **Everyone lands in `na`.** `reset_faction=True` with the default
+  `reset_faction_slug`. Ex-UA characters are not stranded, but nobody keeps a
+  faction. Admin role lives on the `Account`, so admin access survives.
+- **Four faction kits go dark.** `ua`, `coven`, `ephemerists`, `singularity` have
+  built frontend kits (#1632 and others). Their CSS keys stay in
+  `frontend/src/utils/factions.ts` and degrade to `default` — harmless — but the
+  work is invisible until an era brings them back.
+- **The Albescent unlock gets dramatically cheaper.** Its coverage half requires a
+  praxis for every non-sentinel faction in the era: seven in Era 1, **three** here.
+  The level half (`albescent_level_required=8`) does not move. Already flagged in
+  `eras/era_2.py` as knowingly accepted.
+- **Albescent inherits less.** `inherits_faction_perks=True` widens it to the best
+  perk any faction in *this* era holds. No Ephemerists means no Task Vision to
+  inherit; no UA means no habit bonus.
+- **Retired task titles stay reserved forever** — `services/task_import.py` dedupes
+  on title with no status filter, and the whole board retires at rollover. Already
+  documented on `retire_board_at_era_close`; it starts to bite from the second era.
+
+---
+
+## Outcome
+
+Grilled with the owner 2026-08-25. Every open question is settled; the rulings are recorded
+in **[ADR-0087](../adr/0087-structural-faction-slugs-are-not-era-owned.md)** (which amends
+ADR-0042 and ADR-0030) and the vocabulary in `CONTEXT.md`.
+
+**The flip lands last, not first.** Every issue below is independently valuable and passes
+under Era 1, so they land with CI green throughout and `CURRENT_ERA` moves once at the end
+against a suite that already proves Era 2's rules. The branch this was found on has been
+reverted to docs only for that reason.
+
+| Issue | |
+|---|---|
+| [#2705](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2705) | `era_reset.py` cannot roll over into a new `config_key` — F1/F3 |
+| [#2706](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2706) | A dropped faction is `retired`, not `hidden` — F2 |
+| [#2707](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2707) | `EraConfig` must require `na` + `albescent` and pin the two `na`-fields |
+| [#2708](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2708) | Fixtures ask the era for a faction, never name one — F5 |
+| [#2709](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2709) | Per-era rules modules + perk-coverage guard — F5/F6 |
+| [#2710](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2710) | Dev demo fixtures KeyError on a fresh Era 2 DB — F4 |
+| [#2711](https://github.com/pixieofhugs/WorldZeroPlayground/issues/2711) | Point `CURRENT_ERA` at Era 2 — blocked by the six above |
+
+### Rulings that resolved the open options above
+
+- **F1** → the live era is **the latest `Era` row**, full stop (option b). The loud failure the
+  `config_key` filter used to provide moves to a seeder warning on every deploy.
+- **F2** → **option (ii)**: a third `FactionStatus`. `hidden` stays "system row"; `retired` leaves
+  the registry but keeps its task history in the archive.
+- **F5** → a test may know only that it got *some* faction. Fixture default is the first
+  non-sentinel faction the era defines; score assertions derive from the slug the fixture
+  actually used.
+- **F6** → per-era rules modules, one per registered era, with a guard requiring each to name
+  every perk that era grants. The registry it walks already exists (`_MAX_PERK_FIELDS` and
+  siblings, built for #1871).
+- **F4** → the demo fixtures drop the perk-demonstration property; they seed *a* collab.
+- **Structural vs roster** (new, from the owner): `na` is the neutral faction and `albescent`
+  the endgame **in every era**; everything else is roster, and any perk may vanish or move
+  between eras. A faction not in the live era is retired.


### PR DESCRIPTION
Pointing `CURRENT_ERA` at Era 2 for the first time produced **35 integration failures and 3 modules that die at import**. None of them is a bug in Era 2's config. Era 1 was never "the current era" — it was the only era the code had ever run, and its roster had leaked into places that should have been asking the era a question.

This PR is **docs only**. The flip and the two code fixes tried during the investigation were reverted: the grill settled that the flip lands *last*, after six cleanups that each pass under Era 1.

## Two findings the code could not have told us without trying it

**`scripts/era_reset.py` cannot roll over into a new `config_key`.** It looks the *closing* era up by the *new* era's key, so it refuses at exactly the moment it is needed — and the same lookup 500s the app until the rollover it is blocking. Never caught because every existing test rolls Era N into Era N.

**Dropping a faction from the era config did nothing to its row.** Four factions would have stayed joinable-looking in `GET /factions` while `can_join_faction` refused them. `models/faction.py` already documented the intended behaviour; nothing implemented it, because no era had ever dropped one.

## What's here

- **ADR-0087** — structural faction slugs are not era-owned; a dropped faction is retired, not deleted. Amends **ADR-0042** (`starting_faction_slug` / `reset_faction_slug` stop being era-overridable; `na` and `albescent` are structural in every era) and **ADR-0030** (the factions grid's hidden set is no longer just the sentinels).
- **`CONTEXT.md`** — three new entries: *structural slug vs roster faction*, *retired faction*, *per-era rules module*.
- **`docs/agents/era-rollover-findings.md`** — the evidence, seven findings, and the rulings that resolved each.
- ADR index regenerated (87 records).

## Follow-up

#2705 #2706 #2707 #2708 #2709 #2710 land first, each green under Era 1. #2711 is the flip, deliberately unlabelled so an AFK agent cannot pick it up early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
