### PR TITLE
A rune turns in the dark: one clock and its double (#2725)

### DIFF
--- a/frontend/src/components/factionMarks/EphemeristsNotationBand.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsNotationBand.tsx
@@ -41,16 +41,19 @@ import { BAND_INK, BRASS_RULE, CAPTION, QUIET, READING, seededRandom } from "./e
  *
  * Two animations, both in `motion.ornament.css` behind
  * `prefers-reduced-motion: no-preference`, off the critical path (#2073). The
- * SHIMMER breathes a mark between 0.16 and its own peak; the TURN cross-cuts
+ * SHIMMER breathes a mark between nothing and its own peak; the TURN cross-cuts
  * between the two marks each slot holds, so the row changes over time with no
  * render-time randomness at all — a vote landing or a hover firing re-renders
- * this component and it comes back byte-identical.
+ * this component and it comes back byte-identical. The turn's period is exactly
+ * twice the shimmer's (#2725), which is what puts every swap at zero opacity: a
+ * mark is never seen changing, only having changed.
  *
  * Note the inversion against the design, and it is the repo's form (`.evm-arc`,
  * `.cvn-wheel`): the base state IS the stilled state — every mark at its own
  * peak, showing its first frame — and both animations are ADDED under
  * `no-preference`. Written the design's way round a reduced-motion reader gets
- * a row at 0.16 and reads nothing. THERE IS NEVER AN INLINE `animation:`: an
+ * a row at the trough and reads nothing at all — since #2725 that trough is 0,
+ * so the row would not be there. THERE IS NEVER AN INLINE `animation:`: an
  * inline declaration sits outside every media query, so the gate could not
  * exist.
  *

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
@@ -255,14 +255,54 @@ describe("the two sheets: resting frame here, motion over there", () => {
   });
 
   it("adds both animations only under `prefers-reduced-motion: no-preference`", () => {
-    // Written the design's way round — the animation unconditional and
-    // `opacity: .16` as the base — a reader who asked for less motion gets a
-    // row at 16% and reads nothing.
+    // Written the design's way round — the animation unconditional and the
+    // shimmer's trough as the base — a reader who asked for less motion gets a
+    // row that is not there at all, since #2725 dropped that trough to zero.
     const gated = ruleBodies(MOTION, GATE).join("\n");
     expect(ruleBodies(gated, ".eph-rune").join("\n")).toContain("animation: eph-rune-shift");
     expect(ruleBodies(gated, ".eph-rune > span").join("\n")).toContain("animation: eph-rune-turn");
     const ungated = MOTION.split(GATE)[0];
     expect(ungated, "an ungated `.eph-rune` animation").not.toMatch(/\.eph-rune[^}]*animation:/);
+  });
+
+  it("cuts the frame at ZERO opacity — the turn is exactly twice the shimmer (#2725)", () => {
+    // THE SEAM #2725 turns on, and the only place it can be checked without a
+    // person watching a row for fifteen seconds. The swap used to land while a
+    // mark was LIT: a shimmer that bottomed out at 0.16 and never went dark,
+    // against a turn whose 9.4s was picked to be COPRIME with the shimmer's
+    // 5.2s. Both halves are asserted, because either one alone puts the cut
+    // back in the light:
+    //
+    //  • the shimmer's trough is 0, and it sits at 0%/100% — the cycle boundary
+    //    is the only phase the turn's own cuts can be aligned to;
+    //  • the turn's period is EXACTLY twice the shimmer's, so its two cut points
+    //    (the 0%/100% wrap and 50%) land on a trough at every repeat, forever.
+    //
+    // Both animations read `--epg-delay`, which carries the alignment to every
+    // mark whatever its phase: at delay d the troughs fall at d + 5.2k and the
+    // cuts fall at d + 5.2k as well.
+    const shift = ruleBodies(MOTION, "@keyframes eph-rune-shift").join("");
+    expect(shift, "the shimmer's trough").toMatch(/0%,\s*100%\s*\{\s*opacity:\s*0;/);
+
+    const gated = ruleBodies(MOTION, GATE).join("\n");
+    const seconds = (selector: string, name: string): number => {
+      const found = new RegExp(`animation:\\s*${name}\\s+([\\d.]+)s`).exec(
+        ruleBodies(gated, selector).join("\n"),
+      );
+      expect(found, `${selector} names no ${name} duration`).not.toBeNull();
+      return Number(found![1]);
+    };
+    expect(seconds(".eph-rune > span", "eph-rune-turn")).toBe(
+      seconds(".eph-rune", "eph-rune-shift") * 2,
+    );
+
+    // The cut points themselves, and the shared phase that carries them.
+    for (const name of ["eph-rune-turn", "eph-rune-turn-back"]) {
+      expect(ruleBodies(MOTION, `@keyframes ${name}`).join(""), name).toMatch(/50%,\s*100%/);
+    }
+    for (const selector of [".eph-rune", ".eph-rune > span"]) {
+      expect(ruleBodies(gated, selector).join("\n"), selector).toContain("--epg-delay");
+    }
   });
 
   it("leaves a stilled row whole and legible", () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5731,8 +5731,9 @@
    reason `.evm-arc` above states it. The base state IS the stilled state —
    every mark showing its FIRST frame at its own peak — and both animations are
    added under `no-preference`, from the deferred sheet (#2073). Written the
-   design's way round (0.16 as the base, the animation always on) a reduced-motion
-   reader gets a row at 0.16 and reads nothing. Nothing pins the pre-delay state
+   design's way round (the shimmer's trough as the base, the animation always on)
+   a reduced-motion reader gets a row that is not there — #2725 dropped that
+   trough to 0 so the turn's cut lands in the dark. Nothing pins the pre-delay state
    either: a mark holds at its peak until its own cycle starts, which is legible
    from first paint — and legible is all it owes, since a viewer who never
    receives `motion.ornament.css` lands in exactly the reduced-motion frame.

--- a/frontend/src/motion.ornament.css
+++ b/frontend/src/motion.ornament.css
@@ -511,24 +511,38 @@
  * from the surface's seed) and splitting them across two sheets would put half a
  * device on the critical path.
  *
- * THE SHIMMER breathes a mark between 0.16 and its own peak. Note the inversion
- * against the design, which index.css states beside the resting rule: the base
- * IS the stilled state, at the peak, and the dip is what the animation adds.
+ * THE SHIMMER breathes a mark between NOTHING and its own peak. Note the
+ * inversion against the design, which index.css states beside the resting rule:
+ * the base IS the stilled state, at the peak, and the dip is what the animation
+ * adds. The trough is 0 and it is at 0%/100% — read the next paragraph before
+ * moving either, because the turn is aimed at that instant.
  *
  * THE TURN is what makes the row change over time WITHOUT any render-time
  * randomness. Each mark holds two seeded frames stacked in one grid cell; these
  * two keyframes are the same cut read forwards and backwards, so exactly one
- * mark is up at any instant and the swap is hard rather than a cross-fade —
- * `49.99%` and not a `steps()` timing function, because the shimmer on the
- * parent needs its own easing and the two rules are on different elements.
+ * mark is up at any instant and the swap is a hard cut — `49.99%` rather than a
+ * `steps()` timing function, because the shimmer on the parent needs its own
+ * easing and the two rules are on different elements.
  *
- * 9.4s against the shimmer's 5.2s: coprime enough that a mark's frame does not
- * change on the same beat as its own dip, twice a minute, forever.
+ * ONE CLOCK AND ITS DOUBLE, and THAT is the property not to break (#2725). The
+ * turn's 10.4s is EXACTLY twice the shimmer's 5.2s, so the turn's two cut points
+ * — the 0%/100% wrap and 50% — land on the shimmer's trough and nowhere else: a
+ * mark fades to nothing, changes in the dark, and fades back as something else.
+ * The two used to be coprime (9.4s against 5.2s), which is the same statement
+ * with the sign flipped — it guaranteed the swap happened while the mark was
+ * LIT, and it read as a glitch rather than as a hand rewriting. The shared
+ * `--epg-delay` carries the alignment to every mark whatever its phase: at delay
+ * d the troughs are d + 5.2k and the cuts are d + 5.2k too. Cadence is what it
+ * always was, a change about every five seconds.
+ *
+ * A mark therefore goes FULLY invisible on every breath. Peaks and phases are
+ * drawn per mark from the surface's seed, so the row twinkles rather than going
+ * dark all at once.
  *
  * Sheet-less or reduced-motion, `.eph-rune > span + span { opacity: 0 }` in
  * index.css leaves frame one showing in every mark — a whole, legible row. ── */
 @keyframes eph-rune-shift {
-  0%, 100% { opacity: 0.16; }
+  0%, 100% { opacity: 0; }
   50% { opacity: var(--epg-op, 0.8); }
 }
 @keyframes eph-rune-turn {
@@ -545,7 +559,7 @@
     animation-delay: var(--epg-delay, 0s);
   }
   .eph-rune > span {
-    animation: eph-rune-turn 9.4s infinite;
+    animation: eph-rune-turn 10.4s infinite;
     animation-delay: var(--epg-delay, 0s);
   }
   .eph-rune > span + span { animation-name: eph-rune-turn-back; }


### PR DESCRIPTION
Closes #2725

Runes changed glyph while you were looking at them. Now each one fades to nothing, changes in the dark, and fades back as something else.

## The seam

**The timing relationship between the two animations, asserted against the stylesheet** — the two durations and the shimmer's floor. There is no other place this can be checked: the repo's harness has no DOM, no browser and no clock, and the defect is a phase relationship between two `@keyframes` that only a person watching a row for fifteen seconds can otherwise see.

The new test in `frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx` — *"cuts the frame at ZERO opacity — the turn is exactly twice the shimmer (#2725)"* — asserts both halves, because either one alone puts the cut back in the light:

- the shimmer's trough is `0`, **and it sits at `0%`/`100%`** — the cycle boundary is the only phase the turn's own cuts can be aligned to;
- the turn's period is **exactly** twice the shimmer's, parsed out of the gated rules rather than hardcoded, so the assertion survives a future rescaling of both;
- both keyframes cut at `50%, 100%`, and both rules read `--epg-delay`, which is what carries the alignment per mark.

It was written first and failed on `0.16`.

## The change

`frontend/src/motion.ornament.css`, two values:

- `eph-rune-shift`'s floor: `0.16` → `0`
- `eph-rune-turn` / `-turn-back`: `9.4s` → `10.4s`

**Verified, not assumed:** the shimmer's trough really is at `0%, 100%`, so the arithmetic lands rather than nearly landing. At delay *d* the troughs fall at *d* + 5.2*k*; the turn's two cut points are its `0%`/`100%` wrap (*d* + 10.4*m*) and its `50%` (*d* + 5.2 + 10.4*m*), whose union is *d* + 5.2*k* — the same set. Every cut is on a trough, forever, at every mark's own phase. `ease-in-out` also flattens the shimmer's derivative to zero at the trough, so the mark sits at nothing for several frames around the cut rather than for one instant.

Cadence is unchanged in feel: the turn's two cuts per 10.4s period is a change every 5.2s, against 4.7s before.

**Accepted consequence, per the ruling:** a mark now goes fully invisible on every breath instead of resting at 0.16. Peaks and phases are drawn per mark from the surface seed, so the row twinkles and never goes dark all at once.

**Reduced motion is untouched.** The base state is still `opacity: var(--epg-op)` — every mark at its own peak, showing frame one — in the blocking sheet, with both animations added only under `prefers-reduced-motion: no-preference` in the deferred one. The `0` floor lives inside a keyframe and cannot reach the still state. The existing gate tests still pass unchanged.

## Docblocks rewritten, so the old timing cannot be restored from a comment

The reasoning this reverses was written down in three places and all three now state the new invariant:

- `motion.ornament.css` — the **coprime paragraph** is replaced by "ONE CLOCK AND ITS DOUBLE, and THAT is the property not to break", naming the old 9.4s/5.2s and why it was wrong. The "hard cut rather than a cross-fade — `49.99%` and not `steps()`" sentence is kept but re-worded off the superseded justification; `49.99%` itself is unchanged and still correct.
- `EphemeristsNotationBand.tsx`'s **"THE FADE, INVERTED"** — it described the 0.16 base; it now says "between nothing and its own peak" and states the doubling.
- `index.css`'s `.eph-rune` block — same stale 0.16 sentence, same fix.

## Scope

Since #2230 there is one rune component, so this covers the masthead band, both task-card strips, the task page, the composer and the praxis byline in one change. Nothing touches width, inset or bleed — #2724's lane is untouched; this branch is based on `8d6eef0d`, which contains `cbbf7cdc`.

## Verification

Every step the `frontend` job in `.github/workflows/test.yml` names, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 451 files, 9,253 passed, 1 skipped |
| `npm run build` | ok |
| `npm run budget` | **22,689 gzipped CSS bytes — unchanged**, within budget |

The budget did not move: the only real byte deltas are `0.16` → `0` and `9.4s` → `10.4s`, and comments are stripped from the built sheet.

**Visual QA is outstanding.** I have no browser and no dev stack — nothing above renders a pixel. And this is a change only a human watching a rune row for ~15 seconds can actually confirm: the tests prove the two clocks are locked, not that the eye stops catching the swap.

## What to eyeball

- Watch one rune row for ~15 seconds. **No mark should ever be seen mid-change** — each should fade out, be gone, and come back as a different symbol.
- The row should **twinkle**, not blink in unison. If every mark goes dark on the same beat, the per-mark seed is not reaching `--epg-delay`.
- Check a row goes fully invisible in places and that this reads as intentional breathing rather than as marks dropping out — this is the accepted consequence of the `0` floor and the one aesthetic judgement here.
- Turn on **reduced motion** (OS setting) and reload: a still, full-strength, legible row, exactly as today. **Nothing invisible.** This is the one regression that would matter.
- Spot-check more than one surface, since they share the component: masthead band, a task card strip, the task page, the composer, a praxis byline.
- Both themes — the marks take their ink from `ephemeristsPlate`, which this does not touch, but a fade to zero looks different against the dark plate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
