### PR TITLE
Cut the archaeology in the backend: praxis, task, auth and media

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -82,15 +82,14 @@ _COOKIE_MAX_AGE = 7 * 24 * 60 * 60  # 7 days in seconds
 def _set_session_cookie(response: Response, account_id: int) -> None:
     """Put the JWT on `response`. The one place the session cookie's flags live.
 
-    Extracted when the second provider arrived (#1772) so the cookie flags are
-    stated once, and split from the redirect in #2162 when a second *shape* of
-    successful sign-in appeared — the returning player's confirm answers with a
-    JSON body, not a 302, and must not become a second copy of this block. Every
-    kwarg below is a security decision with a reason recorded against it, and
-    any handler that copies them is another place for one to be quietly dropped
-    — the failure mode being a session cookie that ships without `Secure`, which
-    nothing in the test suite would notice. Not shared with `dev_login`: that
-    seam deliberately sets different flags.
+    The cookie flags are stated once because both shapes of a successful
+    sign-in need them: the OAuth callbacks' 302, and the returning player's
+    confirm, which answers with a JSON body. Every kwarg below is a security
+    decision with a reason recorded against it, and any handler that copies them
+    is another place for one to be quietly dropped — the failure mode being a
+    session cookie that ships without `Secure`, which nothing in the test suite
+    would notice. Not shared with `dev_login`: that seam deliberately sets
+    different flags.
     """
     response.set_cookie(
         key="access_token",
@@ -135,10 +134,10 @@ _PROVIDER_ENDED_IT = coded_error(
 
 #: What a callback carries home when the sign-in went STALE rather than being
 #: refused (#1756) — the player started it, wandered off, and came back after
-#: the session cookie holding the OAuth `state` had expired. Ten minutes since
-#: #1755, which is what turns this from a fourteen-day theoretical into the
-#: ordinary outcome of getting distracted. Built, never raised, exactly as
-#: `_PROVIDER_ENDED_IT` above is.
+#: the session cookie holding the OAuth `state` had expired. That cookie lasts
+#: ten minutes (`main.py`'s `max_age`), which makes this the ordinary outcome of
+#: getting distracted rather than a theoretical one. Built, never raised,
+#: exactly as `_PROVIDER_ENDED_IT` above is.
 _STATE_WENT_STALE = coded_error(
     403, ErrorCode.oauth_state_expired, "That sign-in expired before it finished."
 )
@@ -161,8 +160,8 @@ def _sign_in_failed_redirect(exc: Exception) -> Response:
       unverified-email gate (ADR-0075, #1771). Its code rides along in the
       coded detail, so the catalog can say something specific.
     * :class:`MismatchingStateError` — the sign-in went stale: the ``state``
-      came back after the session cookie carrying it had expired. Split from
-      the case below in #1756 because it is the only one the player did not
+      came back after the session cookie carrying it had expired. Kept apart
+      from the case below (#1756) because it is the only one the player did not
       CHOOSE, and the only one where "try again" is real advice.
     * :class:`OAuthError` — the provider ended it, in practice a declined
       consent screen. Carries no detail of ours, so it borrows
@@ -212,9 +211,9 @@ _RETURNING_PLAYER_PATH = "/start/again"
 #: purpose-built token would have been a second set of cookie flags to get
 #: right and a second expiry to keep honest.
 #:
-#: `main.py` used to justify that ten minutes with "nothing in `backend/` reads
-#: `request.session` except authlib". This is the second reader, and it wants
-#: the same number for its own reasons — see the note there.
+#: This module is the SECOND reader of `request.session` (authlib is the first),
+#: and it wants that same ten minutes for its own reason: an unanswered gate
+#: should lapse, not linger. See the note on `max_age` in `main.py`.
 _PENDING_SIGNUP_KEY = "pending_returning_signup"
 
 

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -1,9 +1,9 @@
 """Media upload pipeline.
 
 Owns the side effects (PIL resize, filename sanitization, filesystem I/O,
-MIME-based MediaType detection) that the character-avatar and praxis-media
-HTTP handlers used to inline. Routers stay thin and commit the session;
-this module never calls ``session.commit`` itself.
+MIME-based MediaType detection) behind the character-avatar and praxis-media
+HTTP handlers. Routers stay thin and commit the session; this module never
+calls ``session.commit`` itself.
 """
 
 import io
@@ -67,11 +67,11 @@ def _sanitize_filename(raw: str) -> str:
 #: serves from the API's own origin, keyed by the type we detected.
 #:
 #: This exists because the served ``Content-Type`` is guessed from the stored
-#: filename (Starlette's ``FileResponse`` calls ``mimetypes.guess_type``), and
-#: the filename used to be the player's, verbatim. Uploading ``pwn.html`` while
-#: declaring ``Content-Type: image/png`` passed ``_detect_media_type`` — which
-#: reads only the declared string — and then came back off ``/media`` as
-#: ``text/html``, executing on the API origin with the session cookie attached.
+#: filename (Starlette's ``FileResponse`` calls ``mimetypes.guess_type``). Take
+#: the player's filename verbatim and uploading ``pwn.html`` while declaring
+#: ``Content-Type: image/png`` passes ``_detect_media_type`` — which reads only
+#: the declared string — and then comes back off ``/media`` as ``text/html``,
+#: executing on the API origin with the session cookie attached.
 #:
 #: ``.svg`` is deliberately absent from the image set: SVG carries script.
 _SAFE_EXTENSIONS: dict[MediaType, frozenset[str]] = {
@@ -263,12 +263,12 @@ def restore_media_to_mount(stored_paths: Iterable[str]) -> int:
 def _unlink_owned(stored_path: str | None, owner_directory: str, owner: str) -> bool:
     """Unlink a stored file that lies inside ``owner_directory``. Best-effort.
 
-    The ownership half of the guard, extracted in #2160 so the two things that
-    erase a file on a player's own instruction — an avatar
-    (:func:`delete_stored_avatar`) and a praxis-media upload
-    (:func:`delete_stored_media`) — share one implementation of it rather than
-    two that can drift. The only difference between the callers is which
-    directory counts as theirs, so that is the only parameter.
+    The ownership half of the guard, shared so the two things that erase a file
+    on a player's own instruction — an avatar (:func:`delete_stored_avatar`) and
+    a praxis-media upload (:func:`delete_stored_media`) — have one
+    implementation of it rather than two that can drift. The only difference
+    between the callers is which directory counts as theirs, so that is the only
+    parameter.
 
     Returns whether a file was actually removed. Failures are logged and
     swallowed: a filesystem problem must never block the state change the caller
@@ -393,14 +393,14 @@ async def process_and_save_avatar(
     ``Character.avatar_url``; the caller commits the session.
 
     **Every upload gets its own directory** (#1565), the same mechanism #1336
-    gave praxis media one function below. The avatar used to live at the fully
-    deterministic ``<id>/avatar/avatar.jpg``, so a re-upload changed the bytes
-    but not the URL — and the ``/media`` mount sends no ``Cache-Control``, so
-    browsers applied heuristic freshness and kept showing the old photo.
-    Uniquifying the *directory* rather than the basename changes the URL, which
-    (unlike a ``?v=`` token) no proxy can strip. The avatar is the one media
-    route that replaces rather than appends, which is why it is the one where a
-    stale cache was guaranteed rather than incidental.
+    gives praxis media one function below. A deterministic path
+    (``<id>/avatar/avatar.jpg``) would change the bytes but not the URL on a
+    re-upload — and the ``/media`` mount sends no ``Cache-Control``, so browsers
+    apply heuristic freshness and keep showing the old photo. Uniquifying the
+    *directory* rather than the basename changes the URL, which no proxy can
+    strip. The avatar is the one media route that replaces rather than appends,
+    which is why it is the one where a stale cache is guaranteed rather than
+    incidental.
 
     ``previous_avatar_url`` is the caller's pre-upload ``Character.avatar_url``;
     it is unlinked *after* the new file is written, so a unique path per upload
@@ -463,10 +463,10 @@ async def process_and_save_media(
     unattached ``MediaItem``; the caller is responsible for ``session.add`` +
     commit.
 
-    **Every upload gets its own directory** (#1336). Uploading ``photo.jpg``
-    twice used to write both to one path: the second overwrote the first while
-    both rows survived, so one row served someone else's bytes — and deleting
-    either row removed the only file, 404-ing the survivor. Uniquifying the
+    **Every upload gets its own directory** (#1336). Without it, uploading
+    ``photo.jpg`` twice writes both to one path: the second overwrites the first
+    while both rows survive, so one row serves someone else's bytes — and
+    deleting either row removes the only file, 404-ing the survivor. Uniquifying the
     *directory* rather than the basename keeps ``file_path``'s last segment
     exactly what the player picked, which the composer renders as the
     attachment caption and as the remove button's accessible name.

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1,7 +1,6 @@
 """Canonical praxis service.
 
 Handles all three praxis types: solo, collab, and duel.
-Replaces the old services/submission.py and services/collaboration.py.
 """
 
 from dataclasses import dataclass
@@ -113,13 +112,13 @@ async def get_praxis(
     this helper ultimately feeds a ``build_praxis_out`` caller. The list
     endpoint uses :func:`list_praxes` which loads only what the card needs.
 
-    The loads here are for the *detail view* only. Deleting a praxis no longer
-    depends on them: the FKs into ``praxis.id`` are ``ON DELETE CASCADE`` and
+    The loads here are for the *detail view* only. Deleting a praxis does not
+    depend on them: the FKs into ``praxis.id`` are ``ON DELETE CASCADE`` and
     the collections are ``passive_deletes=True``, so :func:`delete_praxis`
-    works whether or not a collection is loaded. It is the inverse that used to
-    bite — eagerly loading ``media_items``, which has no ``delete-orphan``
-    cascade, is what made ``session.delete(praxis)`` try to write
-    ``praxis_id = NULL`` into a NOT NULL column. See ``MediaItem.praxis_id``.
+    works whether or not a collection is loaded. The inverse is the trap —
+    eagerly loading ``media_items``, which has no ``delete-orphan`` cascade,
+    makes ``session.delete(praxis)`` try to write ``praxis_id = NULL`` into a
+    NOT NULL column. See ``MediaItem.praxis_id``.
     """
     result = await session.execute(
         select(Praxis)
@@ -324,10 +323,9 @@ async def list_praxes(
     never disagree with the slot count.
 
     ``search`` is a free-text ``ilike`` over the praxis title, its body, the
-    linked task's title, and **any member's** handle / display name. The player
-    axis (#681) reverses #658's deliberate exclusion of the author: the
-    maintainer chose one box that finds content OR a person, accepting that a
-    common word can surface every praxis by anyone whose name contains it.
+    linked task's title, and **any member's** handle / display name. One box
+    finds content OR a person (the player axis, #681), accepting that a common
+    word can surface every praxis by anyone whose name contains it.
     It matches *members* rather than the author so a collab surfaces for each
     participant; a duel is two praxis rows of one member each, so each side
     already surfaces for its own duelist. A leading ``@`` is a sigil and is
@@ -431,14 +429,14 @@ async def list_praxes(
             query = query.where(~account_voted, ~account_member)
 
     # Hidden is excluded unconditionally, and the caller's filter may only narrow
-    # within what is left. This used to sit in an `else`, so *any* value for the
-    # ungated `moderation_status` query param removed the exclusion — and
-    # `?moderation_status=hidden` then selected exactly the content an admin had
-    # taken off the site. An invalid value was worse: `except ValueError: pass`
-    # dropped the caller's filter *and* the default, so a typo also published it.
-    # The detail door (`can_view_praxis`) always refused hidden; only this list
-    # door leaked. Asking for `hidden` now yields an empty page, not a 422 —
-    # a distinguishable error would answer "does hidden content exist here?".
+    # within what is left — it may never widen it. `moderation_status` is an
+    # ungated query param, so an exclusion sitting in that filter's `else` would
+    # let `?moderation_status=hidden` select exactly the content an admin has
+    # taken off the site, and an unparseable value would drop the default with
+    # it. The detail door (`can_view_praxis`) refuses hidden outright; this list
+    # door has to reach the same answer. Asking for `hidden` yields an empty
+    # page, not a 422 — a distinguishable error would answer "does hidden
+    # content exist here?".
     query = query.where(Praxis.moderation_status != ModerationStatus.hidden)
     if moderation_status is not None:
         try:
@@ -446,8 +444,8 @@ async def list_praxes(
                 Praxis.moderation_status == ModerationStatus(moderation_status)
             )
         except ValueError:
-            # Still ignored, as before — but now it only costs the caller their
-            # own filter. It used to also discard the hidden exclusion above.
+            # Ignored: an unparseable value costs the caller their own filter
+            # and nothing else — the hidden exclusion above already applies.
             pass
 
     if task_id is not None:
@@ -541,9 +539,10 @@ def meets_task_level(
 ) -> bool:
     """Whether ``character_level`` clears the task's own level bar (#292).
 
-    The single home for the **task-level** gate — the "level half" that used to
-    be ANDed inline into :func:`is_task_eligible_for_character` and the sign-up
-    predicate. A distinct axis from :func:`~services.faction_service.faction_permits`
+    The single home for the **task-level** gate — the "level half", stated once
+    here rather than ANDed inline into both
+    :func:`is_task_eligible_for_character` and the sign-up predicate. A distinct
+    axis from :func:`~services.faction_service.faction_permits`
     (the faction half, #171) and from the era-config thresholds
     (collab/flag/comment/metatask-apply), which each already sit in their own
     purpose-named predicate and share a single ``era.*`` source for their value.
@@ -681,9 +680,9 @@ async def evaluate_signup(
     Anonymous viewers are never eligible (``allowed=False``, no ``reason``).
 
     ``facts`` is the page-wide precompute (:func:`gather_signup_facts`) a list
-    route passes in so this predicate stops being an N+1 (#1377). It must have
-    been gathered for ``character``; omitting it makes every read here, exactly
-    as before. It changes no answer — only how many queries the answer costs.
+    route passes in so this predicate is not an N+1 (#1377). It must have been
+    gathered for ``character``; omitting it makes every read here instead. It
+    changes no answer — only how many queries the answer costs.
     """
     if character is None:
         return SignupEligibility(allowed=False)
@@ -977,20 +976,16 @@ async def create_praxis(
     return await get_praxis(praxis.id, session)
 
 
-# ``update_praxis`` — the debounced autosave's write — is gone (#1743,
-# ADR-0073). ``praxis.title`` and ``praxis.body_text`` are derived columns now,
-# written only by the praxis's room (``services/praxis_room.py``).
+# There is no praxis text write in this service. ``praxis.title`` and
+# ``praxis.body_text`` are derived columns, written only by the praxis's room
+# (``services/praxis_room.py``, ADR-0073), and ADR-0013's "any member may edit"
+# has its one implementation in the room's door — ``_require_member(praxis,
+# character_id, "edit")`` at connect.
 #
-# ``_require_member(praxis, character_id, "edit")`` is unchanged and still the
-# one implementation of ADR-0013's "any member may edit" — the room's door one
-# calls it at connect, which is where it moved to, not where it was duplicated.
-#
-# A text edit triggers ADR-0012's hard reset again (ADR-0079), through the room
-# rather than through a route: ``services.praxis_room._RoomFlusher.write`` calls
-# ``collab_consensus.on_room_edit`` on the trailing edge of its debounce. #1745's
-# freeze — which existed because a CRDT has no discrete edit event to key on — is
-# gone, and with it #1808's close code. Media edits and Withdraw reach the same
-# rule through ``on_member_edit``.
+# A text edit triggers ADR-0012's hard reset (ADR-0079) through that room rather
+# than through a route: ``services.praxis_room._RoomFlusher.write`` calls
+# ``collab_consensus.on_room_edit`` on the trailing edge of its debounce. Media
+# edits and Withdraw reach the same rule through ``on_member_edit``.
 
 
 async def unsubmit_praxis(
@@ -1055,12 +1050,12 @@ async def unsubmit_praxis(
     await session.flush()
     # No thaw to announce (ADR-0079): the room was never sealed. The document
     # this reopens is a fresh one all the same, seeded on first connect from the
-    # ``body_text`` this praxis published with, because publishing destroyed the
-    # old one (ADR-0073 rule 7, which survives).
+    # ``body_text`` this praxis published with, because publishing destroys the
+    # old one (ADR-0073 rule 7).
 
-    # Recalc *every* member: on a collab, co-authors' scores also counted this
-    # praxis while it was submitted, so all of them must drop (the submit paths
-    # already recalc all members — this fixes the prior single-actor under-recalc).
+    # Recalc *every* member, not just the actor: on a collab, co-authors' scores
+    # also counted this praxis while it was submitted, so all of them must drop
+    # — which is the same set the submit paths recalc.
     # The era is the one the praxis was sealed in — the seal time survives the
     # status flip above, and it is that era's row the points came out of (#1345).
     # The forfeit winner's duel side is the same praxis's era by construction.
@@ -1855,12 +1850,12 @@ async def cancel_invite(
     pending (removing an accepted member is :func:`kick_member`'s job). Deletes
     the invite row (#421).
 
-    Until #1415 this was inviter-only, which made the roster's rescind control
-    appear on some pending rows and not others with nothing on screen to explain
-    why. A collab is co-owned — ADR-0013 gives ``created_by_id`` no powers and
-    any member may already invite (:func:`invite_to_praxis`) and kick
-    (:func:`kick_member`) — so "only the person who typed the name may untype
-    it" was the one asymmetric rule in the set, and it is gone.
+    Any member, not the inviter alone (#1415): a collab is co-owned — ADR-0013
+    gives ``created_by_id`` no powers and any member may already invite
+    (:func:`invite_to_praxis`) and kick (:func:`kick_member`) — so "only the
+    person who typed the name may untype it" would be the one asymmetric rule in
+    the set, and it would make the roster's rescind control appear on some
+    pending rows and not others with nothing on screen to explain why.
 
     The guard that remains is membership: an outsider, including the invitee
     themselves, still gets 403. Declining is the invitee's verb
@@ -2039,8 +2034,8 @@ async def moderate_praxis(
 
     Every transition recalculates each member's stats (#1373). ``hidden`` and
     ``failed`` are unscored (see ``services.character_stats``), so both marking
-    and *un*marking moves the members' scores — and a score that only corrects
-    itself on the author's next unrelated vote is the bug this closes. The
+    and *un*marking moves the members' scores — which must not wait for the
+    author's next unrelated vote to correct itself. The
     recalc is unconditional rather than gated on "did the scored-ness change":
     it is the same handful of queries the vote path already runs per vote, and
     an admin action is rare.

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -478,9 +478,9 @@ class TaskSort(str, Enum):
     browse default — easiest first, richest within a level — and is ascending
     only: there is no level-descending twin.
 
-    Closed is the point. Until #1443 an unrecognised ``sort`` fell through to
-    ``level`` and returned 200, so a typo'd or retired value silently bought a
-    different ordering than the one asked for and nothing surfaced the mistake.
+    Closed is the point (#1443): an unrecognised ``sort`` must not fall through
+    to ``level`` and answer 200, or a typo'd value silently buys a different
+    ordering than the one asked for with nothing to surface the mistake.
     Mirrors :class:`services.praxis.PraxisSort`, whose router raises 422 on the
     same input. An *absent* sort is still legal and still means ``level``.
     """
@@ -514,8 +514,8 @@ def pending_visibility_clause(
 
     Stated once and applied at every door that can return a task — the browse
     (:func:`list_tasks`) and the detail read (:func:`get_task_for_viewer`).
-    Before #1725 the browse was the only door that asked, and task ids are
-    sequential, so guessing the next id read a proposal nobody was cleared for.
+    Both have to ask (#1725): task ids are sequential, so a detail read that
+    does not is an id-guessing door onto a proposal nobody was cleared for.
     A second copy of a rule with an era-configured level *and* an age window is
     how the two drift; hence a clause both callers pass to their query rather
     than a predicate each restates.
@@ -537,7 +537,7 @@ def pending_visibility_clause(
     ``viewer_id`` is the reading character's id, or ``None`` for an anonymous
     caller, and exempts the rows that character *wrote* (#2126). Pass it at every
     door: a carve-out one caller states and another forgets is how the profile
-    and the browse came to disagree about the same row in the first place.
+    and the browse end up disagreeing about the same row.
 
     ponytail: if a NON-admin path ever sends a task back to ``pending``,
     ``created_at`` stops being the proposal clock and this wants a dedicated
@@ -551,8 +551,8 @@ def pending_visibility_clause(
     # proposal from *other players* — which is what the propose-success screen
     # promises in so many words — and its author is not one of them. They wrote
     # the row and were just told it is under review, so there is nothing left to
-    # withhold, and hiding it made "Proposed tasks" answer "none" to the one
-    # person who knows better. This is a per-ROW carve-out, not a level, so it
+    # withhold, and hiding it would make "Proposed tasks" answer "none" to the
+    # one person who knows better. This is a per-ROW carve-out, not a level, so it
     # rides in the clause with the window rather than becoming another boolean.
     own = false() if viewer_id is None else Task.created_by == viewer_id
     if viewer_sees_pending_tasks(viewer_level, is_admin, era):
@@ -651,10 +651,8 @@ async def list_tasks(
 
     ``retired`` and ``pending`` rows are gated the same way, by
     ``era.level_to_see_retired_tasks`` and ``era.level_to_see_pending_tasks``.
-    Both are advertised level unlocks, and both were out of step with what this
-    function did — retired was withheld from nobody, pending from everybody
-    below admin. They are enforced at every door here, and
-    :func:`services.character_capabilities.compute_capabilities` states the same
+    Both are advertised level unlocks, so both are enforced at every door here,
+    and :func:`services.character_capabilities.compute_capabilities` states the same
     two thresholds for the ``/auth/me`` flags the UI gates its filter tabs on, so
     a tab is offered exactly when the query behind it will answer.
 
@@ -676,11 +674,11 @@ async def list_tasks(
 
     ``can_sign_up`` (#1130) narrows the list to the tasks ``viewer`` could claim
     right now — the SQL half of :func:`services.praxis.evaluate_signup`, the
-    single sign-up predicate (ADR-0008). It replaces the old ``level`` filter,
-    which could not express either of the live faction abilities that bend the
-    level bar (WOW's once-a-level jump, Ephemerists' retired-task access) and so
-    made them invisible. Anonymous viewers get ``[]``: ``evaluate_signup``
-    refuses them, so there is no honest list to return.
+    single sign-up predicate (ADR-0008). A plain level filter cannot express
+    either of the faction abilities that bend the level bar (WOW's once-a-level
+    jump, Ephemerists' retired-task access), which is why the whole predicate is
+    restated rather than the level alone. Anonymous viewers get ``[]``:
+    ``evaluate_signup`` refuses them, so there is no honest list to return.
 
     ``faction`` is a list of slugs matched as a union (#1364), so the browse
     filter can hold several factions at once; an empty list is no filter.
@@ -713,27 +711,21 @@ async def list_tasks(
 
     # The two status gates, stated once and applied at BOTH doors — an explicit
     # `?status=X` and the `?status=all` catch-all reach the same rows, and a gate
-    # written at only one of them is not a gate. That is exactly how the pending
-    # queue leaked before #1672: the promise lived on a branch an explicit status
-    # routed around.
+    # written at only one of them is not a gate: a promise living on a branch an
+    # explicit status routes around is how the pending queue leaks.
     #
-    # `retired` is the level-2 "the archive opens" unlock (`era_1.py`,
-    # `progression.json`). It had NO enforcement at all — anonymous callers could
-    # read the whole archive — so the ability was advertised and never withheld,
-    # and `services.era.retire_all_tasks`'s "the board un-hides itself as players
-    # climb" was describing a gate that did not exist. It is a level gate, so
+    # `retired` is the "the archive opens" level unlock (`era_1.py`,
+    # `progression.json`), which `services.era.retire_all_tasks` describes as
+    # "the board un-hides itself as players climb". It is a level gate, so
     # `skip_level_check` is what bypasses it.
     #
-    # `pending` is the level-3 "watch proposals move through review" unlock, and
+    # `pending` is the "watch proposals move through review" level unlock, and
     # is the moderation queue, so `is_admin` bypasses it rather than
     # `skip_level_check` (the two answer different questions — see the parameter
-    # docs). #1672 made it admin-ONLY, which silently killed the level-3 reward
-    # while `/auth/me` went on advertising it; the level is restored here as a
-    # deliberate decision, NOT as a revert of that fix. What #1672 closed was
-    # "anyone, signed in or not". Level 3 is 170 points of investment and an
-    # account, so pre-moderation proposals are still withheld from the anonymous
-    # web — but they ARE now visible to established players before an admin has
-    # ruled on them, and that is the trade being made.
+    # docs). The trade it makes is deliberate: reaching that level takes an
+    # account and real investment, so pre-moderation proposals stay withheld
+    # from the anonymous web while established players see them before an admin
+    # has ruled on them.
     # The faction clause is not an exception to the archive gate, it is the only
     # way the perk means anything: a faction the era lets work retired tasks
     # cannot be forbidden from finding them. Without it an Ephemerist below level
@@ -754,9 +746,9 @@ async def list_tasks(
     # a clause: every branch of the status logic below is downstream of this
     # `where`, so there is no door it can be forgotten at. That is the failure
     # this file already carries a comment about — a gate written at only one door
-    # is not a gate — and the redundant `status == "all"` restatement of the
-    # level rule is gone because this clause subsumes it. `get_task_for_viewer`
-    # passes the same clause for the same reason (#1725).
+    # is not a gate — and it is why no branch below restates the level rule for
+    # itself. `get_task_for_viewer` passes the same clause for the same reason
+    # (#1725).
     query = query.where(
         pending_visibility_clause(
             viewer_level, is_admin, era, viewer_id=viewer.id if viewer else None
@@ -789,14 +781,15 @@ async def list_tasks(
             # proposals, reached by knowing their id, and hiding a proposer's
             # accepted work from newcomers reads as a bug rather than a reward.
             #
-            # "All viewers" was one viewer too many (#2126): on your OWN profile
-            # this clause hid the proposal you had just written, so the section
-            # headed "Proposed tasks" said "No proposed tasks yet" and no amount
-            # of waiting fixed it — unlike the review window, this one never
-            # expired. Skipping it for the owner does not widen what anyone ELSE
-            # sees here; the shared pending clause above is still the only thing
-            # that decides whether a pending row is reachable at all, and it
-            # exempts the same author for the same reason.
+            # "All viewers" is one viewer too many (#2126): applied to your OWN
+            # profile this clause hides the proposal you have just written, so
+            # the section headed "Proposed tasks" answers "No proposed tasks
+            # yet" and no amount of waiting fixes it — unlike the review window,
+            # this one never expires. Skipping it for the owner does not widen
+            # what anyone ELSE sees here; the shared pending clause above is
+            # still the only thing that decides whether a pending row is
+            # reachable at all, and it exempts the same author for the same
+            # reason.
             if viewer is None or viewer.id != created_by:
                 query = query.where(Task.status != TaskStatus.pending)
         else:
@@ -866,9 +859,9 @@ async def list_tasks(
         if viewer.faction_slug not in era.allow_praxis_on_pending_task_factions:
             query = query.where(Task.status != TaskStatus.pending)
         # Gate 5 is the exclude_character_id clause below — reused, not rewritten.
-        # This is the ONLY place the viewer becomes that default (#2264). The
-        # route used to do it first, for every caller and regardless of
-        # `can_sign_up`, which made a faction's task count depend on who was
+        # This is the ONLY place the viewer becomes that default (#2264).
+        # Defaulting it in the route instead, for every caller and regardless of
+        # `can_sign_up`, would make a faction's task count depend on who was
         # reading it. Armed here it is scoped to the question that actually asks
         # it: "which tasks could I claim right now" — and a task you are already
         # working is not one of them, which is #1229's browse behaviour intact.
@@ -927,8 +920,8 @@ async def list_tasks(
         query = query.where(Task.primary_faction_slug.notin_(hidden_slugs))
 
     # Exclude tasks the character has already started or completed (via praxis membership).
-    # `era` is threaded rather than defaulted: since #1359 this subquery reads the era's
-    # Double Dipper set, so letting it fall back to CURRENT_ERA would answer with the LIVE
+    # `era` is threaded rather than defaulted: this subquery reads the era's
+    # Double Dipper set (#1359), so letting it fall back to CURRENT_ERA would answer with the LIVE
     # era's abilities for a caller that passed a different one — the drift the `era`
     # parameter exists to prevent.
     if exclude_character_id is not None:


### PR DESCRIPTION
Closes #2759

Part of #2533. Cuts the archaeology and keeps the why in the four backend files
the epic named. **Comment- and docstring-only** — no statement moved.

## Re-measured on `origin/main` at `b215b8ab` (after #2753)

The issue's figures were taken at `8c1021d4`, and its `#`-line counts exclude
docstrings while the epic's include them. Both, measured with `tokenize` +
`ast`:

| file | total | `#` lines | docstring lines | prose |
|---|---|---|---|---|
| `backend/services/praxis.py` | 2,143 | 210 | 628 | 838 |
| `backend/services/task.py` | 949 | 156 | 258 | 414 |
| `backend/routers/auth.py` | 594 | 138 | 131 | 269 |
| `backend/services/media.py` | 519 | 55 | 203 | 258 |

The bulk is docstrings, and the ruling protects most of what a docstring is
for, so this is a narrow sweep: **133 insertions, 146 deletions** across four
files, mostly rewriting a past-tense clause into the hazard it describes rather
than deleting outright. Where a paragraph explained a guard, the guard's reason
stays and only its date does not.

## The seam, and how it was verified

There is no behaviour to go red on: the change is output-neutral and there is
no TypeScript. **The seam is the diff itself**, so it was checked directly
rather than by a test:

For each file, the `origin/main` version and the working version were tokenized
with `tokenize`, COMMENT tokens and docstring STRING tokens dropped, and the
remaining `(type, string)` streams compared — identical for all four. The same
files were parsed with `ast`, docstrings stripped from every module / class /
function body, and `ast.dump(..., include_attributes=False)` compared —
identical for all four. A moved, edited or reflowed statement changes both; a
rewritten comment changes neither.

That check ran after every file. It is not committed: it is a one-off scaffold
for this diff, and a permanent "comments did not change code" test in `backend/`
would be scaffolding for later, which the epic's guard already covers per-PR.

## What was cut, by file

**`services/media.py`** — the `MEDIA_ROOT`/quarantine deployment note and the
`delete_stored_avatar` ownership argument are untouched; both are live
production invariants. Cut: "used to inline" in the module docstring; "the
filename used to be the player's, verbatim" (the `pwn.html` attack it explains
is kept, restated in the present); "extracted in #2160"; and the two
"it used to overwrite / the avatar used to live at" paragraphs, each rewritten
as the hazard the unique-directory rule currently prevents. The `?v=` token
that no one is proposing goes with them.

**`services/task.py`** — the pending/retired block stopped narrating how each
gate came to exist (#1443, #1672, #1725, #2126, #2264) and now states what the
gates do and why. Two hardcoded level numbers and a point threshold went with
that prose: those values live in `backend/eras/era_1.py`, and a comment is not
allowed to restate them. Every gate, `ponytail:` note and ADR reference stays.

**`services/praxis.py`** — the largest single cut is the `update_praxis`
tombstone: fourteen lines narrating a function that no longer exists, plus
#1745's freeze and #1808's close code which are also gone, become five lines
stating what *does* exist (the room owns the text write; a text edit reaches
ADR-0012's reset through `_RoomFlusher.write`). Also: "Replaces the old
services/submission.py and services/collaboration.py" (neither file exists);
the hidden-praxis exclusion's incident report, restated as the hazard — its
whole security argument is kept, including why `hidden` answers an empty page
and not a 422; and the `cancel_invite` "until #1415 this was inviter-only"
paragraph. The `passive_deletes`/`delete-orphan` trap on `get_praxis` is kept
and moved to the present tense — it is still live.

**`routers/auth.py`** — see below. No route handler's docstring was edited at
all: a route docstring is its OpenAPI `description`, so touching one would
demand a regenerated `openapi.json` + `schema.d.ts` pair and put a contract
change inside a comment-only PR.

## Every `routers/auth.py` comment cut (the file to spot-check)

Four hunks, no more. Nothing describing a guard, a token's scope, a cookie
flag or an ordering constraint was removed.

1. **`_set_session_cookie` docstring** — cut "Extracted when the second
   provider arrived (#1772) so the cookie flags are stated once, and split from
   the redirect in #2162 when a second *shape* of successful sign-in appeared".
   Kept, restated: there are two shapes of successful sign-in (the callbacks'
   302 and the returning player's JSON confirm), which is why the flags live
   once here. **Kept verbatim:** the whole "every kwarg is a security decision
   … a session cookie that ships without `Secure`, which nothing in the test
   suite would notice" passage, and the `dev_login` exclusion.

2. **`_STATE_WENT_STALE`** — cut "Ten minutes since #1755, which is what turns
   this from a fourteen-day theoretical into the ordinary outcome". Kept: the
   ten minutes and its effect, now pointing at `main.py`'s `max_age` where the
   number actually lives instead of at the issue that changed it.

3. **`_sign_in_failed_redirect` docstring, `MismatchingStateError` bullet** —
   "Split from the case below in #1756" → "Kept apart from the case below
   (#1756)". The reason (it is the only failure the player did not choose) is
   unchanged, and **the ORDERED-dispatch/MRO paragraph below it is untouched**
   — that is the load-bearing one.

4. **`_PENDING_SIGNUP_KEY`** — cut "`main.py` used to justify that ten minutes
   with 'nothing in `backend/` reads `request.session` except authlib'."
   That sentence is stale twice over: `main.py` no longer says it, and this
   module is the second reader. Replaced with the live fact — second reader,
   same ten minutes, its own reason — still pointing at `main.py`'s note.

**Deliberately kept in `auth.py`**, despite being old prose: the Discord
trailing-slash argument, the `name`-stays-a-bare-string rationale, the
"token used here and discarded" notes on both legs, the `email_verified`
forwarded-not-enforced argument on both legs, the Discord absent-vs-null email
analysis, the snowflake-id keying note, `_LOGIN_PARAM`'s collision argument,
and every route docstring.

## Verification

- `pytest --cov=. --cov-report=term-missing --cov-fail-under=92` from
  `/backend` — **1671 passed**, coverage **94.20%** (gate 92%). Run against a
  dedicated `wz2759_test` database, not the shared `worldzero_test`.
- `ruff` finding counts per file are **byte-identical to `origin/main`**:
  `services/praxis.py` E501 21 / I001 1, `services/task.py` E501 6 / I001 1,
  `routers/auth.py` E501 1 / I001 1, `services/media.py` E501 4 / I001 1.
  `tests/unit/test_ruff_clean.py` passes, so `RUFF_FINDING_TOTAL` is untouched
  in either direction — which is the point: a comment-only PR that moves the
  ratchet has changed code.
- `api-schema` is unaffected: no route signature, `response_model`, Pydantic
  schema or route docstring was touched, so `openapi.json` and
  `schema.d.ts` do not move.
- Every ADR, issue, module, function and test named in a surviving comment was
  checked to exist — including `alembic/versions/0004_onboarding_cross_faction.py`,
  `_RoomFlusher.write`, `scripts/sweep_orphan_media.py` and
  `tests/integration/test_returning_player_gate.py`.

**Visual QA is outstanding** — this agent has no browser. Nothing here can
reach a pixel (no route, schema or response body changed), so the exposure is
nil, but it is not claimed as verified.

## What to eyeball

- **`routers/auth.py`, the four hunks above.** The rule was "when in doubt,
  keep" — check that nothing describing what a guard prevents left with the
  date attached to it.
- **`services/task.py`'s pending/retired block.** The old prose named "level-2",
  "level-3" and "170 points" in a comment; those are `era_1.py`'s to state.
  Confirm the replacement reads correctly for an era that sets them elsewhere.
- **`services/praxis.py`'s `update_praxis` tombstone** (now ten lines above
  `unsubmit_praxis`). It kept every fact that is still true and dropped the
  narrative; confirm nothing you still want to find by grep left with it —
  `#1745` and `#1808` are the two issue numbers that are no longer named
  anywhere in the file.
- **`services/media.py`'s `_SAFE_EXTENSIONS` docblock.** The `pwn.html`
  attack is now stated as a present-tense consequence of dropping the
  allow-list rather than as something that happened. Confirm it still reads as
  a reason not to touch the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
