### PR TITLE
The comment clock speaks from the catalog, and Albescent still has no hour

### DIFF
--- a/frontend/src/locales/README.md
+++ b/frontend/src/locales/README.md
@@ -104,6 +104,39 @@ i18next native plural suffixes — two sibling keys, `_one` and `_other`:
 
 The code passes `count`; i18next picks the right key. Always provide both.
 
+## Ordinals
+
+Same mechanism, one more segment — `_ordinal_one`, `_ordinal_two`, `_ordinal_few`
+and `_ordinal_other`. English needs all four (1st, 2nd, 3rd, 4th), and i18next
+gets the teens right on its own (11th, not 11st):
+
+```json
+{
+  "day_ordinal_one": "the {{count}}st day",
+  "day_ordinal_two": "the {{count}}nd day",
+  "day_ordinal_few": "the {{count}}rd day",
+  "day_ordinal_other": "the {{count}}th day"
+}
+```
+
+### Comment timestamps (`praxis.json` → `comments.time`)
+
+Each faction reads a comment's age in its own voice, and `comments.time.<slug>`
+holds the words for it. `comments.time.default` is the plain form — the one
+`na`, `ua`, `wow`, **and Albescent** read; a faction with no branch of its own
+simply uses it.
+
+**Do not add a `comments.time.albescent` branch.** Albescent had one ("Vigil the
+Third") and #783 removed it: the dialect keys on the comment AUTHOR's faction, so
+a member announced themselves simply by commenting, to anyone, revealed or not.
+Adding the key back would not even work — `utils/commentTime.ts` chooses the
+dialect in code and never looks a slug up in this file — but a test asserts the
+branch stays absent so nobody has to rediscover why.
+
+The figures arrive as `{{count}}` (or `{{hours}}` for S.N.I.D.E., already
+zero-padded). Reword freely around them; the shape of the number — 1-based
+shifts, three-digit hours — is code, not copy.
+
 ## Embedded markup (`<Trans>`)
 
 Some values contain numbered tags for text that must be partly bold, linked,

--- a/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
+++ b/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
@@ -259,8 +259,18 @@ function sourceFiles(dir: string): string[] {
   })
 }
 
-/** Keys a test hands to `t()` **because** they must not resolve. */
-const DELIBERATE_MISSES = new Set(['votes:ephemerists.nonexistent', 'nonexistent:some.key'])
+/**
+ * Keys a test names **because** they must not resolve — a `t()` miss fixture,
+ * or an `i18n.exists(…)).toBe(false)` asserting a collapsed faction branch
+ * stayed collapsed. Both are the absence of copy, which is the opposite of a
+ * missing key.
+ */
+const DELIBERATE_MISSES = new Set([
+  'votes:ephemerists.nonexistent',
+  'nonexistent:some.key',
+  'forms:editPraxis.everymen',
+  'forms:editPraxis.snide',
+])
 
 /**
  * The key literals a file hands to `t()` / `i18n.t()`, already namespaced.
@@ -271,10 +281,17 @@ const DELIBERATE_MISSES = new Set(['votes:ephemerists.nonexistent', 'nonexistent
  * bare shape is the one that matters — it is what every faction body uses, and
  * a plain grep for a namespaced key never sees it.
  *
+ * A third shape is a namespaced literal held in a TABLE and handed to `t()` a
+ * line later — `commentTime.ts` keeps one so its per-faction keys stay literal
+ * and greppable instead of becoming `t(\`praxis:...${slug}...\`)` (#2666). Any
+ * `"ns:dotted.key"` whose namespace is a real catalog file is read, wherever in
+ * the file it sits; that is what makes such a table visible to this sweep at
+ * all, which is the point of writing one.
+ *
  * Template literals and computed keys are skipped on purpose: they are resolved
  * at runtime and the render tests are what cover them.
  */
-function keyLiterals(text: string): string[] {
+function keyLiterals(text: string, namespaceNames: Set<string>): string[] {
   const namespaces = [...text.matchAll(/useTranslation\(\s*["']([a-z]+)["']/g)].map((m) => m[1])
   const bound = namespaces.length === 1 ? namespaces[0] : null
   const out: string[] = []
@@ -288,32 +305,49 @@ function keyLiterals(text: string): string[] {
       out.push(`${bound}:${key}`)
     }
   }
+  for (const m of text.matchAll(/(["'])([a-z]+:[A-Za-z0-9_.-]*\.[A-Za-z0-9_.-]+)\1/g)) {
+    if (namespaceNames.has(m[2].split(':')[0])) out.push(m[2])
+  }
   return out
 }
 
-/** A plural key lives in the catalog under its `_one` / `_other` suffixes. */
+/**
+ * A plural key lives in the catalog under its suffixes, never under the base the
+ * code passes: `_one` / `_other` for cardinals, and `_ordinal_one` … for
+ * ordinals (`comments.time.ephemerists.day` → `day_ordinal_one`, #2666). Both
+ * shapes always carry an `_other`, so that is the one that must be present.
+ */
+const PLURAL_SUFFIXES = ['_one', '_other', '_ordinal_one', '_ordinal_other']
+
 function resolves(key: string, known: Set<string>): boolean {
-  return known.has(key) || known.has(`${key}_one`) || known.has(`${key}_other`) || i18n.exists(key)
+  return (
+    known.has(key) || PLURAL_SUFFIXES.some((s) => known.has(`${key}${s}`)) || i18n.exists(key)
+  )
 }
 
 describe('every i18n key literal in the source tree resolves (#1911)', () => {
   const files = sourceFiles(SRC)
-  const known = new Set(catalogLeaves().map(([id]) => id))
+  const leaves = catalogLeaves()
+  const known = new Set(leaves.map(([id]) => id))
+  const namespaceNames = new Set(leaves.map(([id]) => id.split(':')[0]))
 
   it('finds source files to scan', () => {
     expect(files.length).toBeGreaterThan(300)
   })
 
   it('finds key literals to resolve, in both the namespaced and the bound shape', () => {
-    const all = files.flatMap((f) => keyLiterals(readFileSync(f, 'utf8')))
+    const all = files.flatMap((f) => keyLiterals(readFileSync(f, 'utf8'), namespaceNames))
     expect(all.filter((k) => k.startsWith('feed:')).length).toBeGreaterThan(20)
     expect(all).toContain('factions:detail.default.membersHeading')
+    // The table shape: these are never written inside a `t(` call (#2666).
+    expect(all).toContain('praxis:comments.time.coven.hours')
+    expect(all).toContain('praxis:comments.time.default.now')
   })
 
   it('resolves every one of them to a non-empty string', () => {
     const missing: string[] = []
     for (const file of files) {
-      for (const key of keyLiterals(readFileSync(file, 'utf8'))) {
+      for (const key of keyLiterals(readFileSync(file, 'utf8'), namespaceNames)) {
         if (DELIBERATE_MISSES.has(key) || resolves(key, known)) continue
         missing.push(`${file.slice(SRC.length + 1).replace(/\\/g, '/')} -> ${key}`)
       }

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -181,7 +181,42 @@
     "confirmWithdraw": "Withdraw this comment?",
     "charCount": "{{count}}/{{max}}",
     "editError": "Could not save the edit.",
-    "withdrawError": "Could not withdraw the comment."
+    "withdrawError": "Could not withdraw the comment.",
+    "time": {
+      "default": {
+        "days_one": "{{count}} day ago",
+        "days_other": "{{count}} days ago",
+        "hours_one": "{{count}} hour ago",
+        "hours_other": "{{count}} hours ago",
+        "minutes_one": "{{count}} minute ago",
+        "minutes_other": "{{count}} minutes ago",
+        "now": "just now"
+      },
+      "coven": {
+        "days": "{{count}}d",
+        "hours": "{{count}}h",
+        "minutes": "{{count}}m",
+        "now": "now"
+      },
+      "singularity": {
+        "days": "{{count}}d",
+        "hours": "{{count}}h",
+        "minutes": "{{count}}m",
+        "now": "now"
+      },
+      "snide": {
+        "hours": "{{hours}}H AGO"
+      },
+      "ephemerists": {
+        "day_ordinal_one": "the {{count}}st day",
+        "day_ordinal_two": "the {{count}}nd day",
+        "day_ordinal_few": "the {{count}}rd day",
+        "day_ordinal_other": "the {{count}}th day"
+      },
+      "everymen": {
+        "shift": "Shift {{count}}"
+      }
+    }
   },
   "duelBanner": {
     "versus": "vs.",

--- a/frontend/src/utils/__tests__/commentTime.test.ts
+++ b/frontend/src/utils/__tests__/commentTime.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
+import i18n from '../../i18n'
+import praxisCatalog from '../../locales/en/praxis.json'
 import { formatCommentTime } from '../commentTime'
 
 const NOW = new Date('2026-06-25T12:00:00Z').getTime()
@@ -50,5 +52,96 @@ describe('formatCommentTime — per-faction dialects', () => {
 
   it('unknown slug falls back to relative words', () => {
     expect(formatCommentTime(null, ago(60), NOW)).toBe('1 hour ago')
+  })
+
+  it('na reads the same plain form as an unknown slug — na is a population', () => {
+    for (const minutes of [0, 5, 90, 2 * 1440]) {
+      expect(formatCommentTime('na', ago(minutes), NOW)).toBe(
+        formatCommentTime(undefined, ago(minutes), NOW),
+      )
+    }
+  })
+
+  it('singular deltas drop the plural s', () => {
+    expect(formatCommentTime('ua', ago(1440), NOW)).toBe('1 day ago')
+    expect(formatCommentTime('ua', ago(1), NOW)).toBe('1 minute ago')
+  })
+
+  it('ordinals survive the English teens (11th, not 11st)', () => {
+    for (const [days, word] of [
+      [11, 'the 11th day'],
+      [12, 'the 12th day'],
+      [13, 'the 13th day'],
+      [21, 'the 21st day'],
+      [22, 'the 22nd day'],
+      [23, 'the 23rd day'],
+    ] as const) {
+      expect(formatCommentTime('ephemerists', ago(days * 1440), NOW)).toBe(word)
+    }
+  })
+})
+
+/**
+ * The seam this file tests is `formatCommentTime` itself — the one function every
+ * comment surface routes its timestamp through (`CommentThread` plus the seven
+ * voices, all passing `comment.author.faction_slug`).
+ *
+ * The assertions above pin the rendered words and are the "no visible change"
+ * proof. The ones below pin where those words COME FROM, which is the actual
+ * defect in #2666: on `origin/main` every string here was an English literal in
+ * this module, so a reworded catalog changed nothing and a non-English locale
+ * could not express any of it.
+ */
+describe('formatCommentTime — the catalog owns the words (#2666)', () => {
+  afterEach(() => {
+    i18n.addResourceBundle('en', 'praxis', praxisCatalog, true, true)
+  })
+
+  it('every dialect follows a reworded catalog', () => {
+    i18n.addResourceBundle(
+      'en',
+      'praxis',
+      {
+        comments: {
+          time: {
+            default: { hours_other: 'REWORDED {{count}} hours' },
+            coven: { hours: 'REWORDED {{count}}h' },
+            singularity: { hours: 'REWORDED {{count}}H' },
+            snide: { hours: 'REWORDED {{hours}}' },
+            ephemerists: { day_ordinal_few: 'REWORDED {{count}}rd' },
+            everymen: { shift: 'REWORDED {{count}}' },
+          },
+        },
+      },
+      true,
+      true,
+    )
+
+    expect(formatCommentTime('ua', ago(3 * 60), NOW)).toBe('REWORDED 3 hours')
+    expect(formatCommentTime(null, ago(3 * 60), NOW)).toBe('REWORDED 3 hours')
+    expect(formatCommentTime('coven', ago(3 * 60), NOW)).toBe('REWORDED 3h')
+    expect(formatCommentTime('singularity', ago(3 * 60), NOW)).toBe('REWORDED 3H')
+    expect(formatCommentTime('snide', ago(3 * 60), NOW)).toBe('REWORDED 003')
+    expect(formatCommentTime('ephemerists', ago(3 * 1440), NOW)).toBe('REWORDED 3rd')
+    expect(formatCommentTime('everymen', ago(1440), NOW)).toBe('REWORDED 2')
+  })
+
+  it('has no albescent branch a copy editor could fill in (#783)', () => {
+    // The #783 leak is one JSON key away if the dialect is ever resolved by
+    // slug out of the catalog. It is not — selection lives in code — so the
+    // absence of this branch is the guard, and this is what fails if someone
+    // adds one back.
+    expect(praxisCatalog.comments.time).not.toHaveProperty('albescent')
+
+    // And prove it from the other side: a catalog branch for albescent, even if
+    // one existed, is unreachable from the resolution path.
+    i18n.addResourceBundle(
+      'en',
+      'praxis',
+      { comments: { time: { albescent: { days_other: 'Vigil the {{count}}' } } } },
+      true,
+      true,
+    )
+    expect(formatCommentTime('albescent', ago(3 * 1440), NOW)).toBe('3 days ago')
   })
 })

--- a/frontend/src/utils/commentTime.ts
+++ b/frontend/src/utils/commentTime.ts
@@ -1,9 +1,21 @@
+import i18n from '../i18n'
+import { hasOwnKey } from './hasOwnKey'
+
 /**
  * Per-faction timestamp dialect (ADR-0018). The comment timestamp slot is the
  * same content (when it was posted) presented in each faction's voice — ADR-0002
  * applied to the timestamp. A shared delta is computed once; each faction maps it
- * to its own string. Six are real derivations; singularity uses a plain relative
- * time in its terminal type (its mock "T-0420" is design fluff, ignored).
+ * to its own string.
+ *
+ * The WORDS are not here (#2666). They live in the copy catalog at
+ * locales/en/praxis.json under `comments.time.<slug>`, with `comments.time.default`
+ * as the plain form, and i18next owns the plurals and the ordinals. What stays in
+ * this module is the SHAPE of each dialect — which unit bucket a delta reads as,
+ * whether the figure is zero-padded, whether the count is 1-based — because none
+ * of that is a sentence a translator can write.
+ *
+ * The dialect is still SELECTED in code, not looked up by slug in the catalog,
+ * and that is deliberate: see DIALECTS below for why #783 requires it.
  */
 
 export interface TimeDelta {
@@ -18,40 +30,103 @@ export function timeDelta(iso: string, now: number = Date.now()): TimeDelta {
   return { minutes, hours: Math.floor(minutes / 60), days: Math.floor(minutes / 1440) }
 }
 
-function ordinal(n: number): string {
-  const rem100 = n % 100
-  if (rem100 >= 11 && rem100 <= 13) return `${n}th`
-  switch (n % 10) {
-    case 1:
-      return `${n}st`
-    case 2:
-      return `${n}nd`
-    case 3:
-      return `${n}rd`
-    default:
-      return `${n}th`
-  }
+/**
+ * The coarsest unit a delta has at least one of. Structure, not copy: every
+ * bucketed dialect reads the same delta the same way and only the words differ.
+ */
+type Bucket = 'days' | 'hours' | 'minutes'
+
+function bucket(d: TimeDelta): Bucket | null {
+  if (d.days >= 1) return 'days'
+  if (d.hours >= 1) return 'hours'
+  if (d.minutes >= 1) return 'minutes'
+  return null
 }
 
-/** Plain relative time, full words (UA register, and the singularity fallback). */
-function relative(d: TimeDelta): string {
-  if (d.days >= 1) return `${d.days} day${d.days === 1 ? '' : 's'} ago`
-  if (d.hours >= 1) return `${d.hours} hour${d.hours === 1 ? '' : 's'} ago`
-  if (d.minutes >= 1) return `${d.minutes} minute${d.minutes === 1 ? '' : 's'} ago`
-  return 'just now'
+/**
+ * The catalog keys each bucketed dialect reads, spelled out as literals so they
+ * are greppable exactly as they appear in praxis.json and typechecked against it
+ * (#2666). A `t(\`...${slug}...\`)` here would be invisible to the copy sweep,
+ * which is half of what this change is about.
+ *
+ * `days` / `hours` / `minutes` are i18next plural bases: the catalog holds
+ * `days_one` and `days_other` and i18next picks the suffix from `count`, the same
+ * mechanism `comments.heading` already uses.
+ */
+const BUCKET_KEYS = {
+  default: {
+    days: 'praxis:comments.time.default.days',
+    hours: 'praxis:comments.time.default.hours',
+    minutes: 'praxis:comments.time.default.minutes',
+    now: 'praxis:comments.time.default.now',
+  },
+  coven: {
+    days: 'praxis:comments.time.coven.days',
+    hours: 'praxis:comments.time.coven.hours',
+    minutes: 'praxis:comments.time.coven.minutes',
+    now: 'praxis:comments.time.coven.now',
+  },
+  // Singularity renders like Coven today but is a different voice reaching the
+  // same shape — a bare terminal clock with no "ago" (which is also what keeps
+  // "now ago" off the screen at t<1m). Its own branch is what lets a copy editor
+  // move one without moving the other.
+  singularity: {
+    days: 'praxis:comments.time.singularity.days',
+    hours: 'praxis:comments.time.singularity.hours',
+    minutes: 'praxis:comments.time.singularity.minutes',
+    now: 'praxis:comments.time.singularity.now',
+  },
+} as const
+
+type BucketKeys = (typeof BUCKET_KEYS)[keyof typeof BUCKET_KEYS]
+
+function bucketed(d: TimeDelta, keys: BucketKeys): string {
+  const b = bucket(d)
+  return b === null ? i18n.t(keys.now) : i18n.t(keys[b], { count: d[b] })
 }
 
-/** Terse relative time (coven / singularity terminal). */
-function terse(d: TimeDelta): string {
-  if (d.days >= 1) return `${d.days}d`
-  if (d.hours >= 1) return `${d.hours}h`
-  if (d.minutes >= 1) return `${d.minutes}m`
-  return 'now'
+/**
+ * The factions with a timestamp dialect of their own, and how each shapes the
+ * delta before the catalog words it. Absence from this table is the plain form.
+ *
+ * Selection stays in code rather than becoming a catalog lookup keyed by slug,
+ * for the same reason `voteReframes.ts` keeps its ladder list in code:
+ *
+ * - **Albescent must be unreachable, not merely unfilled (#783).** It had "Vigil
+ *   the Third", keyed on the comment AUTHOR's faction — so a member revealed
+ *   themselves simply by commenting, anywhere, to anyone. Under a catalog lookup
+ *   the leak is one JSON edit away and no code review sees it; under this table
+ *   adding a dialect is a code change, and `commentTime.test.ts` fails first.
+ * - **A dialect is not only words.** "Always hours, zero-padded to three",
+ *   "1-based shifts", "at least day one" are arithmetic. A slug→branch lookup
+ *   could not express them, so the branch would have to exist here anyway.
+ *
+ * `na`, `ua`, `wow`, `albescent` and any unknown slug all read
+ * `comments.time.default`. `na` is a real population, not an error case.
+ */
+const DIALECTS: Record<string, (d: TimeDelta) => string> = {
+  coven: (d) => bucketed(d, BUCKET_KEYS.coven),
+  singularity: (d) => bucketed(d, BUCKET_KEYS.singularity),
+  // ponytail: the zero-padding is composed here rather than in the catalog
+  // because JSON cannot say "three digits". Ceiling — a locale can reword around
+  // the figure but not change its width; upgrade path is `Intl.NumberFormat`
+  // with `minimumIntegerDigits: 3` if one ever needs to.
+  snide: (d) =>
+    i18n.t('praxis:comments.time.snide.hours', { hours: String(d.hours).padStart(3, '0') }),
+  ephemerists: (d) =>
+    i18n.t('praxis:comments.time.ephemerists.day', {
+      count: Math.max(1, d.days),
+      ordinal: true,
+    }),
+  everymen: (d) => i18n.t('praxis:comments.time.everymen.shift', { count: d.days + 1 }),
 }
 
 /**
  * Format a comment timestamp in a faction's dialect. The slug is the comment
  * author's member faction; unknown slugs fall back to the plain relative form.
+ *
+ * Own-property-only (#1821): a bare bracket read reaches `Object.prototype`, so a
+ * slug named after a prototype member would hand back a function and be called.
  */
 export function formatCommentTime(
   slug: string | null | undefined,
@@ -59,24 +134,5 @@ export function formatCommentTime(
   now: number = Date.now(),
 ): string {
   const d = timeDelta(iso, now)
-  switch (slug) {
-    case 'coven':
-      return terse(d)
-    case 'snide':
-      return `${String(d.hours).padStart(3, '0')}H AGO`
-    case 'ephemerists':
-      return `the ${ordinal(Math.max(1, d.days))} day`
-    case 'everymen':
-      return `Shift ${d.days + 1}`
-    // Albescent has no dialect (#783). It had "Vigil the Third", keyed on the
-    // comment AUTHOR's faction — so a member revealed themselves simply by
-    // commenting, anywhere, to anyone. It falls to the plain relative form the
-    // default branch gives `na` and unknown slugs.
-    case 'singularity':
-      // Bare terminal clock (terse, no "ago" — avoids "now ago" at t<1m).
-      return terse(d)
-    case 'ua':
-    default:
-      return relative(d)
-  }
+  return hasOwnKey(DIALECTS, slug) ? DIALECTS[slug](d) : bucketed(d, BUCKET_KEYS.default)
 }


### PR DESCRIPTION
Closes #2666

`commentTime.ts` held every faction's timestamp dialect as English literals in a
`.ts` switch — the plurals, a hand-rolled `ordinal()`, `just now`, `003H AGO`,
`Shift 4`. None of it was in `locales/en/`, so a copy edit changed nothing, no
locale but English could say any of it, and both the copy sweep and
`eslint-plugin-i18next` were blind to it (the lint rule is `mode: 'jsx-text-only'`
— it never looks at a `.ts` util at all).

## The seam

`formatCommentTime(slug, iso, now)` — the one function every comment surface routes
its timestamp through. The census is **eight** files, not the six the issue names:
`components/comments/CommentThread.tsx` plus
`voices/{Coven,Ephemerists,Everymen,Singularity,Snide,Ua,Wow}Comment.tsx`. The
signature is unchanged, so none of those eight is touched.

The loop went red at that seam on the real defect first: with the new catalog in
place but `origin/main`'s module restored, "every dialect follows a reworded
catalog" failed with `expected '3 hours ago' to be 'REWORDED 3 hours'` — the words
were coming from the module, not the catalog. The other twelve assertions in the
file passed against main's implementation, which is the "no visible change" proof.

## The fork the issue left open: selection stays in code

The issue asked whether the *choice* of dialect stays a slug switch or becomes a
catalog lookup with a per-faction default. **It stays a slug-keyed table in code.**
Evidence:

1. **The repo already has this shape, and it is not `factions.json`.**
   `components/vote/voteReframes.ts` is the closest existing analogue — per-faction
   voice, structure in a code table (`LADDERS`), words in `votes.json`, absence from
   the table meaning "the plain form". Its docblock says in as many words why
   Albescent is *absent rather than present-and-empty*. `factions.json`
   `names.<slug>` / `descriptions.<slug>` is the other shape, but it is a **total**
   lookup — every live slug must have an entry, enforced by a backend drift guard.
   That is exactly wrong here, where some slugs must be indistinguishable from the
   default.
2. **#783 has to be enforced where review sees it.** Under a slug-keyed catalog
   lookup, `comments.time.albescent` is one JSON edit away from existing, and a copy
   editor adding it reintroduces the leak with no code change and nobody who knows
   #783 in the diff. Under a code table, adding a dialect is a code change and a test
   fails first. `formatCommentTime` reaches an `albescent` branch by no path — the
   test proves it by *adding* one to the catalog at runtime and asserting the output
   is still `3 days ago`.
3. **A dialect is not only words.** "Always hours, zero-padded to three",
   "1-based shifts", "at least day one" are arithmetic. A slug→branch lookup cannot
   express them, so the code branch would have to exist anyway; a parallel catalog
   branch would only be a second place to be wrong.

So: catalog owns the sentences, plurals and ordinals; code owns which unit bucket a
delta reads as and how the figure is shaped. `na`, `ua`, `wow`, `albescent` and any
unknown slug all read `praxis:comments.time.default` — `na` and unknown share the
arm, as they must.

## Keys are literal

Every key is spelled out in full, greppable exactly as it appears in the catalog —
no `t(\`praxis:...${slug}...\`)`. The four bucketed dialects hold theirs in a
`BUCKET_KEYS` table of literal strings rather than repeating a four-branch `if` per
faction (which `sonarjs/no-identical-functions` would flag anyway).

That table was invisible to the #1911 copy sweep, which only read keys spelled
inside `t("…")` — so the sweep is widened at the choke point to read any
`"ns:dotted.key"` whose namespace is a real catalog file. Across the whole tree that
turned up exactly two other literals, both `i18n.exists(…)).toBe(false)` fixtures
asserting a collapsed faction branch stayed collapsed; they joined
`DELIBERATE_MISSES`. The sweep also learned `_ordinal_*`, which it had never needed
before.

The one place a code key is not character-identical to the catalog is the i18next
plural base (`...default.days` in code, `days_one` / `days_other` in JSON). That is
the mechanism `comments.heading` already uses and the one the issue's constraint 5
asks for; it is not a computed key and the sweep resolves it.

## i18next plurals and ordinals, verified not assumed

Installed i18next is **26.3.6**. Probed against that exact build before writing any
code: `t(key, { count, ordinal: true })` with `_ordinal_one|two|few|other`
reproduces the hand-rolled `ordinal()` for 1–4, 11–13, 21–23, 101 and 111. Both
hand-rolled helpers are gone. A test pins the English teens (11th, not 11st).

## `SingularityComment.tsx` — checked, same thing

`SingularityComment.tsx:287` (not `:283`) passes `comment.author.faction_slug`
inline while the other seven pass a `slug` variable. **They are the same value** —
every one of those files reads `const slug = comment.author.faction_slug` on the
line the grep shows. No bug hiding under it; the inline call is a style
inconsistency, left alone because this PR touches no call site.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **452 files, 9270 passed**, 1 skipped |
| `npm run build` | built |
| `npm run budget` | JS 130.6 KB ok; CSS 22.2 KB WARN |

The CSS warning is pre-existing on `main` — this PR touches no `.css` file (diff is
2 `.ts`, 1 `.json`, 1 `.md`, 1 test). `api-schema` is not implicated: no backend,
route, schema or generated-client file is in the diff.

Typed keys are genuinely enforced here, not silently passing — deliberately
misspelling one key produced `TS2345` naming it, which is how I know the catalog
types cover the new branch including the ordinal.

**Visual QA is outstanding.** I have no browser and no dev stack; everything above
is tests, tsc, eslint, build and the byte budget.

## What to eyeball

Read these back in a real thread — the assertion strings are identical to the ones
on `main`, so what a human is checking is that the *right* voice reaches the *right*
comment, not the wording:

- **A Coven comment inside a non-Coven thread** — should still read `3h` / `12m` /
  `now`. The dialect is the author's, not the surface's, and that is unchanged.
- **A Singularity comment less than a minute old** — must read `now`, never
  `now ago`. This is the one edge the two terse branches exist to protect.
- **A S.N.I.D.E. comment under one hour, and one over 48** — `000H AGO` and
  `048H AGO`; check the zero-padding survived the move into `{{hours}}`.
- **An Ephemerists comment on day 1, day 3, and day 11** — `the 1st day`,
  `the 3rd day`, `the 11th day`. Day 11 is the one i18next now decides instead of
  the deleted helper.
- **An Everymen comment posted today** — `Shift 1`, not `Shift 0`.
- **An Albescent member's comment, viewed by someone who has not revealed them** —
  must read exactly like an unaffiliated one (`2 days ago`). This is #783 and it is
  the single most important line to look at.
- **A UA comment at exactly 1 day / 1 hour / 1 minute** — `1 day ago`, not
  `1 days ago`; the ternaries that used to do this are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
