### PR TITLE
The two vote-store test seams were never in the bundle

### DIFF
--- a/frontend/src/components/vote/__tests__/testSeamsStayOutOfTheBundle.test.ts
+++ b/frontend/src/components/vote/__tests__/testSeamsStayOutOfTheBundle.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The ratchet for #2697: a test seam stays free only while nothing ships it.
+ *
+ * `castTallies.ts` and `pendingCasts.ts` each export a `__reset*` function that
+ * exists purely so one spec cannot see another spec's writes to a module-global
+ * Map. #2697 filed them as dead weight in the production bundle. They are not:
+ * deleting both and rebuilding produces a byte-identical `dist/` — same
+ * content-hashed filenames, same sizes — because Rollup tree-shakes an export
+ * that no module in the application graph imports. The seams cost zero shipped
+ * bytes, so the six specs that depend on them were left alone.
+ *
+ * That verdict rests on a fact about the IMPORT GRAPH rather than about the
+ * functions, which is why it can stop being true without either module
+ * changing a character. A call from reachable application code is the one
+ * precondition for shipping a seam — necessary, if not on its own sufficient,
+ * since Rollup shakes transitively and an import into a dead branch still
+ * goes. Neither module can notice that happening to it: the import lands in
+ * some other file, `tsc` is happy, every spec still passes, and a reset hatch
+ * that blanks a live store is now something a runtime caller can reach.
+ *
+ * The import is therefore the thing worth guarding. It is cheap to detect,
+ * there is no legitimate reason for one, and refusing it outright keeps the
+ * question from having to be re-litigated per call site.
+ *
+ * So this guards the fact rather than the functions. It finds every `__`-
+ * prefixed export declared anywhere under `src/` and refuses any mention of one
+ * from a non-test file. Deliberately a text scan and not an AST walk, for the
+ * same reason `api/__tests__/noSchemaMirrors.test.ts` is: the whole value is in
+ * it being cheap enough to keep.
+ *
+ * TO RE-VERIFY THE BUILD CLAIM, rather than trusting this docblock: delete both
+ * functions, `npm run build`, and diff `dist/` against a build from `main`.
+ * Identical output means they are still free.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+/**
+ * Vitest helpers loaded through `setupFiles`, which are not in the application
+ * graph and may legitimately hold a shared reset. Exempted by path so the
+ * exemption is visible; everything else under `src/` is application code until
+ * proven otherwise.
+ */
+const TEST_HELPER_DIR = `test${sep}`
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...sourceFiles(path))
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(path)
+  }
+  return out
+}
+
+/**
+ * Source with its comments removed, because this file's own reasoning — and the
+ * `__reset*` docblocks the two modules carry — name the seams in prose. A scan
+ * that forbade the NAME would forbid the explanation of why the name is there.
+ * What is left is imports, exports and calls: where a revival would actually
+ * live.
+ */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+const FILES = sourceFiles(SRC)
+  .map((path) => ({
+    path: relative(SRC, path),
+    code: withoutComments(readFileSync(path, 'utf8')),
+  }))
+  .filter(({ path }) => !path.startsWith(TEST_HELPER_DIR))
+
+/** `export function __x` / `export const __x` — a seam and the file that owns it. */
+const SEAMS = FILES.flatMap(({ path, code }) =>
+  [...code.matchAll(/^export (?:function|const) (__\w+)/gm)].map((match) => ({
+    name: match[1],
+    owner: path,
+  })),
+)
+
+describe('test seams are reachable only from tests (#2697)', () => {
+  it('scans the source tree, so a bad path cannot pass this by vacuum', () => {
+    // Without this, an SRC that resolved somewhere empty would give no files,
+    // no seams, and a green run that proved nothing at all.
+    expect(FILES.length).toBeGreaterThan(400)
+  })
+
+  it('finds the two seams #2697 weighed, so the matcher still matches', () => {
+    // These are not a whitelist — every seam found is guarded below, and a new
+    // one needs no edit here. They are the proof that the regex still works
+    // against the real declarations.
+    expect(SEAMS.map((seam) => seam.name)).toEqual(
+      expect.arrayContaining(['__resetCastTallies', '__resetPendingCasts']),
+    )
+  })
+
+  for (const { name, owner } of SEAMS) {
+    it(`${name} is imported by no application module`, () => {
+      const importers = FILES.filter(
+        ({ path, code }) => path !== owner && code.includes(name),
+      ).map(({ path }) => path)
+      expect(
+        importers,
+        `${name} is a test seam declared in ${owner}. Importing it from ` +
+          `application code puts it in the production bundle — which is what ` +
+          `#2697 was filed about, and what the tree-shaking verdict there ` +
+          `depends on NOT being true. Use the module's real API instead.`,
+      ).toEqual([])
+    })
+  }
+})

--- a/frontend/src/components/vote/castTallies.ts
+++ b/frontend/src/components/vote/castTallies.ts
@@ -84,7 +84,25 @@ export function useCastTally(praxisId: number): VoteTallyOut | null {
   return useSyncExternalStore(subscribe, read, () => null)
 }
 
-/** Test seam only. */
+/**
+ * Test seam only. Six specs isolate through it — see the ratchet in
+ * `__tests__/testSeamsStayOutOfTheBundle.test.ts` for why it stays (#2697).
+ *
+ * KEPT DELIBERATELY, and the audit that flagged it was measuring the wrong
+ * thing. Deleting this and `__resetPendingCasts` and rebuilding gives a
+ * byte-identical `dist/` — Rollup shakes an export nothing in the application
+ * graph imports, so the seam costs zero shipped bytes. What it would have cost
+ * to remove is six spec files converted to `vi.resetModules()` plus dynamic
+ * re-imports — and three of those reach this map through a DIFFERENT module
+ * that holds its own reference to it (`api/praxis.ts` and `api/duel.ts` call
+ * `clearCastTallies`; `pendingCasts.ts` calls `recordCastTally`). Each would
+ * have to be re-imported in the same breath as this one or it keeps pointing
+ * at the old Map, and the isolation silently becomes a no-op that still passes.
+ * That is a lot of new ways to be quietly wrong in exchange for zero bytes.
+ *
+ * The seam is free only while no application module imports it, which the
+ * ratchet enforces. Do not re-file this without re-running the build diff.
+ */
 export function __resetCastTallies(): void {
   tallies.clear()
   emit()

--- a/frontend/src/components/vote/pendingCasts.ts
+++ b/frontend/src/components/vote/pendingCasts.ts
@@ -206,7 +206,19 @@ export function applyPendingCast(
   return merged
 }
 
-/** Test seam only. */
+/**
+ * Test seam only. One spec isolates through it — see the ratchet in
+ * `__tests__/testSeamsStayOutOfTheBundle.test.ts` for why it stays (#2697).
+ *
+ * KEPT DELIBERATELY, on the same evidence as `__resetCastTallies`: removing
+ * both leaves `dist/` byte-identical, so neither ships. This one also has a
+ * hazard its sibling does not, which is the second reason it stayed. The
+ * `clearTimeout` loop above is the point of the function, and the suggested
+ * replacement — `vi.resetModules()` — drops the module's reference to those
+ * handles WITHOUT cancelling them, so a spec that leaves a cast pending would
+ * fire a timer into a torn-down module. Cancelling the timers is a thing only
+ * code holding this map can do.
+ */
 export function __resetPendingCasts(): void {
   for (const entry of casts.values()) if (entry.timer) clearTimeout(entry.timer)
   casts.clear()


### PR DESCRIPTION
Closes #2697

## Verdict: **neither seam is cut**, because neither one ships

The issue's premise is that `__resetCastTallies` and `__resetPendingCasts`
"ship test seams in the production bundle." I checked that by building rather
than by reasoning about it, and it is false.

**Method.** Built `dist/` at `origin/main` (8c1021d4) and snapshotted it.
Deleted both functions outright. Rebuilt. Diffed the two trees.

```
$ diff -r --brief /tmp/wz2697_dist_before dist
BYTE-IDENTICAL: every file in dist/ matches the pre-deletion build
```

All 337 emitted files match, including the content-hashed JS chunk names —
`index-HLYnKPwz.js` before and after, which is itself the proof, since Vite
derives that hash from the file's bytes. Rollup already tree-shakes both
exports: nothing in the application graph imports either one. **The seams cost
zero shipped bytes.**

Same check re-run against this branch's final build: `dist/` is byte-identical
to the baseline from `main`, so this PR ships no code at all.

## The seam I tested at

Not the two functions — **the import graph**. That is the load-bearing fact,
and it is the only one that can silently stop being true.

A seam is free exactly while no application module calls it. Neither
`castTallies.ts` nor `pendingCasts.ts` can detect that changing: the import
would land in some other file, `tsc` stays happy, all 9,269 tests stay green,
and the bundle quietly grows a hatch that a runtime caller can fire to blank a
live store. So the check goes on the import, which is cheap to detect and has
no legitimate instance.

`testSeamsStayOutOfTheBundle.test.ts` finds every `__`-prefixed export declared
under `src/` and refuses any mention of one from a non-test file. It is not a
whitelist of these two — a new seam is guarded with no edit to the test.

**Red first, on the real defect.** I appended a genuine application-code import
to `useVotedPraxis.ts` and ran it:

```
× __resetCastTallies is imported by no application module
  → ...expected [ 'components\vote\useVotedPraxis.ts' ] to deeply equal []
```

It names the offending file. Two anti-vacuum cases sit alongside it, matching
the house pattern in `api/__tests__/noSchemaMirrors.test.ts`: one asserts the
walk found >400 source files (a mis-resolved `SRC` would otherwise pass by
finding nothing), one asserts the regex still matches both real declarations.

## Why cutting them was the worse trade

The issue offers `vi.resetModules()` plus dynamic re-import. Weighed against
zero bytes saved, the cost is six spec files — and three of them have a failure
mode worth naming, because it is silent:

| spec | reaches the map via |
|---|---|
| `api/__tests__/duelCastTallies.test.ts` | `api/duel.ts` → `clearCastTallies` |
| `api/__tests__/praxisRequests.test.ts` | `api/praxis.ts` → `clearCastTallies` |
| `components/vote/__tests__/pendingCasts.test.ts` | `pendingCasts.ts` → `recordCastTally` |

Each of those modules holds **its own reference** to the module-global `Map`.
`vi.resetModules()` plus a re-import of `castTallies` alone gives the spec a
fresh map while `api/duel.ts` keeps writing to the old one — the isolation
becomes a no-op that still passes. Every dependent module would have to be
re-imported in lockstep, forever, as a standing invariant nothing enforces.

(The other three — `castTallies.test.ts`, `applyCastTally.test.ts`,
`scoreStamp.test.tsx` — are same-module or pure; `applyCastTally` takes the
tally as an argument. I originally wrote "four" in a docblock, checked it, and
corrected it to three.)

`__resetPendingCasts` additionally has the hazard the issue already named: its
`clearTimeout` loop **is** the function, and `vi.resetModules()` drops the
reference to those handles without cancelling them.

## What changed

- `frontend/src/components/vote/castTallies.ts` — docblock only, naming why the
  seam stayed and how to re-verify the build claim.
- `frontend/src/components/vote/pendingCasts.ts` — same, plus the timer hazard.
- `frontend/src/components/vote/__tests__/testSeamsStayOutOfTheBundle.test.ts` — new ratchet.

`grep -rn "__reset" frontend/src` returns the two declarations, their six test
consumers, and the ratchet — the "only what you deliberately kept, with its
reason in a comment" branch of the issue's Done-when.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | pass |
| `npm run typecheck` (`tsc --noEmit` + e2e tsconfig) | pass |
| `npm run typecheck:design-sync` | pass |
| `npm test` | **453 files, 9269 passed**, 1 skipped |
| `npm run build` | pass |
| `npm run budget` | exit 0 |

No backend file, Pydantic schema or route signature touched, so `api-schema`
and `test` are unaffected. No CSS touched.

The budget step prints a pre-existing `WARN CSS 22.2 KB` (warn line 22.2 KB,
fail 24.4 KB) — non-blocking and not from this PR: the emitted
`index-BRPq1uh_.css` is byte-identical to the baseline built from unmodified
`main`.

## What to eyeball

- **The verdict itself.** This closes #2697 without deleting the thing it asked
  to delete. If you want them gone on style grounds — a `__`-prefixed mutable
  reset is a smell regardless of cost — that is a legitimate call, but it is a
  different argument than the one the issue makes, and it costs the six specs
  and the lockstep-re-import invariant above.
- **Is the ratchet worth its 116 lines?** The minimum answer to the issue was
  two comments. I added the test because a comment claiming "tree-shaken" rots
  in exactly one way, and this repo already ratchets that class of claim. Say
  if you would rather have just the comments.
- **The `src/test/` exemption.** Vitest `setupFiles` helpers are outside the
  application graph, so they may legitimately hold a shared reset. Exempted by
  path and commented. Nothing currently uses it.
- **No visual QA** — no browser tools and no dev stack in this worktree. Nothing
  rendered changed: the diff is two comments and a test file, and the build
  output is byte-identical, so there is no pixel to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
