### PR TITLE
The two JS clocks read the Animations switch, and the shortcut note goes with them

### DIFF
--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useSyncExternalStore, type CSSProperties } from 'react'
+import { useState, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useMotionTick } from '../../hooks/useMotion'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteError } from './VoteShell'
@@ -36,7 +37,8 @@ import { VoteLoginGate, VoteError } from './VoteShell'
  * MOTION. Two separate things move, and both are gated:
  *  - the rising-wave bob reuses the shared `.spectrum-dot--reached` class, which
  *    lives behind `prefers-reduced-motion: no-preference` in index.css;
- *  - the morph is a JS clock, so it reads the media query directly and FREEZES.
+ *  - the morph is a JS clock, so it runs on {@link useMotionTick} and FREEZES
+ *    whenever motion is off — the OS query and the Settings switch both (#2622).
  * Stilled, every dot holds a distinct static polygon and still fills with its
  * slice of the spectrum — the control reads and votes exactly the same.
  */
@@ -86,30 +88,6 @@ function polyClipN(sides: number): string {
   return `polygon(${points.join(',')})`
 }
 
-/** matchMedia-backed reduced-motion flag; defaults to stilled when absent (SSR/test). */
-function usePrefersReducedMotion(): boolean {
-  return useSyncExternalStore(
-    (onChange) => {
-      const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-      mql.addEventListener('change', onChange)
-      return () => mql.removeEventListener('change', onChange)
-    },
-    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
-    () => true,
-  )
-}
-
-/** 120ms morph clock; frozen (never ticks) when `enabled` is false. */
-function useMorphTick(enabled: boolean): number {
-  const [tick, setTick] = useState(0)
-  useEffect(() => {
-    if (!enabled) return
-    const id = setInterval(() => setTick((value) => value + 1), TICK_MS)
-    return () => clearInterval(id)
-  }, [enabled])
-  return tick
-}
-
 export default function AlbescentVote({
   praxisId,
   currentValue,
@@ -117,8 +95,7 @@ export default function AlbescentVote({
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
   const [hovered, setHovered] = useState(0)
-  const reducedMotion = usePrefersReducedMotion()
-  const tick = useMorphTick(!reducedMotion)
+  const tick = useMotionTick(TICK_MS)
 
   if (!user) {
     return <VoteLoginGate />

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useSyncExternalStore } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useMotionTick } from '../../hooks/useMotion'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteError } from './VoteShell'
@@ -20,9 +21,10 @@ import { VOTE_REFRAMES } from './voteReframes'
  *
  * The always-on scramble is a JS interval (a decode strip that stood still would
  * read as broken, not stilled), so it cannot be class-gated like the other widgets'
- * CSS animations. Instead it reads `prefers-reduced-motion` directly and FREEZES the
- * tick when set — the strip still shows noise vs. resolved glyphs, it just stops
- * churning.
+ * CSS animations. It runs on {@link useMotionTick}, which FREEZES it whenever motion
+ * is off — whether the OS asked for reduced motion or the reader turned the Settings
+ * switch off (#2622). Frozen, the strip still shows noise vs. resolved glyphs; it
+ * just stops churning.
  */
 
 /** Density glyphs a resolved tier prints, tier 1→5: noise floor → solid block. */
@@ -45,36 +47,11 @@ const SCRAMBLE_INTERVAL_MS = 120
 
 const TIERS = VOTE_REFRAMES['singularity'].tiers
 
-/** matchMedia-backed reduced-motion flag; defaults to stilled when absent (SSR/test). */
-function usePrefersReducedMotion(): boolean {
-  return useSyncExternalStore(
-    (onChange) => {
-      const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
-      mql.addEventListener('change', onChange)
-      return () => mql.removeEventListener('change', onChange)
-    },
-    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
-    () => true,
-  )
-}
-
-/** 120ms scramble clock; frozen (never ticks) when `enabled` is false. */
-function useScrambleTick(enabled: boolean): number {
-  const [tick, setTick] = useState(0)
-  useEffect(() => {
-    if (!enabled) return
-    const id = setInterval(() => setTick((value) => value + 1), SCRAMBLE_INTERVAL_MS)
-    return () => clearInterval(id)
-  }, [enabled])
-  return tick
-}
-
 export default function SingularityVote({ praxisId, currentValue }: VoteUIProps) {
   const { t } = useTranslation('votes')
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
   const [hovered, setHovered] = useState(0)
-  const reducedMotion = usePrefersReducedMotion()
-  const tick = useScrambleTick(!reducedMotion)
+  const tick = useMotionTick(SCRAMBLE_INTERVAL_MS)
 
   if (!user) {
     return <VoteLoginGate />

--- a/frontend/src/hooks/__tests__/useMotion.test.tsx
+++ b/frontend/src/hooks/__tests__/useMotion.test.tsx
@@ -271,6 +271,13 @@ describe('useMotionStilled — the answer a JS clock asks for', () => {
     // for itself would animate here; reading `motion` cannot.
     expect(renderStilled('on', true)).toBe('true')
   })
+
+  it('answers stilled outside a provider instead of throwing', () => {
+    // A control must not be handed a private copy of the setting, so `useMotion`
+    // throws. An ornament is the other case: rendered outside the app root it
+    // should hold still, not start a clock nothing will stop.
+    expect(readStilled(renderToStaticMarkup(<StilledProbe />))).toBe('true')
+  })
 })
 
 describe('scheduleMotionTick — stilled means nothing is scheduled', () => {

--- a/frontend/src/hooks/__tests__/useMotion.test.tsx
+++ b/frontend/src/hooks/__tests__/useMotion.test.tsx
@@ -15,7 +15,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 
 import {
   DEFAULT_MOTION,
@@ -26,7 +26,9 @@ import {
   nextMotion,
   readReducedMotion,
   resolveInitialMotion,
+  scheduleMotionTick,
   useMotion,
+  useMotionStilled,
 } from '../useMotion'
 
 const INDEX_CSS = readFileSync(
@@ -203,4 +205,143 @@ describe('index.css carries the kill switch the attribute drives', () => {
     expect(body).toMatch(/animation:\s*none\s*!important/)
     expect(body).toMatch(/transition:\s*none\s*!important/)
   })
+})
+
+/**
+ * #2622 — the half of the switch a stylesheet cannot reach.
+ *
+ * Two faction vote skins animate from a `setInterval` re-render rather than a
+ * CSS animation, so `[data-motion="off"]` had no property to null and they kept
+ * ticking with the switch off. NOT an accessibility defect: both honoured the
+ * OS query before this change and still do (the `systemReduced` cases below).
+ * What was broken is only the device-local switch reaching them.
+ *
+ * The seam is this hook, and the harness has no DOM, so the scheduling decision
+ * is asserted where it is made rather than by counting repaints.
+ */
+
+/** Pretend the reader has (or has not) stored a choice. */
+function withStoredMotion<T>(stored: string | null, body: () => T): T {
+  const holder = globalThis as { localStorage?: unknown }
+  const previous = holder.localStorage
+  holder.localStorage = { getItem: () => stored, setItem: () => {} }
+  try {
+    return body()
+  } finally {
+    if (previous === undefined) delete holder.localStorage
+    else holder.localStorage = previous
+  }
+}
+
+function StilledProbe() {
+  return <span data-testid="stilled">{String(useMotionStilled())}</span>
+}
+
+const readStilled = (html: string) =>
+  /<span data-testid="stilled">([^<]+)<\/span>/.exec(html)?.[1]
+
+const renderStilled = (stored: string | null, systemReduced: boolean) =>
+  readStilled(
+    withStoredMotion(stored, () =>
+      withSystemReduced(systemReduced, () =>
+        renderToStaticMarkup(
+          <MotionProvider>
+            <StilledProbe />
+          </MotionProvider>,
+        ),
+      ),
+    ),
+  )
+
+describe('useMotionStilled — the answer a JS clock asks for', () => {
+  it('is not stilled by default, so the skins animate as designed', () => {
+    expect(renderStilled(null, false)).toBe('false')
+  })
+
+  it('is stilled when the reader turned the Settings switch off (#2622)', () => {
+    expect(renderStilled('off', false)).toBe('true')
+  })
+
+  it('is stilled when the OS asks for reduced motion, switch untouched', () => {
+    expect(renderStilled(null, true)).toBe('true')
+  })
+
+  it('takes the composed answer, never the raw stored choice', () => {
+    // 'on' stored + OS asking = off in effect. A skin re-deriving the switch
+    // for itself would animate here; reading `motion` cannot.
+    expect(renderStilled('on', true)).toBe('true')
+  })
+})
+
+describe('scheduleMotionTick — stilled means nothing is scheduled', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('schedules no timer at all while motion is stilled', () => {
+    const onTick = vi.fn()
+    const stop = scheduleMotionTick(true, onTick, 120)
+    expect(vi.getTimerCount(), 'a stilled clock must not hold a timer').toBe(0)
+    vi.advanceTimersByTime(1000)
+    expect(onTick).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('ticks on its interval while motion is on', () => {
+    const onTick = vi.fn()
+    const stop = scheduleMotionTick(false, onTick, 120)
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(360)
+    expect(onTick).toHaveBeenCalledTimes(3)
+    stop()
+  })
+
+  /**
+   * The flip-while-mounted half, which a naive test misses: `stilled` is a dep
+   * of the effect that calls this, so React runs this teardown the moment a
+   * reader turns the switch off with a vote widget on screen — the widget does
+   * not go on ticking until it unmounts.
+   */
+  it('tears down its timer, so a flip to off stops an already-running clock', () => {
+    const onTick = vi.fn()
+    const stop = scheduleMotionTick(false, onTick, 120)
+    stop()
+    expect(vi.getTimerCount(), 'teardown left a timer running').toBe(0)
+    vi.advanceTimersByTime(1000)
+    expect(onTick).not.toHaveBeenCalled()
+  })
+
+  it('is safe to tear down a clock that never started', () => {
+    expect(() => scheduleMotionTick(true, () => {}, 120)()).not.toThrow()
+  })
+})
+
+/**
+ * Neither skin may keep a private clock or a private copy of the OS query — a
+ * second one would escape the switch exactly as the first pair did, and no
+ * render in this DOM-less harness can see it.
+ */
+describe('the two JS-driven vote skins read the shared clock', () => {
+  for (const skin of ['AlbescentVote', 'SingularityVote'] as const) {
+    const source = readFileSync(
+      fileURLToPath(new URL(`../../components/vote/${skin}.tsx`, import.meta.url)),
+      'utf8',
+    )
+
+    it(`${skin} schedules no interval of its own`, () => {
+      expect(source).not.toContain('setInterval')
+    })
+
+    it(`${skin} does not re-derive the motion state from matchMedia`, () => {
+      expect(source).not.toContain('matchMedia')
+    })
+
+    it(`${skin} drives its clock from useMotionTick`, () => {
+      expect(source).toContain('useMotionTick')
+    })
+  }
 })

--- a/frontend/src/hooks/useMotion.tsx
+++ b/frontend/src/hooks/useMotion.tsx
@@ -195,9 +195,15 @@ export function useMotion(): MotionState {
  * `[data-motion="off"]`, and the composed answer — the OS has already had its
  * say inside `effectiveMotion`, so a caller must never pair this with its own
  * `prefers-reduced-motion` read (#2622).
+ *
+ * Unlike `useMotion`, this does NOT throw without a provider; it answers
+ * "stilled". Its callers are ornaments rather than controls, so a wrong answer
+ * is asymmetric: an ornament rendered outside the app root (a test, an isolated
+ * preview) should hold still rather than start a clock nothing will stop. That
+ * is the same default the vote skins' own matchMedia hooks carried before this.
  */
 export function useMotionStilled(): boolean {
-  return useMotion().motion === 'off'
+  return (useContext(MotionContext)?.motion ?? 'off') === 'off'
 }
 
 /**

--- a/frontend/src/hooks/useMotion.tsx
+++ b/frontend/src/hooks/useMotion.tsx
@@ -225,9 +225,10 @@ export function scheduleMotionTick(
 
 /**
  * A counter that increments every `intervalMs` while motion is on, for an
- * ornament that animates by re-rendering rather than by CSS. Frozen at 0 while
- * motion is stilled, and — because `stilled` is a dependency of the effect —
- * torn down mid-life the moment a reader flips the switch off.
+ * ornament that animates by re-rendering rather than by CSS. While motion is
+ * stilled it holds whatever value it had reached (0 if it never ran), and —
+ * because `stilled` is a dependency of the effect — its timer is torn down
+ * mid-life the moment a reader flips the switch off.
  */
 export function useMotionTick(intervalMs: number): number {
   const stilled = useMotionStilled()

--- a/frontend/src/hooks/useMotion.tsx
+++ b/frontend/src/hooks/useMotion.tsx
@@ -41,14 +41,14 @@ import {
  * disabled state is DELIBERATE — it is not a bug, and it is not a loading
  * state.
  *
- * KNOWN GAP (deliberate, #2154 scope). Two faction vote skins animate from JS
- * rather than CSS — `SingularityVote`'s scramble clock and `AlbescentVote`'s
- * morph clock are `setInterval` re-renders. A CSS kill switch cannot reach
- * either. Both already honour the OS `prefers-reduced-motion` query, which is
- * the accessibility-critical half; wiring them to this preference as well is a
- * separate change to two faction components.
- * ponytail: the upgrade path is to export `useMotionStilled()` from here and
- * have both skins read it instead of their duplicated local matchMedia hook.
+ * WHAT THE ATTRIBUTE CANNOT DRIVE
+ * -------------------------------
+ * A stylesheet can only null a property that exists. Motion driven from JS —
+ * `SingularityVote`'s scramble clock and `AlbescentVote`'s morph clock, both
+ * `setInterval` re-renders — has no `animation` or `transition` for the rule
+ * above to reach, so the switch left them ticking (#2622). Those two now read
+ * `useMotionTick` below and schedule nothing while motion is off. Anything else
+ * that animates from JS belongs on the same clock for the same reason.
  */
 export type Motion = 'on' | 'off'
 
@@ -188,4 +188,47 @@ export function useMotion(): MotionState {
     throw new Error('useMotion must be used within a MotionProvider')
   }
   return value
+}
+
+/**
+ * Is motion stilled right now? The JS-clock equivalent of matching
+ * `[data-motion="off"]`, and the composed answer — the OS has already had its
+ * say inside `effectiveMotion`, so a caller must never pair this with its own
+ * `prefers-reduced-motion` read (#2622).
+ */
+export function useMotionStilled(): boolean {
+  return useMotion().motion === 'off'
+}
+
+/**
+ * Start a repeating clock unless motion is stilled, returning its teardown.
+ *
+ * Lifted out of `useMotionTick` because "off schedules nothing" is the whole
+ * claim of #2622 and the test harness has no DOM to observe an effect in. Plain
+ * function, no React: the test can assert the timer directly.
+ */
+export function scheduleMotionTick(
+  stilled: boolean,
+  onTick: () => void,
+  intervalMs: number,
+): () => void {
+  if (stilled) return () => {}
+  const id = setInterval(onTick, intervalMs)
+  return () => clearInterval(id)
+}
+
+/**
+ * A counter that increments every `intervalMs` while motion is on, for an
+ * ornament that animates by re-rendering rather than by CSS. Frozen at 0 while
+ * motion is stilled, and — because `stilled` is a dependency of the effect —
+ * torn down mid-life the moment a reader flips the switch off.
+ */
+export function useMotionTick(intervalMs: number): number {
+  const stilled = useMotionStilled()
+  const [tick, setTick] = useState(0)
+  useEffect(
+    () => scheduleMotionTick(stilled, () => setTick((value) => value + 1), intervalMs),
+    [stilled, intervalMs],
+  )
+  return tick
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5423,9 +5423,10 @@
    case rather than lying about a control that would do nothing — see
    `hooks/useMotion.tsx` and `pages/settings/sections/AppearanceSection.tsx`.
 
-   KNOWN GAP: two faction vote skins animate from a `setInterval` in JS, which
-   no stylesheet can reach. Both already honour the OS query. See the note in
-   `hooks/useMotion.tsx`.
+   WHAT THIS RULE CANNOT REACH (#2622): motion driven from JS declares no
+   property for it to null. The two faction vote skins that animate from a
+   `setInterval` read `useMotionTick` in `hooks/useMotion.tsx` instead, which
+   is fed by the same setting that paints the attribute this rule selects on.
    ══════════════════════════════════════════════════════════════ */
 [data-motion="off"] *,
 [data-motion="off"] *::before,


### PR DESCRIPTION
Closes #2622

The Animations switch is one CSS rule, so it only ever reaches things that
declare an `animation` or a `transition`. Two faction vote skins animate by
re-rendering from a `setInterval`, which declares neither — turn the switch off
and Albescent's blobs kept morphing and Singularity's decode strip kept
churning. Per the owner ruling (shape 1), the two skins now read the setting.

**This is not an accessibility fix.** Both skins honoured
`prefers-reduced-motion` before this change and still do — a reader whose device
asks for stillness got a still widget then and gets one now. What was broken is
only the *device-local* switch reaching them.

## The seam

`useMotion`, as the ruling named. The OS ask and the stored choice already
compose there into one `motion` value, so nothing here re-derives either.

Three exports, replacing what the two skins each kept a private copy of:

- `useMotionStilled()` — the name the `ponytail:` comment proposed. Reads the
  composed `motion`, not the raw choice.
- `useMotionTick(intervalMs)` — the clock itself. Both skins had not just their
  own `matchMedia` reduced-motion hook but their own near-identical tick hook,
  differing in one constant; this is one rung past `useMotionStilled()` alone
  and deletes 40 lines of duplication. Nothing in either file needed the stilled
  flag for anything but the clock.
- `scheduleMotionTick(stilled, onTick, ms)` — the scheduling decision as a plain
  function. It exists because "off schedules nothing" is the whole claim and the
  harness has no DOM in which to observe an effect.

`useMotionStilled` deliberately does **not** throw without a provider, where
`useMotion` still does. Twelve existing card and vote suites render these
widgets with no `MotionProvider` above them, and the asymmetry is real: a
control must never be handed a private copy of the setting, but an ornament
rendered outside the app root should hold still rather than start a clock
nothing will stop. That is exactly the default the skins' own hooks carried
(`() => true` as their server snapshot), so no behaviour moved.

The `ponytail:` note in `useMotion.tsx` and the `KNOWN GAP` note on the
`[data-motion]` block in `index.css` are both deleted — each is replaced by a
line saying what a stylesheet cannot reach and where JS motion goes instead.
(`index.css` is otherwise untouched: comment text only, no rule, no token.)

## Tests

In `hooks/__tests__/useMotion.test.tsx`, driven at the hook rather than at
pixels. All fourteen were red on `main` before the fix:

- `useMotionStilled` through a real `MotionProvider`: not stilled by default,
  stilled with the switch off (the defect), stilled with the OS asking, and
  stilled with `'on'` stored *and* the OS asking — a skin re-deriving the switch
  for itself would animate in that last case.
- `scheduleMotionTick` under fake timers: stilled holds **zero** timers and
  never fires; on holds one and ticks; teardown leaves zero. That teardown is
  the flip-while-mounted half — `stilled` is a dep of the effect, so React runs
  it the moment the switch flips with a widget on screen, rather than the widget
  ticking on until it unmounts.
- A source guard that neither skin contains `setInterval` or `matchMedia` and
  that both drive their clock from `useMotionTick`. A third private clock would
  escape the switch exactly as these two did, and no render in this harness
  could see it.

## Checks run locally

Every step in `.github/workflows/test.yml`'s `frontend` job:

- `npm run lint` — clean
- `npm run typecheck` (app + e2e) — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 453 files, 9,294 passed, 1 skipped
- `npm run build` — clean
- `npm run budget` — exit 0. The JS line is on its pre-existing WARN (141.0 KB
  against a 130.9 KB warn, 175.8 KB fail); this diff is net −20 source lines,
  adds no dependency and no chunk, and both skins are lazy chunks either way.

`api-schema` is not applicable — no route, `response_model` or Pydantic schema
was touched.

Out of scope, as the issue and ruling both state: `useMentionAutocomplete`'s
`requestAnimationFrame` (a focus/caret restore, not an animation), and the
switch's help copy, which now under-describes what it does rather than
over-promising.

## What to eyeball

No browser was available here, so visual QA is outstanding.

- With Settings → Appearance → **Animations off** (and the OS asking for
  nothing): open a praxis filed under **Albescent** — the ferrofluid blobs
  should hold a static polygon each, still filled with their slice of the
  spectrum, and voting should behave identically. Same for a **Singularity**
  praxis — the decode strip should show noise vs. resolved glyphs but stop
  churning.
- Flip the switch **off while a vote widget is on screen**: both should stop on
  the spot, not at the next navigation.
- Flip it back **on**: both resume.
- **The OS path must be unchanged.** With the OS set to reduced motion, the
  Appearance switch renders off and disabled as it already did, and both widgets
  are still — same as before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
