### PR TITLE
Six documents stop describing pickVariant's fallback and na's missing manifest as current fact

### DIFF
--- a/.design-sync/BRIEF-duel-surfaces.md
+++ b/.design-sync/BRIEF-duel-surfaces.md
@@ -51,7 +51,7 @@ screen either way.
 
 1. **Skins dispatch on the *task's* faction, not the viewer's.** "The Everymen skin"
    means duels on Everymen tasks —
-   `pickVariant(surfaceMap('duelSeal'), taskFactionSlug, …)`. Only the figures follow the
+   `resolveVariant(surfaceMap('duelSeal'), taskFactionSlug)`. Only the figures follow the
    viewer, off their own multipliers. The brief itself had this backwards.
 2. **`pending` shows no stakes tiles.** `StakesTiles` emits the single
    `duelStakes.soloFallback` sentence instead, so a pending mock drawing a win/lose pair

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,8 @@ Python conventions live in `backend/CLAUDE.md`; frontend conventions in
 - Backend: `uvicorn main:app --reload` from `/backend`
 - Frontend: `npm run dev` from `/frontend`
 - DB: `docker-compose up -d`; `alembic upgrade head` after pulling
-- Tests: `pytest --cov=. --cov-fail-under=92` from `/backend`
+- Tests: `pytest --cov=. --cov-fail-under=92` from `/backend` — the gate is
+  `.github/workflows/test.yml`; if that number and this one disagree, it wins
 
 Every backend command above needs `backend/.venv` activated, and the backend
 preview does **not** work from a worktree — worktrees carry no venv. Read

--- a/docs/adr/0084-a-page-wears-a-faction-when-it-has-exactly-one-faction-to-wear.md
+++ b/docs/adr/0084-a-page-wears-a-faction-when-it-has-exactly-one-faction-to-wear.md
@@ -278,3 +278,42 @@ it. (`FactionSigil`'s injected slug is no longer open — #2529 closed it; see �
 **The known sharp edge** is §5's exception. It is the one entry here that a
 future reader can mistake for an oversight, and the only guard against that is
 §6 staying attached to it. Anyone editing §5 without §6 has removed the guard.
+
+## Amendment (2026-08-27, #2530): the seam is `resolveVariant`, and `na` has a manifest
+
+*Consequences* above listed "whether `na` gains a real manifest (#2530), which
+changes the *mechanism* under §2 without touching which pages use it" as an open
+question. **It landed.** This note records what moved; nothing this record
+decided changes, and §2's invariant is the same invariant.
+
+**§2's heading and first paragraph name a helper that no longer has that shape.**
+`pickVariant` had a third parameter — an explicit `Default*` fallback — because
+`na` was the one faction not in the registry, so ~20 dispatchers each re-stated
+the unknown-slug rule by hand. `frontend/src/factions/default.ts` registers all
+twenty na surfaces now, `DEFAULT_MANIFEST` is the ninth entry in
+`FACTION_MANIFESTS`, and the rule is one function — `resolveSlug`. Read §2 as:
+
+> **The seam is `surfaceMap(<key>)` + `resolveVariant`.** A page that dresses
+> calls `surfaceMap('<key>')` and hands the result to `resolveVariant`, which
+> resolves an absent slug to `na`'s own row. There is no fallback argument and no
+> `Default*` named at the call site.
+
+`pickVariant` still exists in `utils/factionDispatch.ts`, with two arguments and
+a different job: it answers "is there a **bespoke** variant for this slug",
+returning `undefined` rather than reaching for na's row. That is what the
+surface-dispatch registration tests ask, and it is not what a dispatcher asks.
+
+**The bypass clause is unaffected.** §2's "no dispatcher may inject a slug at the
+call site" and the record of `FactionSigil`'s single exception closed by #2529
+stand exactly as written — the guard in `surfaceDispatch.test.ts` is the same
+guard. The `pickVariant({ albescent: … }, slug, DefaultSigilAdapter)` call quoted
+there is a quotation of retired code, which is the point of quoting it.
+
+**§5's `ProposeTask` paragraph quotes a `ponytail:` note that has been reworded.**
+`pages/ProposeTask.tsx` now says *"Add a `resolveVariant` dispatch here when one
+does"*. The ruling is untouched: still no ruling either way, still tracked in
+#2538.
+
+The body above is preserved as written, including both readings of the seam, so
+that a reader meeting a `pickVariant(map, slug, Default)` call in old history or
+an old design brief can still find out what it was.

--- a/docs/agents/load-time.md
+++ b/docs/agents/load-time.md
@@ -37,10 +37,10 @@ const CovenTaskDetail = lazyArchetype(() => import('../pages/taskDetail/archetyp
 taskDetail: () => CovenTaskDetail,
 ```
 
-Nothing else has to change. `surfaceMap()` and `pickVariant()` don't know the
+Nothing else has to change. `surfaceMap()` and `resolveVariant()` don't know the
 difference, no dispatcher is touched, and the chunk is fetched only when a
-surface for that faction actually renders. Adding a skin to all eight factions
-adds eight chunks that load for at most one faction at a time.
+surface for that faction actually renders. Adding a skin to all nine factions
+adds nine chunks that load for at most one faction at a time.
 
 Pages are the same story: every route in `App.tsx` is behind `React.lazy` under
 one `<Suspense>`. A new page is one more `lazy(() => import(...))` line and
@@ -54,7 +54,7 @@ manifest, add routes the way the neighbours do, and you get this for free."**
 Every regression will be one of these.
 
 **1. A static import from something eager.** The original bug. `factions/index.ts`
-imports all eight manifests, so anything a manifest imported *statically* landed
+imports all nine manifests, so anything a manifest imported *statically* landed
 in the entry chunk — all ~184 archetypes of it. If you find yourself writing
 `import Foo from './heavy'` at the top of a manifest, or importing an archetype
 directly from a dispatcher, you have re-created it.

--- a/docs/kit-structure.md
+++ b/docs/kit-structure.md
@@ -14,14 +14,13 @@ vote widget, a comment voice, a whole page. The list is
 construction — a `satisfies` clause makes the array and the `FactionManifest`
 interface check each other, so a surface cannot exist without appearing in both.
 Each surface has exactly one dispatcher, which calls `surfaceMap('<key>')` and
-hands the result to `pickVariant`.
+hands the result to `resolveVariant`.
 
-An **identity** is a faction slug. Eight ship a manifest
-(`frontend/src/factions/index.ts`); the ninth is `na`, which ships none on
-purpose — see below.
+An **identity** is a faction slug. All nine ship a manifest
+(`frontend/src/factions/index.ts`), `na` included since #2530 — see below.
 
 Do not maintain those two numbers here. Count them with
-`SURFACE_KEYS.length` and `FACTION_MANIFESTS.length + 1`; this section exists to
+`SURFACE_KEYS.length` and `FACTION_MANIFESTS.length`; this section exists to
 say what the numbers *mean*, not to cache them. (They were 21 and 9 when this
 file was written, which is worth stating only because the epic that commissioned
 it went in believing the second number was 10. The first is 20 since ADR-0078
@@ -45,10 +44,13 @@ but the composition itself is hand-written per faction. When two skins genuinely
 converge, the fix is to lift the shared thing into the library, not to merge the
 skins behind a flag.
 
-The manifest is **override-only**: every field is optional, and an undeclared
-surface falls through to that surface's `Default*` archetype. A faction that
-declares nothing renders correctly everywhere, including on surfaces that do not
-exist yet. **Partial registration is the normal case, not a degraded one.**
+Every manifest field is optional, so a faction that declares nothing still
+renders correctly everywhere, including on surfaces that do not exist yet. An
+undeclared surface is not a hole: the surface map simply has no row under that
+slug, and `resolveSlug` reads `na`'s row instead. **That is a lookup in the
+ninth manifest, not a fallback mechanism behind the manifests** — `na` declares
+all twenty surfaces itself (`frontend/src/factions/default.ts`), which is why
+there is only one way a surface gets drawn.
 
 ## `Default` ≡ `na` ≡ Unaffiliated is one identity
 
@@ -58,30 +60,43 @@ are named. There is no separate "default faction" and no fallback-that-isn't-a-
 faction. ADR-0039 settles it: `na` resolves to the neutral `--faction-default-*`
 set — a spectrum, not a hue — and never borrows another faction's colour.
 
-**The naming rule: an na component is `Default*`, never `Na*`.** This is why
-`na` has no manifest file. Registering it would mean naming, for every surface,
-the component that surface *already* falls back to.
+**The naming rule: an na component is `Default*`, never `Na*`.** The name says
+which identity the component draws; it has never meant "the thing reached when
+lookup fails".
 
-### The three `Default*` archetypes that are functions, not files
+### `na` ships a manifest, and four of its rows are not `Default*.tsx` files
 
-`Default*` names an **archetype, not necessarily a module**. Three surfaces keep
-their na rendering inside the dispatcher:
+`na` used to be the one faction with no manifest, reached instead by a second
+mechanism — a `Default*` handed to `pickVariant` as a third argument, spelled
+out by hand at ~20 dispatchers. **#2530 retired that.** `frontend/src/factions/default.ts`
+declares all twenty na surfaces the way the other eight declare theirs, and
+`defaultManifest.test.tsx` fails the build if a key is missing.
 
-| Surface | What renders for `na` |
-|---|---|
-| `avatar` | `DefaultAvatar`, a local function in `components/avatar/FactionAvatar.tsx` |
-| `feedFrame` | `DefaultFeedFrame`, a local function in `components/feed/FactionFeedFrame.tsx` |
-| `backdrop` | `WatercolorBackground`, imported from `components/layout/` |
+`Default*` still names an **archetype, not necessarily a module of that name**.
+Four rows point somewhere other than a matching `Default*.tsx`:
 
-All three are designed, shipped and rendering today — `DefaultAvatar`'s conic
-spectrum ring was drawn in #1127, `DefaultFeedFrame`'s spectrum spine in #1148 —
-and a test already pins the feed frame as the Unaffiliated chassis rather than a
-passthrough (#1194).
+| Surface | What the row points at | Why |
+|---|---|---|
+| `backdrop` | `WatercolorBackground` in `components/layout/` | the site's watercolour ground *is* the designed neutral; a `DefaultBackdrop.tsx` would be a re-export with a nicer name |
+| `sigil` | `DefaultSigilAdapter`, a named export of `components/sigil/FactionSigil.tsx` | co-located with its dispatcher, reached by a `.then()` that picks the export |
+| `comment` | `DefaultComment`, a named export of `components/comments/CommentThread.tsx` | same |
+| `duelSeal` | `DefaultDuelSealConfirm`, a named export of `components/duel/DuelSealConfirm.tsx` | same |
 
-This table is here for one reason: **the absence of `DefaultAvatar.tsx` has been
+Co-location is not a bypass: the manifest is the only thing that reads those
+three exports.
+
+`avatar` and `feedFrame` were on this list until #2530 — both were functions
+defined inside their own dispatchers, and both are now modules
+(`components/avatar/DefaultAvatar.tsx`, `components/feed/DefaultFeedFrame.tsx`),
+extracted unchanged so the manifest had something to point at. They are designed,
+shipped and rendering — `DefaultAvatar`'s conic spectrum ring was drawn in #1127,
+`DefaultFeedFrame`'s spectrum spine in #1148 — and a test pins the feed frame as
+the Unaffiliated chassis rather than a passthrough (#1194).
+
+This section is here for one reason: **the absence of a `Default*.tsx` has been
 read as a hole in the na kit by four separate audits.** It is a file-layout
-observation. Counting skin *files* undercounts these three surfaces by one each.
-If you are about to file "the na kit is missing an avatar", it is not.
+observation. If you are about to file "the na kit is missing a backdrop", it is
+not — read `default.ts`, which is now the one place that answers the question.
 
 ## Albescent's partial coverage is the steady state, not a gap
 
@@ -182,7 +197,7 @@ drift is a red build for everyone.
 | Question | Answer |
 |---|---|
 | Which surfaces exist? | `SURFACE_KEYS`, `frontend/src/factions/manifest.ts` |
-| Which factions exist? | `FACTION_MANIFESTS`, `frontend/src/factions/index.ts`, plus `na` |
+| Which factions exist? | `FACTION_MANIFESTS`, `frontend/src/factions/index.ts` — all nine, `na` included |
 | Which faction dresses which surface? | that faction's `frontend/src/factions/<slug>.ts` |
 | What does a surface's prop contract look like? | the field's type in `manifest.ts` |
 | Why does a surface look the way it does? | its ADR in `docs/adr/` |

--- a/docs/spec/SPEC-faction-ui-profile.md
+++ b/docs/spec/SPEC-faction-ui-profile.md
@@ -10,7 +10,7 @@
 
 ## 1. The per-faction boundary (Tier 3)
 
-> **§1 is the *contract*** — what a faction *may* own. For the *state* (which factions actually have each surface wired today, and where they fall back to a default), grep the dispatchers in `frontend/src` (`pickVariant` / `Record<slug, …>` maps + `MOBILE_ARCHETYPE_BY_SLUG`) — the code is the source of truth, not a hand-maintained matrix.
+> **§1 is the *contract*** — what a faction *may* own. For the *state* (which factions actually have each surface wired today, and where they fall back to a default), read the manifests in `frontend/src/factions/` — each faction's `<slug>.ts` declares the surfaces it dresses, and `default.ts` is `na`'s. The code is the source of truth, not a hand-maintained matrix.
 
 ### Per-faction — a faction owns its own version of each of these
 


### PR DESCRIPTION
Six documents described two mechanisms retired by #2530 as current fact. Each was a wrong
instruction to the next agent, not a stale note. Docs-only: six markdown files, zero code.

Closes #2647

## The seam

**`frontend/src/utils/factionDispatch.ts`** — the dispatch seam these documents describe. Every
claim below was re-derived from that file and its call sites at `origin/main` 8c1021d4 before a
sentence was rewritten, because the premise of this issue is that documents rot and the brief is
a document too.

What the code actually says today:

- `resolveVariant(map, slug)` is what dispatchers call. `resolveSlug` resolves an absent slug to
  `na` — that is the whole unknown-slug rule.
- `pickVariant(map, slug)` still exists, **two arguments, no fallback**, answering a different
  question: "is there a *bespoke* variant for this slug", returning `undefined` rather than na's
  row. So `pickVariant` is not a dead name and mentions of it are not automatically wrong.
- `DEFAULT_MANIFEST` is the **ninth** entry in `FACTION_MANIFESTS`. `factions/default.ts` declares
  all twenty na surfaces; `defaultManifest.test.tsx` holds it there.
- `components/avatar/DefaultAvatar.tsx` and `components/feed/DefaultFeedFrame.tsx` are real files.
- The real duel call site is `resolveVariant(surfaceMap('duelSeal'), taskFactionSlug)`
  (`DuelSealConfirm.tsx:185`).

There is no failing-test-first loop here: the defect is prose, and its one runnable check already
exists (`backend/tests/test_adr_index.py`). Inventing a grep-test that asserts what documents may
say would be an unrequested abstraction with a brittle definition of "wrong".

## Part 2 was already done — verified, not redone

`CLAUDE.md:80` already read `--cov-fail-under=92` on main, matching
`.github/workflows/test.yml:60`. **Nothing was churned to "fix" it.**

I took the issue's *second* suggestion instead, which was not done: the line now names
`.github/workflows/test.yml` as the authority and says it wins on disagreement. Rationale — the
number has rotted twice (#1504, #1584) and nothing said which copy was authoritative; this changes
the failure mode from "agent trusts a stale number silently" to "agent knows where to check". I
kept the runnable command rather than replacing it with a pointer, because dropping the number
would make the most-run command in the file require opening a second file first.

Scoped to that one line — #2711 is editing the routing table in this same batch.

## ADR-0084 is amended, not edited

Per #2600, in the shape #2640 used on ADR-0053: a dated `## Amendment` section appended, original
body intact. **The diff is 39 additions, 0 deletions.** No new ADR number.

The record had already anticipated this: its *Consequences* listed "whether `na` gains a real
manifest (#2530), which changes the *mechanism* under §2 without touching which pages use it" as an
open question. The note records that it landed, restates §2 with `resolveVariant`, and is explicit
about what did **not** move — the no-injected-slug invariant and #2529's bypass closure stand as
written.

### One deviation from the brief, deliberate — status stays `Accepted`

The brief said "status line updated". **I did not update it, because it cannot be done and would
fail CI.** `scripts/adr_index.py` accepts exactly four status forms, and the only amendment form is
`Amended by ADR-NNNN` — free text in that value is rejected by design. This issue mints no ADR (the
brief forbids one), so there is no number to point at. `Accepted` is also the honest value: nothing
0084 decided changed, only the name of the helper its seam calls. Flagging it rather than burying
it; say the word if you want a real ADR minted instead.

`python scripts/adr_index.py` was re-run. The generated index is byte-identical — the expected
result of an unchanged status line — and `backend/tests/test_adr_index.py` passes 4/4.

## Two scope calls to sanity-check

**1. Dropped "Partial registration is the normal case, not a degraded one" from
`docs/kit-structure.md`.** Beyond the issue's line list. All nine manifests declare all twenty
surfaces (180/180 — counted, not assumed), so it is flatly false, and it restated the retired model
in the same paragraph I was correcting. I did not want to leave a false sentence adjacent to the fix.

**2. Corrected `docs/spec/SPEC-faction-ui-profile.md:13`**, which the issue did not list. It told
readers to find the dispatchers by grepping `pickVariant` / `MOBILE_ARCHETYPE_BY_SLUG`. Neither
works — the seam is `resolveVariant` (39 files) and `ARCHETYPE_BY_SLUG` survives only inside
comments. It also trips the issue's own "Done when" grep. One line, points at the manifests now.
(`SPEC-backend-architecture.md` and the `frontend`/`backend` `CLAUDE.md` pair were left alone as
instructed.)

## Done when

- [x] `grep -rn "pickVariant" docs/ .design-sync/` describes no fallback argument. One hit remains
      outside `docs/adr/` — `kit-structure.md:70`, my own sentence, **explicitly past-tense**
      ("`na` used to be… **#2530 retired that**"). It earns its place: it is what stops the section
      being re-misread the way four audits already misread it. Call it if you disagree.
- [x] No document outside `docs/adr/` calls the `Default*` archetypes functions rather than files.
- [x] ADR-0084 carries an amendment note, body untouched; `adr_index.py` re-run.
- [x] `CLAUDE.md` states 92 **and** points at the workflow.

## Spotted, deliberately not fixed (for #2533)

`docs/kit-structure.md` still says Albescent "declares a minority of the 21 surfaces" and that the
count "is never expected to reach 21" — two rots at once: the file itself says 20 since ADR-0078,
and Albescent now declares all 20 as wrappers. That is a different retired mechanism than the two
this issue names, so I left it rather than widen the diff.

## Verification

- `backend/tests/test_adr_index.py` — **4 passed**.
- `python scripts/adr_index.py` — regenerates byte-identically.
- Zero code files touched, so tsc, vitest, `typecheck:design-sync`, build, byte budget and
  `api-schema` are structurally unaffected — no route, schema, `.ts`/`.tsx` or preview fixture is
  in the diff.
- Confirmed nothing in the tree cites the section heading I renamed.
- **No visual QA** — this agent has no browser tools or dev stack. Nothing here renders.

## What to eyeball

Prose correctness is the whole deliverable, so this is a reading review, not a running one:

1. **`docs/kit-structure.md`** — the rewritten `### na ships a manifest, and four of its rows are
   not Default*.tsx files` section. Check the four-row table against
   `frontend/src/factions/default.ts:52-71`: `backdrop`→`WatercolorBackground`, and `sigil` /
   `comment` / `duelSeal` reached by a `.then()` picking a named export. If that table is wrong it
   will be re-misread as a coverage hole, which is the exact failure it exists to prevent.
2. **`docs/adr/0084-…md`** — read the appended `## Amendment` against the untouched §2 above it and
   confirm the record still reads as a record. Specifically: does the amendment overreach into
   re-deciding anything, or does it only rename the mechanism? And is `Accepted` the status you want
   given the constraint above?
3. **`CLAUDE.md`** — one line, the "Running locally" test command. Confirm it stays clear of #2711's
   routing-table edit.
4. **`docs/spec/SPEC-faction-ui-profile.md:13`** — an out-of-list fix; confirm you want it here
   rather than in #2533.
5. **`docs/agents/load-time.md`** — the eight→nine manifest counts, against
   `FACTION_MANIFESTS` in `frontend/src/factions/index.ts:68-79`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
