### PR TITLE
A faction the live era drops is retired, not hidden

### DIFF
--- a/backend/alembic/schema_snapshot.txt
+++ b/backend/alembic/schema_snapshot.txt
@@ -25,7 +25,7 @@
 enum accountstatus = active, suspended, deleted
 enum characterstatus = active, banned
 enum duelstatus = pending, active, settled, declined, resolved
-enum factionstatus = visible, hidden
+enum factionstatus = visible, hidden, retired
 enum mediatype = image, video, audio
 enum moderationstatus = visible, flagged, hidden, failed, deleted
 enum praxisinvitestatus = pending, accepted, declined

--- a/backend/alembic/versions/0016_faction_status_retired.py
+++ b/backend/alembic/versions/0016_faction_status_retired.py
@@ -1,0 +1,46 @@
+"""``factionstatus`` gains ``retired`` (#2706, ADR-0087).
+
+A carry-forward for already-deployed databases. ``models/faction.py`` declares
+the column as ``Enum(FactionStatus, create_type=False)``, so the PG type is
+owned by migrations and never by SQLAlchemy — a new member has to arrive here or
+it does not arrive at all.
+
+``ADD VALUE IF NOT EXISTS`` because ``0002_squashed.ENUMS`` still builds a fresh
+database with only ``visible`` and ``hidden``. That list is deliberately frozen
+at the squash; this revision is what a deployed database gets instead (the same
+shape ``0015_account_tombstone`` uses for ``accountstatus.deleted``).
+
+The value is appended, so Postgres sorts it last. Nothing orders factions by
+status, and the two readers that care compare for equality
+(``routers.factions.list_factions`` on ``visible``,
+``services.faction_service.hidden_faction_slugs`` on ``hidden``).
+
+No data migration: under Era 1 the live era lists every faction, so the mirror
+in ``seed.upsert_era_factions`` retires nothing. This ships **before** the
+``CURRENT_ERA`` flip on purpose, and the seed run after that flip is what writes
+the first ``retired`` row.
+
+``downgrade()`` is a no-op. Postgres cannot remove an enum member, and inventing
+a ``DROP``/``CREATE``/rewrite dance is more risk than the reversal is worth —
+the residue is one unused label, exactly as ``0015`` reasoned.
+
+Revision ID: 0016_faction_status_retired
+Revises: 0015_account_tombstone
+Create Date: 2026-08-26
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0016_faction_status_retired"
+down_revision: Union[str, None] = "0015_account_tombstone"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE factionstatus ADD VALUE IF NOT EXISTS 'retired'")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/models/faction.py
+++ b/backend/models/faction.py
@@ -8,16 +8,36 @@ from models.mixins import TimestampMixin
 
 
 class FactionStatus(enum.Enum):
-    """A faction row is either listed or not.
+    """Whether a faction is in the live era, in a past one, or a system row.
 
-    There is no ``deprecated``: ``seed.py`` writes ``visible`` or ``hidden`` and
-    nothing else ever writes this column, so ``deprecated`` was a third value
-    every reader had to spell out (``hidden/deprecated``) and no writer could
-    produce. Retiring a faction means dropping it from the era config, which
-    leaves its row ``hidden``. Removed in the #1398 squash.
+    - ``visible`` — in the live era. Listed in the registry, joinable subject to
+      the ordinary gates.
+    - ``retired`` — was in some past era, not in the live one. Out of the
+      registry and out of the join options; **its task history stays in the
+      archive**.
+    - ``hidden`` — a system row (``na``, ``aged_out``) no player should ever act
+      on. Never listed anywhere, and its tasks are dropped from every listing by
+      :func:`services.faction_service.hidden_faction_slugs`.
+
+    **This enum had a third value before, and the argument for deleting it is
+    void — do not re-delete it on that argument (ADR-0087).** The #1398 squash
+    dropped ``deprecated`` because "nothing else ever writes this column... no
+    writer could produce it", and left the docstring saying retirement leaves a
+    row ``hidden``. Era 2 is the writer that was missing:
+    ``seed.upsert_era_factions`` is now a two-way mirror and marks ``retired``
+    every row the live era does not list.
+
+    ``retired`` is not a synonym for ``hidden``, and the difference is Era 1's
+    task archive. ``hidden``'s one reader drops a faction's tasks from every
+    listing, so retiring four real factions through it would have taken most of
+    a closed era's history off the site — including the archive
+    ``level_to_see_retired_tasks`` unlocks at level 2 — while the praxes written
+    against those tasks stayed visible, linking to tasks in no listing.
+    Retirement removes a faction from the *registry*, not from the *record*.
     """
 
     visible = "visible"
+    retired = "retired"
     hidden = "hidden"
 
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -46,9 +46,22 @@ from models.task import Task, TaskStatus, TaskType
 HIDDEN_FACTION_SLUGS = frozenset({"aged_out", UNAFFILIATED_FACTION_SLUG})
 
 
-async def upsert_era_factions(session, era) -> int:
-    """Give every faction in the era config a `Faction` row, and return how many
-    were added.
+async def upsert_era_factions(session, era) -> tuple[int, int]:
+    """Mirror the live era's faction roster onto the `Faction` table.
+
+    Two-way (ADR-0087, #2706): every slug the era lists gets a row, and every
+    row the era does *not* list is marked `retired`. Returns
+    `(added, retired)`.
+
+    **Nothing is ever deleted.** `character.faction_slug` and
+    `task.primary_faction_slug` are foreign keys onto this table, and a closed
+    era's characters and tasks are the history those columns point at.
+
+    Retiring is also **not** `hidden`. `hidden` is the system-row flag, and its
+    one reader (`services.faction_service.hidden_faction_slugs`) drops that
+    faction's tasks from every listing — so a retired faction flagged `hidden`
+    would take its era's whole task archive off the site. Retirement removes a
+    faction from the registry, not from the record.
 
     The `Faction` table is a thin display mirror of the era config — slug plus
     status, no rules (ADR-0038) — so this is idempotent and safe to run against
@@ -57,19 +70,46 @@ async def upsert_era_factions(session, era) -> int:
     faction_slug` a plain string foreign key, so a new faction needs a row here
     and never an Alembic migration.
     """
+    existing = {
+        row.slug: row
+        for row in (await session.execute(select(Faction))).scalars()
+    }
+
     added = 0
     for slug in era.factions:
-        existing = await session.execute(
-            select(Faction).where(Faction.slug == slug)
+        status = (
+            FactionStatus.hidden
+            if slug in HIDDEN_FACTION_SLUGS
+            else FactionStatus.visible
         )
-        if existing.scalar_one_or_none() is None:
-            status = FactionStatus.hidden if slug in HIDDEN_FACTION_SLUGS else FactionStatus.visible
+        row = existing.get(slug)
+        if row is None:
             # ADR-0038: the row is slug + status only; name/description prose
             # lives in frontend/src/locales/en/factions.json.
             session.add(Faction(slug=slug, status=status))
             added += 1
+        elif row.status is FactionStatus.retired:
+            # A later era listing a retired slug again brings its tile back.
+            row.status = status
+
+    retired = 0
+    for slug, row in existing.items():
+        # A system row is never a roster member, so it never retires: `hidden`
+        # outranks the mirror. Tested both ways — by slug, so a system row the
+        # era stops listing is still safe, and by status, so a row hidden for
+        # some other reason does not have its tasks silently un-hidden here.
+        if (
+            slug in era.factions
+            or slug in HIDDEN_FACTION_SLUGS
+            or row.status is FactionStatus.hidden
+        ):
+            continue
+        if row.status is not FactionStatus.retired:
+            row.status = FactionStatus.retired
+            retired += 1
+
     await session.flush()
-    return added
+    return added, retired
 
 
 # ---------------------------------------------------------------------------
@@ -477,11 +517,15 @@ async def seed(env: str, yes: bool) -> None:
         # ------------------------------------------------------------------
         # Phase 1: Factions (from era config, upsert)
         # ------------------------------------------------------------------
-        faction_count = await upsert_era_factions(session, era)
+        faction_count, retired_count = await upsert_era_factions(session, era)
         if faction_count > 0:
             print(f"  >Factions ({faction_count} new)")
         else:
             print("  >Factions already exist — skipping")
+        if retired_count > 0:
+            # The rollover deploy's one visible sign that the roster shrank
+            # (ADR-0087). Rows are retired, never deleted.
+            print(f"  >Factions ({retired_count} retired — not in {era.config_key})")
 
         # ------------------------------------------------------------------
         # Phase 2: Admin bootstrap (Pixie account + character + era + role)

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -52,7 +52,14 @@ def faction_permits(
 
 
 async def hidden_faction_slugs(session: AsyncSession) -> list[str]:
-    """Slugs of factions that are not ``visible`` — i.e. ``hidden``.
+    """Slugs of ``hidden`` factions — the system rows, and nothing else.
+
+    ``hidden`` **only**, never "not ``visible``" (ADR-0087). Since #2706 there is
+    a third status, and a ``retired`` faction — one a past era listed and the
+    live one does not — must not land here: its tasks stay in the archive. This
+    predicate is the seam that would take them out of it, so widening the
+    comparison back to ``!=`` would empty most of a closed era's task history off
+    the site while the praxes written against those tasks stayed visible.
 
     Listing visibility is a faction-*status* axis, not a per-character permit,
     so it can't route through :func:`faction_permits`; it lives here so all
@@ -68,7 +75,7 @@ async def hidden_faction_slugs(session: AsyncSession) -> list[str]:
     ``visible`` rows directly, so ``na`` remains absent from the registry.
     """
     result = await session.execute(
-        select(Faction.slug).where(Faction.status != FactionStatus.visible)
+        select(Faction.slug).where(Faction.status == FactionStatus.hidden)
     )
     return [row[0] for row in result.all() if row[0] != UNAFFILIATED_FACTION_SLUG]
 

--- a/backend/tests/integration/test_faction_retirement.py
+++ b/backend/tests/integration/test_faction_retirement.py
@@ -1,0 +1,248 @@
+"""A faction the live era drops is retired, not hidden (#2706, ADR-0087).
+
+Two seams, and the tests below sit on both:
+
+1. **The writer** — ``seed.upsert_era_factions``. It used to only ever *add*,
+   so a slug the live era stopped listing kept its ``visible`` row and stayed in
+   the registry while ``can_join_faction``, which reads the era config, refused
+   it. It is now a two-way mirror: add what the era lists, retire what it does
+   not, delete nothing.
+2. **The reader** — ``services.faction_service.hidden_faction_slugs``, whose one
+   caller (``services.task.list_tasks``) drops those factions' tasks from every
+   listing. It must keep answering ``hidden`` *only*. That is the entire reason
+   ``retired`` is a third value rather than a reuse of ``hidden``: retirement
+   takes a faction out of the **registry**, not out of the **record**, so Era 1's
+   task archive survives the rollover.
+
+These tests never fabricate an era. A row the *live* era does not list is the
+production scenario verbatim, so a synthetic slug exercises the mirror under
+Era 1 (which drops nothing) and under every era after it.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.task import Task, TaskStatus
+from seed import HIDDEN_FACTION_SLUGS, upsert_era_factions
+from services.faction_service import can_join_faction, hidden_faction_slugs
+
+#: A slug no era config lists — i.e. exactly what a dropped faction looks like
+#: to the seeder the deploy after its era ends.
+DROPPED_SLUG = "retired_test_faction"
+
+
+def _era_listed_slug() -> str:
+    """Some ordinary roster slug of the live era.
+
+    ADR-0087: a test may not name a faction to get one. All this needs is a slug
+    the era lists and does not flag as a system row.
+    """
+    return next(
+        slug for slug in CURRENT_ERA.factions if slug not in HIDDEN_FACTION_SLUGS
+    )
+
+
+async def _add_faction(session: AsyncSession, slug: str, status: FactionStatus) -> Faction:
+    row = Faction(slug=slug, status=status)
+    session.add(row)
+    await session.commit()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# The writer: seed.upsert_era_factions is a two-way mirror
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_retires_a_slug_the_live_era_does_not_list(
+    db_session: AsyncSession,
+):
+    """The mirror's whole point: drop it from the config, the row goes retired."""
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.visible)
+
+    await upsert_era_factions(db_session, CURRENT_ERA)
+
+    row = await db_session.get(Faction, DROPPED_SLUG)
+    assert row is not None
+    assert row.status is FactionStatus.retired
+
+
+@pytest.mark.asyncio
+async def test_seed_never_deletes_a_row(
+    db_session: AsyncSession,
+    character: Character,
+):
+    """Rows are FK targets — ``character.faction_slug`` points at history.
+
+    A deleting mirror would take the closed era's characters and tasks with it,
+    so the count may only ever grow.
+    """
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.visible)
+    before = (await db_session.execute(select(func.count()).select_from(Faction))).scalar_one()
+
+    await upsert_era_factions(db_session, CURRENT_ERA)
+
+    after = (await db_session.execute(select(func.count()).select_from(Faction))).scalar_one()
+    assert after >= before
+    assert await db_session.get(Faction, DROPPED_SLUG) is not None
+    assert await db_session.get(Faction, character.faction_slug) is not None
+
+
+@pytest.mark.asyncio
+async def test_seed_leaves_a_system_row_hidden(db_session: AsyncSession):
+    """``na`` / ``aged_out`` are system rows: hidden outranks the mirror.
+
+    Retiring one would un-hide its tasks — ``hidden_faction_slugs`` is what keeps
+    them out of every listing — which is the opposite of what retirement means.
+    """
+    system_slug = next(iter(HIDDEN_FACTION_SLUGS - set(CURRENT_ERA.factions)))
+    await _add_faction(db_session, system_slug, FactionStatus.hidden)
+
+    await upsert_era_factions(db_session, CURRENT_ERA)
+
+    row = await db_session.get(Faction, system_slug)
+    assert row is not None
+    assert row.status is FactionStatus.hidden
+
+
+@pytest.mark.asyncio
+async def test_seed_unretires_a_slug_a_later_era_lists_again(
+    db_session: AsyncSession,
+):
+    """The mirror is two-way, so a returning faction gets its tile back."""
+    slug = _era_listed_slug()
+    await _add_faction(db_session, slug, FactionStatus.retired)
+
+    await upsert_era_factions(db_session, CURRENT_ERA)
+
+    row = await db_session.get(Faction, slug)
+    assert row is not None
+    assert row.status is FactionStatus.visible
+
+
+# ---------------------------------------------------------------------------
+# The registry: out of GET /factions, out of the join options
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retired_faction_is_absent_from_the_registry(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    faction_ua: Faction,
+):
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.retired)
+
+    resp = await client.get("/factions")
+
+    assert resp.status_code == 200
+    assert DROPPED_SLUG not in [f["slug"] for f in resp.json()]
+
+
+@pytest.mark.asyncio
+async def test_retired_faction_is_unjoinable(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+):
+    """``can_join_faction`` reads the era config, and the era no longer lists it."""
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.retired)
+
+    assert not await can_join_faction(
+        character.id, DROPPED_SLUG, era.id, db_session
+    )
+
+
+# ---------------------------------------------------------------------------
+# The record: the task archive survives retirement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hidden_faction_slugs_answers_hidden_only(db_session: AsyncSession):
+    """The reader must not widen to the third value.
+
+    Written as ``status != visible``, this would sweep every retired faction into
+    the listing filter and take most of a closed era's task history off the site.
+    """
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.retired)
+    await _add_faction(db_session, "hidden_test_faction", FactionStatus.hidden)
+
+    slugs = await hidden_faction_slugs(db_session)
+
+    assert DROPPED_SLUG not in slugs
+    assert "hidden_test_faction" in slugs
+
+
+@pytest.mark.asyncio
+async def test_retired_factions_tasks_stay_listable(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+):
+    """An active task authored by a retired faction is still on the board."""
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.retired)
+    task = Task(
+        title="Task from a closed era",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug=DROPPED_SLUG,
+    )
+    db_session.add(task)
+    await db_session.commit()
+
+    resp = await client.get("/tasks")
+
+    assert resp.status_code == 200
+    assert task.id in [t["id"] for t in resp.json()]
+
+
+@pytest.mark.asyncio
+async def test_retired_factions_tasks_stay_in_the_archive(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+    auth_headers: dict,
+):
+    """The archive ``level_to_see_retired_tasks`` unlocks still holds them.
+
+    Retiring through ``hidden`` instead would have emptied it while the praxes
+    written against those tasks stayed visible, linking to tasks in no listing.
+    """
+    await _add_faction(db_session, DROPPED_SLUG, FactionStatus.retired)
+    task = Task(
+        title="Archived task from a closed era",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.retired,
+        created_by=character.id,
+        primary_faction_slug=DROPPED_SLUG,
+    )
+    db_session.add(task)
+    stats = (
+        await db_session.execute(
+            select(CharacterStats).where(
+                CharacterStats.character_id == character.id,
+                CharacterStats.era_id == era.id,
+            )
+        )
+    ).scalar_one()
+    stats.level = CURRENT_ERA.level_to_see_retired_tasks
+    await db_session.commit()
+
+    resp = await client.get("/tasks?status=retired", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert task.id in [t["id"] for t in resp.json()]

--- a/backend/tests/integration/test_faction_retirement.py
+++ b/backend/tests/integration/test_faction_retirement.py
@@ -48,11 +48,16 @@ def _era_listed_slug() -> str:
     )
 
 
-async def _add_faction(session: AsyncSession, slug: str, status: FactionStatus) -> Faction:
-    row = Faction(slug=slug, status=status)
-    session.add(row)
+async def _add_faction(
+    session: AsyncSession, slug: str, status: FactionStatus
+) -> None:
+    session.add(Faction(slug=slug, status=status))
     await session.commit()
-    return row
+
+
+async def _faction_count(session: AsyncSession) -> int:
+    result = await session.execute(select(func.count()).select_from(Faction))
+    return result.scalar_one()
 
 
 # ---------------------------------------------------------------------------
@@ -85,12 +90,11 @@ async def test_seed_never_deletes_a_row(
     so the count may only ever grow.
     """
     await _add_faction(db_session, DROPPED_SLUG, FactionStatus.visible)
-    before = (await db_session.execute(select(func.count()).select_from(Faction))).scalar_one()
+    before = await _faction_count(db_session)
 
     await upsert_era_factions(db_session, CURRENT_ERA)
 
-    after = (await db_session.execute(select(func.count()).select_from(Faction))).scalar_one()
-    assert after >= before
+    assert await _faction_count(db_session) >= before
     assert await db_session.get(Faction, DROPPED_SLUG) is not None
     assert await db_session.get(Faction, character.faction_slug) is not None
 

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 771
+RUFF_FINDING_TOTAL = 770
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 772
+RUFF_FINDING_TOTAL = 771
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -151,7 +151,7 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "scripts/seed_demo_praxes.py::E501": 11,
     "scripts/seed_demo_praxes.py::I001": 1,
     "scripts/sweep_orphan_media.py::E501": 11,
-    "seed.py::E501": 4,
+    "seed.py::E501": 3,
     "seed.py::F541": 2,
     "seed.py::I001": 1,
     "services/activity_feed.py::E501": 8,


### PR DESCRIPTION
Implements ADR-0087's third `FactionStatus` value. Under Era 1 the live era lists every faction, so the mirror retires nothing and this is a **pure addition** — it lands before the `CURRENT_ERA` flip, not with it. `CURRENT_ERA` is untouched.

Closes #2706

## The seam

Two, and both are covered by `backend/tests/integration/test_faction_retirement.py`:

- **The writer** — `seed.upsert_era_factions`. It only ever *added*, so the day an era drops a faction the registry keeps offering it while `can_join_faction` (which reads the era config) refuses it.
- **The reader** — `services.faction_service.hidden_faction_slugs:54`, whose one caller is `services/task.py:692`. It asked for `Faction.status != FactionStatus.visible`. That is the line that made this more than an additive change: the moment a third value exists, `!=` sweeps every retired faction into the task-listing filter and takes a closed era's task archive off the site.

The failing test went red on exactly that, not on the enum: `test_hidden_faction_slugs_answers_hidden_only` and `test_retired_factions_tasks_stay_listable` fail against a `retired` row until the comparison narrows to `== FactionStatus.hidden`.

## What changed

| File | Change |
|---|---|
| `backend/models/faction.py` | `FactionStatus.retired`. The docstring that explained why there was no third value now explains why there is one — #1398 removed `deprecated` because "no writer could produce it", and the mirror is that writer. |
| `backend/alembic/versions/0016_faction_status_retired.py` | `ALTER TYPE factionstatus ADD VALUE IF NOT EXISTS 'retired'`. The column is `Enum(..., create_type=False)`, so the type is migration-owned. Same shape as `0015`'s `accountstatus.deleted`; `downgrade()` is a no-op because Postgres cannot remove an enum member. |
| `backend/seed.py` | `upsert_era_factions` becomes a two-way mirror returning `(added, retired)`. Adds every slug the era lists, un-retires one a later era lists again, marks `retired` every other row, **deletes nothing**, and leaves system rows (`na`, `aged_out`) `hidden` — guarded both by slug and by status. |
| `backend/services/faction_service.py` | `hidden_faction_slugs` narrows to `== hidden`, with the reason stated at the line so it does not drift back. |
| `backend/alembic/schema_snapshot.txt` | One line: `enum factionstatus = visible, hidden, retired`, carried by `0016`. |
| `backend/tests/unit/ruff_allowlist.py` | `seed.py::E501` 4 → 3 (total 772 → 771). The mirror rewrite broke the over-long status ternary onto its own lines; the ratchet requires an exact match. |

Scope kept to `upsert_era_factions` and its Phase-1 caller print. `DUEL_FIXTURE_TASK_FACTION_SLUG` and the "Seed complete!" summary block are untouched (#2710 / #2705).

## Verification

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz2706_test \
  pytest --cov=. --cov-report=term-missing --cov-fail-under=92
```
→ **1608 passed**, coverage 94.34% (floor 92).

Against a real Postgres, on a scratch DB, because a green pytest proves nothing about a migration:

- `alembic upgrade head` → `factionstatus` = `visible, hidden, retired`
- `downgrade -1` → `upgrade head` round-trip clean (the `IF NOT EXISTS` re-run is a no-op)
- `python seed.py --env dev` → 9 rows, `na` hidden, nothing retired (Era 1 drops nothing)
- inserted a `legacy_faction` row the era does not list, re-seeded → `>Factions (1 retired — not in era_1)`, row flipped to `retired`, **no row deleted**, `na` still `hidden`; a third run retires 0

`api-schema`: `scripts/dump_openapi.py` produces **no diff**. `FactionOut.status` is a plain `str`, so the wire contract is unchanged and no frontend file is touched. `ruff check` on every touched file is clean.

## What to eyeball

Backend-only, verified by tests and a real migration run — **no browser QA was possible from this worktree**, so the visual half is outstanding:

1. **The Factions grid is unchanged today.** `/factions` should still show all 8 non-`na` tiles under Era 1. This PR must be visually invisible; anything missing is a regression, not the feature.
2. **The Tasks page still lists everything it did.** This is the risky half — the listing filter changed. Browse `/tasks` with no filters and confirm the faction facet still offers every faction and the counts match `main`.
3. **The archive at level 2.** As a character at or above `level_to_see_retired_tasks`, open the retired-task view and confirm it is not empty. That is the outcome the third value exists to protect.
4. **A seed run's output.** `python seed.py --env dev` against a database that already has all 9 rows should print `>Factions already exist — skipping` and *no* retirement line.
5. **After the Era 2 flip (a later PR, not this one):** the grid should lose `coven`, `ephemerists`, `singularity`, `ua`, while their tasks stay on the board and their praxes still link to a task that renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
