### PR TITLE
Cut the retirement register out of factions/manifest.ts and factions/index.ts

### DIFF
--- a/frontend/src/factions/index.ts
+++ b/frontend/src/factions/index.ts
@@ -45,25 +45,14 @@ export { SURFACE_KEYS } from './manifest'
  * consumer that iterates gets the house order for free, with `na` last —
  * outside the rainbow, the way it is outside `FACTION_RAINBOW_ORDER`.
  *
- * `na` HAS A MANIFEST SINCE #2530, and the sentence that used to stand here
- * ("unaffiliated is a state rather than a faction and deliberately has no
- * manifest: it falls through to the neutral `Default*` skins everywhere") was
- * true about the game and false about this file. It is still a state rather than
- * a faction — `CSS_KEY['na'] === 'default'` and `isKnownFaction('na')` is still
- * false (ADR-0039, #749) — but "falls through" described a SECOND dispatch
- * mechanism, `pickVariant`'s third argument, hand-written at ~20 call sites for
- * this one slug. `./default.ts` is the same twenty components reached the same
- * way as everyone else's; nothing about what renders changed.
+ * `na` has a manifest here (`./default.ts`) and is nonetheless a state rather
+ * than a faction everywhere else: `CSS_KEY['na'] === 'default'` and
+ * `isKnownFaction('na')` is false (ADR-0039, #749). Being in this list means it
+ * is reached by the registry like the other eight, not that it joined them.
  *
- * `wow` (Warriors of Whimsy) began with no manifest (#784 moved its old pink
- * identity to Cozy Coven) and then only a yellow THEME (#812). #821 gave it its
- * FIRST bespoke surfaces: the praxis card (the cream/gold/plum chronicle), its
- * mobile twin and the balloon vote widget; #840 added the score stamp and #835
- * the edit-praxis composer ("The Squire's Writ") — which #836 gave a mobile twin
- * and #1181 collapsed back to one responsive component when ADR-0065 retired the
- * `mobileEditPraxis` surface. It claims every key in `SURFACE_KEYS` now, and
- * `surfaceDispatch.test.ts` is what holds it there: that file derives the bar
- * from what the reference factions skin, so a new surface raises it by itself.
+ * `surfaceDispatch.test.ts` is the executable record of which slugs skin which
+ * surface — a de-registration flips a bespoke row red, an accidental
+ * registration flips a defaulted row red.
  */
 export const FACTION_MANIFESTS: readonly FactionManifest[] = [
   EVERYMEN_MANIFEST,

--- a/frontend/src/factions/manifest.ts
+++ b/frontend/src/factions/manifest.ts
@@ -1,10 +1,9 @@
 /**
  * Per-faction manifest — the shape a faction fills in to claim its surfaces.
  *
- * BEFORE (#782): each *surface* owned a slug-keyed map of every faction, so
- * adding a faction meant editing 30 modules and discovering the one you forgot
- * visually, weeks later. NOW each *faction* owns one manifest declaring only the
- * surfaces it overrides, and the dispatchers read from it.
+ * Each *faction* owns one manifest declaring only the surfaces it overrides
+ * (#782), and the dispatchers read from it — no dispatcher holds a slug-keyed
+ * map of its own.
  *
  * The manifest is OVERRIDE-ONLY, WITH ONE EXCEPTION. Every field is optional; an
  * undeclared surface resolves to na's row for that surface, and a faction that
@@ -16,13 +15,6 @@
  * names no `Default*` of its own, so an unclaimed na surface renders NOTHING
  * rather than falling further back.
  *
- * PARTIAL REGISTRATION WAS "THE NORMAL CASE" AND IS NOT ANY MORE, which is what
- * #2530 was for. All 160 (surface × faction) slots are filled, so `Default*` had
- * stopped being a fallback and become simply na's skin — reached, alone among
- * the nine, by `pickVariant`'s third argument at ~20 hand-written call sites
- * instead of by the registry. The contract above is unchanged for the other
- * eight; what changed is that the ninth is now stated in the same place.
- *
  * Adding a faction: one new module here, one line in `./index.ts`. Adding a
  * SURFACE: one field here, one entry in `SURFACE_KEYS`, and the dispatcher calls
  * `surfaceMap('<key>')` instead of declaring its own map.
@@ -30,11 +22,10 @@
  * WHY EVERY ENTRY IS A THUNK (`taskCard: () => UaTaskCard`)
  * ---------------------------------------------------------
  * Dispatcher modules and archetype modules already import each other: an
- * archetype pulls shared atoms out of its dispatcher (`AlbescentAvatar` imports
- * `BadgedAvatar` from `FactionAvatar`), and ten archetypes are defined *inside*
- * their dispatcher outright (the seven praxis cards in `PraxisCard.tsx`, the
- * three sigil adapters in `FactionSigil.tsx`). Once a dispatcher also reads the
- * manifest index, that closes a module cycle.
+ * archetype pulls shared atoms out of its dispatcher (`CovenAvatar` imports
+ * `BadgedAvatar` from `FactionAvatar`), and some archetypes are defined *inside*
+ * their dispatcher outright (the sigil adapters in `FactionSigil.tsx`). Once a
+ * dispatcher also reads the manifest index, that closes a module cycle.
  *
  * A plain object literal — `{ sigil: UaSigilAdapter }` — READS the imported
  * binding while the modules are still evaluating. Whenever the dispatcher
@@ -86,10 +77,8 @@ export interface FactionManifest {
   // ─── Cards & chrome (desktop) ──────────────────────────────────────────────
   /**
    * The faction's task card. ONE responsive component per faction (ADR-0056):
-   * it sizes itself for the phone via `useFormFactor()` internally, so there is
-   * no `mobileTaskCard` twin — that surface was retired when the owner's QA
-   * verdict accepted the unified card. "desktop" here names the section, not
-   * the form factor this one serves.
+   * it sizes itself for the phone via `useFormFactor()` internally. "desktop"
+   * here names the section, not the form factor this one serves.
    */
   readonly taskCard?: Lazy<ComponentType<CardProps>>
   readonly praxisCard?: Lazy<ComponentType<PraxisCardProps>>
@@ -101,12 +90,10 @@ export interface FactionManifest {
   readonly sigil?: Lazy<ComponentType<SigilVariantProps>>
   readonly comment?: Lazy<CommentComponent>
   /**
-   * The faction's activity-feed CHASSIS (surface #12). #1194 widened this from
-   * `{ children }` to {@link FeedFrameProps}: a frame that owned only children
-   * could not draw the kicker band, the timestamp or the archive control, all
-   * three of which every design sheet puts on the chassis. Read that interface's
-   * docblock before writing a faction skin — nothing may be written against the
-   * old shape.
+   * The faction's activity-feed CHASSIS. It owns the kicker band, the
+   * timestamp and the archive control as well as its children, because every
+   * design sheet puts all three on the chassis — read {@link FeedFrameProps}'s
+   * docblock before writing a faction skin.
    */
   readonly feedFrame?: Lazy<ComponentType<FeedFrameProps>>
   readonly vote?: Lazy<ComponentType<VoteUIProps>>
@@ -117,8 +104,8 @@ export interface FactionManifest {
   readonly scoreStamp?: Lazy<ComponentType<ScoreStampProps>>
   /**
    * The seal an issuing faction leaves on a praxis it metatasked (#927). One
-   * responsive component per faction — no mobile twin, the sticker renders
-   * near-identical at 340px.
+   * responsive component per faction: the sticker renders near-identical at
+   * 340px, so it needs no phone branch at all.
    */
   readonly metataskSeal?: Lazy<ComponentType<SealSkinProps>>
 
@@ -132,9 +119,7 @@ export interface FactionManifest {
   /**
    * Character creation (#2346). ONE responsive component per faction — each
    * archetype reads `useFormFactor()` itself, the way `editPraxis` and the
-   * profile bodies do. This is NOT the retired mobile-only
-   * `mobileCreateCharacter` coming back under a new name; see the retirement
-   * note below for what that slot was and why it went.
+   * profile bodies do.
    *
    * The slug this dispatches on is not the viewer's faction and not the
    * character's — no character exists yet. It is `factionSlug` out of
@@ -148,98 +133,33 @@ export interface FactionManifest {
   readonly createCharacter?: Lazy<Stateful<CreateCharacterState>>
 
   // ─── Duel surfaces ─────────────────────────────────────────────────────────
-  // ONE responsive component per faction, both form factors (#1313): the seven
-  // skins hang their interior in `components/duel/DuelSealSheet`, which is the
-  // single place the seal reads `useFormFactor()`. The duel SEAL is the only
-  // dispatched duel surface. `duelRail` /
-  // `mobileDuelRail` were retired outright in #1090: the duel stopped being a
-  // dispatched surface at all. It is now a card INSIDE the praxis-detail
-  // archetype (`pages/praxisDetail/DuelCard.tsx`), so a faction dresses it by
-  // dressing its `praxisDetail` — there is no second dispatcher left to feed.
-  // #1153 finished that thought: the card takes `style`, `heading` AND `ink`, so
-  // an archetype can reach every part of it a rail skin used to own.
+  // The duel SEAL is the only dispatched duel surface. ONE responsive component
+  // per faction, both form factors (#1313): the skins hang their interior in
+  // `components/duel/DuelSealSheet`, which is the single place the seal reads
+  // `useFormFactor()`.
   //
-  // This is deliberately NOT the `praxisDetail` move (#1089), which kept its
-  // field with zero registrations because the epic-#1085 designs were about to
-  // re-register there — as all eight since have. A
-  // surface with no dispatcher is not "empty"; it is gone, and keeping the field
-  // would mean keeping a dead `DuelRailSkinProps` alive to type it.
+  // The duel ITSELF is not dispatched. It is a card inside the praxis-detail
+  // archetype (`pages/praxisDetail/DuelCard.tsx`), so a faction dresses it by
+  // dressing its `praxisDetail`: the card takes `style`, `heading` and `ink`
+  // (#1153), which is every part of it an archetype can reach.
   readonly duelSeal?: Lazy<ComponentType<DuelSealConfirmProps>>
 
   // ─── Mobile twins (#494 form-factor dispatch) ──────────────────────────────
-  // Task cards, task detail, praxis detail, the EDIT-PRAXIS COMPOSER, the PRAXIS
-  // CARD, the CHARACTER PROFILE, the DUEL SEAL and now the FACTION PAGE have no
-  // mobile twin: ADR-0056, ADR-0058, ADR-0061/#1085, ADR-0065/#1181, ADR-0067,
-  // #1319, #1313 and ADR-0078 each collapsed their surface to one responsive
-  // component per faction and retired it. Every one of those licences is scoped
-  // to its own surface — ADR-0035 still governs `mobileFieldDesk` below, and
-  // each record says in terms that it licenses no further collapse: the next
-  // surface needs its own record, the same way. `mobileFieldDesk` is not the
-  // next one: it is a genuinely different screen rather than a narrow rendering
-  // of the roster, and #1320 says so.
+  // The field desk is the ONLY form-factor-dispatched surface. Everywhere else
+  // a faction ships one responsive component that reads `useFormFactor()`
+  // itself, and each of those collapses is licensed by its own record
+  // (ADR-0056, ADR-0058, ADR-0061, ADR-0065, ADR-0067, ADR-0078, #1313, #1319).
+  // Every one of those licences is scoped to its surface and says in terms that
+  // it licenses no further collapse: the next surface needs its own record, the
+  // same way.
   //
-  // `mobileFactionPage` is the eighth (ADR-0078). It looked like the others —
-  // eight skins beside eight bodies — and was not: the two registries held two
-  // DIFFERENT CONTENT SETS. Coven's body reads twenty bespoke `coven.*` keys;
-  // Coven's phone skin read one, plus a shared generic set, so a phone got
-  // generic chrome in a faction dress and the manifesto, the spotlight and the
-  // bespoke join flow did not exist there at all. The collapse was therefore not
-  // output-neutral, and that was the point of it. `.wz-faction-grid` already
-  // carried the ≤860px drop to one column, so no chassis was needed; the one
-  // skin that wants the viewport reads `useFormFactor()` itself.
+  // The field desk is not the next one. ADR-0035 governs it, and #1320 says why:
+  // it is a genuinely different screen rather than a narrow rendering of the
+  // roster, so there is no one component for the two widths to share.
   //
-  // `mobileDuelSeal` is the seventh (#1313). It was the tightest pair in the
-  // set: SEVEN twins whose difference was the positioning shell — a centred
-  // 460px card over a scrim, or a full-bleed sheet — repeated seven times, with
-  // byte-identical slots, tokens, contrast-measured inks and copy modes on both
-  // sides of each pair. That shell is `DuelSealSheet` now: a skin declares its
-  // `ground` (paper, ink, face, the opponent's edge) and its `card` (border,
-  // radius, clip, shadow — the chrome that only means something while it floats)
-  // and the chassis picks. No skin lost its frame; the branch went from fourteen
-  // files to one.
-  //
-  // `mobileProfile` is the sixth (#1319). It was the clearest case for the
-  // collapse and the weakest seam in the set: TWO of nine slugs ever filled it
-  // (na by being the call site's Default, wow by registering), so a Coven or UA
-  // player got the na spectrum profile on a phone and their own dress on a
-  // laptop. Both skins are now the mobile branch of their own `profileBody`
-  // (`DefaultProfileBody`, `WowProfileBody`), and every other faction reaches
-  // its own body at both widths through `ProfileSkin`, which grew the same
-  // `useFormFactor()` read.
-  //
-  // `mobilePraxisCard` is the fifth (ADR-0067). It was the last CARD-level twin
-  // and the largest — ten skins and a 556-line slot library that re-derived the
-  // byline, task ref, title, excerpt, roster, mode chip, media gallery and vote
-  // footer the desktop slots already drew from the same fields. The mobile feed
-  // page survives; only its cards changed.
-  //
-  // `mobileEditPraxis` is gone rather than kept empty, which is the same choice
-  // `duelRail` made and the OPPOSITE of what `praxisDetail` did (#1089 kept its
-  // field with zero registrations because the epic-#1085 designs were about to
-  // re-register there). ADR-0065 §2 picks the retirement deliberately: all nine
-  // composer designs were committed before a single archetype was rebuilt, so
-  // the mobile skins are superseded by a committed design rather than held open
-  // pending one. There is no partial-registration story for a surface that no
-  // longer exists, and no future issue should try to re-register it.
-  //
-  // `mobileCreateCharacter`, `mobileEditCharacter`, `mobileFactionsDirectory`
-  // and `mobilePlayersDirectory` are gone the same way. They were declared by
-  // #516/#901 and never claimed by a single faction, so all four dispatchers
-  // resolved to their `Default*` skin on every render. Those four pages now
-  // render the Default directly. A future faction skin for one of them adds the
-  // field back with a registration in the same commit — a slot no faction fills
-  // is not a seam, it is a lookup that always returns the same answer.
-  //
-  // #2346 IS THAT COMMIT, for the first of the four, and it is worth reading
-  // what it did and did not restore. `createCharacter` above is a NEW,
-  // RESPONSIVE surface, not `mobileCreateCharacter` un-retired: the mobile-only
-  // slot stays dead and `mobileArchetypes/DefaultCreateCharacter` was folded
-  // into `archetypes/DefaultCreateCharacter` rather than left as a second
-  // mobile path, so the page has one archetype per faction at both widths like
-  // every collapse above it. And it landed WITH its first registrations
-  // (ephemerists, #2347) in the same PR, which is the whole of the rule this
-  // note states — the chassis was never merged with an empty slot. The other
-  // three remain retired and unclaimed.
+  // Adding another mobile-only surface takes a record of its own AND its first
+  // registration in the same commit. A slot no faction fills is not a seam; it
+  // is a lookup that always returns the same answer.
   readonly mobileFieldDesk?: Lazy<Stateful<FieldDeskHomeState>>
 }
 


### PR DESCRIPTION
Closes #2756

Part of #2533. **Comment-only.** No non-comment line changes — not a reorder, not a reformat.

## The seam

There is no behaviour to go red on: the change is output-neutral by construction. **The seam is the diff itself**, and it is verified two ways:

1. `git diff -U0` — every `+`/`-` line is a comment line.
2. Stripping comment lines from both revisions and diffing the remainder:

```
git show origin/main:frontend/src/factions/manifest.ts | grep -vE '^\s*(\*|//|/\*)' > a
grep -vE '^\s*(\*|//|/\*)' frontend/src/factions/manifest.ts             > b
diff a b   # empty, for both files
```

Non-comment lines are byte-identical to `origin/main` in both files.

## What was cut

`manifest.ts` carried **12** lines naming a surface that no longer exists; `index.ts` carried **1**. Verified before cutting that none of the 13 was live code. Zero survive:

`mobileDuelSeal mobileEditPraxis mobileCreateCharacter duelRail mobileDuelRail mobilePraxisCard mobileFactionPage mobileFactionsDirectory mobileEditCharacter mobilePlayersDirectory mobileProfile` — plus `mobileTaskCard`, which the register in the `taskCard` docblock named on a thirteenth line.

Also cut, per the epic's rule:

- `manifest.ts` — the `BEFORE (#782)` / `NOW` framing; the `#2530` "partial registration was the normal case and is not any more" paragraph; the `#1194` "widened this from `{ children }`" narration on `feedFrame`; the `duelRail` / `praxisDetail` (#1089) comparison; the whole per-surface retirement register under "Mobile twins".
- `index.ts` — na's "the sentence that used to stand here", and wow's build history (#784 → #812 → #821 → #840 → #835 → #836 → #1181).

`mobileFieldDesk` is untouched: it is a live key in `SURFACE_KEYS`, registered by all nine factions.

## What was kept

- **The thunk note in full.** Reading a manifest entry at module-evaluation time captures `undefined` and the faction falls back forever, invisible to `tsc`. Live trap; the epic names it as the example worth every line.
- `index.ts`'s matching `surfaceMap()`-is-lazy cycle note.
- The override-only contract and `./default.ts`'s exception (it must claim all twenty; nothing is behind it).
- The add-a-faction / add-a-surface recipe.
- `SURFACE_KEYS_ARE_EXHAUSTIVE`'s docblock — a live compile-time guard.
- `createCharacter`'s dispatch-slug explanation (the slug is the calling being picked *right now*, not the viewer's and not the character's) — non-obvious and live.
- Canonical rainbow order with `na` last (#352), `CSS_KEY['na'] === 'default'`, `isKnownFaction('na')` false (ADR-0039, #749).
- The rule the register existed to state, now stated once: every collapse is licensed by its own record, each scoped to its surface, and the next surface needs its own. ADR-0035 / #1320 for why the field desk is not the next one.

## Two stale claims fixed rather than kept

The thunk note's concrete examples had rotted, so keeping them verbatim would have failed "describes something that currently exists":

- `AlbescentAvatar` no longer imports `BadgedAvatar` — it imports `avatarDim`. Now names `CovenAvatar`, which does import `BadgedAvatar` from the avatar dispatcher.
- "ten archetypes… the seven praxis cards in `PraxisCard.tsx`" — `PraxisCard.tsx` is 39 lines and defines none. `FactionSigil.tsx` still defines its adapters inline, so that half stands and the count is gone.

`feedFrame`'s "surface #12" also went: `feedFrame` is the 8th entry in `SURFACE_KEYS`.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally, on a real `npm ci` in this worktree (vite **8.2.2**, matching `package-lock.json` — the junction to the main checkout resolved vite 5 and was discarded):

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **453 files, 9294 passed**, 1 skipped |
| `npm run build` | ok (pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` warning, unchanged) |
| `npm run budget` | **byte-identical to `origin/main`** |

The budget canary was run against a baseline build of `origin/main` in the same worktree with the same `node_modules`. Every figure and **every content hash** matches — `index-BnTqLzgF.js`, `index-s3yOQWkV.css`, all 18 blocking assets. JS 141.0 KB, CSS 21.6 KB on both sides. The JS `WARN` is pre-existing on `main` and is not introduced here.

`api-schema` is not exercised: no route signature, `response_model` or Pydantic schema is touched.

## Not in scope

#2758 sweeps the eleven retired names from the other 42 files and adds the guard test. It is serialized after this merges — none of its work is here. (Noted in passing: `pages/praxisDetail/DuelCard.tsx`'s docblock still narrates the twelve `*DuelRail` skins, and `components/duel/DuelSealConfirm.tsx` still names `mobileDuelSeal`. Both are #2758's.)

## What to eyeball

- **Whether the "Mobile twins" rewrite keeps the rule you wanted kept.** The register is gone; what stands in its place is one paragraph saying each collapse needs its own record and lists the eight records. If you want the ADR list gone too, it is a two-line cut.
- **The two stale-claim fixes.** They are the only places I wrote a *new* factual assertion rather than deleting one. Both were checked against the source (`CovenAvatar.tsx` line 1; `FactionSigil.tsx` declares four adapters; `PraxisCard.tsx` is 39 lines).
- **`index.ts`'s na paragraph.** I kept the three live facts and added one sentence of framing — "being in this list means it is reached by the registry like the other eight, not that it joined them." That is my phrasing of the distinction the cut paragraph was making; check it says what you meant.
- **The `duelSeal` block.** It now says the seal is the only dispatched duel surface and the duel itself is a card in the praxis-detail archetype. Both verified (`DuelSealSheet.tsx` is the one `useFormFactor()` read; `DuelCard.tsx` takes `style`, `heading`, `ink`), but it is the block I compressed hardest.

**Visual QA is outstanding** — I have no browser and no dev stack. Comments do not ship and the built bytes are identical to `main`, so there is nothing visual to regress, but I have not looked at a rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
