### PR TITLE
HAND MERGE ONLY - Metamorphosis becomes the live era: one line, and the paperwork that pins it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ identity + era-as-ruleset in ADR-0041 / ADR-0042.
 
 | Need... | Go to |
 |---|---|
-| Active rule values (signup cap, vote budget, level thresholds, resets) | `backend/eras/era_1.py` (live `ERA_1`; `CURRENT_ERA` resolves here) |
-| Factions, tasks, level ranks/unlocks + taunt structure for the live era | `backend/eras/era_1.py` |
+| Active rule values (signup cap, vote budget, level thresholds, resets) | the live era file in `backend/eras/` — whichever one `CURRENT_ERA` resolves to in `backend/game_config.py` |
+| Factions, tasks, level ranks/unlocks + taunt structure for the live era | the same live era file in `backend/eras/` |
 | Taunt & rank/unlock **wording** (ADR-0031: backend emits keys) | `frontend/src/locales/en/{taunts,progression}.json` |
 | Faction **name/description** wording (ADR-0038: backend emits slug) | `frontend/src/locales/en/factions.json` (`names.<slug>`, `descriptions.<slug>`) |
 | Era config *shape* (dataclass fields) | `backend/game_config.py` |
@@ -28,7 +28,7 @@ identity + era-as-ruleset in ADR-0041 / ADR-0042.
 | Which ADRs are still rules (vs. superseded, amended, reversed) | `docs/adr/README.md` — generated; regenerate with `python scripts/adr_index.py` |
 | Account vs. Character, anti-self-voting | ADR-0041 + CONTEXT.md ("Account", "Character") |
 | DB schema | `backend/models/*.py` (source of truth) |
-| Scoring formulas / era-reset semantics | `backend/services/scoring.py` + `praxis_scoring.py` + `services/era.py`; **values** in `backend/eras/era_1.py`; rationale in ADR-0014/0042/0043/0044 |
+| Scoring formulas / era-reset semantics | `backend/services/scoring.py` + `praxis_scoring.py` + `services/era.py`; **values** in the live era file under `backend/eras/`; rationale in ADR-0014/0042/0043/0044 |
 | API routes + auth guards | `backend/routers/` (source files) |
 | Pages, routing, components | `frontend/src/` (source files) |
 | Frontend API clients | `frontend/src/api/` |

--- a/backend/eras/era_2.py
+++ b/backend/eras/era_2.py
@@ -1,9 +1,14 @@
 """
 Era 2 — Metamorphosis.
 
-Authored, not activated: ``CURRENT_ERA`` still resolves to Era 1. This file
-exists so that everything which varies by era has a second ruleset to be tested
-against, and so the rollover has somewhere to go when it happens.
+The live era: ``CURRENT_ERA`` resolves here (#2711). Era 1 stays importable by
+name — ``game_config._ERA_ATTRIBUTE_BY_CONFIG_KEY`` resolves a stored ``era_1``
+row back to Renaissance's rules, which is how a past era keeps being labelled
+with its own instead of being relabelled with this one.
+
+Deploying this config does not by itself open the era: ``scripts/era_reset.py``
+writes the new ``Era`` row. Between the two the app serves these rules against
+Era 1's row, and the seeder warns about it on every deploy.
 
 The one rule Metamorphosis actually changes is the own/other split — 1.2 / 0.8
 on solo and duel — plus a smaller roster. Everything else is Era 1's, unchanged.

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -478,17 +478,18 @@ def __getattr__(name: str):
         # the first such call after the flip would rebind CURRENT_ERA to Era 1
         # for the life of the process — while every module that imported it at
         # start-up kept the new one. Found rehearsing the flip in #2708.
-        from eras.era_1 import ERA_1 as _era_1
-        globals()["CURRENT_ERA"] = _era_1
-        return _era_1
+        from eras.era_2 import ERA_2 as _era_2
+        globals()["CURRENT_ERA"] = _era_2
+        return _era_2
     if name in ("ERA_1", "ERA_1_FACTIONS"):
         from eras.era_1 import ERA_1 as _era_1
         globals()["ERA_1"] = _era_1
         globals()["ERA_1_FACTIONS"] = _era_1.factions
         return globals()[name]
     if name in ("ERA_2", "ERA_2_FACTIONS"):
-        # Era 2 (Metamorphosis) is authored, not activated: CURRENT_ERA stays
-        # Era 1 above.
+        # Era 2 (Metamorphosis) is the live era (#2711). This branch is still
+        # separate from the CURRENT_ERA one above for the reason given there:
+        # resolving an era BY NAME must never rebind the live one.
         from eras.era_2 import ERA_2 as _era_2
         globals()["ERA_2"] = _era_2
         globals()["ERA_2_FACTIONS"] = _era_2.factions

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -222,14 +222,23 @@ def test_era1_level_profiles_use_slug_keys():
 
 
 # ---------------------------------------------------------------------------
-# Era 2 — Metamorphosis, authored but not activated (#1618)
+# Era 2 — Metamorphosis, the live era (#1618, activated in #2711)
 # ---------------------------------------------------------------------------
 
 
-def test_era_2_is_authored_not_activated():
+def test_era_2_is_the_live_era():
+    """The one pin on the rollover lever, kept in exactly one place.
+
+    Flipped rather than deleted at the rollover (#2711): this assertion is what
+    a revert of the one line in ``game_config.__getattr__`` reddens, so the
+    lever cannot move silently in either direction. Era 1 stays importable by
+    name — ``_ERA_ATTRIBUTE_BY_CONFIG_KEY`` is what lets a stored ``era_1`` row
+    keep being labelled with its own rules.
+    """
     assert ERA_2.name == "Metamorphosis"
     assert ERA_2.config_key == "era_2"
-    assert CURRENT_ERA is ERA_1, "Metamorphosis is authored, not activated"
+    assert CURRENT_ERA is ERA_2, "Metamorphosis is the live era"
+    assert ERA_1 is not ERA_2 and era_config_for_key("era_1") is ERA_1
 
 
 def test_era_2_roster_is_five_factions_and_no_ua():


### PR DESCRIPTION
Closes #2711

# ⚠️ Merging this does NOT open the era — it only deploys the config

**Merging this PR deploys Era 2's rules to production** (`main` auto-deploys). It does **not** write the new `Era` row. `scripts/era_reset.py` does, and it must be run against the target database afterwards:

```
python scripts/era_reset.py <admin-username> --env prod        # prints the plan, changes nothing
python scripts/era_reset.py <admin-username> --env prod --yes  # performs it
```

**Between the deploy and that run, the app serves Era 2's rules against Era 1's `Era` row.** The seeder warns about it on every deploy.

**There is no undo.** Scores, levels, vote budgets and faction membership reset per the era's flags; every unresolved duel freezes into a permanent result; the whole board retires.

I have not run `era_reset.py` against anything. This PR is a **draft** deliberately — the rollover is the owner's call, not this branch's.

Note (from the issue): a **wiped** database never exercises the rollover at all — `bootstrap_admin` writes the `Era` row only on an un-bootstrapped database, so a fresh seed just creates `era_2` directly. To test the rollover as an operation, test it on a database that already has an `era_1` row.

---

## The seam

`game_config.__getattr__`'s `CURRENT_ERA` branch — the single lever. Everything downstream reads `era.*` off whatever that branch returns, so this is the one place the rollover is expressible and the one place it is pinned.

The loop went red at that seam first: I flipped the assertion in `test_era_config.py` before touching `game_config.py`, and it failed on the real defect (`CURRENT_ERA` was `EraConfig(name='Renaissance', config_key='era_1', ...)`). Then the one line made it green.

## What changed — 4 files, 29 insertions

| File | Change |
|---|---|
| `backend/game_config.py` | The one line: `CURRENT_ERA`'s branch imports `ERA_2` instead of `ERA_1`. The stale "authored, not activated" comment on the `ERA_2` branch now restates *why that branch is still separate* (#2708's half-flipped-process bug). |
| `backend/eras/era_2.py` | Docstring: "Authored, not activated" → the live era, plus the deploy-vs-rollover distinction above. |
| `backend/tests/unit/test_era_config.py` | `test_era_2_is_authored_not_activated` → `test_era_2_is_the_live_era`. **Assertion flipped, not deleted** — the lever stays pinned in exactly one place, so it cannot move silently in either direction. |
| `CLAUDE.md` | The three routing rows that named `era_1.py` as the live era. |

### Era 1 is still importable by name — verified

`_ERA_ATTRIBUTE_BY_CONFIG_KEY` is untouched. The flipped test now also asserts it directly:

```python
assert ERA_1 is not ERA_2 and era_config_for_key("era_1") is ERA_1
```

and `test_resolving_a_past_era_does_not_rebind_the_live_one` (#2708) is now doing real work rather than being vacuous: under Era 1 that test's stand-in flip was asserting a no-op, and from this commit on the two branches genuinely resolve different objects.

### `CLAUDE.md` — I took the self-maintaining phrasing

Per the owner's comment, the three rows now name `backend/eras/` and `CURRENT_ERA` rather than a specific era file, so the next flip does not have to remember this file:

- "the live era file in `backend/eras/` — whichever one `CURRENT_ERA` resolves to in `backend/game_config.py`"
- "the same live era file in `backend/eras/`"
- "**values** in the live era file under `backend/eras/`"

Scoped to the three routing rows only, so it merges cleanly alongside the concurrent "Running locally" edit — which has since landed on `main`, and this branch is rebased onto it. **Flagging for review that this PR edits `CLAUDE.md`**, since that file steers every agent: the edit adds no directive and removes a pointer, but it deserves a human eye.

## Verification

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz2711_test \
  pytest --cov=. --cov-report=term-missing --cov-fail-under=92
```

**`1657 passed, 13 skipped` — coverage 93.67%, gate 92%.** Run on the rebased tree (base `55882cef`). Dedicated DB `wz2711_test`, not the shared one.

### Acceptance criterion: reverting returns everything to green under Era 1 — verified

I ran `git revert --no-commit` on the flip commit and re-ran the full suite: **`1671 passed`, coverage 94.22%.** Then restored. The revert is a clean, complete undo of the config change.

### The 13 skips are #2708's fixtures working, not failures

They are all the era-agnostic fixtures declining to test a perk no faction in the live era holds — the expected consequence of no UA and no Ephemerists in Metamorphosis:

- `test_habit_bonus.py` ×9 — "the live era's first real faction does not hold the habit bonus" (UA's perk)
- `test_praxes.py`, `test_task_can_sign_up_filter.py` — "no faction in the live era holds Task Vision" (Ephemerists' perk)
- `test_game_config.py` — "no faction in era_2 reads the array" (Singularity's perk)
- `test_backfill_metatask_multiplier.py` — "era_2 prices this solo at ×1.2, so no metatask in it can sit at a unit multiplier" — i.e. the own/other split, the point of this era

### The collected-test count moves by one, and that is also the fixtures

I diffed `--collect-only` across both eras. Three deltas, all era-agnostic parametrization following the live roster:

- `test_task_visibility_gates.py::test_the_flag_and_the_query_agree` — 4 rows (`ephemerists`, `ua`×3) become 3 (`snide`×3). This is the whole −1.
- `test_fixtures_follow_the_era.py::test_a_praxis_scores_under_an_era_the_live_roster_never_had` — its "other era" parameter flips `[era_2]` → `[era_1]`, which is exactly what that test is for.
- The renamed pin.

### The API contract gate is unaffected — verified, not assumed

An era flip *can* move `/factions` output, so I checked rather than assumed: I ran `backend/scripts/dump_openapi.py` (the same generator `scripts/regen_api_client.py` calls) on the rebased tree and `git status` came back clean. `backend/openapi.json` is byte-identical. The era supplies response *values*, not response *shape* — no `EraConfig` value is baked into a Pydantic default or a `Literal`. Nothing to commit, and `frontend/src/api/generated/schema.d.ts` cannot move either since it is derived from that unchanged JSON.

### The `frontend` CI job is untouched by this diff

Zero files under `frontend/` changed and the generated schema is unmoved. `CLAUDE.md` is at the repo root and outside Tailwind's content globs (`./index.html`, `./src/**/*.{ts,tsx}`), so the byte budget cannot move either.

## Expected consequences — recorded so they are not re-filed as bugs

Per the issue, these are the era's design, not defects:

- **Everyone lands in `na`** (`reset_faction=True`). Admin role lives on the `Account`, so admin access survives.
- **Four faction kits go dark** — `ua`, `coven`, `ephemerists`, `singularity`. Their CSS keys stay in `frontend/src/utils/factions.ts` and degrade to `default`. ADR-0087's "kits go dark, the work is dormant". **Nothing frontend was deleted or gated in this PR**, and the ~193 kit tests still pass because the frontend never reads the era config — it takes slugs from `GET /factions` at runtime and `CSS_KEY` statically.
- **The Albescent unlock gets much cheaper.** Its coverage half needs a praxis per non-sentinel faction: seven in Era 1, **three** here. The level half does not move. Knowingly accepted in `eras/era_2.py`.
- **Albescent inherits less** — no Ephemerists means no Task Vision, no UA means no habit bonus.
- **Retired task titles stay reserved forever** — `task_import` dedupes on title with no status filter, and the whole board retires at rollover.
- **`docs/spec/*` and `WORLD_ZERO_STYLE.md`** saying "seven / eight / nine factions" count *built archetypes*, not the era roster, and stay true. Left alone.

## What to eyeball

1. **The one line, and that it is still alone in its branch.** `backend/game_config.py` — `CURRENT_ERA` must not share a branch with `ERA_1`/`ERA_2` resolution. #2708 found that folding them means the first `era_config_for_key("era_1")` call after the flip silently puts the process back on Era 1 for every late reader while start-up importers keep the new era. A half-flipped process is worse than either era.
2. **That the pin reads as a pin.** `test_era_2_is_the_live_era` is the only assertion in the suite that names the live era. If a future reviewer thinks it is redundant and deletes it, the lever becomes unguarded.
3. **The `CLAUDE.md` rows** — do they read well generalised, or would you rather they name `era_2.py` outright? I took the lazy/self-maintaining option you suggested; the specific option is a two-word change.
4. **The Albescent unlock cheapening.** Three non-sentinel factions instead of seven is a large real-game shift and the one consequence most worth a second look before the rollover runs.
5. **The rollover itself.** I have not run `era_reset.py`. Consider rehearsing it on a copy of prod that already has an `era_1` row — a wiped DB takes the `bootstrap_admin` path and never exercises the rollover.

**Visual QA is outstanding.** I have no browser tools and no dev stack; everything above is tests, the OpenAPI generator, and static reasoning. The four dark kits in particular have not been looked at in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
