### PR TITLE
WOW's bunting counts its own pennants instead of clipping them (#2728)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/wowBunting.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/wowBunting.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * WOW'S BUNTING, AND ITS TWO CLIPS (#2728).
+ *
+ * Both defects were measured in a browser and neither is visible to this
+ * harness — the repo renders with `renderToStaticMarkup`, so there is no jsdom,
+ * no layout and nothing to measure. What IS checkable is the arithmetic that
+ * decides the count, which is pure, and the box model the container declares,
+ * which is inline style and therefore in the markup.
+ *
+ *  • THE HORIZONTAL CLIP. A pennant is a CSS triangle — `border-left: 7px` plus
+ *    `border-right: 7px` — and A BORDER CANNOT SHRINK, so the old `flex: 1;
+ *    min-width: 0` was decorative: thirty pennants had a hard 536px floor and
+ *    `overflow: hidden` ate the rest (measured `clientWidth 263 /
+ *    scrollWidth 536` at a 593px window). The count is now measured off the
+ *    container, the way `EphemeristsNotationBand` does it, and
+ *    {@link buntingPennantCount} is that arithmetic. It is the seam: a strip
+ *    that packs one pennant too many looks perfectly plausible and is the exact
+ *    bug reported.
+ *  • THE VERTICAL CLIP. Tailwind preflight makes everything `border-box`, so a
+ *    mount passing padding shrank a fixed `height: 22` container's CONTENT box —
+ *    `WowFactionBody` passes `var(--space-sm)` off the top and the strip
+ *    measured `clientHeight 22 / scrollHeight 28`. The fix belongs to the
+ *    component, not the mount, so no future mount can clip the pennants it is
+ *    spacing: the well is `content-box`, and `min-height` rather than `height`.
+ *
+ * An unmeasured strip draws NOTHING — the band's rule, for the band's reason: a
+ * strip that paints thirty pennants and then snaps to twelve is the twitch the
+ * measurement exists to remove, and in a browser the layout effect runs before
+ * paint so the empty state is never seen. That is why the count assertions
+ * below are at the function and not in the markup.
+ */
+import type { CSSProperties } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+import { Bunting, buntingPennantCount, pennantStyle } from "../wowOrnament";
+
+/** The pennant's own geometry, restated so this file is an independent check of
+ *  it: 7px + 7px of mitre is the flag, `--space-xs` is the gap between two. */
+const PENNANT = 14;
+const GAP = 4;
+
+/** What the strip must satisfy at every width: the pennants and their gaps fit
+ *  inside the well, and one more pennant would not. */
+function widthOf(count: number): number {
+  return count <= 0 ? 0 : count * PENNANT + (count - 1) * GAP;
+}
+
+describe("buntingPennantCount — as many whole pennants as fit (#2728)", () => {
+  it("draws nothing until it has been measured", () => {
+    // Before the layout effect, under the Node harness where effects never run,
+    // and in a container that has no width yet.
+    expect(buntingPennantCount(0)).toBe(0);
+    expect(buntingPennantCount(-1)).toBe(0);
+    expect(buntingPennantCount(Number.NaN)).toBe(0);
+  });
+
+  it("takes the pennant's 14px floor seriously", () => {
+    expect(buntingPennantCount(13), "narrower than one flag").toBe(0);
+    expect(buntingPennantCount(14), "exactly one flag").toBe(1);
+    expect(buntingPennantCount(31), "one flag and most of a gap").toBe(1);
+    expect(buntingPennantCount(32), "two flags and the gap between them").toBe(2);
+  });
+
+  it("never overflows, and never leaves room for one more", () => {
+    for (let width = 320; width <= 1440; width += 1) {
+      const count = buntingPennantCount(width);
+      expect(widthOf(count), `${width}px overflows`).toBeLessThanOrEqual(width);
+      expect(widthOf(count + 1), `${width}px has room for another`).toBeGreaterThan(width);
+    }
+  });
+
+  it("fits the strip that was clipped in half on prod", () => {
+    // The reported measurement: a 593px window, `clientWidth 263 /
+    // scrollWidth 536`. Thirty pennants never fit; this many do.
+    expect(widthOf(buntingPennantCount(263))).toBeLessThanOrEqual(263);
+    expect(buntingPennantCount(263)).toBeLessThan(30);
+  });
+});
+
+describe("pennantStyle — the flag itself is unchanged (#2728)", () => {
+  it("alternates gold and plum and keeps the 2px stagger", () => {
+    expect(pennantStyle(0).borderTop).toContain("--faction-wow-chronicle-gold");
+    expect(pennantStyle(1).borderTop).toContain("--faction-wow-card-accent");
+    expect(pennantStyle(0).transform).toBe("translateY(0px)");
+    expect(pennantStyle(1).transform).toBe("translateY(2px)");
+  });
+
+  it("draws a triangle rather than a flexed trapezoid", () => {
+    // `flex: 1` stretched the CONTENT box of a zero-height bordered span, which
+    // is what made a wide strip's flags read as trapezoids (33.5px on a 1121px
+    // window). A pennant is 14px wide everywhere now.
+    const style = pennantStyle(0);
+    expect(style.flex, "a border cannot shrink, so flex was always a lie").toBeUndefined();
+    expect(style.borderLeft).toBe("7px solid transparent");
+    expect(style.borderRight).toBe("7px solid transparent");
+  });
+});
+
+describe("the bunting's well cannot be clipped by a mount's padding (#2728)", () => {
+  const markup = (style?: CSSProperties) =>
+    renderToStaticMarkup(<Bunting style={style} />);
+
+  it("sizes its well by the content box, not the border box", () => {
+    const html = markup();
+    // Tailwind preflight's `border-box` is what let `WowFactionBody`'s padding
+    // eat 8px of an 18px pennant.
+    expect(html).toContain("box-sizing:content-box");
+    // `min-height:22px` contains the substring, so the fixed height has to be
+    // matched at a declaration boundary.
+    expect(html, "a fixed height is the clip").not.toMatch(/[;"]height:22px/);
+    expect(html).toContain("min-height:22px");
+  });
+
+  it("still lets a mount space it", () => {
+    expect(markup({ padding: "var(--space-sm) var(--space-lg) 0" })).toContain(
+      "padding:var(--space-sm) var(--space-lg) 0",
+    );
+  });
+});

--- a/frontend/src/components/factionMarks/wowOrnament.tsx
+++ b/frontend/src/components/factionMarks/wowOrnament.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import { factionRoleVar } from "../../utils/factionRoles";
@@ -226,37 +227,132 @@ export function BalloonBunch({
   );
 }
 
-/** How many pennants a strip carries. They flex, so this is a density, not a width. */
-const BUNTING_PENNANTS = 30;
+/**
+ * THE PENNANT, AND WHY THE STRIP COUNTS ITSELF (#2728).
+ *
+ * A pennant is a CSS triangle: two transparent 7px side borders under an 18px
+ * top border. So it is 14px wide, and A BORDER CANNOT SHRINK. The strip used to
+ * hang a fixed thirty of them at `flex: 1; min-width: 0` under a comment
+ * claiming "they flex, so this is a density, not a width" — which was false in
+ * both directions. Below ~536px the flex could not shrink past the mitres and
+ * `overflow: hidden` ate the tail (measured on prod: `clientWidth 263 /
+ * scrollWidth 536` at a 593px window — half the strip gone). Above it, the flex
+ * stretched the zero-height CONTENT box instead, and each flag opened out into a
+ * trapezoid with a 33.5px flat top.
+ *
+ * So the count is MEASURED off the container and every pennant is drawn at its
+ * own size — the pattern `EphemeristsNotationBand` already uses (#2143), and
+ * deliberately not a second mechanism. The strip carries as many whole flags as
+ * fit, at one PITCH rather than one count, and nothing is ever clipped.
+ *
+ * All four numbers are raw px because all four are ornament geometry (§4a), and
+ * the GAP is a number rather than `var(--space-xs)` because it is now arithmetic
+ * as well as paint: one constant cannot drift out of step with itself the way a
+ * token in the style and a 4 in the maths could.
+ */
+const PENNANT_WIDTH = 14;
+const PENNANT_GAP = 4;
+const PENNANT_HEIGHT = 18;
+/** Every other flag hangs 2px lower, so the strip reads as string rather than as
+ *  a rule. A TRANSFORM, so it paints below the flag's layout box — which is why
+ *  the well below is 22 and not 18. */
+const PENNANT_STAGGER = 2;
+
+/**
+ * How many whole pennants a strip of this width carries. Exported for its test:
+ * it is measured off a real element, so a harness with no DOM can only check the
+ * arithmetic at the function — and a strip that packs one flag too many looks
+ * entirely plausible and is the bug that was reported.
+ *
+ * An unmeasured strip (width 0, before the layout effect, or under the SSR-only
+ * test harness where effects never run) draws NOTHING rather than a guess:
+ * `EphemeristsNotationBand`'s rule, for its reason — a strip that paints thirty
+ * flags and then snaps to twelve is the twitch the measurement removes. The
+ * layout effect runs before paint, so no reader sees the empty state.
+ */
+export function buntingPennantCount(width: number): number {
+  if (!(width > 0)) return 0;
+  return Math.floor((width + PENNANT_GAP) / (PENNANT_WIDTH + PENNANT_GAP));
+}
+
+/** One flag. Exported for the same reason: with the count measured, the markup a
+ *  Node harness sees is an empty strip, so the alternation and the stagger are
+ *  only checkable here. */
+export function pennantStyle(index: number): CSSProperties {
+  const odd = index % 2 === 1;
+  return {
+    height: 0,
+    borderLeft: `${PENNANT_WIDTH / 2}px solid transparent`,
+    borderRight: `${PENNANT_WIDTH / 2}px solid transparent`,
+    borderTop: `${PENNANT_HEIGHT}px solid ${odd ? PLUM : GOLD}`,
+    transform: `translateY(${odd ? PENNANT_STAGGER : 0}px)`,
+  };
+}
+
+/** The twin of `EphemeristsNotationBand`'s and `SegmentedRail`'s: a layout effect
+ *  measures before the browser paints, so the strip fills in without a frame of
+ *  emptiness, and `useEffect` is the Node-side fallback where there is no layout
+ *  to read. */
+const useMeasureEffect = typeof document === "undefined" ? useEffect : useLayoutEffect;
 
 /** Gold and plum pennants strung across the head of a page. */
 export function Bunting({ style }: { style?: CSSProperties }): ReactNode {
+  const strip = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  const measure = useCallback(() => {
+    const element = strip.current;
+    if (!element) return;
+    // The CONTENT box, not `clientWidth`, which includes whatever padding the
+    // mount added — `WowFactionBody` adds `--space-lg` either side — while the
+    // flags only ever get the content box. Counting off `clientWidth` would
+    // re-open the horizontal clip on the very mount that reported the other one.
+    const box = getComputedStyle(element);
+    setWidth(
+      element.clientWidth - parseFloat(box.paddingLeft) - parseFloat(box.paddingRight),
+    );
+  }, []);
+
+  useMeasureEffect(measure);
+
+  useEffect(() => {
+    const element = strip.current;
+    // Guarded as the band guards its own: the constructor is a browser global
+    // and this module is imported by a Node-side harness.
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [measure]);
+
   return (
     <div
+      ref={strip}
       aria-hidden="true"
+      // The strip's handle in the markup. With the count measured there are no
+      // pennants for a DOM-less test to find, so this is what a surface test
+      // asserts to say "the bunting hangs here, and it is the shared primitive".
+      data-wow-bunting=""
       style={{
         display: "flex",
         alignItems: "flex-start",
-        gap: "var(--space-xs)",
-        height: 22,
+        gap: PENNANT_GAP,
+        // THE WELL, AND THE SECOND CLIP (#2728). Tailwind preflight makes
+        // everything `border-box`, so a mount passing padding used to shrink the
+        // CONTENT box of a fixed `height: 22` — `WowFactionBody` takes 8px off
+        // the top, which left 14px for an 18px flag (`clientHeight 22 /
+        // scrollHeight 28`). `content-box` keeps the well 22 however a mount
+        // spaces it, and `min-height` lets it only ever grow: a mount can no
+        // longer clip the ornament it is positioning.
+        boxSizing: "content-box",
+        minHeight: PENNANT_HEIGHT + 2 * PENNANT_STAGGER,
         overflow: "hidden",
         opacity: 0.9,
         ...style,
       }}
     >
-      {Array.from({ length: BUNTING_PENNANTS }).map((_, index) => (
-        <span
-          key={index}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            height: 0,
-            borderLeft: "7px solid transparent",
-            borderRight: "7px solid transparent",
-            borderTop: `18px solid ${index % 2 ? PLUM : GOLD}`,
-            transform: `translateY(${index % 2 ? 2 : 0}px)`,
-          }}
-        />
+      {Array.from({ length: buntingPennantCount(width) }, (_, index) => (
+        <span key={index} style={pennantStyle(index)} />
       ))}
     </div>
   );

--- a/frontend/src/components/taskCard/__tests__/wowTaskCardV3.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/wowTaskCardV3.test.tsx
@@ -138,9 +138,16 @@ describe('the bunting replaces the barber ribbon (#2032)', () => {
     const html = render()
     expect(html, 'the strip the flags replace').not.toContain('--faction-wow-quest-ribbon')
     // Derived, not redrawn: WORLD_ZERO_STYLE §6 says a faction's device is one
-    // primitive, and `wowOrnament`'s `Bunting` is it. The pennant's mitred
-    // border is that component's signature and no hand-rolled twin's.
-    expect((html.match(/border-left:7px solid transparent/g) ?? []).length).toBeGreaterThan(20)
+    // primitive, and `wowOrnament`'s `Bunting` is it.
+    //
+    // This used to count the pennants' mitred borders. Since #2728 the strip
+    // MEASURES its container and draws as many whole flags as fit, so under this
+    // harness — `renderToStaticMarkup`, no DOM, effects never run — a rendered
+    // strip is an EMPTY strip by construction and there are no borders to count.
+    // `data-wow-bunting` is the primitive's handle, which a hand-rolled twin
+    // would not carry; the flags themselves are checked at their own seam in
+    // `factionMarks/__tests__/wowBunting.test.tsx`.
+    expect(html, 'the shared primitive hangs here').toContain('data-wow-bunting')
   })
 })
 

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -353,9 +353,14 @@ describe("WOW praxis detail — the dress", () => {
 
   it("strings the bunting and bobs exactly one bunch of balloons", () => {
     const { html } = render(state());
-    // The bunting pennants alternate gold and plum; the bunch is the page's one
-    // bobbing ornament, and its motion is CLASS-gated, never inline.
-    expect(html, "bunting is drawn").toContain("18px solid var(--faction-wow-card-accent)");
+    // The bunch is the page's one bobbing ornament, and its motion is
+    // CLASS-gated, never inline.
+    //
+    // The bunting is asserted by its handle rather than by a pennant's plum
+    // border: since #2728 the strip measures its container and draws as many
+    // whole flags as fit, so with no DOM here it renders empty. The alternation
+    // and the stagger are pinned at `factionMarks/__tests__/wowBunting.test.tsx`.
+    expect(html, "bunting is strung").toContain("data-wow-bunting");
     expect(html.match(/wow-balloon-bunch/g)?.length, "one bunch, not a soup").toBe(1);
     expect(html, "motion is never inline").not.toContain("animation:");
   });


### PR DESCRIPTION
Closes #2728

WOW's bunting was clipped twice over, and the two clips have nothing to do with each other.

## The seam I tested at

`buntingPennantCount(width)` in `frontend/src/components/factionMarks/wowOrnament.tsx` — the count-from-width arithmetic, pure and checkable with no DOM. `pennantStyle(index)` is exported beside it for the same reason. New test: `frontend/src/components/factionMarks/__tests__/wowBunting.test.tsx`, red on both defects before the fix (7 of 8 failing), green after.

The property the loop pins, at every width from 320 to 1440: the flags and their gaps **fit** the well, and **one more would not**.

## Horizontal — a border cannot shrink

A pennant is a CSS triangle: two transparent 7px side borders under an 18px top border. So `flex: 1; min-width: 0` was decorative — thirty flags had a hard 536px floor, and `overflow: hidden` ate the tail (`clientWidth 263 / scrollWidth 536` at a 593px window). Above that floor the flex stretched the zero-height *content* box instead, so each flag opened into a trapezoid with a 33.5px flat top.

The strip now **measures its container and draws as many whole 14px flags as fit** — `ResizeObserver` plus a layout effect, the mechanism `EphemeristsNotationBand` already uses, not a second one. It measures the **content** box (`clientWidth` minus computed padding), because the one mount that passes padding passes `--space-lg` either side and counting off `clientWidth` would re-open the clip on exactly that surface.

The `flex: 1` stretch is gone, so a wide desktop strip is now more, smaller flags at one pitch rather than thirty stretched ones — that is the visible change, and it is what the ruling asked for.

## Vertical — Tailwind preflight vs. a mount's padding

`height: 22` under `box-sizing: border-box` meant a mount passing padding shrank the *content* box: `WowFactionBody` takes `--space-sm` off the top, leaving 14px for an 18px pennant (`clientHeight 22 / scrollHeight 28`).

Fixed in the component, not the mount. The well is `box-sizing: content-box` **and** `min-height: 22` rather than `height: 22`:

- `min-height` alone does **not** close it. With border-box and 8px of padding the content box lands at 18px, while the strip's painted extent is 20px — the 2px `translateY` stagger paints below the flag's layout box and is included in Chrome's scrollable overflow. That leaves the odd pennants clipped by 2px, which is why this is `content-box` as well.
- `content-box` is the one that makes the class of bug impossible: any mount, any padding, any side.

## Also

- Rewrote the comment that claimed *"They flex, so this is a density, not a width"* — it was false in both directions, and the docblock now says why.
- `BUNTING_PENNANTS = 30` is deleted. There is no ceiling: at a wide width capping the count would leave the strip half empty.
- The gap is one constant used by both the maths and the paint rather than `var(--space-xs)` in the style and a `4` in the arithmetic that could drift apart. Ornament geometry, per WORLD_ZERO_STYLE §4a and the same call `EphemeristsNotationBand`'s `PITCH` makes.
- The container carries `data-wow-bunting`. A measured strip renders **empty** under `renderToStaticMarkup` (effects never run here), so `wowTaskCardV3.test.tsx` and `wowPraxisDetail.test.tsx` could no longer count mitred borders in markup; both now assert the primitive's handle, and the flags' own geometry is pinned at the new seam. No mount was touched.
- Balloon code untouched, and `Balloon` is still unexported — #2727 owns that.

Green locally: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (446 files, 9105 tests), `npm run build`, `npm run budget` (JS 130.1 KB, CSS 22.1 KB — unchanged).

**Visual QA is outstanding.** I have no browser and no dev stack: every claim above about pixels is arithmetic and the prod measurements in the issue, not something I saw.

## What to eyeball

Narrow the window through **320px, 375px, 593px** (the reported width), **768px** and **1280px** on each of the five mounts, and check the bunting ends cleanly inside its box — no half flag at the right edge, no flat-topped trapezoids, alternating gold/plum with every other flag hanging 2px lower:

1. **Faction page → the "about" panel** (`WowFactionBody`) — the padded one. Whole pennants now, and the panel is ~8px taller than it was because the padding no longer eats them.
2. **Task card** (`WowTaskCard`) — in a narrow feed column, where a card is far narrower than the window.
3. **Task detail** (`WowTaskDetail`).
4. **Praxis detail** (`WowPraxisDetail`).
5. **Create character** (`WowCreateCharacter`).

Worth a DevTools check on any one of them: `scrollWidth === clientWidth` and `scrollHeight === clientHeight` on `[data-wow-bunting]`, and no flicker on a slow drag-resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
