### PR TITLE
The live era is the latest Era row, so a rollover can change config_key

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -423,6 +423,36 @@ async def seed_dev_demo(session, created_by_id: int) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Deploy-window warning: configured era vs. the era row that is actually live
+# ---------------------------------------------------------------------------
+
+async def stale_era_warning(session, era) -> str | None:
+    """What to tell the operator when the configured era has no Era row yet.
+
+    The seeder does not open an era for an unseen ``config_key`` — the rollover
+    does, because it is what stamps ``Era.started_by``. So a deploy that flips
+    ``CURRENT_ERA`` forward leaves the app running the new rules against the old
+    row, and since #2705 it does that *quietly*: the live era is the latest row
+    whatever its key, which is what keeps the rollover runnable instead of
+    500ing every character-stats read. This is where the noise went. ``start.sh``
+    runs the seeder on every deploy, so it lands in front of the one person who
+    can act on it.
+
+    Returns None when the live row already matches; the caller prints.
+    """
+    live = (
+        await session.execute(select(Era).order_by(Era.id.desc()).limit(1))
+    ).scalar_one_or_none()
+    if live is not None and live.config_key == era.config_key:
+        return None
+    live_key = live.config_key if live is not None else "absent"
+    return (
+        f"\nWARNING: {era.config_key} is configured but the live Era row is "
+        f"{live_key}.\n         Run scripts/era_reset.py to open it."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main seed function
 # ---------------------------------------------------------------------------
 
@@ -519,6 +549,10 @@ async def seed(env: str, yes: bool) -> None:
         print(f"  pixie account  : pixieofhugs@gmail.com")
         print(f"  pixie character: @pixie (admin)")
         print(f"  era-config tasks: {len(era.tasks)} (Era 1 ships none — #1398)")
+
+        warning = await stale_era_warning(session, era)
+        if warning:
+            print(warning)
 
     await engine.dispose()
 

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -22,10 +22,10 @@ from services.vote_tally import get_tally, tally_votes
 
 
 async def get_current_era_row(session: AsyncSession) -> Era:
-    """Return the Era DB row for CURRENT_ERA.
+    """Return the live Era DB row — see :func:`get_current_era_row_safe`.
 
-    Raises 500 if the era has not been seeded yet. Run the initial seed or
-    migration before creating characters.
+    Raises 500 only on a genuinely fresh database (no ``Era`` rows at all). Run
+    the initial seed or migration before creating characters.
     """
     era_row = await get_current_era_row_safe(session)
     if era_row is None:
@@ -37,12 +37,24 @@ async def get_current_era_row(session: AsyncSession) -> Era:
 
 
 async def get_current_era_row_safe(session: AsyncSession) -> Era | None:
-    """Like ``get_current_era_row`` but returns None on missing era instead of raising."""
+    """Like ``get_current_era_row`` but returns None on missing era instead of raising.
+
+    The live era is **the latest ``Era`` row, whatever its ``config_key``** — the
+    same append-only invariant :func:`get_closing_era_id` and
+    :func:`get_next_era_row` read ("rows are only ever appended, one per reset").
+    It used to filter on ``CURRENT_ERA.config_key``, which deadlocked the one
+    lever that switches the game (ADR-0042): pointing ``CURRENT_ERA`` at a new
+    era file left no row carrying that key, so ``scripts/era_reset.py`` refused
+    to run — and creating that row is its job — while every path resolving a
+    character's stats 500ed in the meantime (#2705).
+
+    The cost, taken knowingly: "unseeded" now means *no rows at all* rather than
+    *no row for this key*, so between the deploy and the rollover the app serves
+    the new rules against the old row instead of failing loudly. The loudness
+    lives in ``seed.py``, which runs on every deploy and says so.
+    """
     result = await session.execute(
-        select(Era)
-        .where(Era.config_key == CURRENT_ERA.config_key)
-        .order_by(Era.id.desc())
-        .limit(1)
+        select(Era).order_by(Era.id.desc()).limit(1)
     )
     return result.scalar_one_or_none()
 

--- a/backend/tests/integration/test_era_reset_script.py
+++ b/backend/tests/integration/test_era_reset_script.py
@@ -22,6 +22,7 @@ from models.era import Era
 from models.faction import Faction
 from models.roles import AccountRole, Role
 from scripts.era_reset import reset_era
+from services.era import get_closing_era_id, get_current_era_row_safe
 from tests.integration.factories import make_admin
 
 
@@ -109,3 +110,50 @@ async def test_an_unknown_operator_is_refused(
 
     assert exit_code == 1
     assert await _era_count(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_rollover_into_a_new_config_key_opens_it_and_closes_the_old(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+):
+    """The rollover CURRENT_ERA exists for: the live row carries the *old* key (#2705).
+
+    Every other test here rolls Era N into Era N — the ``era`` fixture builds its
+    row from ``CURRENT_ERA.config_key``, so the keys always matched and the bug
+    hid. Re-keying the seeded row to the era it succeeded is the same shape as
+    flipping ``CURRENT_ERA`` forward, without re-binding the constant in two
+    modules: what matters is that the live row's key is not the configured one.
+    """
+    await make_admin(db_session, account, commit=False)
+    era.config_key = "era_0_previous"
+    await db_session.commit()
+
+    # No 500 in the deploy window: the live era is the latest row, whatever key
+    # it carries. This is the read every character-stats path makes.
+    live = await get_current_era_row_safe(db_session)
+    assert live is not None and live.id == era.id
+
+    exit_code = await reset_era(db_session, character.username, confirmed=True)
+
+    assert exit_code == 0
+    new_era = (
+        await db_session.execute(select(Era).order_by(Era.id.desc()).limit(1))
+    ).scalar_one()
+    assert new_era.id != era.id
+    assert new_era.config_key == CURRENT_ERA.config_key
+    assert await get_closing_era_id(new_era, db_session) == era.id
+
+    # apply_era_reset ran against the era it opened.
+    stats = (
+        await db_session.execute(
+            select(CharacterStats).where(
+                CharacterStats.character_id == character.id,
+                CharacterStats.era_id == new_era.id,
+            )
+        )
+    ).scalar_one()
+    assert stats.era_id == new_era.id

--- a/backend/tests/integration/test_praxis_feed_scope.py
+++ b/backend/tests/integration/test_praxis_feed_scope.py
@@ -13,10 +13,11 @@ from datetime import datetime, timedelta
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.character import Character
+from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction, FactionStatus
 from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
@@ -143,15 +144,20 @@ async def test_era_scope_falls_through_when_the_era_is_unseeded(
     character: Character,
     era: Era,
 ):
-    """No Era row for the live config key ⇒ unscoped, not empty."""
+    """No Era rows at all ⇒ unscoped, not empty.
+
+    Since #2705 the live era is the latest ``Era`` row whatever its
+    ``config_key``, so "unseeded" is the empty table — a fresh database — and
+    nothing else. Clear the stats rows first; they FK the era.
+    """
     old = await _make_praxis(
         db_session,
         character,
         title="Ancient",
         submitted_at=era.started_at - timedelta(days=365),
     )
-    # Simulate the unseeded era without breaking the CharacterStats FK.
-    era.config_key = "era_not_seeded"
+    await db_session.execute(delete(CharacterStats))
+    await db_session.execute(delete(Era))
     await db_session.commit()
 
     got = await list_praxes(db_session, status=PraxisStatus.submitted)

--- a/backend/tests/integration/test_seed_stale_era_warning.py
+++ b/backend/tests/integration/test_seed_stale_era_warning.py
@@ -1,0 +1,63 @@
+"""The seeder's deploy-window warning about a configured era with no row (#2705).
+
+Seam under test: ``seed.stale_era_warning`` — the string the summary block prints
+at the end of every deploy, because ``start.sh`` runs the seeder there.
+
+It is the only loud thing left in the rollover window. Resolving the live era
+stopped filtering on ``config_key`` so that ``scripts/era_reset.py`` can run at
+all (``services.era.get_current_era_row_safe``), which means a deployed-but-not-
+rolled-over app now serves the new rules against the old row instead of 500ing.
+Silence there is the trade; this warning is what pays for it.
+"""
+from dataclasses import replace
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character_stats import CharacterStats
+from models.era import Era
+from seed import stale_era_warning
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_the_live_row_is_the_configured_era(
+    db_session: AsyncSession,
+    era: Era,
+):
+    assert await stale_era_warning(db_session, CURRENT_ERA) is None
+
+
+@pytest.mark.asyncio
+async def test_a_configured_era_with_no_row_names_both_keys_and_the_script(
+    db_session: AsyncSession,
+    era: Era,
+):
+    """The state a deploy that flips CURRENT_ERA forward leaves behind."""
+    next_era = replace(CURRENT_ERA, config_key="era_2")
+
+    warning = await stale_era_warning(db_session, next_era)
+
+    assert warning is not None
+    assert (
+        f"era_2 is configured but the live Era row is {CURRENT_ERA.config_key}."
+        in warning
+    )
+    assert "Run scripts/era_reset.py to open it." in warning
+
+
+@pytest.mark.asyncio
+async def test_an_empty_era_table_warns_rather_than_crashing_the_seed(
+    db_session: AsyncSession,
+    era: Era,
+):
+    """A summary line that raises would take the whole deploy's seed down."""
+    await db_session.execute(delete(CharacterStats))
+    await db_session.execute(delete(Era))
+    await db_session.commit()
+
+    warning = await stale_era_warning(db_session, CURRENT_ERA)
+
+    assert warning is not None
+    assert "the live Era row is absent" in warning

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 772
+RUFF_FINDING_TOTAL = 771
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -166,7 +166,7 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "services/collab_consensus.py::E501": 3,
     "services/duel.py::E501": 5,
     "services/duel.py::I001": 1,
-    "services/era.py::E501": 2,
+    "services/era.py::E501": 1,
     "services/era.py::I001": 1,
     "services/faction_service.py::F401": 1,
     "services/media.py::E501": 4,


### PR DESCRIPTION
Closes #2705

Pointing `CURRENT_ERA` at a new era file is the one lever that switches the live game (ADR-0042), and it deadlocked: `scripts/era_reset.py` looked the **closing** era up by the **new** era's `config_key`, so the moment no row carried that key the rollover refused to run — and creating that row is its job. The same resolver backs the app, so between the deploy and the rollover every path that resolves a character's stats 500ed.

## Seam under test

`services.era.get_current_era_row_safe` — "what is the live era row?" — reached through `scripts.era_reset.reset_era`. The failing test went first: with the live row carrying a key that is not the configured one, `get_current_era_row_safe` returned `None` and `reset_era` exited 1. Red on the defect, then green.

## What changed

- **`backend/services/era.py`** — `get_current_era_row_safe` drops the `where(Era.config_key == CURRENT_ERA.config_key)` clause and keeps `order_by(Era.id.desc()).limit(1)`. The live era is the latest `Era` row, full stop — the append-only invariant `get_closing_era_id` and `get_next_era_row` already document, and the one `alembic/versions/0014` already assumes with `era_id = (SELECT max(id) FROM era)`. An empty table still answers `None`, so `get_current_era_row`'s fresh-database guard is unchanged.
- **`backend/tests/integration/test_era_reset_script.py`** — new `test_a_rollover_into_a_new_config_key_opens_it_and_closes_the_old`. This is the gap that hid the bug: the `era` fixture builds its row from `CURRENT_ERA.config_key`, so every existing test rolled Era N into Era N. The new one re-keys the seeded row to the era it succeeded, which is the same shape as flipping `CURRENT_ERA` forward without re-binding the constant in two modules — what matters is that the live row's key is not the configured one. It asserts the new row opens, `get_closing_era_id` names the old one, `apply_era_reset` wrote stats against the new era, and — before the reset — that the resolver answers at all, which is the "no 500 in the deploy window" half.
- **`backend/tests/integration/test_praxis_feed_scope.py`** — `test_era_scope_falls_through_when_the_era_is_unseeded` simulated unseeded with `era.config_key = "era_not_seeded"`. That state no longer exists; it now deletes the `Era` rows (and the `CharacterStats` that FK them), which is what "unseeded" means now.
- **`backend/seed.py`** — new `stale_era_warning`, printed at the end of the summary block. `start.sh` runs the seeder on every deploy, so this is where the loudness went.
- **`backend/tests/unit/ruff_allowlist.py`** — total 772 → 771; the resolver lost a long line.

## The trade-off, taken knowingly (owner, 2026-08-25)

"The era is unseeded" stops meaning *no row for this key* and starts meaning *no rows at all*. A deployed-but-not-rolled-over app therefore serves the new rules against the old row instead of failing loudly. That is the point of the change — it is what keeps the rollover runnable. The loudness moves to the seeder:

```
WARNING: era_2 is configured but the live Era row is era_1.
         Run scripts/era_reset.py to open it.
```

`seed.py` still does **not** create the row for an unseen `config_key` — deferred as out of scope, because it collides with the rollover, which creates that row itself to stamp `started_by`.

`CURRENT_ERA` is untouched: this ships with Era 1 live.

## Verification

`pytest --cov=. --cov-report=term-missing --cov-fail-under=92` from `backend/`, against a dedicated `wz2705_test` database: **1603 passed**, coverage 94.33%.

No route signature, `response_model` or Pydantic schema was touched, so `openapi.json` / `schema.d.ts` are unaffected. No frontend files touched.

## What to eyeball

No browser or dev stack was available here, so all visual/operational QA is outstanding:

1. **The seeder's new warning, in a real run.** `python seed.py --env dev` against a DB whose latest `Era` row is `era_1` while `CURRENT_ERA` is still `era_1` — the summary block should look exactly as it did, with **no** warning. That is the everyday case and the one a false positive would spam on every deploy.
2. **The same run with the keys mismatched.** Temporarily hand-edit the live `era` row's `config_key` (e.g. to `era_0_previous`) and re-run the seeder: the two warning lines should appear after `era-config tasks:`, indented as shown above, with a blank line before them.
3. **The rollover plan, printed.** `python scripts/era_reset.py pixie` (no `--yes`) with those keys mismatched. `Closing` should name the **old** row and its old key; `Opening` should name `CURRENT_ERA`. Before this change the script printed nothing but `ERROR: no era row for the current config`.
4. **The app during the mismatch.** With the live row re-keyed and the server running, load a profile, the praxis feed, and `/auth/me` — levels, scores and vote budget should render normally rather than 500. This is the outage the change removes.
5. **Then put the row back** (or roll over for real on a throwaway DB) — step 2 mutates data by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
