### PR TITLE
The comment foot rule stops fading with the owner controls (#2733)

### DIFF
--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -25,7 +25,6 @@ import {
   OwnerControls,
   useOwnerEdit,
   useOwnerReveal,
-  ownerRevealStyle,
 } from './OwnerControls'
 import { CommentFlagControl, canFlagComment } from './FlagControl'
 
@@ -165,10 +164,10 @@ export function DefaultComment(props: CommentProps) {
   // something to show: the author's edit/withdraw or a flag affordance. Hidden
   // while editing, since the inline editor owns Save/Cancel then.
   const showControls = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN comment the foot holds nothing but the gated owner row, so the
-  // rule above it fades with the row — a hairline over empty space is a state
-  // the sheet never draws. A flaggable (someone else's) comment keeps its foot.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
   return (
     <Sheet
       slug={slug}
@@ -245,7 +244,6 @@ export function DefaultComment(props: CommentProps) {
             paddingTop: 'var(--space-sm)',
             // A divider INSIDE the sheet is quieter than the sheet's own edge.
             borderTop: '1px solid var(--faction-default-composer-hair)',
-            ...footGate,
           }}
         >
           <OwnerControls owner={owner} reveal={reveal} />

--- a/frontend/src/components/comments/__tests__/commentFootRule.test.tsx
+++ b/frontend/src/components/comments/__tests__/commentFootRule.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The foot rule on your OWN comment is permanent; only the controls reveal (#2733).
+ *
+ * THE SEAM: the subtree of the element carrying the reveal gate. `useOwnerReveal`
+ * and `ownerRevealStyle` are correct and untouched — the defect was purely what
+ * each voice put INSIDE the gate. Every voice wrapped its foot rule and its
+ * `edit · delete` cluster in one gated element, so the divider faded out with the
+ * controls and your own comment lost its rule whenever the pointer left.
+ *
+ * The gate's signature in markup is `transition:opacity` (nothing else in these
+ * voices installs one), so the assertion is exact: the gated subtree must not
+ * contain the voice's rule, and the rule must still be drawn.
+ *
+ * HARNESS: `renderToStaticMarkup`, the comments-test convention — no DOM, so
+ * `useOwnerReveal` takes its static branch (hover assumed capable, `revealed`
+ * false). That is precisely the "pointer elsewhere" reading the issue reports,
+ * which is why the bug is visible here at all.
+ *
+ * WHAT THIS CANNOT PROVE: that the rule is *pretty*, or that the fade actually
+ * animates. Both still need eyeballing in a browser.
+ */
+import type { ComponentType } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CommentProps } from '../shared'
+
+// Who is signed in decides all three readings: the author (gated controls), a
+// different member (flag row, never gated), and nobody (no foot at all).
+const authState = vi.hoisted(() => ({ user: null as unknown }))
+vi.mock('../../../auth/AuthContext', () => ({ useAuth: () => authState }))
+
+import { DefaultComment } from '../CommentThread'
+import AlbescentComment from '../voices/AlbescentComment'
+import CovenComment from '../voices/CovenComment'
+import EphemeristsComment from '../voices/EphemeristsComment'
+import EverymenComment from '../voices/EverymenComment'
+import SingularityComment from '../voices/SingularityComment'
+import SnideComment from '../voices/SnideComment'
+import UaComment from '../voices/UaComment'
+import WowComment from '../voices/WowComment'
+
+/** Nine voices, nine bespoke dresses — each names its own rule. */
+const VOICES: [string, ComponentType<CommentProps>, RegExp][] = [
+  ['na / default', DefaultComment, /border-top:1px solid var\(--faction-default-composer-hair\)/],
+  // A pass-through to na's sheet: it inherits the fix and is listed to prove it.
+  ['albescent', AlbescentComment, /border-top:1px solid var\(--faction-default-composer-hair\)/],
+  ['coven', CovenComment, /class="cvn-braid"/],
+  ['ephemerists', EphemeristsComment, /border-top:1px solid/],
+  ['everymen', EverymenComment, /border-top:1px solid var\(--faction-everymen-sheet-hair\)/],
+  ['singularity', SingularityComment, /border-top:1px dashed/],
+  ['snide', SnideComment, /border-top:1px solid var\(--faction-snide-slip-rule\)/],
+  ['ua', UaComment, /border-top:1px solid var\(--faction-ua-hair\)/],
+  // The crown at the top of the WOW sheet paints the same ribbon, so the rule is
+  // named by RibbonRule's own held-back opacity, not by the pigment alone.
+  ['wow', WowComment, /height:3px;background:var\(--faction-wow-quest-ribbon\);opacity:0\.75/],
+]
+
+const AUTHOR_ID = 42
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'the rule stays, the controls come and go',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: AUTHOR_ID,
+    username: 'ada',
+    display_name: 'Adabel',
+    avatar_url: '',
+    faction_slug: 'na',
+  },
+  mentions: [],
+}
+
+function row(Voice: ComponentType<CommentProps>): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Voice mode="row" comment={COMMENT} />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  authState.user = null
+})
+
+// ── A string walk over the markup (there is no DOM in this harness) ──────────
+
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta',
+  'param', 'source', 'track', 'wbr',
+])
+// Quoted attribute values are matched whole, so a '>' inside copy or a data URI
+// cannot end a tag early.
+const TAG = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:[^>"']|"[^"]*"|'[^']*')*)>/g
+
+const GATE = /transition:opacity/
+
+/**
+ * The outer HTML of the first element whose attributes match, or null if none
+ * does. Its own opening tag is included: on five voices the rule was a
+ * `border-top` on the gated element ITSELF, not a child of it.
+ */
+function subtreeOf(html: string, matches: RegExp): string | null {
+  TAG.lastIndex = 0
+  let match: RegExpExecArray | null
+  let start = -1
+  let depth = 0
+  while ((match = TAG.exec(html)) !== null) {
+    const [full, closing, name, attributes] = match
+    const childless =
+      VOID_ELEMENTS.has(name.toLowerCase()) || attributes.trimEnd().endsWith('/')
+    if (start === -1) {
+      if (closing || !matches.test(attributes)) continue
+      if (childless) return full
+      start = match.index
+      depth = 1
+      continue
+    }
+    if (childless) continue
+    if (!closing) {
+      depth += 1
+      continue
+    }
+    depth -= 1
+    if (depth === 0) return html.slice(start, match.index + full.length)
+  }
+  return null
+}
+
+describe('your own comment keeps its foot rule while the controls fade (#2733)', () => {
+  it.each(VOICES)('%s: the rule is drawn with the pointer elsewhere', (_name, Voice, RULE) => {
+    authState.user = { character: { id: AUTHOR_ID } }
+    expect(row(Voice)).toMatch(RULE)
+  })
+
+  it.each(VOICES)('%s: the rule is outside the reveal gate', (_name, Voice, RULE) => {
+    authState.user = { character: { id: AUTHOR_ID } }
+    const html = row(Voice)
+    const gated = subtreeOf(html, GATE)
+    // The gate must exist — otherwise this passes for the wrong reason.
+    expect(gated, 'the owner row is still gated').not.toBeNull()
+    expect(gated).toContain('aria-label="edit"')
+    expect(gated).not.toMatch(RULE)
+  })
+
+  it.each(VOICES)('%s: someone else\'s comment is unchanged — rule, no gate', (_name, Voice, RULE) => {
+    authState.user = { character: { id: AUTHOR_ID + 1 } }
+    const html = row(Voice)
+    expect(html).toMatch(RULE)
+    // OwnerControls renders nothing for a non-author, so no gate is installed.
+    expect(subtreeOf(html, GATE)).toBeNull()
+  })
+
+  it.each(VOICES)('%s: a signed-out viewer still gets no foot at all', (_name, Voice, RULE) => {
+    const html = row(Voice)
+    expect(html).not.toMatch(RULE)
+    expect(html).not.toMatch(GATE)
+  })
+})
+
+describe('the walker itself', () => {
+  it('returns the matched element with its own attributes and its subtree', () => {
+    const html = '<div style="a"><span style="transition:opacity"><b>x</b></span><i>y</i></div>'
+    expect(subtreeOf(html, GATE)).toBe('<span style="transition:opacity"><b>x</b></span>')
+  })
+
+  it('returns null when nothing matches', () => {
+    expect(subtreeOf('<div style="a"></div>', GATE)).toBeNull()
+  })
+})

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -8,7 +8,6 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
 import {
   CommentEditor,
   OwnerControls,
-  ownerRevealStyle,
   useOwnerEdit,
   useOwnerReveal,
 } from '../OwnerControls'
@@ -172,10 +171,10 @@ export default function CovenComment(props: CommentProps) {
   // or a flag affordance. Hidden while editing — the inline editor owns
   // Save/Cancel then.
   const showFoot = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN comment the foot holds nothing but the gated owner row, so the
-  // braid above it fades with the row: a thread ruling off empty space is a state
-  // this sheet never draws. Someone else's (flaggable) comment keeps its foot.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
 
   return (
     <Slip
@@ -245,7 +244,7 @@ export default function CovenComment(props: CommentProps) {
       </div>
 
       {showFoot && (
-        <div style={{ marginTop: 'var(--space-md)', ...footGate }}>
+        <div style={{ marginTop: 'var(--space-md)' }}>
           {/* the braided thread rules the foot off the body. `.cvn-braid` owns
               both its pigments and its dark override — a data-URI SVG is a
               separate document, so `var(--…)` inside one never resolves. */}

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -54,7 +54,6 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
 import {
   CommentEditor,
   OwnerControls,
-  ownerRevealStyle,
   useOwnerEdit,
   useOwnerReveal,
 } from '../OwnerControls'
@@ -224,10 +223,10 @@ export default function EphemeristsComment(props: CommentProps) {
   // drawn only when one of them has something to show — hidden while editing,
   // since the inline editor owns Save/Cancel then.
   const showControls = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN note the foot holds nothing but the gated owner row, so its rule
-  // fades with the row: a brass hairline over empty space is a state this sheet
-  // never draws. Someone else's (flaggable) note keeps its foot lit.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
 
   return (
     <Leaf
@@ -294,7 +293,6 @@ export default function EphemeristsComment(props: CommentProps) {
             paddingTop: 'var(--space-sm)',
             // A hairline INSIDE the leaf is quieter than the leaf's own edge.
             borderTop: `1px solid ${LINE}`,
-            ...footGate,
           }}
         >
           <OwnerControls owner={owner} reveal={reveal} />

--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -49,7 +49,6 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
 import {
   CommentEditor,
   OwnerControls,
-  ownerRevealStyle,
   useOwnerEdit,
   useOwnerReveal,
 } from '../OwnerControls'
@@ -240,10 +239,10 @@ export default function EverymenComment(props: CommentProps) {
   // The foot only exists when it holds something: the author's edit/withdraw or
   // a flag affordance. Hidden while editing — the inline editor owns Save/Cancel.
   const showControls = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN comment the foot holds nothing but the gated owner row, so the
-  // rule above it fades with the row: a hairline over empty space is a state the
-  // sheet never draws. Someone else's (flaggable) comment keeps its foot.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
 
   return (
     <Slip
@@ -308,7 +307,6 @@ export default function EverymenComment(props: CommentProps) {
             paddingTop: 'var(--space-sm)',
             // A rule INSIDE the panel is quieter than the form's own edge.
             borderTop: '1px solid var(--faction-everymen-sheet-hair)',
-            ...footGate,
           }}
         >
           <OwnerControls owner={owner} reveal={reveal} />

--- a/frontend/src/components/comments/voices/SingularityComment.tsx
+++ b/frontend/src/components/comments/voices/SingularityComment.tsx
@@ -7,7 +7,6 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
 import {
   CommentEditor,
   OwnerControls,
-  ownerRevealStyle,
   useOwnerEdit,
   useOwnerReveal,
 } from '../OwnerControls'
@@ -247,10 +246,10 @@ export default function SingularityComment(props: CommentProps) {
   // The foot exists only when it holds something. Hidden while editing — the
   // inline editor owns Save/Cancel then.
   const showFoot = !owner.editing && (owner.isOwner || canFlag)
-  // On your own comment the foot holds nothing but the gated owner row, so the
-  // rule above it fades with the row: a hairline over empty space is a state the
-  // sheet never draws. A flaggable (someone else's) comment keeps its foot.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
 
   return (
     <Pane
@@ -331,7 +330,6 @@ export default function SingularityComment(props: CommentProps) {
             marginTop: 'var(--space-md)',
             paddingTop: 'var(--space-sm)',
             borderTop: `1px dashed ${HAIR}`,
-            ...footGate,
           }}
         >
           {/* Two repoints, deliberately not one — see the docblock. */}

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -11,7 +11,6 @@ import {
   OwnerControls,
   useOwnerEdit,
   useOwnerReveal,
-  ownerRevealStyle,
 } from '../OwnerControls'
 import { CommentFlagControl, canFlagComment } from '../FlagControl'
 import { Ransom } from '../../factionMarks/snideAtoms'
@@ -173,10 +172,10 @@ export default function SnideComment(props: CommentProps) {
   // flag affordance for everyone else. The inline editor owns Save/Cancel while
   // editing, so the foot stands down then.
   const showControls = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN slip the foot holds nothing but the gated owner row, so the
-  // censor rule above it fades with the row — a hairline over empty space is a
-  // state the sheet never draws.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
 
   return (
     <div style={slip(mobile)} {...reveal.containerProps}>
@@ -235,8 +234,7 @@ export default function SnideComment(props: CommentProps) {
                 paddingTop: 'var(--space-sm)',
                 // A censor rule inside the slip, quieter than its cut edge.
                 borderTop: '1px solid var(--faction-snide-slip-rule)',
-                ...footGate,
-              }}
+                  }}
             >
               <OwnerControls owner={owner} reveal={reveal} />
               <CommentFlagControl comment={comment} />

--- a/frontend/src/components/comments/voices/UaComment.tsx
+++ b/frontend/src/components/comments/voices/UaComment.tsx
@@ -10,7 +10,6 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
 import {
   CommentEditor,
   OwnerControls,
-  ownerRevealStyle,
   useOwnerEdit,
   useOwnerReveal,
 } from '../OwnerControls'
@@ -126,9 +125,10 @@ export default function UaComment(props: CommentProps) {
   // a flag affordance on somebody else's note. Hidden while editing — the inline
   // editor owns Save/Cancel then.
   const showFoot = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN note the foot holds nothing but the gated row, so its hairline
-  // fades with the row: a rule over empty space is a state the sheet never draws.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
   return (
     <div style={note(false)} {...reveal.containerProps}>
       <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
@@ -196,8 +196,7 @@ export default function UaComment(props: CommentProps) {
               // The faintest divider UA has: a rule inside the note is quieter
               // than the note's own edge.
               borderTop: '1px solid var(--faction-ua-hair)',
-              ...footGate,
-            }}
+              }}
           >
             <OwnerControls owner={owner} reveal={reveal} />
             <CommentFlagControl comment={comment} />

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -9,7 +9,6 @@ import { type CommentProps, authorToCharacter, ComposerControls, MentionText } f
 import {
   CommentEditor,
   OwnerControls,
-  ownerRevealStyle,
   useOwnerEdit,
   useOwnerReveal,
 } from '../OwnerControls'
@@ -225,10 +224,10 @@ export default function WowComment(props: CommentProps) {
   // The foot exists only when it holds something: the author's edit/withdraw or
   // a flag affordance. Hidden while editing — the inline editor owns Save/Cancel.
   const showControls = !owner.editing && (owner.isOwner || canFlag)
-  // On your OWN comment the foot holds nothing but the gated owner row, so the
-  // rule above it fades with the row. A flaggable (someone else's) comment keeps
-  // its foot always. Same condition as `DefaultComment`, the behaviour spec.
-  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+  // The foot RULE is never gated (#2733): on your own comment it always draws,
+  // and only the edit/delete cluster fades. `<OwnerControls reveal>` gates
+  // itself — and it alone knows to stay pinned through the withdraw-confirm
+  // strip, which an outer gate used to fade out from under mid-answer.
 
   return (
     <Sheet
@@ -289,7 +288,7 @@ export default function WowComment(props: CommentProps) {
       </div>
 
       {showControls && (
-        <div style={footGate ?? undefined}>
+        <div>
           <RibbonRule style={{ marginTop: 'var(--space-md)' }} />
           <div
             style={{


### PR DESCRIPTION
Closes #2733

On your own comment the foot rule always renders; only the `edit · delete` cluster is gated behind the hover/focus reveal. A comment that is not yours is unchanged.

## The seam

**The subtree of the element carrying the reveal gate.** `useOwnerReveal` / `ownerRevealStyle` were already correct — the defect was purely *what each voice put inside the gate*. In markup the gate's signature is `transition:opacity`, and nothing else in these voices installs one, so the assertion is exact: the gated subtree must not contain the voice's rule, and the rule must still be drawn.

`frontend/src/components/comments/__tests__/commentFootRule.test.tsx` renders each of the nine voices at `mode="row"` under three viewers (author / another member / signed out). Written first, it went red on exactly the nine "the rule is outside the reveal gate" cases and green on the other 29 — the `renderToStaticMarkup` harness takes `useOwnerReveal`'s static branch with `revealed` false, which *is* the "pointer elsewhere" reading the issue reports.

## The fix is a deletion, not a split

The issue prescribed splitting each gated element in two. Tracing it, the gate turned out to be **doubled**, so no split is needed:

- `<OwnerControls owner={owner} reveal={reveal}>` already gates itself, in all eight files.
- `footGate` was `owner.isOwner && !canFlag`, and `canFlagComment` is exactly "signed in and *not* the author" — so whenever `footGate` was live, its sibling `<CommentFlagControl>` rendered `null`.

The outer gate therefore covered nothing but the rule. Removing it (one `const`, one spread, one now-unused import per file) satisfies the ruling with the shortest diff and **no shared foot component** — each voice keeps its own dress.

It also fixes a second, unreported bug on the way out: `OwnerControls` deliberately pins the withdraw-confirm strip open through a mouse-leave ("a question already asked"), and the outer `opacity: 0` faded that question out from under the answer. Opacity multiplies; the pin could not win.

## Free properties, kept

Opacity-only, buttons still mounted (Tab still reaches them), no layout shift in either state, no conditional rendering, no `display: none`. A non-owner's flag row is still ungated. A device reporting no hover capability still never gates.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (446 files / 9135 tests), `npm run build`, `npm run budget` — all green locally. No backend or schema surface touched.

**Visual QA is outstanding.** There is no browser in this environment; the tests pin the structure (which element carries the rule, which carries the gate) and cannot see a pixel or an actual fade.

## What to eyeball

On your *own* comment in each voice: the rule is there with the pointer elsewhere, does not move or change on hover, and `edit · delete` fades in. Then hit `delete` and move the pointer off — the "withdraw / keep" question must stay put.

1. **na / default** (`CommentThread.tsx`) — the composer hairline
2. **albescent** — pass-through to na's sheet; not edited, inherits the fix
3. **coven** — the `.cvn-braid` thread
4. **ephemerists** — the brass hairline in the leaf
5. **everymen** — the sheet hair inside the panel
6. **singularity** — the dashed terminal hair
7. **snide** — the censor rule inside the slip
8. **ua** — the note's faint hairline
9. **wow** — the `RibbonRule` divider

🤖 Generated with [Claude Code](https://claude.com/claude-code)
