### PR TITLE
The Albescent comment leaf wears the drifting spectrum ring, not na's cap (#2732)

### DIFF
--- a/frontend/src/__tests__/albescentWrapperKinds.test.tsx
+++ b/frontend/src/__tests__/albescentWrapperKinds.test.tsx
@@ -22,21 +22,29 @@
  *
  * Byte-identity is a strong claim on purpose. It fails on a stray wrapper
  * element, a re-ordered prop, a class added "while we are here" — every quiet way
- * a wrapper that was supposed to be inert starts dressing something. Three of
- * the five are held to it.
+ * a wrapper that was supposed to be inert starts dressing something. TWO of the
+ * five are held to it unconditionally, and the comment leaf is held to it for an
+ * UNREVEALED viewer only: ADR-0088 §3 turned that one from a pass-through into a
+ * re-cut, and #1192 decision 13 and #2531 are reversed with it (#2732).
  *
- * ## Why the two re-cuts are asserted from both ends
+ * ## Why the re-cuts are asserted from both ends
  *
- * `strip the class and na is byte-identical` is the invariant on ALL FIVE — it
- * is what keeps Albescent's dress off unaffiliated players. For the three
- * pass-throughs there is no class to strip and identity is the whole test. For a
- * re-cut, identity must hold with the wrapper removed and must FAIL with it in
- * place, so both halves are asserted: the delta is the wrapper's classes and
- * nothing else, and those classes reach mounts na draws.
+ * `strip the dress and na is byte-identical` is the invariant on ALL FIVE — it
+ * is what keeps Albescent's dress off unaffiliated players. For the two
+ * pass-throughs there is nothing to strip and identity is the whole test. For a
+ * re-cut, identity must hold with the dress removed and must FAIL with it in
+ * place, so both halves are asserted: the delta is the wrapper's own and nothing
+ * else, and it reaches mounts na draws.
  *
- * The tile adds a third question the other four do not raise. Its ground is
- * CONDITIONAL — `.alb-prism` arrives with the reveal (epic #2496 ruling 8) — so
- * "does it dress?" has two right answers on one surface and both are pinned.
+ * The tile and the leaf each add a question the others do not raise, and it is
+ * the same question: the dress is CONDITIONAL. `.alb-prism` arrives with the
+ * reveal (epic #2496 ruling 8) and so does the leaf's ring (ADR-0088 §3), so
+ * "does it dress?" has two right answers on those surfaces and both are pinned.
+ *
+ * The leaf is also the one wrapper whose delta is NOT a class on a wrapper div:
+ * na's cap is inline and computed from the slug, so the re-cut had to go through
+ * a slot on the shared `Sheet`. Its identity half is therefore asserted against
+ * `DefaultComment` unredacted rather than by stripping an element.
  *
  * ## Harness
  *
@@ -211,7 +219,7 @@ function at(width: 'mobile' | 'desktop', markup: () => string): string {
   }
 }
 
-/* ── The three pass-throughs ────────────────────────────────────────────── */
+/* ── The two pass-throughs, and the one that stopped being a third ─────── */
 
 describe('backdrop — PASS-THROUGH: the watercolour, unchanged', () => {
   it('renders the na fallback byte for byte', () => {
@@ -257,8 +265,8 @@ describe('backdrop — PASS-THROUGH: the watercolour, unchanged', () => {
  * change to na's own sheet moves both sides together.
  *
  * Nothing here proves a pixel travelled — `renderToStaticMarkup`, no DOM. The
- * ring's rest state and its drift are CSS, guarded as CSS by
- * `albescentCommentEdge.test.ts`.
+ * ring's rest state, its carrier weight and its drift are CSS, guarded as CSS by
+ * `spectrumRingCollapse.test.ts`, where the other nine mounts already live.
  */
 describe('comment — RE-CUT: the leaf trades na\'s cap for the travelling ring', () => {
   const row = (Voice: typeof DefaultComment) =>

--- a/frontend/src/__tests__/albescentWrapperKinds.test.tsx
+++ b/frontend/src/__tests__/albescentWrapperKinds.test.tsx
@@ -232,7 +232,35 @@ describe('backdrop — PASS-THROUGH: the watercolour, unchanged', () => {
   })
 })
 
-describe('comment — PASS-THROUGH: na keeps the voice (epic #1192 decision 13)', () => {
+/**
+ * THE COMMENT LEAF — RE-CUT, AND REVEAL-GATED (#2732, ADR-0088 §3).
+ *
+ * This block used to assert the opposite. It held `AlbescentComment` to
+ * byte-identity with `DefaultComment` in both modes, on epic #1192 decision 13
+ * and #2531 — both of which ADR-0088 reverses FOR THIS SURFACE. The finding
+ * those rulings rested on is still true (the cap is `factionFill(slug,'bar')`
+ * inline, so no wrapper class reaches it); what changed is the conclusion drawn
+ * from it. na's `Sheet` grew an `edge` slot, the wrapper fills it, and the cap
+ * steps aside when it does.
+ *
+ * ## The seam
+ *
+ * THREE RENDERS OF THE SAME `Sheet`, which is the whole of this issue:
+ *
+ *   • REVEALED Albescent — no cap, one `.alb-comment-edge` span.
+ *   • UNREVEALED Albescent — today's sheet exactly, cap and all.
+ *   • na — byte-identical to today, whatever the reveal says.
+ *
+ * The third is the one that would go unnoticed: the `edge` slot defaults to
+ * undefined, so a slug that never asks for it renders the same bytes it always
+ * did. It is asserted against `DefaultComment` given the SAME fixture, so a
+ * change to na's own sheet moves both sides together.
+ *
+ * Nothing here proves a pixel travelled — `renderToStaticMarkup`, no DOM. The
+ * ring's rest state and its drift are CSS, guarded as CSS by
+ * `albescentCommentEdge.test.ts`.
+ */
+describe('comment — RE-CUT: the leaf trades na\'s cap for the travelling ring', () => {
   const row = (Voice: typeof DefaultComment) =>
     renderToStaticMarkup(
       <MemoryRouter>
@@ -254,31 +282,71 @@ describe('comment — PASS-THROUGH: na keeps the voice (epic #1192 decision 13)'
       </MemoryRouter>,
     )
 
-  it('row mode is byte-identical to DefaultComment', () => {
-    expect(row(AlbescentComment)).toBe(row(DefaultComment))
-  })
+  /** The na leaf, for the identity half — an unaffiliated author, same shape. */
+  const naRow = () =>
+    renderToStaticMarkup(
+      <MemoryRouter>
+        <DefaultComment
+          mode="row"
+          comment={{ ...COMMENT, author: { ...COMMENT.author, faction_slug: 'na' } }}
+        />
+      </MemoryRouter>,
+    )
 
-  it('composer mode is byte-identical to DefaultComment', () => {
-    expect(composer(AlbescentComment)).toBe(composer(DefaultComment))
-  })
+  afterEach(() => setAlbescentRevealed(false))
+
+  for (const [name, render] of [
+    ['row', row],
+    ['composer', composer],
+  ] as const) {
+    it(`${name} mode: a revealed viewer gets the ring and loses the cap`, () => {
+      setAlbescentRevealed(true)
+      const html = render(AlbescentComment)
+      expect(html, 'the tenth mount of the shared ring').toContain('alb-comment-edge')
+      // The CAP, named exactly — `--faction-default-rainbow-conic` is the
+      // avatar disc two elements up and belongs to a different issue.
+      expect(html, "na's 3px cap is the carrier that comes off").not.toContain(
+        'background:var(--faction-default-rainbow)',
+      )
+      expect(html, 'a re-cut that shifts nothing did not do its job').not.toBe(
+        render(DefaultComment),
+      )
+    })
+
+    it(`${name} mode: an unrevealed viewer sees today's sheet exactly`, () => {
+      setAlbescentRevealed(false)
+      expect(render(AlbescentComment)).toBe(render(DefaultComment))
+    })
+  }
 
   /**
-   * The FINDING, made executable. na's two marks here are both out of a
-   * wrapper's reach: the sheet's hairline is `factionFill(slug, 'bar')`, a ramp
-   * COMPUTED from the slug, so no class can carry it (`spectrumClasses.test.tsx`
-   * names the same hold-out for the rung dots); the @mention ink is
-   * `background-clip: text`, which the epic's pre-painted-`::before` technique
-   * cannot dress at all. If either ever becomes a class, this goes red and the
-   * pass-through should be reconsidered as a re-cut.
+   * THE INVARIANT THE SLOT MUST KEEP. `Sheet` is shared with na and with every
+   * unregistered slug; the prop that suppresses the cap defaults to today's
+   * behaviour, so nobody who does not ask can be moved by it — in EITHER reveal
+   * state, because the reveal is a fact about the viewer and na is not Albescent.
    */
-  it("na's marks here are still unclassed, so there is nothing to re-cut", () => {
-    const html = row(DefaultComment)
-    expect(html, 'the sheet hairline is still inline and per-slug').toContain(
-      '--faction-default-rainbow',
+  for (const revealed of [false, true]) {
+    it(`na's own leaf is untouched with the reveal ${revealed ? 'on' : 'off'}`, () => {
+      setAlbescentRevealed(revealed)
+      const html = naRow()
+      expect(html, 'na keeps its spectrum cap').toContain(
+        'background:var(--faction-default-rainbow)',
+      )
+      expect(html, 'and never wears Albescent chrome').not.toContain('alb-comment-edge')
+    })
+  }
+
+  /**
+   * NOT TOUCHED, and this is the assertion that says so out loud. #2531's second
+   * reason still holds: resolved @mentions are `background-clip: text`, which the
+   * epic's pre-painted-`::before` technique cannot dress at all, and they are a
+   * player's own words. The ring is chrome; the ink is not.
+   */
+  it('leaves the @mention ink alone, revealed or not', () => {
+    setAlbescentRevealed(true)
+    expect(row(AlbescentComment), "the mention ink stays na's clipped spectrum").toContain(
+      'rainbow-ink',
     )
-    expect(html, 'no linear cut class to dress').not.toContain('spectrum-rule')
-    expect(html, 'no conic cut class to dress').not.toContain('spectrum-dial')
-    expect(html, 'the other mark is clipped TEXT').toContain('rainbow-ink')
   })
 })
 

--- a/frontend/src/__tests__/motionSplit.test.ts
+++ b/frontend/src/__tests__/motionSplit.test.ts
@@ -93,7 +93,7 @@ const MOTION_SCAFFOLDING: Record<string, string> = {
     'pointer-events:none, parked at left:-55% outside its own overflow:hidden ' +
     'track, and declared nowhere but inside the gate — so with the sheet absent ' +
     'there is no band, which is exactly the reduced-motion rendering.',
-  '.alb-task-edge::before, .alb-praxis-card-edge::before, .alb-detail-edge::before, .alb-praxis-edge::before, .alb-feed-edge::before, .alb-desk-edge::before, .alb-plate-edge::before, .alb-profile-edge::before':
+  '.alb-task-edge::before, .alb-praxis-card-edge::before, .alb-detail-edge::before, .alb-praxis-edge::before, .alb-feed-edge::before, .alb-desk-edge::before, .alb-plate-edge::before, .alb-comment-edge::before, .alb-profile-edge::before':
     "the Albescent spectrum edges' travelling ramp (#2498; the faction page's " +
     'plates joined at #2504, the phone home at #2505, the praxis ' +
     "CARD's own 3px ring at #2499 when it stopped borrowing the rail's 1px one). Two " +
@@ -105,7 +105,9 @@ const MOTION_SCAFFOLDING: Record<string, string> = {
     'frame a reduced-motion reader already gets. EIGHT since #2553 took the ' +
     "composer's ring off — that sheet already wore na's OWN 3px spectrum " +
     'border (#2520), so the ring was a second frame just inside the first. ' +
-    'All are masked rings ' +
+    "NINE since #2732 hung the comment leaf's ring on it (ADR-0088 §3): that " +
+    'leaf had been the standing exception to #2404, and stilling it again is ' +
+    'the one-line retreat noted at the mount. All are masked rings ' +
     'since #2519: the odd one out used to be `.alb-desk .spectrum-rule`, a ' +
     "filled hairline travelling in place of an edge the field desk's identity " +
     'card did not have, and the design canvas takes that bar off and gives the ' +

--- a/frontend/src/__tests__/spectrumRingCollapse.test.ts
+++ b/frontend/src/__tests__/spectrumRingCollapse.test.ts
@@ -207,6 +207,80 @@ describe("the collapsed spectrum ring resolves to what each mount had (#2407)", 
   });
 });
 
+/**
+ * THE TENTH MOUNT — the comment leaf's ring (#2732, ADR-0088 §3).
+ *
+ * It has no row in `BEFORE` because it has no before: the leaf wore na's 3px
+ * spectrum CAP and no edge at all. So what is pinned here is not "unchanged", it
+ * is JOINED CORRECTLY — which is the failure this family has actually had. #2504
+ * and #2505 each built a mount from issue prose, took the shared list's hairline
+ * defaults, and shipped the faintest possible mark on a surface the design draws
+ * carrying a 3px border at full strength; #2519 was the correction. A tenth
+ * mount landing at 1px/0.6 is that bug a third time, and it would be invisible
+ * to every assertion above, all of which iterate a fixed list.
+ *
+ * The markup end — that the span is mounted at all, and only past the reveal —
+ * is `albescentWrapperKinds.test.tsx`. This is the CSS end.
+ */
+describe("the comment leaf's ring is a full member of the family (#2732)", () => {
+  const RING = ".alb-comment-edge";
+
+  it("is the shared masked ring, with the shared loop-cut ramp", () => {
+    const resolved = resolve(RING);
+    expect(resolved.size, "no rule matches .alb-comment-edge").toBeGreaterThan(0);
+    expect(resolved.get("mask")).toBe(MASK);
+    expect(resolved.get("-webkit-mask-composite")).toBe("xor");
+    expect(resolved.get("background-image")).toBe(RAMP);
+    expect(resolved.get("position")).toBe("absolute");
+    expect(resolved.get("pointer-events")).toBe("none");
+  });
+
+  it("carries the CARRIER's weight, not a hairline's — the #2519 bug", () => {
+    // The cap it replaced was 3px at full strength, so the amount of rainbow on
+    // the leaf is unchanged and only its GEOMETRY moved. The shared list's
+    // defaults are the rail's (1px at 0.6) and would halve it silently. Read off
+    // the task card's row rather than restated, so the four carriers and this
+    // one cannot drift apart without a test saying which.
+    const resolved = resolve(RING);
+    expect(resolved.get("padding"), "the shared list's hairline default leaked").toBe(
+      before(".alb-task-edge").find(([one]) => one === "padding")?.[1],
+    );
+    expect(resolved.get("opacity"), "a carrier is never dimmed").toBe("1");
+  });
+
+  it("takes the sheet's own corner rather than minting a literal", () => {
+    // `inherit` reads the DIRECT parent, and the span is a direct child of the
+    // sheet, whose corner is `SHEET_RADIUS` inline in CommentThread. If that
+    // number ever moves, the ring follows it — which is the whole point of not
+    // writing it twice, so the pairing is asserted rather than commented.
+    expect(resolve(RING).get("border-radius")).toBe("inherit");
+    expect(
+      read("../components/comments/CommentThread.tsx"),
+      "the sheet lost the corner the ring inherits",
+    ).toContain("const SHEET_RADIUS = 10");
+  });
+
+  it("sits above a static body and under the composer's @mention listbox", () => {
+    // The family's number, and load-bearing on this mount: the composer this
+    // same sheet dresses positions its listbox at 30 inside itself.
+    expect(resolve(RING).get("z-index")).toBe("1");
+  });
+
+  it("drifts, on the shared keyframe, behind the reduced-motion gate", () => {
+    expect(resolve(RING).get("animation"), "colour may not defer; motion must").toBeUndefined();
+    const at = MOTION.search(/\.alb-comment-edge(::before)?\s*[,{]/);
+    expect(at, "the leaf's ring has no drift rule at all").toBeGreaterThan(0);
+    const gateAt = MOTION.lastIndexOf("@media", at);
+    expect(
+      MOTION.slice(gateAt, at),
+      "the leaf travels outside the reduced-motion gate",
+    ).toContain("prefers-reduced-motion: no-preference");
+    expect(MOTION, "a tenth keyframe where the shared one does").not.toContain(
+      "@keyframes alb-comment",
+    );
+  });
+});
+
 describe("the travel moved to the deferred sheet, and only the travel (#2407)", () => {
   it("index.css runs none of the five", () => {
     // Motion may arrive late for free; colour and layout may never. What stays

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -32,9 +32,19 @@ import { CommentFlagControl, canFlagComment } from './FlagControl'
  * THE SPECTRUM BUBBLE — the comment voice of the UNAFFILIATED (`na`) identity,
  * and the fallback for any slug with no voice of its own. `default ≡ na ≡
  * Unaffiliated` is one identity (ADR-0039 / 0046 / 0048): this IS the
- * unaffiliated kit, not a generic neutral. Albescent renders through it too and
- * stays that way — `albescent ≡ na + drift` (ADR-0048), its card carries the
- * difference — so nothing here may narrow to `na`.
+ * unaffiliated kit, not a generic neutral. Albescent renders through it too —
+ * `albescent ≡ na + drift` (ADR-0048) — so nothing here may narrow to `na`.
+ *
+ * ALBESCENT NOW RE-CUTS ONE OF THE TWO na TELLS (#2732, ADR-0088 §3), and this
+ * docblock used to say the opposite: "Albescent renders through it too and stays
+ * that way". It does not. A revealed viewer sees the leaf ringed in the shared
+ * travelling spectrum edge and wearing NO cap. The cap cannot be dressed away
+ * from outside — it is `factionFill(slug,'bar')` inline and COMPUTED FROM THE
+ * SLUG, so it has no class and no wrapper reaches it — which is why `Sheet` grew
+ * the `edge` slot below instead of a class. #1192 decision 13 and #2531 are
+ * REVERSED for this surface: their finding stands, their conclusion does not.
+ * `AlbescentComment` owns the reveal gate and the class; nothing here knows the
+ * slug, and an unfilled slot is today's sheet to the byte.
  *
  * The na tells, and only these: a spectrum hairline across the top of every
  * sheet, and gradient-clipped @mentions (#970). Both reached through
@@ -73,11 +83,30 @@ function Sheet({
   avatar,
   children,
   containerProps,
+  edge,
 }: {
   slug: string | null | undefined
   avatar: React.ReactNode
   children: React.ReactNode
   containerProps?: React.ComponentPropsWithoutRef<'div'>
+  /**
+   * THE SUPPRESSION SLOT (#2732, ADR-0088 §3). Fill it and the sheet trades its
+   * top cap for whatever this draws around the whole edge; leave it undefined
+   * — which is na, every unregistered slug, and an unrevealed Albescent viewer
+   * — and the sheet renders exactly the bytes it always did.
+   *
+   * A SLOT RATHER THAN A BOOLEAN so this component never learns a faction's
+   * name. It cannot be a wrapper: the cap is inline and computed from the slug,
+   * so it has no class, and the ring has to be a CHILD of this box to trace it.
+   * That is the change to a shared signature #2531 said a wrapper alone could
+   * not make, and the reason `AlbescentComment` stopped being a pass-through.
+   *
+   * THE CONTRACT ON WHAT GOES IN: an `inset: 0` absolutely-positioned,
+   * `pointer-events: none` overlay. The containing block is provided below and
+   * `border-radius: inherit` resolves to `SHEET_RADIUS` from here, so a mount
+   * needs no corner of its own.
+   */
+  edge?: React.ReactNode
 }) {
   return (
     <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
@@ -90,6 +119,12 @@ function Sheet({
           background: factionCssVar(slug, 'card-bg'),
           border: `1px solid ${factionCssVar(slug, 'border')}`,
           borderRadius: SHEET_RADIUS,
+          // The containing block the `edge` slot's overlay needs, and ONLY when
+          // one is mounted: an unfilled slot must not change one byte of na's
+          // style attribute. Nothing else here depends on it — the composer's
+          // @mention listbox carries its own positioned parent in
+          // `ComposerControls`, so it does not re-anchor either way.
+          ...(edge ? { position: 'relative' as const } : null),
           // NO `overflow: hidden` here (#1255) — the composer this wraps owns
           // the @mention listbox, an absolutely positioned child, and a
           // clipping ancestor cuts it off. The hairline below rounds its own
@@ -102,21 +137,34 @@ function Sheet({
             voice, and then it gets its own solid hue, not a borrowed one. It
             carries the sheet's top corners itself: an element's background is
             clipped by its OWN border-radius, so the stripe stays inside the
-            card's curve with nothing clipping it from above. */}
-        <div
-          style={{
-            height: 3,
-            borderRadius: `${SHEET_RADIUS}px ${SHEET_RADIUS}px 0 0`,
-            ...factionFill(slug, 'bar'),
-          }}
-        />
+            card's curve with nothing clipping it from above.
+
+            IT IS THE CARRIER, so it steps aside for one (#2732). `edge ?? cap`
+            rather than both: the kit's rule is ONE CARRIER PER OBJECT, and a
+            surface that grows a 3px spectrum ring keeps no 3px spectrum bar. */}
+        {edge ?? (
+          <div
+            style={{
+              height: 3,
+              borderRadius: `${SHEET_RADIUS}px ${SHEET_RADIUS}px 0 0`,
+              ...factionFill(slug, 'bar'),
+            }}
+          />
+        )}
         <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>{children}</div>
       </div>
     </div>
   )
 }
 
-export function DefaultComment(props: CommentProps) {
+/**
+ * `edge` is the ONE prop beyond the archetype contract, and it is forwarded
+ * whole to `Sheet` in both modes (#2732). The dispatcher never passes it —
+ * `CommentComponent` is `ComponentType<CommentProps>` and this stays assignable
+ * to it — so only a voice that renders `DefaultComment` by hand can fill it.
+ */
+export function DefaultComment(props: CommentProps & { edge?: React.ReactNode }) {
+  const { edge } = props
   const { t } = useTranslation('praxis')
   const { user } = useAuth()
   const reveal = useOwnerReveal()
@@ -124,7 +172,7 @@ export function DefaultComment(props: CommentProps) {
     const { character, value, onChange, onSubmit, submitting } = props
     const slug = character.faction_slug
     return (
-      <Sheet slug={slug} avatar={<FactionAvatar character={character} size="sm" />}>
+      <Sheet slug={slug} avatar={<FactionAvatar character={character} size="sm" />} edge={edge}>
         {/* `.content-text` rides the wrapper on purpose: the ONE slot inside
             without a size of its own is the textarea (`font: inherit`), and a
             comment draft is content-tier text (§4). Every other slot — count,
@@ -173,6 +221,7 @@ export function DefaultComment(props: CommentProps) {
       slug={slug}
       avatar={<FactionAvatar character={authorToCharacter(comment.author)} size="sm" />}
       containerProps={reveal.containerProps}
+      edge={edge}
     >
       <div
         style={{

--- a/frontend/src/components/comments/voices/AlbescentComment.tsx
+++ b/frontend/src/components/comments/voices/AlbescentComment.tsx
@@ -1,48 +1,75 @@
-/**
- * Albescent's comment voice (#2531) — A PASS-THROUGH WRAPPER. It renders
- * `DefaultComment` and changes not one pixel; `renderToStaticMarkup` here is
- * byte-identical to the na sheet in both modes, and
- * `albescentWrapperKinds.test.tsx` asserts it.
- *
- * THE ISSUE ASKED FOR THE FINDING FIRST — "check whether na has a comment voice
- * at all before assuming a wrapper is possible" — SO HERE IT IS. na has one: the
- * spectrum bubble in `CommentThread.tsx`, and it carries two na marks. Neither
- * can be re-cut from out here, for two different reasons, and both are
- * pre-existing rulings rather than anything this issue decided.
- *
- *  1. THE SHEET'S HAIRLINE IS CONDITIONAL, so it has no class. The 3px stripe
- *     across the top of every sheet is `factionFill(slug, 'bar')` inline — the
- *     ramp is COMPUTED FROM THE SLUG (a rainbow for na, a solid hue for a themed
- *     slug that registered no voice), and `.spectrum-rule` may not be conditional.
- *     `spectrumClasses.test.tsx` already names that exact hold-out for the
- *     praxis-detail rung dots. So the dresser `.alb-moves` feeds — the whole
- *     mechanism by which nine other Albescent surfaces move — reaches nothing on
- *     this one. Classing it would mean editing na's own conditional paint, which
- *     is a change to `na`, not a wrapper over it.
- *
- *  2. THE OTHER MARK IS TEXT. Resolved @mentions are gradient-clipped spectrum
- *     ink (`.rainbow-ink`, #970). The epic's technique ruling is a PRE-PAINTED
- *     `::before` slid by `transform` (#2498, enforced by
- *     `spectrumRingCollapse.test.ts`); a `background-clip: text` fill cannot be
- *     dressed that way at all — the only thing that would move it is walking a
- *     gradient parameter, which is the one technique the epic forbids. It is
- *     also a player's own words, which is the last ink in the app that should
- *     start moving under them.
- *
- * AND THE DECISION WAS ALREADY MADE, twice, in the same direction. Epic #1192
- * decision 13: Albescent keeps `DefaultComment`, because its feed CARD is
- * sufficiently distinct once the light is on it. `CommentThread`'s own docblock
- * says the same from the other side — "Albescent renders through it too and
- * stays that way". This file changes neither ruling; it records them in the
- * manifest so the map stops answering "does Albescent dress this?" with silence.
- *
- * No class, no colour, no copy, no motion. Strip nothing — there is nothing to
- * strip — and na is byte-identical, which is the invariant all four of #2531's
- * registrations keep.
- */
 import { DefaultComment } from '../CommentThread'
 import type { CommentProps } from '../shared'
+import { ALBESCENT_FACTION_SLUG, isFactionRedacted } from '../../../utils/factions'
 
+/**
+ * Albescent's comment voice — a RE-CUTTING wrapper, reveal-gated (#2732,
+ * ADR-0088 §3).
+ *
+ * A revealed viewer sees the leaf ringed in the shared travelling spectrum edge
+ * and wearing NO cap. An unrevealed viewer sees na's sheet, cap and all, exactly
+ * as before — this file is the gate, and `<DefaultComment>` with the slot left
+ * empty is byte-identical to what shipped yesterday.
+ *
+ * ── THIS FILE USED TO ARGUE THE OPPOSITE, AND THE ARGUMENT IS OVERRULED ──────
+ *
+ * It was a pass-through, and forty lines explaining that it could never be
+ * anything else. The FINDING it rested on is still true and is worth keeping:
+ *
+ *   THE SHEET'S CAP IS CONDITIONAL, SO IT HAS NO CLASS. The 3px stripe across
+ *   the top of every sheet is `factionFill(slug, 'bar')` inline — the ramp is
+ *   COMPUTED FROM THE SLUG (a rainbow for na, a solid hue for a themed slug that
+ *   registered no voice) — so `.spectrum-rule` may not be conditional and the
+ *   dresser `.alb-moves` feeds reaches nothing here.
+ *
+ * What that finding actually proves is that a WRAPPER cannot do it, which is
+ * what #2531 concluded. ADR-0088 takes the next step instead of stopping: na's
+ * `Sheet` grew an `edge` slot, filling it suppresses the cap, and this file
+ * fills it. **#1192 decision 13 and #2531 are both REVERSED for this surface.**
+ * Do not restore the pass-through from a docblock; the reasoning that would ask
+ * you to is above, and it has been answered.
+ *
+ * ── WHAT IS STILL NOT TOUCHED ───────────────────────────────────────────────
+ *
+ * Resolved @mentions stay `.rainbow-ink`. #2531's SECOND reason holds unchanged:
+ * a `background-clip: text` fill can only be moved by walking a gradient
+ * parameter, which is the one technique the epic forbids (#2498), and it is a
+ * player's own words — the last ink in the app that should start moving under
+ * them. The ring is chrome; the ink is not.
+ *
+ * ── THE THREE DECISIONS THIS FILE MAKES ─────────────────────────────────────
+ *
+ * **IT DRIFTS**, with the other nine (#2404: all Albescent borders move slowly).
+ * This is the surface that had been the exception, on #2502's objection — which
+ * was written about a 24px avatar disc turning inside a grid of forty. A thread
+ * is a short column of wide leaves, where a slow edge reads as that person's
+ * card rather than as a beacon. The motion lives in `motion.ornament.css`,
+ * behind `prefers-reduced-motion`, and stilling it is a one-line retreat noted
+ * at that mount.
+ *
+ * **THE GATE IS THE REDACTION**, not a second predicate. `isFactionRedacted` is
+ * ADR-0082's, the same answer the select tile and the leaderboard lane read
+ * (#2409); a mark this file gated on anything else would eventually disagree
+ * with the words beside it.
+ *
+ * **BOTH MODES, ONE SHEET.** The composer is the same leaf with a draft in it,
+ * and an Albescent member reading her own thread would otherwise watch her post
+ * change dress the moment she submitted it. It is also the smaller diff: the
+ * slot goes into `DefaultComment`, which mounts one `Sheet` per mode.
+ */
 export default function AlbescentComment(props: CommentProps) {
-  return <DefaultComment {...props} />
+  // The slug is the constant and not `props`: this voice is dispatched on
+  // `albescent` in both modes, and reading it off the payload would let a future
+  // caller hand this component a leaf it must not dress.
+  if (isFactionRedacted(ALBESCENT_FACTION_SLUG)) return <DefaultComment {...props} />
+  return (
+    <DefaultComment
+      {...props}
+      // The tenth mount of the shared ring (#2407 → index.css). A bare span, no
+      // paint of its own: colour and geometry are the class's, `aria-hidden`
+      // because it is chrome, and the corner comes from `border-radius: inherit`
+      // reading the sheet's own.
+      edge={<span aria-hidden="true" className="alb-comment-edge" />}
+    />
+  )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6140,6 +6140,7 @@
 .alb-profile-edge,
 .alb-plate-edge,
 .alb-desk-edge,
+.alb-comment-edge,
 .spectrum-frame::before {
   position: absolute;
   inset: 0;
@@ -6913,9 +6914,39 @@
 .alb-plate-edge,
 .alb-desk-edge,
 .alb-task-edge,
-.alb-praxis-card-edge {
+.alb-praxis-card-edge,
+.alb-comment-edge {
   padding: 3px;
   opacity: 1;
+}
+/* Albescent — the COMMENT LEAF's ring, the tenth mount (#2732, ADR-0088 §3).
+   The sheet in `CommentThread` carried na's 3px spectrum CAP across its top and
+   no edge at all; a revealed viewer now gets this instead, and the cap comes off
+   in the same breath. That is the carrier rule above applied literally — one
+   carrier per object — which is why this joins that list rather than the
+   hairline defaults: the leaf's spectrum was already 3px at full strength, so
+   the amount of rainbow on the surface is unchanged and only its GEOMETRY moved,
+   from a bar across the top to a frame round the whole leaf.
+
+   It states nothing else. The corner is the shared `border-radius: inherit`,
+   which reads `SHEET_RADIUS` (10px, inline at the mount) off the sheet the span
+   is a direct child of — no literal, and it follows if that number ever changes.
+
+   THE ONE THING IT DOES SAY. `z-index: 1` is the FAMILY's number, the same one
+   `.alb-task-edge` and `.alb-praxis-card-edge` carry, and it is load-bearing
+   here: the composer this sheet also dresses positions its @mention listbox
+   inside itself. The listbox sits at 30 and stays over the ring; a static body
+   sits under it. Without a number the ring would be beatable by any positioned
+   descendant that declares one.
+
+   REVEAL-GATED IN THE COMPONENT, NOT HERE. `AlbescentComment` mounts this span
+   only past `isFactionRedacted` (ADR-0082), and an unrevealed viewer gets na's
+   cap with no ring — so there is no redacted state for this rule to know about.
+
+   The travel is the shared `alb-edge-travel` in `motion.ornament.css`; no
+   keyframe is minted here, and stopped it reads as a still spectrum edge. */
+.alb-comment-edge {
+  z-index: 1;
 }
 /* The praxis card's twin of it (#2499). Its own rule states only the two things
    the task card's does not: this span hangs off a wrapper whose corner is the

--- a/frontend/src/motion.ornament.css
+++ b/frontend/src/motion.ornament.css
@@ -642,7 +642,20 @@
    carrier per object), so the mount became `.alb-desk-edge`, a ninth masked
    ring, and the track it needed — the loop-cut ramp, the 300% tile, the
    `overflow: hidden` — is the shared ring's already. Nine mounts, nine rings,
-   one child. ── */
+   one child.
+
+   #2732 HANGS THE TENTH ON IT: `.alb-comment-edge`, the comment leaf's ring,
+   which replaced na's 3px spectrum cap on that sheet for a revealed viewer
+   (ADR-0088 §3). It is the surface that had been the standing exception to
+   #2404 — all Albescent borders move slowly — on #2502's objection, and that
+   objection was written about a 24px avatar disc turning inside a grid of
+   forty. A thread is a short column of wide leaves, where a slow edge reads as
+   that person's card rather than as a beacon.
+
+   IF IT PROVES TOO LOUD IN A LIVE THREAD, THE RETREAT IS ONE LINE: delete
+   `.alb-comment-edge::before` from the list below and the ring stands still,
+   keeping its colour, its weight and its corner. Nothing else has to move,
+   because everything else about it is `index.css`'s. ── */
 @keyframes alb-edge-travel { to { transform: translateX(-50%); } }
 @media (prefers-reduced-motion: no-preference) {
   .alb-task-edge::before,
@@ -652,6 +665,7 @@
   .alb-feed-edge::before,
   .alb-desk-edge::before,
   .alb-plate-edge::before,
+  .alb-comment-edge::before,
   .alb-profile-edge::before {
     content: "";
     position: absolute;


### PR DESCRIPTION
The Albescent comment leaf wore na's 3px spectrum cap and no edge, while every
other Albescent surface wore the drifting spectrum ring. It now wears the ring —
and loses the cap — for a revealed viewer.

Closes #2732

Governed by **ADR-0088 §3**. **#1192 decision 13 and #2531 are REVERSED for this
surface**, and both files that argued against it have been rewritten so the next
reader cannot restore the pass-through from a docblock.

## The seam

**The redaction gate plus the suppression slot: three renders of the same
`Sheet`.**

| viewer | cap | ring |
|---|---|---|
| revealed Albescent | — | `.alb-comment-edge`, drifting |
| unrevealed Albescent | na's 3px cap | — |
| na (and every unregistered slug) | na's 3px cap | — |

The third row is the one that would go unnoticed, so it is asserted in both
reveal states: the reveal is a fact about the *viewer*, and na is not Albescent.

## Why na's component had to change

The cap cannot be dressed away. It is `factionFill(slug, 'bar')` **inline and
computed from the slug** — a rainbow for na, a solid hue for a themed slug that
registered no voice — so it has no class, and no wrapper reaches it. That finding
is #2531's and it still stands; what ADR-0088 rejects is the conclusion drawn
from it.

So `Sheet` grew one optional prop, `edge?: React.ReactNode`:

- **A slot, not a boolean**, so `CommentThread` never learns a faction's name.
  `AlbescentComment` owns the gate and the class.
- **`edge ?? cap`** — filling it suppresses the cap. That is the kit's own rule
  applied literally: one carrier per object, and whatever bar was doing that job
  comes off.
- **Undefined is today's behaviour**, to the byte, including the style attribute
  — the `position: relative` the overlay needs is only added when the slot is
  filled.
- `DefaultComment` forwards it whole and stays assignable to
  `ComponentType<CommentProps>`, so the dispatcher can never pass it.

`AlbescentComment` stopped being a pass-through and fills the slot past
`isFactionRedacted` (ADR-0082's predicate, the same one the select tile and the
leaderboard lane read — not a second answer).

## The ring

`.alb-comment-edge` is the **tenth mount** of the shared masked ring — added to
the existing selector list in `index.css`, not hand-copied — at the **carrier
weight** (3px, opacity 1), joining `.alb-task-edge` and friends rather than
taking the shared list's hairline defaults. The leaf's spectrum was already 3px
at full strength, so the amount of rainbow is unchanged and only its *geometry*
moved, from a bar across the top to a frame round the whole leaf. Taking the
defaults would have halved it silently, which is the #2504/#2505 bug that #2519
had to correct; a test now names that.

Its corner is the shared `border-radius: inherit`, resolving to `SHEET_RADIUS`
off the sheet it is a direct child of — no literal, and the pairing is asserted.
`z-index: 1` is the family's number and load-bearing here: the composer this same
sheet dresses puts its @mention listbox at 30, which stays above.

**It drifts**, on the shared `alb-edge-travel` in `motion.ornament.css`, behind
`prefers-reduced-motion: no-preference`, with no new keyframe. #2502's objection
was written about a 24px avatar disc turning inside a grid of forty; a thread is
a short column of wide leaves. **If it proves too loud in a live thread, the
retreat is one line** — delete `.alb-comment-edge::before` from that list and the
ring stands still keeping its colour, weight and corner. That is noted at the
mount.

**Both modes.** The composer is the same leaf with a draft in it; an Albescent
member would otherwise watch her post change dress the moment she submitted it.
It is also the smaller diff — the slot lands in `DefaultComment`, which mounts
one `Sheet` per mode.

## Not touched

Resolved @mentions stay `.rainbow-ink`. #2531's second reason holds unchanged: a
`background-clip: text` fill can only be moved by walking a gradient parameter,
which the epic forbids (#2498), and it is a player's own words. Asserted, so it
stays deliberate.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(447 files, 9152 passing), `npm run build`, `npm run budget` — all green on this
head. CSS 22.1 KB gzipped against a 22.2 KB warn line, unmoved: the new rule is
two selector lines and a `z-index`, and CSS comments are stripped at build.

The loop went red on the real defect first — `albescentWrapperKinds.test.tsx`
failed on the missing mount before any CSS existed.

Tests: the markup end in `albescentWrapperKinds.test.tsx` (that describe block
used to assert the opposite and was rewritten); the CSS end in
`spectrumRingCollapse.test.ts`, where the other nine mounts already live.

**Visual QA is outstanding.** There is no browser and no dev stack in this
worktree — nothing here proves a pixel travelled, only that both ends of the
selector meet.

## What to eyeball

- [ ] A revealed viewer, Albescent comment in a thread: a 3px spectrum frame
      round the whole leaf, **no stripe across the top**, drifting slowly.
- [ ] The ring follows the sheet's 10px corner cleanly — no squared-off frame,
      no seam where the ramp wraps a corner.
- [ ] The Albescent **composer** at the foot of the thread wears the same ring,
      and the @mention dropdown still opens **over** it, not under.
- [ ] An unrevealed viewer: the leaf is exactly as it shipped — cap, no ring.
- [ ] na's own comment leaf, and one themed faction's (Coven, WOW), unchanged.
- [ ] With reduced motion on, the ring is a still spectrum edge at the same
      weight and colour, not absent and not faded.
- [ ] Dark mode, both reveal states — the ramp flips with the theme on its own.
- [ ] A thread with several Albescent leaves in a row: is the drift a shimmer or
      a beacon? This is the judgement call the one-line retreat exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
