### PR TITLE
The empty vote slot forks: the hairlines take one number, the prism takes its own

### DIFF
--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -151,7 +151,13 @@ export default function AlbescentVote({
             transition: MORPH_TRANSITION,
             // Unreached blobs sit as a faint neutral fill (the spectrum has not
             // reached them yet); reached ones window the shared rainbow.
-            backgroundColor: reached ? 'transparent' : 'var(--faction-default-dot-ring)',
+            //
+            // `-dot-fill`, not the `-dot-ring` the other two vote surfaces read
+            // (#2608). Same token until light forked: this blob composites on
+            // `.alb-prism`'s multiply sweep rather than the flat na card, where
+            // the ring's value reads 2.70:1. The name is `default`-family
+            // because `CSS_KEY` maps albescent -> default (ADR-0039 / #783).
+            backgroundColor: reached ? 'transparent' : 'var(--faction-default-dot-fill)',
             backgroundImage: reached ? 'var(--faction-default-rainbow)' : 'none',
             backgroundRepeat: 'no-repeat',
             backgroundSize: `${SPAN}px ${size}px`,

--- a/frontend/src/components/vote/__tests__/dotRingBoundary.test.ts
+++ b/frontend/src/components/vote/__tests__/dotRingBoundary.test.ts
@@ -1,30 +1,35 @@
 /**
- * `--faction-default-dot-ring` is a COMPONENT BOUNDARY, and it is measured at
- * 3:1 (#2524).
+ * The unreached vote petal is a COMPONENT BOUNDARY, and it is measured at 3:1
+ * in BOTH cascades (#2524 dark, #2608 light).
  *
  * ## The seam
  *
- * The token's own value, composited over the card it is drawn on. Not text: an
- * unreached petal is what tells you the control has a fifth position at all, so
- * WCAG **1.4.11** governs it at 3:1 and 1.4.3's 4.5 does not apply. That
- * distinction is the whole reason the number below is 3 and not 4.5, and it is
- * why this file exists beside `factionContrast.test.ts` rather than inside it —
- * that registry is a text sweep asserted both ways.
+ * The token's own value, composited over the ground the consumer actually draws
+ * on. Not text: an unreached petal is what tells you the control has a fifth
+ * position at all, so WCAG **1.4.11** governs it at 3:1 and 1.4.3's 4.5 does not
+ * apply. That distinction is the whole reason the numbers below are 3 and not
+ * 4.5, and it is why this file exists beside `factionContrast.test.ts` rather
+ * than inside it — that registry is a text sweep asserted both ways.
  *
- * ## The consumer list is the load-bearing part
+ * ## The consumer list is the load-bearing part, and it FORKED in #2608
  *
- * The board's patch was written against ONE site, `AlbescentVote`'s fill. The
- * token has three readers and none of them is text:
+ * The token has three readers and none of them is text. #2524 lifted them
+ * together because dark's one value cleared 3:1 on both grounds. Light does not
+ * have that luxury, so the owner ruled the split (2026-08-26):
  *
- *   `components/vote/AlbescentVote.tsx`               fill (the reported site)
- *   `components/vote/DefaultVote.tsx`                 `inset 0 0 0 1.5px` ring
- *   `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx`   the same ring
+ *   `components/vote/DefaultVote.tsx`                        ring, na card
+ *   `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx`  ring, na card
+ *   `components/vote/AlbescentVote.tsx`                      fill, the PRISM
  *
- * So it was LIFTED rather than forked: a 1.5px hairline is a thinner target than
- * a 44px blob and wants at least what the blob wants, which means a fork would
- * have had to hand the two rings the higher number anyway. `names its three
- * readers and no more` below is what makes that reasoning re-checkable — a
- * fourth consumer, or one of these three turning into TEXT, re-opens the choice.
+ * The two `inset 0 0 0 1.5px` hairlines composite on the flat light na card
+ * `--faction-default-card-bg`. Albescent's 42px blob does not: `.alb-prism`
+ * paints a multiply sweep INTO that card, so the blob sits on a ground up to
+ * ~10pp darker, and a ring value tuned on the flat card reads 2.70:1 there.
+ * Two grounds, two values — "mint the name, keep the per-site alpha".
+ *
+ * Dark did NOT fork and must not: `--faction-default-dot-fill` aliases the ring
+ * under `[data-theme="dark"]`, where the one cream reads 5.73:1 flat and 5.97:1
+ * on the prism. Both rows below therefore run in both themes.
  */
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -34,12 +39,21 @@ import {
   contrastRatio,
   formatRatio,
   parseColor,
+  relativeLuminance,
   type Rgba,
 } from '../../../utils/contrast'
-import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
+import {
+  declarationsIn,
+  readThemes,
+  resolveVar,
+  ruleBodies,
+  stripComments,
+  type Theme,
+} from '../../../utils/__tests__/cssVars'
 
 const CSS_PATH = fileURLToPath(new URL('../../../index.css', import.meta.url))
-const THEMES = readThemes(readFileSync(CSS_PATH, 'utf8'))
+const CSS = readFileSync(CSS_PATH, 'utf8')
+const THEMES = readThemes(CSS)
 
 function resolve(token: string, theme: Theme): Rgba {
   const raw = resolveVar(token, theme, THEMES)
@@ -49,67 +63,129 @@ function resolve(token: string, theme: Theme): Rgba {
   return parsed!
 }
 
-/** The card all three readers draw on — na's, and Albescent's through it. */
+/** The flat card the two hairlines draw on — na's. */
 const card = (theme: Theme) => resolve('--faction-default-card-bg', theme)
+
+/**
+ * Albescent's ground, worst pixel.
+ *
+ * `.alb-prism` sets `--faction-default-card-sheet` to a `multiply` sweep over
+ * `--faction-default-card-bg`, so the ground under an Albescent petal is
+ * `card x stop` at the darkest of the sweep's stops. Under
+ * `prefers-reduced-motion` the SAME layer list is composited TWICE (epic #2496
+ * ruling 6 — the rest frame), which is where the ground is deepest and so where
+ * the fill has the least to work with. `depth` is that layer count.
+ *
+ * The stops are read out of index.css rather than restated here: retune the
+ * prism and this measurement follows it, which is the whole point of measuring
+ * the composited ground instead of the declared token.
+ */
+const PRISM_SELECTOR = '.alb-prism,\n.alb-faction-hero,\n.alb-faction-body'
+
+const prismStops = (): Rgba[] => {
+  const bodies = ruleBodies(stripComments(CSS), PRISM_SELECTOR)
+  expect(bodies, 'the light .alb-prism rule is still one rule').toHaveLength(1)
+  const sheet = declarationsIn(bodies).get('--faction-default-card-sheet')
+  expect(sheet, '.alb-prism still declares the sheet').toBeDefined()
+  const stops = [...sheet!.matchAll(/#[0-9a-f]{6}/gi)].map(([hex]) => parseColor(hex)!)
+  expect(stops.length, 'the light prism sweep still has stops to measure').toBeGreaterThan(0)
+  return stops
+}
+
+/** CSS `multiply` of an opaque source over an opaque backdrop. */
+const multiply = (back: Rgba, source: Rgba): Rgba => ({
+  r: (back.r * source.r) / 255,
+  g: (back.g * source.g) / 255,
+  b: (back.b * source.b) / 255,
+  a: 1,
+})
+
+function darkestPrismPixel(depth: number): Rgba {
+  let worst = card('light')
+  for (const stop of prismStops()) {
+    let ground = card('light')
+    for (let layer = 0; layer < depth; layer += 1) ground = multiply(ground, stop)
+    if (relativeLuminance(ground) < relativeLuminance(worst)) worst = ground
+  }
+  return worst
+}
 
 const ring = (theme: Theme) => contrastRatio(resolve('--faction-default-dot-ring', theme), card(theme))
 
-describe('the unreached petal is visible against the card it sits on', () => {
-  it('dark clears the 3:1 graphic floor', () => {
-    const ratio = ring('dark')
-    expect(ratio, `the ring is ${formatRatio(ratio)} on the dark card`).toBeGreaterThanOrEqual(
+describe('the unreached petal is visible against the ground it sits on', () => {
+  it.each(['light', 'dark'] as const)('the hairline rings clear 3:1 on the %s na card', (theme) => {
+    const ratio = ring(theme)
+    expect(ratio, `the ring is ${formatRatio(ratio)} on the ${theme} card`).toBeGreaterThanOrEqual(
       AA_LARGE,
     )
   })
 
-  it('and 0.3 — the alpha it shipped with — would not', () => {
-    // The load-bearing half of the lift. `AlbescentVote` filled the blob with
-    // this and the vote row read as an empty line; walk the alpha back and this
-    // row goes red rather than the defect returning quietly.
+  it('and the cream it shipped with would not', () => {
+    // The load-bearing half of the lift, light side. `#d6cfbf` is what stood
+    // here until #2608 and it read 1.53:1 — a 4-of-5 vote showed two petals
+    // rather than two of four. Walk the value back and this row goes red rather
+    // than the defect returning quietly.
+    const ratio = contrastRatio(parseColor('#d6cfbf')!, card('light'))
+    expect(ratio, `the old cream is ${formatRatio(ratio)}`).toBeLessThan(AA_LARGE)
+  })
+
+  it('and 0.3 — the alpha dark shipped with — would not either', () => {
     const cream = { ...resolve('--faction-default-dot-ring', 'dark'), a: 0.3 }
     const ratio = contrastRatio(cream, card('dark'))
     expect(ratio, `at 0.3 the ring is ${formatRatio(ratio)}`).toBeLessThan(AA_LARGE)
   })
 
-  // ponytail: LIGHT IS A SECOND, UNFIXED DEFECT AND THIS ROW IS THE RECORD OF
-  // IT. #2524 measured the dark alpha and states in as many words that "light is
-  // unaffected: the light value is the opaque #d6cfbf" — true of the CHANGE, and
-  // not a pass: that cream on `--faction-default-card-bg` reads 1.53:1, which is
-  // the same 1.4.11 failure at half the ratio, on the theme most players use.
-  //
-  // It is not fixed here because fixing it repaints every player's vote row and
-  // the praxis detail's dot rail in the dominant theme, which is a visible design
-  // change the issue explicitly scoped out and no ruling covers. The ceiling of
-  // this file is therefore "dark is guarded"; the upgrade path is an owner
-  // ruling on the light value, after which this row becomes the same
-  // `toBeGreaterThanOrEqual(AA_LARGE)` as the dark one above.
-  it('light is still under the same floor, and that is an open finding', () => {
-    const ratio = ring('light')
-    expect(ratio, `the light ring is ${formatRatio(ratio)} on the light card`).toBeLessThan(
-      AA_LARGE,
+  // Albescent's blob, on Albescent's ground. `depth: 2` is the reduced-motion
+  // rest frame and is the binding case — the moving frame is strictly lighter,
+  // so a value that clears at 2 clears at 1. Both are asserted so a regression
+  // says WHICH frame broke.
+  it.each([1, 2])('the Albescent fill clears 3:1 on the prism at depth %i', (depth) => {
+    const ground = darkestPrismPixel(depth)
+    const ratio = contrastRatio(resolve('--faction-default-dot-fill', 'light'), ground)
+    expect(
+      ratio,
+      `the fill is ${formatRatio(ratio)} on the prism's darkest pixel at depth ${depth}`,
+    ).toBeGreaterThanOrEqual(AA_LARGE)
+  })
+
+  it('and the ring value would not survive the prism — which is why they forked', () => {
+    // The evidence for the split, not a restatement of it. If the two ever
+    // become interchangeable this row goes red and the fork can be re-argued.
+    const ratio = contrastRatio(resolve('--faction-default-dot-ring', 'light'), darkestPrismPixel(1))
+    expect(ratio, `the ring on the prism is ${formatRatio(ratio)}`).toBeLessThan(AA_LARGE)
+  })
+
+  it('dark did not fork: the fill is the ring there', () => {
+    expect(resolveVar('--faction-default-dot-fill', 'dark', THEMES)).toBe(
+      resolveVar('--faction-default-dot-ring', 'dark', THEMES),
     )
   })
 })
 
-describe('names its three readers and no more', () => {
+describe('names its three readers, by token, and no more', () => {
   // A consumer audit rots the moment it is written down, so it is asserted
-  // instead. Note the shape this has to survive: `--spectrum-glow-N` in these
-  // same two files is built by INTERPOLATION, so a grep for a token name is not
-  // a reliable census — the check below is scoped to files rather than to a
-  // pattern for that reason.
-  const READERS = [
-    '../AlbescentVote.tsx',
-    '../DefaultVote.tsx',
-    '../../../pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx',
+  // instead — and since #2608 it is asserted per TOKEN, because which of the two
+  // a file reads is the ruling. Note the shape this has to survive:
+  // `--spectrum-glow-N` in these same two files is built by INTERPOLATION, so a
+  // grep for a token name is not a reliable census — the check below is scoped
+  // to files rather than to a pattern for that reason.
+  const READERS: [path: string, token: string][] = [
+    ['../AlbescentVote.tsx', '--faction-default-dot-fill'],
+    ['../DefaultVote.tsx', '--faction-default-dot-ring'],
+    ['../../../pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx', '--faction-default-dot-ring'],
   ]
 
-  it.each(READERS)('%s still draws the ring as paint, not as ink', (path) => {
+  it.each(READERS)('%s draws %s as paint, not as ink', (path, token) => {
     const source = readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8')
-    expect(source, `${path} reads the token`).toContain('var(--faction-default-dot-ring)')
+    expect(source, `${path} reads ${token}`).toContain(`var(${token})`)
+    // It must read ITS token and not the other one — a file that reads both has
+    // lost the fork.
+    const other = READERS.find(([, name]) => name !== token)![1]
+    expect(source, `${path} does not also read ${other}`).not.toContain(`var(${other})`)
     // A bare `color:` would make it TEXT, and text is a 4.5 question rather than
-    // a 3.0 one — at which point 0.6 is no longer enough and this whole file is
-    // measuring against the wrong floor. `backgroundColor` is not that, and the
-    // word boundary is what keeps the two apart.
-    expect(source).not.toMatch(/\bcolor:\s*['"`]?var\(--faction-default-dot-ring/)
+    // a 3.0 one — at which point these values are no longer enough and this whole
+    // file is measuring against the wrong floor. `backgroundColor` is not that,
+    // and the word boundary is what keeps the two apart.
+    expect(source).not.toMatch(new RegExp(`\\bcolor:\\s*['"\`]?var\\(${token}`))
   })
 })

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -810,8 +810,37 @@
      the four petals that outlived their reader here and on Coven. The tier is
      named by the dots filling to it. Do not mint them back for a caption that
      was removed on purpose; the contrast history (#1675 walked `-vote-off` from
-     3.23:1 to 4.68:1) is in those issues, not in this file. */
-  --faction-default-dot-ring: #d6cfbf;
+     3.23:1 to 4.68:1) is in those issues, not in this file.
+
+     #d6cfbf -> #989388 (#2608), and the pair below is a FORK, not a rename.
+     #2524 lifted dark's one value for all three readers and said in as many
+     words that "light is unaffected" — true of that change, not of the surface:
+     the cream read 1.53:1 on this card, so a 4-of-5 vote showed two petals
+     rather than two of four. 1.4.11 governs an unreached petal at 3:1, and the
+     owner ruled (2026-08-26) the smallest lift that clears and no further —
+     past ~5.7:1 the empty slot starts reading as an object of its own, which is
+     the other way to get this wrong.
+
+     WHY TWO NAMES. The two readers of `-dot-ring` are `inset 0 0 0 1.5px`
+     hairlines on this flat card: #989388 is 3.01:1 there. The third reader,
+     `AlbescentVote`'s 42px blob, is NOT on this card — `.alb-prism` multiplies a
+     sweep into it, so the ground under the blob is up to ~10pp darker and
+     #989388 reads only 2.70:1 on it. One value cannot serve both grounds in
+     light; dark's could, and still does (see the dark block). `-dot-fill` is
+     therefore a `default`-family name and not an Albescent one — `CSS_KEY` maps
+     albescent -> default (ADR-0039 / #783) and `--faction-albescent-*` does not
+     exist.
+
+     #878379 is measured on the prism's darkest pixel with the sheet composited
+     TWICE — the reduced-motion rest frame (epic #2496 ruling 6), which is the
+     deepest ground an Albescent petal ever sits on. 3.01:1 there, 3.34:1 on the
+     moving prism, 3.72:1 if the card falls back to the flat sheet (Albescent's
+     praxis card drops `.alb-prism` over busy media). Tuning to the moving frame
+     alone would have given #8f8b80 and left reduced-motion readers at 2.70:1,
+     i.e. the same half-measured mistake this issue exists to correct.
+     `components/vote/__tests__/dotRingBoundary.test.ts` measures all of it. */
+  --faction-default-dot-ring: #989388;
+  --faction-default-dot-fill: #878379;
   /* The unaffiliated PLAIN CREAM SHEET (#842). The design's card is a quiet
      sheet, and the rainbow appears in exactly four places on it — the eyebrow
      text-clip, the score-box rule, the total, and one 2px divider. The
@@ -3468,10 +3497,17 @@
      than a 44px blob and wants at least what the blob wants, so a fork would have
      had to give the two rings the higher number anyway; one value, 5.73:1 on this
      card / 5.97 on the prism, is the design board's own patch. 0.45 (3.81 / 3.87)
-     clears too and was rejected for the hairlines' sake. Light is a different
-     shape of problem and is NOT touched here: it is opaque `#d6cfbf` and reads
-     1.53:1 on the light card, which no alpha change reaches. */
+     clears too and was rejected for the hairlines' sake. Light was a different
+     shape of problem and was not touched here; #2608 fixed it separately, and
+     no alpha change would have reached it — the light value was opaque.
+
+     DARK DID NOT FORK, and the alias is how that is stated. Light needed two
+     values because the flat na card and the prism are ~10pp apart there; this
+     cream clears both grounds at once (5.73 / 5.97), so `-dot-fill` points at
+     `-dot-ring` rather than restating it. Give dark its own fill value only if a
+     measurement forces it, and then say which ground forced it. */
   --faction-default-dot-ring: rgba(240, 230, 208, 0.6);
+  --faction-default-dot-fill: var(--faction-default-dot-ring);
   /* The cream sheet, lights out (#842) — the design's own dark card, not an
      inversion: the hairline becomes a white scrim and the stamp plate lifts off
      the sheet rather than sinking into it. Both narrow rainbows still swap their


### PR DESCRIPTION
Closes #2608

The unfilled vote petal read **1.53:1 on the light na card**. #2524 lifted the dark half of the same token and recorded "light is unaffected" — true of that change, not of the surface. This is the light half, built to the owner ruling of 2026-08-26.

## The seam

`components/vote/__tests__/dotRingBoundary.test.ts` — **the token's value composited over the ground each consumer actually draws on**, not the declared token. No browser needed: the compositing is done in code, the way `factionContrast.test.ts` already does. The loop went red at `the ring is 1.53:1 on the light card: expected 1.5269644850789061 to be greater than or equal to 3` before any CSS moved.

Two cross-checks that the compositing model is the right one: it reproduces the owner's reference number for the rings (`#989388` → **3.0113:1**, ruling says 3.01) and index.css's own recorded rest-frame figure for the prism (**78.5% L**, matching the `.alb-prism` docblock's "ground 78.5% L").

## Premises re-derived at `8c1021d4`

`git grep -n faction-default-dot-ring frontend/src` — three consumers, exactly as the issue says, plus two test sites:

| site | role | ground |
|---|---|---|
| `components/vote/DefaultVote.tsx` | boundary, `inset 0 0 0 1.5px` | flat light na card |
| `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx` | boundary, dot rail ring | flat light na card |
| `components/vote/AlbescentVote.tsx` | fill, the 42px blob | the `.alb-prism` sweep |

`pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx:470` pins the rail's token (unchanged, still `-dot-ring`). Nothing in `utils/factions.ts` — this is not a `factionCssVar` suffix.

## What landed

**The two boundary rings** — `--faction-default-dot-ring`, `#d6cfbf` → **`#989388`**, hue held, luminance only. Smallest lift that clears on `--faction-default-card-bg` light: **3.0113:1**. That is the owner's reference reproduced, not copied.

**Albescent's fill** — a new `default`-family name, `--faction-default-dot-fill`: **`#878379`**. Not the ring's number: `.alb-prism` multiplies a sweep into the na card, so the ground under the blob is up to ~10pp darker and `#989388` reads only **2.70:1** there. There is a test row asserting exactly that, so the fork stays re-checkable rather than asserted in prose.

`#878379` is measured on the prism's **darkest pixel with the sheet composited twice** — the `prefers-reduced-motion` rest frame (epic #2496 ruling 6), which is the deepest ground an Albescent petal ever sits on:

| Albescent ground | ratio |
|---|---|
| rest frame (sheet ×2), darkest stop | **3.0067:1** |
| moving prism, darkest stop | 3.3417:1 |
| flat na card (praxis card drops `.alb-prism` over busy media) | 3.7225:1 |

Tuning to the moving frame alone gives `#8f8b80` and leaves reduced-motion readers at **2.70:1** — the same half-measured mistake this issue exists to correct. Still far from the 5.71:1 the ruling named as the wrong end; the floor is where this stands.

**No `--faction-albescent-*` was created.** `CSS_KEY` maps `albescent` → `default` (ADR-0039 / #783), so the fill's name is `default`-family.

**Dark did not fork and must not.** Its one cream already clears both grounds (5.73 flat / 5.97 prism), so `[data-theme="dark"]` declares `--faction-default-dot-fill: var(--faction-default-dot-ring)` — an alias, not a restatement (WORLD_ZERO_STYLE §3). A test row asserts the two resolve identically in dark. **Dark is unchanged in value.**

## Byte budget

`npm run budget`, gzip level 9 on `dist/assets/index-*.css`:

| | raw | gzip |
|---|---|---|
| before (`8c1021d4`) | 116,930 | **22,740** |
| after | 117,026 | **22,755** |

**+15 gzip bytes** for the second token name. The 22,700 warn line was already crossed on `main` at 22,740, so this neither crosses a threshold nor changes the job's verdict (`WARN CSS 22.2 KB`, `fail>24.4 KB`). Comments are stripped by the build, so the docblocks are free.

## The pinned row was updated, and the `ponytail:` is gone

`dotRingBoundary.test.ts` carried a `ponytail:` naming "dark is guarded" as the ceiling and pinning light at its failing value. The ceiling is lifted, so the comment is deleted rather than left to outlive it. The file now:

- asserts both cascades ≥3:1 for the rings, **by token name** (`it.each` over `[path, token]` pairs), not by count;
- asserts each reader draws *its* token and **not** the other one, so a file that loses the fork goes red;
- measures the Albescent fill on the prism at both frame depths, with the stops **read out of `index.css`** — retune the prism and the measurement follows it;
- keeps the two "and the old value would not clear" rows (light `#d6cfbf` at 1.53:1, dark alpha `0.3`) so walking either back goes red rather than the defect returning quietly.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally: `lint` clean, `typecheck` clean, `typecheck:design-sync` clean, `npm test` **452 files / 9,270 passed**, `build` clean, `budget` as above. `factionContrast.test.ts` (1,088 rows) green. No backend, route, `response_model` or Pydantic change, so `api-schema` is not engaged.

## What to eyeball — visual QA is OUTSTANDING

**No agent here has a browser.** This is a visible repaint in the dominant theme and nothing above proves it looks right; it proves it measures right.

1. **The na vote row, LIGHT, partially filled** (e.g. 2 of 5, so filled and unfilled petals sit side by side) — `DefaultVote`'s `inset 0 0 0 1.5px` hairline. The defect was that a 4-of-5 read as "two petals" instead of "two of four"; check the empty slots now read as *slots* and not as objects of their own.
2. **The praxis-detail dot rail, LIGHT, partially filled** — same value, thinner target, on the na card.
3. **The Albescent vote row, LIGHT, on the prism ground**, partially filled — both on a card wearing `.alb-prism` and on an Albescent praxis card over busy media (which drops `.alb-prism` and falls back to the flat sheet), so the one value is seen on both grounds.
4. **The same Albescent row under `prefers-reduced-motion: reduce`** — the rest frame is the deeper ground the fill was tuned against, and it is the case a normal pass will not show.
5. **DARK, all three surfaces — must be unchanged.** Only the light values moved; dark's fill aliases dark's ring.

## Coordination

#2622 (motion) touches `components/vote/AlbescentVote.tsx` and `index.css` and is serialized after this — it rebases onto this branch. None of its work is done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
