### PR TITLE
Cut the archaeology in utils/factions.ts and api/praxis.ts (comment-only)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -7,9 +7,7 @@ import type { FlagReason } from '../utils/flagReasons'
 // ---------------------------------------------------------------------------
 // Types. Every one below is an alias of the generated
 // `components['schemas'][…]`, so "matches the backend exactly" is a fact rather
-// than a heading — there is no second declaration left to drift. The mirrors
-// these replaced were close but demonstrably not exact: the wire carries
-// `PraxisOut.voter_count`, which none of them declared (#1400).
+// than a heading — there is no second declaration left to drift (#1400).
 // ---------------------------------------------------------------------------
 
 export type PraxisType = components['schemas']['PraxisType']
@@ -23,9 +21,8 @@ export type PraxisInviteStatus = components['schemas']['PraxisInviteStatus']
  * the `deleted` tombstone — only comments do. The schema has no way to express
  * that, so `PraxisOut.moderation_status` admits five values where four are
  * reachable. Narrowing the alias here would put a frontend type back in
- * contradiction with the contract it is checked against, which is the drift
- * this file exists to have retired; `UNSCORED_MODERATION_STATUSES` below is
- * where the narrower truth is spent.
+ * contradiction with the contract it is checked against;
+ * `UNSCORED_MODERATION_STATUSES` below is where the narrower truth is spent.
  */
 export type ModerationStatus = components['schemas']['ModerationStatus']
 export type MediaType = components['schemas']['MediaType']
@@ -41,8 +38,8 @@ export type MediaType = components['schemas']['MediaType']
  *
  * Lives beside {@link ModerationStatus} because it is a fact about the wire
  * enum, not about any one surface, and because the pair is only safe as ONE
- * list — the defect in #1444 was a card that stamped a computed total on a
- * praxis whose score the backend had already declined to bank.
+ * list: a card that computes its own total must not stamp it on a praxis whose
+ * score the backend has declined to bank (#1444).
  */
 export const UNSCORED_MODERATION_STATUSES: ReadonlySet<ModerationStatus> = new Set([
   'hidden',
@@ -62,9 +59,8 @@ export type MediaItemOut = components['schemas']['MediaItemOut']
  * - `nudged_at` is when the VIEWER last nudged this member about this praxis
  *   (#1083), and null once that 24h window lapses. The server owns both facts
  *   through one constant, so "there is a timestamp" and "you may not nudge
- *   again yet" can never disagree — and a reload cannot un-nudge the button,
- *   which is what made the design's local-state version dishonest. Null on
- *   list-route cards, which have no nudge button.
+ *   again yet" can never disagree — and a reload cannot un-nudge the button.
+ *   Null on list-route cards, which have no nudge button.
  */
 export type PraxisMemberOut = components['schemas']['PraxisMemberOut']
 
@@ -102,17 +98,14 @@ export type PraxisInviteOut = components['schemas']['PraxisInviteOut']
  *   anonymous viewers, who get the client's own login gate instead.
  * - `viewer_vote` is the viewer's own star (1-5); null when unvoted or
  *   anonymous (#1382). Same field and meaning as `PraxisCardOut.viewer_vote`.
- *   Detail used to be the one surface without it, which is why the client once
- *   recovered the viewer's cast from the voters list into an overlay store.
  */
 export type PraxisOut = components['schemas']['PraxisOut']
 
 /**
  * A praxis as the feed and every list surface see it.
  *
- * The score fields are the same ONE set as `PraxisOut`'s (ADR-0053, supersedes
- * ADR-0047), resolved for the praxis AUTHOR for every type including collab.
- * "Merit" (base + votes, multipliers discarded) is retired, and nothing derives
+ * The score fields are the same ONE set as `PraxisOut`'s (ADR-0053), resolved
+ * for the praxis AUTHOR for every type including collab. Nothing derives
  * vote-points or a multiplier by subtraction. `score` is the stamp headline,
  * shown to 1 decimal.
  *
@@ -213,8 +206,7 @@ export async function listPraxes(filters?: {
 }): Promise<PraxisCardOut[]> {
   // The faction union travels as repeated bare `faction=` keys, which is what
   // FastAPI's `List[str] = Query(None)` reads and what the transport writes by
-  // default — the axios serializer this replaced had to be told (#1366,
-  // asserted in `__tests__/client.test.ts`).
+  // default (#1366, asserted in `__tests__/client.test.ts`).
   //
   // Note what the seam does NOT check: `filters` is a VARIABLE, so TypeScript's
   // excess-property check does not apply and a query key the backend renamed or
@@ -243,12 +235,12 @@ export async function getPraxis(id: number): Promise<PraxisOut> {
  * on (#1379).
  *
  * Every signup path — the task list, the task detail page and the home
- * FieldDesk — does `createPraxis(...)` then `navigate('/praxis/{id}/edit')`,
- * and the composer's first act was `getPraxis(id)`: a full round trip to read
- * back a row the client had been handed milliseconds earlier. `POST /praxes`
- * and `GET /praxes/{id}` both return `build_praxis_out(praxis, viewer=...)`
- * with the same viewer, so the two payloads are the same object — the read was
- * pure latency, and on the deepest waterfall in the app.
+ * FieldDesk — does `createPraxis(...)` then `navigate('/praxis/{id}/edit')`.
+ * `POST /praxes` and `GET /praxes/{id}` both return
+ * `build_praxis_out(praxis, viewer=...)` with the same viewer, so the composer
+ * reading the row back would be a full round trip for a payload the client was
+ * handed milliseconds earlier — pure latency, on the deepest waterfall in the
+ * app.
  *
  * ONE SLOT, CONSUMED ONCE. It lives in module memory rather than in router
  * state deliberately: history state survives Back/Forward, so a carried praxis
@@ -461,9 +453,8 @@ export type InviteResponseOut = components['schemas']['InviteResponseOut']
 /**
  * Accept or decline a collab invite.
  *
- * Answers an ack, not the praxis (#1383). This route used to return a full
- * tally-bearing `PraxisOut` — mistyped here as `PraxisInviteOut` — and every
- * caller discarded it, then navigated or refreshed the feed.
+ * Answers an ack, not the praxis (#1383): every caller navigates or refreshes
+ * the feed rather than reading a returned row.
  */
 export async function respondToInvite(
   praxisId: number,

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -6,13 +6,10 @@
  * dark mode arrives free via the [data-theme="dark"] cascade and there is no
  * second table to keep in sync.
  *
- * There used to be one. The docblock here asked humans to mirror every
- * --faction-* value by hand, and it drifted: `ua` sat at #c2541f in JS against
- * #c24a18 in CSS, and #c2541f is verbatim --faction-default-stop-2 — the
- * unaffiliated spectrum's orange. Every JS-sourced surface painted UA in na's
- * hue. Worse, a hex literal has no dark half by construction, so no amount of
- * mirroring could have reached the dark lift. Deleting the table is what makes
- * the drift impossible rather than merely tested (#1269).
+ * Never reintroduce a JS colour table. A hand-mirrored one cannot be made
+ * correct: a hex literal has no dark half by construction, so no amount of
+ * mirroring reaches the dark lift, and the mirroring itself drifts silently
+ * (#1269). Having no table is what makes that impossible rather than tested.
  *
  * What is left is the slug→theme mapping (CSS_KEY), which is about identity,
  * not colour: which slugs have a theme at all, and which resolve to `default`.
@@ -61,15 +58,12 @@ const CSS_KEY: Record<string, string> = {
   everymen: "everymen",
   coven: "coven",
   snide: "snide",
-  // Warriors of Whimsy is themed again (#812) — this is the flip the #784
-  // comment anticipated. This ONE line is what re-themes WOW, because
+  // This ONE line is what themes Warriors of Whimsy (#812), because
   // isKnownFaction tests the mapped VALUE (`!== "default"`), not key presence
-  // (#749). Its colour was the rainbow's yellow and is the chronicle plum since
-  // #2068; its SKIN is the cream/gold/plum chronicle, which is a different thing
-  // and does not follow the hue (#838, ADR-0050) — the two merely agree on a
-  // value now, in light, which is not the same as being one token. WOW still
-  // registers only a few manifest surfaces, so the rest fall back to Default*
-  // until #840.
+  // (#749). Its hue is the chronicle plum (#2068); its SKIN is the
+  // cream/gold/plum chronicle, which is a different thing and does not follow
+  // the hue (#838, ADR-0050) — the two merely agree on a value now, in light,
+  // which is not the same as being one token.
   wow: "wow",
   ephemerists: "ephemerists",
   singularity: "singularity",
@@ -77,8 +71,7 @@ const CSS_KEY: Record<string, string> = {
   // hiding in plain sight, so it points at `default` exactly like `na` below:
   // same neutral scalars, same rainbow through factionFill, and — because the
   // predicate reads the mapped VALUE — isKnownFaction('albescent') === false.
-  // That is the intended outcome, not a gap. It was first-class (#232) with a
-  // 35-declaration --faction-albescent-* block; the block is gone.
+  // That is the intended outcome, not a gap.
   albescent: "default",
   // `na` (unaffiliated) is a state, not a faction: it reads the neutral/rainbow
   // --faction-default-* set (#418), so factionCssVar('na') is grey, never a
@@ -127,9 +120,8 @@ function resolveCssKey(slug: string | null | undefined): string {
  *
  * Exactly one of those is a SURFACE. `card-bg` is the sheet; `light` is a tint
  * wash; everything else is ink meant for `color:`. Reaching for `card-muted` as
- * a `background:` is what #694 was — it filled the collab roster's cast row
- * with the faction's muted TEXT ink and printed the accent pill on it at
- * 1.05:1.
+ * a `background:` fills a surface with the faction's muted TEXT ink and prints
+ * on it at about 1:1 (#694).
  *
  * `card-notice` / `card-alarm` / `card-credit` exist because a shared,
  * faction-themed component paints state colours on eight different sheets, and
@@ -143,9 +135,8 @@ function resolveCssKey(slug: string | null | undefined): string {
  * actually paints, which for four factions is a different token (#1302).
  *
  * `card-notice` and `card-alarm` are ONE role split in two: cautionary and
- * destructive. They existed as a single ink until #1449, which is why anything
- * reading `card-notice` for a red meaning is a site to re-check rather than a
- * precedent to copy.
+ * destructive (#1449). A site reading `card-notice` for a red meaning is a bug
+ * to re-check, not a precedent to copy.
  *
  * With no suffix this is also the answer for genuine SCALAR ink on a dynamic
  * slug — the feed actor's name, the invitation letter's link. `na` and
@@ -184,11 +175,10 @@ export function factionCssVar(
  * `"disc"` is `"dot"` grown large enough to hold depth (#1269): the 28px avatar
  * circle a feed row or companion card paints behind a monogram. A real faction
  * gets a 135° two-stop ramp of its own hue rather than the flat fill a 10px dot
- * takes, because at that size a flat disc reads as a sticker. It exists as a
- * shape because three feed cards had each written that ramp by hand out of an
- * interpolated hex — which is how the JS hue drifted from the CSS one in the
- * first place. na is identical to `"dot"`: the conic spectrum, already the right
- * answer at 28px.
+ * takes, because at that size a flat disc reads as a sticker. It is a shape
+ * here rather than a caller's ramp so that no surface hand-writes it out of an
+ * interpolated hex. na is identical to `"dot"`: the conic spectrum, already the
+ * right answer at 28px.
  */
 export type FactionFillShape = "bar" | "dot" | "disc" | "pill" | "frame" | "rule";
 
@@ -204,10 +194,9 @@ export type FactionFillShape = "bar" | "dot" | "disc" | "pill" | "frame" | "rule
  *                for a vertical rule, where the horizontal ramp would compress
  *                seven stops into the rule's ~3px width
  *   - `"dot"`  → the conic rainbow (`--faction-default-rainbow-conic`; a 7-stop
- *                linear is mud at 10–12px). SMOOTH, not wedged: the hard-wedge
- *                conic this used to name was deleted in #1127, because its seven
- *                light stops sit inside a 0.184 luminance band and the wedge
- *                edges merged into one dark band
+ *                linear is mud at 10–12px). SMOOTH, not wedged: the seven light
+ *                stops sit inside a 0.184 luminance band, so hard wedge edges
+ *                merge into one dark band (#1127)
  *   - `"pill"` → the rainbow as a *frame* (border-box) around a neutral paper
  *                interior with ink text — no single ink is legible across the
  *                spectrum, so the label never sits on it.
@@ -222,10 +211,10 @@ export type FactionFillShape = "bar" | "dot" | "disc" | "pill" | "frame" | "rule
  *                opaque paper for exactly this reason; `frame` keeps that fill but
  *                drops the ink so the caller owns its own text colour (#794).
  *
- * The scalar (`border/ring`) contexts that used to reach for `factionCssVar` and
- * land on grey now ask for `"frame"` instead. A real faction's `"frame"` is a
- * plain solid `var(--faction-{key})` border, so `factionCssVar` + `"frame"` agree
- * for known factions and only `na`/unregistered slugs change.
+ * A scalar `border`/`ring` context asks for `"frame"` rather than reaching for
+ * `factionCssVar` and landing on grey. A real faction's `"frame"` is a plain
+ * solid `var(--faction-{key})` border, so `factionCssVar` and `"frame"` agree
+ * for known factions and only `na`/unregistered slugs differ.
  *
  * Prefer this over `factionCssVar(slug)` for any `background:` that renders a
  * dynamic slug (one that can be `na` at runtime). Genuine single-ink TEXT
@@ -296,9 +285,9 @@ export function factionFill(
 /**
  * A card SHEET — the ground a `Default*` surface paints itself on (#2497).
  *
- * Spread it where `background: factionCssVar(slug, 'card-bg')` used to sit. The
- * rendered result for `na` is byte-identical to that one line; what it buys is a
- * seam. Albescent's kit (#2496) is "the na component plus ornament, never a
+ * Spread it wherever a card ground is painted. The rendered result for `na` is
+ * byte-identical to `background: factionCssVar(slug, 'card-bg')`; what it buys
+ * is a seam. Albescent's kit (#2496) is "the na component plus ornament, never a
  * skin", so its prism sweep (#2499) arrives by overriding three custom
  * properties under its own wrapper class — no component learns anything, and no
  * selector surgery reaches into eight files.
@@ -534,10 +523,10 @@ export function redactableText(
  * for two viewers.
  *
  * Albescent is a secret society: a player who was never invited must not
- * encounter the word. The name was leaking through every surface that labels a
- * thing with its faction — praxis bylines, task cards, metatask seals, the
- * character switcher, a sidebar `aria-label` — about thirty-five call sites,
- * each of which would have needed its own gate, and each of which is a place a
+ * encounter the word. The name reaches every surface that labels a thing with
+ * its faction — praxis bylines, task cards, metatask seals, the character
+ * switcher, a sidebar `aria-label` — about thirty-five call sites, each of
+ * which would otherwise need its own gate, and each of which is a place a
  * future page can forget.
  *
  * Putting the gate HERE is what makes a page written next month secret by
@@ -551,11 +540,10 @@ export function redactableText(
  *
  * ── THIS IS *NOT* WHERE THE REDACTION LIVES, AND THE SPLIT IS DELIBERATE ────
  *
- * #2409 asked whether the mask should become `[REDACTED]` everywhere. The
- * owner ruled it should not, and the ruling restores the sentence directly
- * above: where a name LABELS a thing already on screen, "Unaffiliated" is
- * right. A byline, a task card, a seal and a switcher row are labels, so this
- * function is unchanged by ADR-0082.
+ * The mask is deliberately not `[REDACTED]` everywhere (ADR-0082, #2409):
+ * where a name LABELS a thing already on screen, "Unaffiliated" is right. A
+ * byline, a task card, a seal and a switcher row are labels, so this function
+ * does not redact.
  *
  * The two surfaces that are ABOUT the society — the `/factions` select tile
  * and the leaderboard's eighth lane — redact instead, by calling
@@ -601,9 +589,9 @@ export function factionDescription(slug: string | null | undefined): string {
 /**
  * Every slug that has a theme of its own, in declaration order.
  *
- * Derived from CSS_KEY rather than kept as a second list: the colour table this
- * used to read was a parallel registry, and a parallel registry is what #1269
- * was. `albescent` and `na` are excluded for free — they map to `default`, and
+ * Derived from CSS_KEY rather than kept as a second list, which would be the
+ * parallel registry #1269 removed. `albescent` and `na` are excluded for
+ * free — they map to `default`, and
  * "has a resolvable theme" is exactly what isKnownFaction means.
  */
 export function getAllFactions(): FactionConfig[] {
@@ -626,45 +614,35 @@ export function getAllFactions(): FactionConfig[] {
  * dark twin #ef5350 is h1.1), so a raw ascending sort of the light values would
  * wrap it to the tail. Move a slug here only after re-reading the hue.
  *
- * #2068 moved two hues and #2075 left this array alone, so it spent one release
- * claiming a spectrum it no longer had: WOW's yellow became a plum and the
- * Ephemerists' teal a plate brass. #2078 is the owner's ruling to follow the
- * hues — `ephemerists` up to index 2, `wow` down to index 5 — accepting the
- * repaint of every surface that reads this order. There is no teal in the
- * spectrum at all now, and green→blue is one long jump rather than two short
- * ones. The adjacency that ruling had to clear is UA's sienna beside the brass,
- * the exact "second brown" pairing the old yellow was tuned deep to avoid:
- * ΔE2000 31.1 light / 30.3 dark, against 34.2 / 31.0 for the yellow it replaces
- * and 12.4 / 13.5 for everymen|ua, which already ships as the tightest pair.
- * Measured, not assumed — and not assertable here, because this module holds no
- * colour (#1269).
+ * The order follows the hues, not the slugs: there is no teal in the spectrum,
+ * and green→blue is one long jump. The adjacency it has to carry is UA's sienna
+ * beside the Ephemerists' plate brass — a "second brown" pairing — at ΔE2000
+ * 31.1 light / 30.3 dark, against 12.4 / 13.5 for everymen|ua, which already
+ * ships as the tightest pair. Measured, not assumed — and not assertable here,
+ * because this module holds no colour (#1269).
  *
  * Albescent is deliberately absent (#783). It is a secret society hiding in
  * plain sight: /factions omits it server-side until an account is revealed to it
- * (ADR-0027, #390), so any bar built from this array would have leaked its
- * existence — in its own near-black, no less — to every unrevealed player.
- * `DefaultFactionsDirectory` worked around that by driving its legend off the
- * visible rows; `Leaderboard` and `DefaultPlayers` did not, and shipped the
- * leak. Removing the slug closes all three at the source.
+ * (ADR-0027, #390), so any bar built from this array would leak its existence —
+ * in its own near-black, no less — to every unrevealed player. Keeping the slug
+ * out closes that at the source, for every consumer at once.
  *
  * Consumers must not assume a length, and only one of them paints these fills
  * with a hard edge between them: the mobile factions directory's stripe bar,
  * which distributes stops evenly across whatever is here. `factionStandings`
  * takes this array as the ROSTER of race lanes and then re-sorts by points, and
- * the filter facet lists gapped rows — neither shows an adjacency. (The
- * Leaderboard's own bar and `Meadow`'s bloom were the other two touching
- * surfaces until #1868 and #1763 retired them.)
+ * the filter facet lists gapped rows — neither shows an adjacency.
  */
 export const FACTION_RAINBOW_ORDER: readonly string[] = [
   "everymen",
   "ua",
-  // Took the gold slot when #2068 emptied the teal one, so it moved up from
-  // index 4 to sit between UA's sienna and S.N.I.D.E.'s acid green (#2078).
+  // The gold slot: a plate brass sits between UA's sienna and S.N.I.D.E.'s
+  // acid green (#2078).
   "ephemerists",
   "snide",
   "singularity",
-  // Held index 2 as the yellow from #812; a plum belongs between the blue and
-  // the pink, which is the only index a plum can hold (#2068, #2078).
+  // A plum belongs between the blue and the pink, which is the only index a
+  // plum can hold (#2068, #2078).
   "wow",
   // Cozy Coven takes the pink slot, because it took the pink (#784).
   "coven",

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -590,9 +590,9 @@ export function factionDescription(slug: string | null | undefined): string {
  * Every slug that has a theme of its own, in declaration order.
  *
  * Derived from CSS_KEY rather than kept as a second list, which would be the
- * parallel registry #1269 removed. `albescent` and `na` are excluded for
- * free — they map to `default`, and
- * "has a resolvable theme" is exactly what isKnownFaction means.
+ * parallel registry #1269 removed. `albescent` and `na` are excluded for free —
+ * they map to `default`, and "has a resolvable theme" is exactly what
+ * isKnownFaction means.
  */
 export function getAllFactions(): FactionConfig[] {
   return Object.keys(CSS_KEY)


### PR DESCRIPTION
Closes #2757

Part of #2533 — "cut the archaeology, keep the why", cluster 2.

## The seam

There is no behaviour to go red on: this is comment-only and output-neutral, so the
**diff itself is the seam**. Verified two ways, not one:

1. Every added/removed line in `git diff` is a comment line (`*`, `//`, `/**`, `*/`).
2. Stronger: both files were run through `ts.transpileModule(..., { removeComments: true })`
   at `origin/main` and at HEAD, and the emitted JS is **byte-identical** for both. Not a
   line moved, not a token reformatted. (Throwaway probe; not committed.)

The bundle canary agrees: building `origin/main`'s copies of the two files and building
this branch produce the **same chunk hash** (`index-BnTqLzgF.js`) and the same
`npm run budget` figures — 141.0 KB JS / 21.6 KB CSS. The JS `WARN` in that output is
pre-existing on `main`, not from this PR.

## What went

`frontend/src/api/praxis.ts` — 548 → 539 lines

- The header's narration of the hand-written type mirrors these aliases replaced.
- `ModerationStatus`: the "which is the drift this file exists to have retired" clause.
  The don't-narrow-the-alias rule stays.
- `UNSCORED_MODERATION_STATUSES`: #1444 restated as a live rule instead of as a defect report.
- `PraxisMemberOut`: "which is what made the design's local-state version dishonest".
- `PraxisOut.viewer_vote`: the overlay-store recovery the client "once" did.
- `PraxisCardOut`: the retired "Merit" definition. `nothing derives by subtraction` stays.
- `listPraxes`: the axios-serializer aside. The "what the seam does NOT check" trap stays in full.
- `justCreatedPraxis`: kept the whole why (same `build_praxis_out`, same viewer, deepest
  waterfall) and the ONE SLOT / CONSUMED ONCE invariant; only the past tense went.
- `respondToInvite`: the old `PraxisOut`-mistyped-as-`PraxisInviteOut` return type.

The `ponytail:` marker on the multipart-upload docblock (now line 382) is **untouched** —
confirmed by grep after the edit.

`frontend/src/utils/factions.ts` — 687 → 665 lines

Everything explaining *why a hue, a `CSS_KEY` alias or a token resolves as it does* stays.
Untouched in full: `resolveCssKey`'s `Object.prototype` trap, `isKnownFaction`'s whole
value-vs-presence docblock, the `na` mapping note, `factionSheet`'s four-properties and
trailing-`border-box` notes, `factionSpectrumSheet`'s list-arity note, the Albescent
reveal/redaction gate, and — deliberately — the entire hue-angle sort record on
`FACTION_RAINBOW_ORDER` ("SORTED BY … LAST RE-SORTED … the wheel is cut at RED … move a
slug here only after re-reading the hue").

Cut: the deleted JS colour table's drift story, the #812/#784 WOW re-theming sequence,
Albescent's old 35-declaration `--faction-albescent-*` block, the #2068/#2075/#2078 re-sort
narration, and two retired touching surfaces (`Leaderboard`'s own bar, `Meadow`'s bloom).

## Borderline cuts in `utils/factions.ts` — please spot-check these

The brief says prefer leaving a borderline comment over cutting it. These are the ones I
was least sure about, each with what I kept in its place:

1. **Header, the `ua` #c2541f-vs-#c24a18 drift story.** Replaced with the rule it exists to
   protect: never reintroduce a JS colour table, because a hex literal has no dark half by
   construction (#1269). The specific hexes went; the reason went nowhere.
2. **`wow:` — "WOW still registers only a few manifest surfaces, so the rest fall back to
   `Default*` until #840."** Cut as build history, and it is also a claim about
   `factions/manifest.ts` (a file I am not allowed to touch here), so it is the kind of
   sentence that rots invisibly. If you want a manifest-coverage note it should live in the
   manifest.
3. **`card-notice`/`card-alarm` — "They existed as a single ink until #1449."** Kept the
   re-check instruction ("a site reading `card-notice` for a red meaning is a bug to
   re-check, not a precedent to copy") and dropped the before-picture. If that instruction
   is still an active migration you are tracking, the before-picture may be worth restoring.
4. **`"disc"` — "three feed cards had each written that ramp by hand out of an interpolated
   hex."** Rewritten forward-looking: the shape exists so no surface hand-writes the ramp.
5. **`#694`'s collab-roster cast row at 1.05:1.** Generalised to "fills a surface with the
   faction's muted TEXT ink and prints on it at about 1:1 (#694)". The number lost a decimal
   of precision; the rule did not.
6. **`FACTION_RAINBOW_ORDER`'s ΔE2000 table.** I kept the current adjacency (UA sienna beside
   Ephemerists brass, 31.1 light / 30.3 dark) and the everymen|ua baseline (12.4 / 13.5), and
   dropped only `34.2 / 31.0 for the yellow it replaces` — a measurement of a hue that no
   longer exists. This is the one where a measured number was deleted, so it is worth a look.
7. **`FACTION_RAINBOW_ORDER`'s Albescent paragraph.** "`DefaultFactionsDirectory` worked
   around that by driving its legend off the visible rows; `Leaderboard` and `DefaultPlayers`
   did not, and shipped the leak" → "Keeping the slug out closes that at the source, for every
   consumer at once."
8. **`factionName`'s ADR-0082 section.** "#2409 asked whether the mask should become
   `[REDACTED]` everywhere. The owner ruled it should not" → "The mask is deliberately not
   `[REDACTED]` everywhere (ADR-0082, #2409)". Same ruling, pointer kept, deliberation dropped.
   The "if that reads as an inconsistency, it is a ruled one" guard is untouched.

**Kept on purpose, though it reads like archaeology:** the inline `// 53% is the `88` alpha
suffix the three hand-written copies carried…` in `factionFill`. Cutting it leaves a bare
magic number with no provenance, which felt like the worse trade.

I also checked that every surviving named consumer still exists: `factionStandings`
(`pages/players/playersData.ts`), the filter facet
(`components/ui/FilterBar/factionFacet.tsx`) and the mobile factions directory's stripe bar
(`pages/factions/mobileArchetypes/FactionsDirectoryView.tsx`) are all present. Neither file
names any of the eleven retired surface keys — grepped, so this is not a name sweep and
does not overlap #2758.

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job, run locally against a
fresh `npm ci` in the worktree (vite 8.2.2 / vitest 4.1.11, matching the lockfile):

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 453 files, 9294 passed, 1 skipped
- `npm run build` — clean
- `npm run budget` — identical to `main` (same chunk hash)

The `api-schema` job is not implicated: no route, `response_model` or Pydantic schema is
touched, and no generated file changed.

**Visual QA is outstanding.** I have no browser and did not run a dev server. Nothing here
can change a pixel — the emitted JS is byte-identical — but that is an argument, not an
observation, so it is stated rather than claimed as verified.

## What to eyeball

- The eight numbered borderline cuts above, in `frontend/src/utils/factions.ts`. That is the
  whole ask — everything else is either a live invariant left alone or an unambiguous
  "this used to be X".
- Item 6 in particular: it is the only place a measured number was deleted.
- Item 3: whether the `card-notice` re-check note is a migration you still want the
  before-picture for.
- That the `ponytail:` note at `frontend/src/api/praxis.ts:382` reads unchanged.
- Whether the header's "Never reintroduce a JS colour table" replacement says enough. It is
  the load-bearing rule of the file and it is now four lines instead of seven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
