### PR TITLE
Sweep twelve retired surface names from 52 files, and guard the register shut

### DIFF
--- a/frontend/src/__tests__/retiredSurfaces.test.ts
+++ b/frontend/src/__tests__/retiredSurfaces.test.ts
@@ -1,0 +1,99 @@
+/**
+ * A retired SURFACE stays retired — no shipped file names one, in code or prose.
+ *
+ * Twelve manifest surfaces have been collapsed away since #1090, and each one
+ * left a paragraph behind: what it was, which issue took it, which skins went
+ * with it, and why it is not coming back. #2533 measured ninety-six such
+ * references across the tree, in files whose CODE never mentions the surface at
+ * all. That is a retirement register, maintained by hand, in the docblocks of
+ * whichever module happened to be adjacent. #2758 cut it. This stops it growing
+ * back: the thirteenth retirement adds a name here instead of a paragraph
+ * somewhere else.
+ *
+ * WHY THIS ONE READS RAW SOURCE, WHERE ITS NEIGHBOURS STRIP COMMENTS
+ * -----------------------------------------------------------------
+ * Every other guard on `sourceScan` — `retiredIdentities`, the ink rules, the
+ * inline-animation sweep — calls `readStripped`, because it is hunting a draw
+ * call and the docblock above it legitimately names the thing being banned.
+ * This rule is the exact inverse. Not one of the ninety-six references was
+ * code; the register IS comments. A comment-stripping scan here would police
+ * nothing and pass on the day it was written.
+ *
+ * WHY IT IS A SIBLING OF `retiredIdentities.test.ts` AND NOT A ROW IN IT
+ * ----------------------------------------------------------------------
+ * That file's header says "a fourth retirement is a row, not a file", and a
+ * retired surface looks like a fourth retirement. It is not: its table runs one
+ * `describe.each` over `readStripped`, and the paragraph above is the whole
+ * reason this rule exists. Adding a row would mean adding a per-row reader knob
+ * to a three-row table so that one row could invert the premise its header
+ * states ("Only a draw call counts"). Two files, two premises.
+ *
+ * SCOPE is `sourceFiles()`'s defaults, unmodified: `frontend/src`, TS/TSX,
+ * `__tests__` excluded. That default exists for the documented reason — a guard
+ * asks about SHIPPED code — and here it also settles a conflict for free.
+ * `duelSealFormFactor.test.tsx` and `profileFormFactor.test.tsx` each hold a
+ * live `expect(SURFACE_KEYS).not.toContain(...)`, which is #2533's own
+ * prescription ("if a rule must survive its surface, it belongs in an ADR or a
+ * test name"). A guard that flagged those would be arguing with the ruling that
+ * authorised it. `docs/` is out of scope too: ADRs are supposed to be
+ * historical, and `docs/kit-structure.md` teaches a live rule through a
+ * retired surface as its example.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+import { SURFACE_KEYS } from '../factions/manifest'
+import { sourceFiles, toRelative } from '../test/sourceScan'
+
+/**
+ * Surface keys that once existed in `SURFACE_KEYS` and no longer do.
+ *
+ * ponytail: a hand-maintained denylist, because the repo keeps no list of
+ * retired keys — `SURFACE_KEYS` holds only the live ones, and a key's removal
+ * leaves nothing behind to derive this from. The upgrade path is one line: a
+ * thirteenth retirement appends its name. If that ever stops being cheap,
+ * `manifest.ts` grows a `RETIRED_SURFACE_KEYS` export and this reads it.
+ *
+ * `mobileFieldDesk` is deliberately absent — it is LIVE in `SURFACE_KEYS`, and
+ * a pattern matching `mobile*` broadly would take it out. So would
+ * `factionCard`, which #2533's table lists but which was never a surface key.
+ */
+const RETIRED_SURFACES = [
+  'duelRail',
+  'mobileDuelRail',
+  'mobileDuelSeal',
+  'mobileTaskCard',
+  'mobilePraxisCard',
+  'mobileEditPraxis',
+  'mobileProfile',
+  'mobileFactionPage',
+  'mobileFactionsDirectory',
+  'mobilePlayersDirectory',
+  'mobileCreateCharacter',
+  'mobileEditCharacter',
+] as const
+
+/** `path:line names \`key\`` for every hit, so a failure points at the line. */
+const namings = (path: string): string[] =>
+  readFileSync(path, 'utf8')
+    .split('\n')
+    .flatMap((line, index) =>
+      RETIRED_SURFACES.filter((key) => line.includes(key)).map(
+        (key) => `${toRelative(path)}:${index + 1} names \`${key}\``,
+      ),
+    )
+
+describe('a retired surface stays retired (#2758)', () => {
+  it('no shipped source file names one', () => {
+    // No "the sweep saw a non-empty tree" assertion here: this walks exactly
+    // `sourceFiles()`'s default set, and `retiredIdentities.test.ts` already
+    // asserts that set is >100 files for the whole harness.
+    expect(sourceFiles().flatMap(namings)).toEqual([])
+  })
+
+  it('bans nothing that is still a live surface', () => {
+    // Guards the denylist itself: un-retire a key and this fails before the
+    // sweep above starts reporting every honest use of it.
+    expect(RETIRED_SURFACES.filter((key) => (SURFACE_KEYS as readonly string[]).includes(key))).toEqual([])
+  })
+})

--- a/frontend/src/components/duel/CovenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenDuelSealConfirm.tsx
@@ -1,10 +1,9 @@
 /**
  * Cozy Coven duel seal-confirm (#720, re-dressed by #1209) — the ward, asking
- * you to be sure. ONE responsive component since #1313 retired the
- * `mobileDuelSeal` twin: `DuelSealSheet` hangs this ward in a centred card on a
- * laptop and full-bleed on a phone, and the phone keeps the opponent's spine
- * rather than the twin's rounded top edge and grab handle — a bottom sheet you
- * cannot drag has no edge to advertise.
+ * you to be sure. ONE responsive component: `DuelSealSheet` hangs this ward in
+ * a centred card on a laptop and full-bleed on a phone, and the phone keeps the
+ * opponent's spine rather than a rounded top edge and grab handle — a bottom
+ * sheet you cannot drag has no edge to advertise.
  *
  * The Default dialog's content, re-hung on the coven's own paper: a slip band
  * across the head carrying the coven's witch hat and a braided thread, the

--- a/frontend/src/components/duel/DuelSealConfirm.tsx
+++ b/frontend/src/components/duel/DuelSealConfirm.tsx
@@ -22,9 +22,8 @@
  *
  * The Default skin below is the only one this issue ships; the manifest seam
  * exists so per-faction skins (#720 for Coven, one issue per faction after) are a
- * `duelSeal` row and nothing else — ONE responsive component per faction since
- * #1313 retired the `mobileDuelSeal` twin. Skins own the FRAME only — every
- * figure and every branch lives in `duel/shared.tsx`.
+ * `duelSeal` row and nothing else — ONE responsive component per faction. Skins
+ * own the FRAME only — every figure and every branch lives in `duel/shared.tsx`.
  *
  * TWO MODES, ONE SURFACE (#751)
  * -----------------------------
@@ -174,9 +173,8 @@ export function DefaultDuelSealConfirm({
  * composer's own archetype is chosen the same way), not the opponent's — the
  * dialog is a piece of the composer, and only its tokens are foreign.
  *
- * ONE dispatch, both form factors (#1313). This used to branch on
- * `useFormFactor()` through a parallel `mobileDuelSeal` surface; the branch is
- * `DuelSealSheet`'s now, and the slug is the whole story here.
+ * ONE dispatch, both form factors: the form-factor branch is `DuelSealSheet`'s,
+ * so the slug is the whole story here.
  */
 export default function DuelSealConfirm({
   taskFactionSlug,

--- a/frontend/src/components/duel/EphemeristsDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EphemeristsDuelSealConfirm.tsx
@@ -4,12 +4,11 @@
  * an incised small-caps masthead over the brass/nile double rule, and an italic
  * hand for the body.
  *
- * ONE responsive component since #1313 retired the `mobileDuelSeal` twin.
- * `DuelSealSheet` holds the plate in a centred card on a laptop and lets it fill
- * the screen on a phone. The papyrus and the opponent's edge are `ground`; the
- * hairline that frames a floating plate is `card`. The twin's centred masthead
- * went with it — the incised caps read left-aligned at both widths, as they do
- * on every other Ephemerists surface.
+ * ONE responsive component. `DuelSealSheet` holds the plate in a centred card on
+ * a laptop and lets it fill the screen on a phone. The papyrus and the
+ * opponent's edge are `ground`; the hairline that frames a floating plate is
+ * `card`. The masthead is never centred — the incised caps read left-aligned at
+ * both widths, as they do on every other Ephemerists surface.
  *
  * TWO MODES, ONE FILE (#751). `mode` is `'submit'` or `'forfeit'` and every
  * string for both comes from `useDuelSealCopy` — heading, body, note, confirm

--- a/frontend/src/components/duel/EverymenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EverymenDuelSealConfirm.tsx
@@ -1,12 +1,11 @@
 /**
  * Everymen duel seal-confirm (#721) — the design's `EvDuelDialog.dc.html`.
  *
- * ONE responsive component since #1313 retired the `mobileDuelSeal` twin. The
- * form is the same document at both widths: `DuelSealSheet` serves it as a
- * bordered card over a scrim on a laptop and full-bleed on a phone, and the
- * masthead / scrolling middle / pinned action band the twin introduced survive
- * here as plain flex regions — they cost nothing on an auto-height card and are
- * what puts the actions under a thumb on a phone.
+ * ONE responsive component. The form is the same document at both widths:
+ * `DuelSealSheet` serves it as a bordered card over a scrim on a laptop and
+ * full-bleed on a phone, and the masthead / scrolling middle / pinned action
+ * band are plain flex regions — they cost nothing on an auto-height card and
+ * are what puts the actions under a thumb on a phone.
  *
  * Everymen files everything as paperwork, so the one irreversible beat in the
  * duel becomes a stamped form served over the composer: red masthead with a

--- a/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
@@ -1,11 +1,10 @@
 /**
  * Singularity duel seal-confirm (#723).
  *
- * ONE responsive component since #1313 retired the `mobileDuelSeal` twin.
- * `DuelSealSheet` centres this terminal in a card on a laptop and lets it BE the
- * screen on a phone — which is exactly what the twin did, and its whole reason
- * to exist. The glass, the scanlines and the opponent's spine are `ground`; the
- * small radius and the hairline frame are `card`.
+ * ONE responsive component. `DuelSealSheet` centres this terminal in a card on a
+ * laptop and lets it BE the screen on a phone. The glass, the scanlines and the
+ * opponent's spine are `ground`; the small radius and the hairline frame are
+ * `card`.
  *
  * The Default dialog's content re-hung inside the faction's cold green-on-black
  * terminal: near-black ground lifted by two large soft radial glows (phosphor

--- a/frontend/src/components/duel/SnideDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideDuelSealConfirm.tsx
@@ -4,12 +4,11 @@
  * acid-green border, the opponent's colour on a fat left edge, and a hard offset
  * shadow tinted hot pink. Square corners throughout.
  *
- * ONE responsive component since #1313 retired the `mobileDuelSeal` twin.
- * `DuelSealSheet` centres this clipping over a scrim on a laptop and lets it
- * take the whole screen on a phone. The halftone and the opponent's fat edge are
- * `ground` and survive full-bleed; the acid frame and the pink offset shadow are
- * `card`, because a hard 6px shadow and a border at the viewport edge are a card
- * pretending it still floats.
+ * ONE responsive component. `DuelSealSheet` centres this clipping over a scrim
+ * on a laptop and lets it take the whole screen on a phone. The halftone and the
+ * opponent's fat edge are `ground` and survive full-bleed; the acid frame and
+ * the pink offset shadow are `card`, because a hard 6px shadow and a border at
+ * the viewport edge are a card pretending it still floats.
  *
  * Pure frame. `StakesTiles` computes the win/lose figures from `useGameConfig()`
  * and the VIEWER's own faction — which is why a Snide duelist correctly reads a

--- a/frontend/src/components/duel/UaDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/UaDuelSealConfirm.tsx
@@ -2,12 +2,11 @@
  * University of Asthmatics duel seal-confirm (#725) — the breath before the
  * stroke.
  *
- * ONE responsive component since #1313 retired the `mobileDuelSeal` twin.
- * `DuelSealSheet` serves this sheet as a centred card on a laptop and full-bleed
- * on a phone; the masthead, the opponent bar, the scrolling middle and the
- * pinned action band are flex regions that behave as the twin did on a phone and
- * as the card always did on a laptop. The twin's extra inner "practice sheet"
- * plate around the body went with it — one sheet, not a sheet on a sheet.
+ * ONE responsive component. `DuelSealSheet` serves this sheet as a centred card
+ * on a laptop and full-bleed on a phone; the masthead, the opponent bar, the
+ * scrolling middle and the pinned action band are flex regions that carry both
+ * widths. There is no inner "practice sheet" plate around the body — one sheet,
+ * not a sheet on a sheet.
  *
  * UA is the last core faction to get a duel dialog, and it arrives in the
  * practice's own register rather than the mock's. `UaDuel.dc.html` /

--- a/frontend/src/components/duel/WowDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowDuelSealConfirm.tsx
@@ -1,14 +1,12 @@
 /**
  * Warriors of Whimsy duel seal-confirm (#895) — THE LISTS SEAL.
  *
- * ONE responsive component since #1313 retired the `mobileDuelSeal` twin.
- * `DuelSealSheet` frames the enclosure in gold on a plum scrim at laptop width
- * and lets it take the whole screen on a phone — "there is nothing for it to
- * float above at 375px" was the twin's own reasoning, and it is now the chassis
- * rule for all eight sheets. The kit's 46px seal buttons survive the collapse
- * through `phoneClassName`; the twin's pinned action bar does not, because the
- * band under it was drawn for a phone and the actions sit inside the enclosure
- * on the kit's laptop sheet.
+ * ONE responsive component. `DuelSealSheet` frames the enclosure in gold on a
+ * plum scrim at laptop width and lets it take the whole screen on a phone —
+ * there is nothing for it to float above at 375px, and that is the chassis rule
+ * for all eight sheets. The kit's 46px seal buttons survive the collapse through
+ * `phoneClassName`; there is no pinned action bar, because the actions sit
+ * inside the enclosure on the kit's laptop sheet.
  *
  * The kit's `16-duel-seal.html`: a gold-framed enclosure on a plum scrim, the
  * checkered barrier along its top edge, the crest set beside the title, the

--- a/frontend/src/components/duel/__tests__/duelSealFormFactor.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSealFormFactor.test.tsx
@@ -1,17 +1,12 @@
 /**
  * The seam: `DuelSealConfirm`'s dispatch × `useFormFactor()` (#1313).
  *
- * Before this issue the seal was TWO dispatches out of one dispatcher — the
- * `formFactor === 'mobile'` branch picked through a `mobileDuelSeal` manifest
- * surface and the wide branch through `duelSeal`, so every faction shipped two
- * near-identical files whose only real difference was the positioning shell
- * (centred card + scrim vs. full-bleed sheet).
+ * There is ONE responsive component per faction and ONE surface. What this file
+ * pins is the surface a caller reaches, not the internals of any skin:
  *
- * After the collapse there is ONE responsive component per faction and ONE
- * surface. What this file pins is the surface a caller reaches, not the
- * internals of any skin:
- *
- *  - the `mobileDuelSeal` surface is gone from `SURFACE_KEYS`;
+ *  - the retired phone surface stays out of `SURFACE_KEYS` — the one assertion
+ *    below that names it, because a test name is where a rule outlives its
+ *    surface (epic #2533);
  *  - a phone reaches the SAME component the laptop does, per faction;
  *  - the eight sheets stay eight — no skin quietly falls through to Default on
  *    one form factor, which is the failure mode a shared chassis invites;

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -7,26 +7,20 @@
  * (plus its Default fallback) at BOTH form factors, so the faction skins that
  * follow Coven fail here the moment one of them loses a slot.
  *
- * IT USED TO WALK TWO REGISTRIES (#1313). `duelSeal` and `mobileDuelSeal` held
- * a pair of near-identical files per faction; the seal is one responsive
- * component now and `DuelSealSheet` owns the only form-factor branch. The
- * coverage did not shrink with the registry: every skin is rendered at both
- * widths here instead, which is the same number of assertions against half the
- * files — and it now also catches a phone shell that drops a slot, which two
- * separate component lists could never have caught for a faction that only
- * registered one.
+ * ONE REGISTRY, BOTH WIDTHS (#1313). The seal is one responsive component and
+ * `DuelSealSheet` owns the only form-factor branch, so a skin is rendered here
+ * at both widths rather than once per registry — which is also what catches a
+ * phone shell that drops a slot, something two separate component lists could
+ * never catch for a faction that only registered one.
  *
  * The seal skins mount the real `StakesTiles` / `RaceRoster` / `SealActions`, so
  * the assertion is on the anchors those slots leave behind. The game config is
  * mocked; this is about composition, not transport.
  *
- * THE RAIL HALF OF THIS FILE IS GONE (#1090). `duelRail` / `mobileDuelRail` were
- * not merely de-registered like `praxisDetail` was — the surfaces themselves
- * were retired, because the duel is no longer dispatched at all: it is a card
- * inside the praxis-detail archetype (`pages/praxisDetail/DuelCard.tsx`), and
- * its readings are guarded by `praxisDetail/__tests__/duelCard.test.tsx`. There
- * is no registry left to walk, which is why this is a deletion and not a
- * zero-entry loop.
+ * THE SEAL IS THE ONLY DUEL REGISTRY. The duel itself is not dispatched (#1090):
+ * it is a card inside the praxis-detail archetype
+ * (`pages/praxisDetail/DuelCard.tsx`), and its readings are guarded by
+ * `praxisDetail/__tests__/duelCard.test.tsx`.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect, vi } from 'vitest'

--- a/frontend/src/components/duel/wowLists.tsx
+++ b/frontend/src/components/duel/wowLists.tsx
@@ -5,9 +5,7 @@
  * a checkered barrier rail, a rosette for the rider who comes from elsewhere,
  * and a ribbon that goes home with the loser. This module holds the pieces that
  * would otherwise be drawn twice — the token names, the barrier band, the
- * rosette, and (until #1909) the seal's voice resolver. It shipped serving FOUR surfaces; the
- * two `*DuelRail` skins went with the rail in #1090 and the phone seal went with
- * the `mobileDuelSeal` SURFACE in #1313, so the consumer is now
+ * rosette, and (until #1909) the seal's voice resolver. Its one consumer is
  * `WowDuelSealConfirm` — one responsive component, both form factors.
  *
  * WHY THE ROSETTE IS THE ONLY PLACE THE OPPONENT'S COLOUR LANDS

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -77,9 +77,8 @@ describe('one score per card (#888, closes #663)', () => {
     expect(body).not.toMatch(/\d/)
   })
 
-  // `MobileVoteFooter` had the identical assertion against an identical
-  // `VoteUI` call. It is gone with the `mobilePraxisCard` surface (ADR-0067);
-  // the desktop case above is what a phone renders now.
+  // One case, not two: the praxis card is one responsive component (ADR-0067),
+  // so the `VoteUI` call asserted above is the one a phone renders.
 
   /**
    * #1444 — and no score at all on a praxis that banked none.
@@ -301,10 +300,8 @@ describe('the applied-metatask seal stack (#932)', () => {
     expect(text(html)).not.toContain('Sealmark')
   })
 
-  // The two `MobilePraxisBody` cases are gone with the `mobilePraxisCard`
-  // surface (ADR-0067). They asserted the same seal placement against a second
-  // body that composed the same `MetataskSeal` from the same field; `PraxisBody`
-  // above is now the only anatomy, on both form factors.
+  // `PraxisBody` above is the only anatomy, on both form factors (ADR-0067), so
+  // seal placement is pinned once rather than once per form factor.
 })
 
 describe('the faction font pair (#888)', () => {

--- a/frontend/src/components/praxisCard/__tests__/votedByMarker.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/votedByMarker.test.tsx
@@ -33,7 +33,6 @@ describe('voted-by marker', () => {
     ).toBe('')
   })
 
-  // The two `MobileVotedByMarker` cases are gone with the `mobilePraxisCard`
-  // surface (ADR-0067). The marker read the same `voted_by_name` field through
-  // the same catalog key; the desktop cases above now pin both form factors.
+  // The praxis card is one responsive component (ADR-0067), so the cases above
+  // pin both form factors — there is no second marker to assert against.
 })

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -27,8 +27,7 @@ import { useFormFactor } from "../../hooks/useFormFactor";
  * tokens stay declared: other surfaces still paint with them.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
- * different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * different card. There is no mobile twin — this file serves both form factors.
  *
  * All colour via `--faction-coven-slip-*`; light/dark flips through the
  * `[data-theme="dark"]` cascade, never a ternary. Three of the design's inks are

--- a/frontend/src/components/taskCard/DefaultTaskCard.tsx
+++ b/frontend/src/components/taskCard/DefaultTaskCard.tsx
@@ -27,8 +27,7 @@ import DefaultPointsRing from "../factionMarks/DefaultPointsRing";
  * Prime everything else.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not
- * a different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * a different card. There is no mobile twin — this file serves both form factors.
  *
  * All colour through the ROLE MAP (#2672) — `--na-task-card-paper` / `-ink` /
  * `-quiet` / `-accent`, spread on the `<article>` and each read with today's

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -52,8 +52,7 @@ import {
  * left are the `--faction-ephemerists-card-*` aliases in `index.css`.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
- * different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * different card. There is no mobile twin — this file serves both form factors.
  *
  * All colour via `--faction-ephemerists-plate-*`; light/dark flips through the
  * `[data-theme="dark"]` cascade, never a ternary. `-brass` is a rule colour and

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -27,8 +27,7 @@ import { factionRoleVars } from "../../utils/factionRoles";
  * POINTS hero → title → brief → in-progress → CTA.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
- * different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * different card. There is no mobile twin — this file serves both form factors.
  *
  * v3 ornament (#2034): the seal is now the SHARED {@link PointsRoundel} rather
  * than a second circle drawn here, the poster rays converge on the sheet's

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -40,8 +40,7 @@ import { factionRoleVars } from "../../utils/factionRoles";
  * ternary here; both halves live in index.css.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
- * different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * different card. There is no mobile twin — this file serves both form factors.
  *
  * Motion is entirely index.css's (#911 retired component-injected `<style>`):
  * the design names `sgBlink`/`sgSweep`/`sgPulse` and defines none of them, and

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -37,8 +37,7 @@ import { useGroundIsBusy } from "../backdrop/BackdropContext";
  * forty-character title.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
- * different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * different card. There is no mobile twin — this file serves both form factors.
  *
  * All colour via `--faction-snide-note-*`, which unlike the faction's older
  * ink-dark families FLIPS under `[data-theme="dark"]`: the clipping is a sheet

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -24,8 +24,7 @@ import { UA_DISPLAY, UA_EYEBROW, UA_TEXT, UaEnsoScore } from "../factionMarks/ua
  * left margin is gone; the gilt-sandwich salon it replaced is still gone.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
- * different card. There is no mobile twin: ADR-0056 was accepted and the
- * `mobileTaskCard` surface retired, so this file serves both form factors.
+ * different card. There is no mobile twin — this file serves both form factors.
  *
  * TWO MARKS, AND THE COUNT IS THE POINT (WORLD_ZERO_STYLE §6). The design draws
  * the ensō three times — in the eyebrow, behind the score, and again on the

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -33,11 +33,9 @@ import { BalloonBunch, Bunting, Zig } from "../factionMarks/wowOrnament";
  * pink spell slip.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set.
- * There is no mobile twin: ADR-0056 was accepted and the `mobileTaskCard`
- * surface retired, so this file serves both form factors. The balloons used to
- * drop on mobile because the corner they were tucked into is the corner a 340px
- * card does not have; #2032 moves them into the sign-up row, which both form
- * factors do have, so the size set no longer forks over them.
+ * There is no mobile twin — this file serves both form factors. The balloons sit
+ * in the sign-up row (#2032), which both form factors have, rather than in a
+ * corner a 340px card does not have, so the size set does not fork over them.
  *
  * THE ORNAMENT PASS (#2032, task cards v3 phase 2). Four changes, all of them
  * dress on anatomy #2029 and #2030 already fixed:

--- a/frontend/src/factions/__tests__/archetypeReachability.test.ts
+++ b/frontend/src/factions/__tests__/archetypeReachability.test.ts
@@ -6,8 +6,8 @@
  * collapse deletes manifest rows — and `surfaceDispatch.test.ts` catches that,
  * because its BESPOKE table flips red when a slug de-registers.
  *
- * What nothing catches is the FILE. De-registering `mobileEditPraxis` removes the
- * manifest line; it does not remove `WowEditPraxisMobile.tsx`. The orphan still
+ * What nothing catches is the FILE. De-registering a skin removes the manifest
+ * line; it does not remove `WowEditPraxisMobile.tsx`. The orphan still
  * compiles, still passes `tsc`, still passes lint, and still passes every render
  * test — because no test renders a component no dispatcher can reach. It is
  * invisible until someone greps for a component name and finds two.

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -76,24 +76,20 @@ const CORE_SIX = ['coven', 'snide', 'ephemerists', 'singularity', 'everymen', 'u
 // registration freeze was reversed with the praxis-detail epic (#1151), which
 // changes whether a row may exist, not what shape it takes.
 //
-// FIVE MOBILE ROWS ARE ABSENT BY DECISION, not by oversight, and all five used
-// to exist. There is no mobile task-card row (ADR-0056, surface retired by
-// #1044), no mobile task-detail row (ADR-0058, #1068), no mobile praxis-detail
-// row (ADR-0061 + epic #1085, #1089), since #1181 no `mobileEditPraxis` row
-// (ADR-0065), and since #1314 no `mobileFactionPage` row (ADR-0078): each
-// verdict accepted one responsive component per faction, so task cards partition
-// on `taskCard` alone, task detail on `taskDetail` alone, praxis detail on
-// `praxisDetail` alone, the composer on `editPraxis` alone and faction detail on
-// `factionBody` alone, for both form factors. Re-adding any of the five means
-// re-adding the surface, which those ADRs call drift rather than a rollback.
+// THERE ARE NO PHONE-ONLY ROWS, by decision. ADR-0056 (task card), ADR-0058
+// (task detail), ADR-0061 (praxis detail), ADR-0065 (the composer) and ADR-0078
+// (faction detail) each accepted one responsive component per faction, so task
+// cards partition on `taskCard` alone, task detail on `taskDetail` alone, praxis
+// detail on `praxisDetail` alone, the composer on `editPraxis` alone and faction
+// detail on `factionBody` alone, for both form factors. Adding a phone-only row
+// means adding a phone-only surface, which those ADRs call drift rather than a
+// rollback.
 // Note what that buys albescent: its single `taskDetail` registration now covers
 // the phone too, and it never needs a second row it would have had to stay out
 // of.
 //
-// THE `editPraxis` ROW IS NEW (#1181). It exists because retiring
-// `mobileEditPraxis` also retired the only test that proved composer dispatch at
-// all (`mobileArchetypes/__tests__/dispatch.test.tsx`), and the composer should
-// not be the one big surface with no row here.
+// THE `editPraxis` ROW (#1181) exists because the composer should not be the one
+// big surface with no row here.
 //
 // It said it would grow no further, and #2505 grew it by one. The claim was
 // about SKINS — all seven of those are registered and epic #1179 rebuilt them in
@@ -154,22 +150,15 @@ const BESPOKE: Record<string, string[]> = {
   // not say is WHICH of "na draws nothing to grab" and "nobody got to it" was
   // meant, and it turned out to be neither.
   createCharacter: ['ephemerists', 'snide', 'wow', 'ua', 'everymen', 'coven', 'singularity', 'albescent'],
-  // Was `mobileFactionPage` with this exact slug list until ADR-0078 collapsed
-  // faction detail to one responsive component per faction. Same move the
-  // praxis-card row made below: the row follows the surviving surface rather
-  // than dying with the retired one. `factionBody` is what a phone renders now,
-  // and it carries the same seven registrations the phone twin did — which is
-  // why the deleted twin was drift rather than a second design.
+  // `factionBody` is what a phone renders too (ADR-0078): faction detail is one
+  // responsive component per faction, so this one row covers both widths.
   // `albescent` appended by #2504 — a WRAPPER over `DefaultFactionBody`, not an
   // eighth skin: it forwards the whole na body and hands its plates one ornament
   // node. The row is here because the dispatch is real, not because the dress is.
   factionBody: [...CORE_SIX, 'wow', 'albescent'],
   mobileFieldDesk: [...CORE_SIX, 'wow', 'albescent'],
-  // Was `mobilePraxisCard` with this exact slug list until ADR-0067 collapsed
-  // the praxis card to one responsive component per faction. The row moved to
-  // the surviving surface rather than dying with the retired one: all eight
-  // slugs register `praxisCard`, and that card is now what a phone renders, so
-  // this proves the same dispatch it always did on the only card left.
+  // `praxisCard` is what a phone renders too (ADR-0067): the praxis card is one
+  // responsive component per faction, and all eight slugs register it.
   praxisCard: [...CORE_SIX, 'wow', 'albescent'],
 }
 
@@ -200,9 +189,7 @@ for (const [surface, bespoke] of Object.entries(BESPOKE)) {
 
 // The bar, derived so a new core surface raises it automatically: every surface
 // the reference core factions all skin — `duelSeal` included, since all five
-// register it. It used to exclude `mobileProfile` (only wow ever filled it) and
-// `mobileDuelSeal`; #1319 and #1313 retired both surfaces outright, so there is
-// nothing left to exclude. The crested profile is the mobile branch of
+// register it. Nothing is excluded: the crested profile is the mobile branch of
 // `profileBody` and every seal is one responsive component behind `duelSeal`,
 // and every reference faction already skins both.
 const REFERENCE_FACTIONS = ['snide', 'ephemerists', 'singularity', 'everymen', 'ua']

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -338,8 +338,8 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * read their own words while typing — legibility beats the tell, so the tell
    * moved to the sheet's edge, where it owes no ratio.
    *
-   * One responsive component, both widths (ADR-0065 §2): there is no
-   * `mobileEditPraxis` surface to register a second row on.
+   * One responsive component, both widths (ADR-0065 §2): this one row covers
+   * the phone too.
    */
   editPraxis: () => AlbescentEditPraxis,
 

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -149,9 +149,8 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * the same "NA + drift" shape as the praxis cards above. It renders
    * `DefaultTaskCard` and washes two flourishes over it (a drifting spectrum
    * edge, a breathing aurora), so the design's whole delta from unaffiliated is
-   * MOTION. Note there is no `mobileTaskCard` sibling: the v2 task card is one
-   * responsive component (ADR-0056), so this single row covers both form
-   * factors.
+   * MOTION. The v2 task card is one responsive component (ADR-0056), so this
+   * single row covers both form factors.
    */
   taskCard: () => AlbescentTaskCard,
 

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -16,10 +16,9 @@
  * #895 adds THE LISTS — the duel seal on both form factors, dressed as a tourney
  * joust (gold-framed enclosure, checkered barrier, the opponent held as a
  * rosette ring, a ribbon for the loser). The shared vocabulary lives in
- * `components/duel/wowLists.tsx`. It shipped as FOUR surfaces; the two rail
- * skins went with the `duelRail` / `mobileDuelRail` surfaces themselves in
- * #1090, when the duel became a card inside praxis detail rather than a
- * dispatched surface of its own.
+ * `components/duel/wowLists.tsx`. The duel itself is a card inside praxis
+ * detail, not a dispatched surface of its own (#1090), so the seal is all the
+ * kit registers for it.
  *
  * #835 adds the DESKTOP edit-praxis composer — "The Squire's Writ", the kit's
  * one form surface — and #836 its phone twin: the same writ dress on the settled
@@ -84,10 +83,9 @@
  * order and its join flow when #1611 derived that body, so nothing was left in
  * the phone skin that the body did not say better.)
  * The shared vocabulary lives in `components/factionMarks/wowMobile.tsx`.
- * `mobileCreateCharacter`, `mobileEditCharacter`, `mobileFactionsDirectory` and
- * `mobilePlayersDirectory` were unclaimed here on purpose — nothing in the kit
- * described them — and since no other faction claimed them either, the four
- * slots were retired outright; those pages render their `Default*` skin.
+ * Edit-character, the factions directory and the players directory are NOT
+ * skinned here on purpose — nothing in the kit describes them — and no other
+ * faction skins them either, so those pages render their `Default*` skin.
  *
  * Override-only, like every manifest — WOW simply overrides all of it now: it
  * claims every key in `SURFACE_KEYS`, and `surfaceDispatch.test.ts` holds it
@@ -161,10 +159,8 @@ export const WOW_MANIFEST: FactionManifest = {
   profileBody: () => WowProfileBody,
   factionSelectCard: () => WowSelectCard,
 
-  // #895 — the lists: the duel seal, both form factors from ONE component since
-  // #1313 retired the `mobileDuelSeal` twin (the Lists sheet is responsive now,
-  // not deleted). Its rail skins went with the `duelRail` / `mobileDuelRail`
-  // SURFACES in #1090, not with WOW.
+  // #895 — the lists: the duel seal, both form factors from ONE responsive
+  // component.
   duelSeal: () => WowDuelSealConfirm,
 
   // #901 — the field pavilion: WOW's general MOBILE surfaces. The kit drew ONE
@@ -181,7 +177,6 @@ export const WOW_MANIFEST: FactionManifest = {
   // no design was needed, because the DECREE task card and the WRIT composer
   // carry the register between them: the decree's head (barber ribbon, pennants,
   // balloons) over the writ's chassis (gilt sheet, parchment fields, one zigzag,
-  // the full-bleed gold cast band). ONE responsive component; the
-  // `mobileCreateCharacter` slot retired with #901's note above and stays retired.
+  // the full-bleed gold cast band). ONE responsive component.
   createCharacter: () => WowCreateCharacter,
 }

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -414,10 +414,9 @@ export default function CharacterProfile() {
     onSignup: user ? handleSignup : undefined,
   };
 
-  // ONE dispatch, both form factors (#1319). The page used to branch on
-  // `useFormFactor()` through a `mobileProfile` surface only WOW ever filled,
-  // which meant every OTHER faction wore the na spectrum skin on a phone. Each
-  // profile body is responsive now, so the slug dispatch is the whole story.
+  // ONE dispatch, both form factors (#1319). Every profile body is responsive, so
+  // the slug dispatch is the whole story — no faction can end up wearing the na
+  // spectrum skin on a phone.
   return (
     <>
       {/* The only thing a failed sign-up can be answered with: the success path

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -23,9 +23,8 @@
  * of #418/#636).
  *
  * ONE ARCHETYPE PER FACTION AT BOTH WIDTHS. There is no form factor to branch on
- * here: each archetype calls `useFormFactor()` itself, so the mobile-only
- * `mobileCreateCharacter` slot stays retired and the phone column is a branch
- * INSIDE `DefaultCreateCharacter` rather than a second file beside it.
+ * here: each archetype calls `useFormFactor()` itself, so the phone column is a
+ * branch INSIDE `DefaultCreateCharacter` rather than a second file beside it.
  */
 import { useCreateCharacter } from './characterPaths/useCreateCharacter'
 import { resolveVariant } from '../utils/factionDispatch'

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -82,8 +82,8 @@ export default function EditCharacter() {
   const state = useEditCharacter()
   const formFactor = useFormFactor()
 
-  // No faction ever claimed `mobileEditCharacter`, so the slot and its dispatch
-  // are gone: mobile renders the Default skin directly.
+  // No faction skins this page on the phone, so mobile renders the Default skin
+  // directly rather than dispatching on the slug.
   if (formFactor === 'mobile') return <DefaultEditCharacter state={state} />
 
   return <DesktopEditCharacter state={state} />

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -74,8 +74,7 @@ export default function EditPraxis() {
   }
 
   const slug = state.task?.primary_faction_slug ?? null;
-  // One archetype at both widths (ADR-0065 §2). The `mobileEditPraxis` surface
-  // and its eight files were retired in #1181: each archetype calls
+  // One archetype at both widths (ADR-0065 §2): each archetype calls
   // `useFormFactor()` internally for its own size set, so the dispatcher has no
   // form factor to branch on.
   // ONE component per slug, drawing whichever stage the praxis is in.

--- a/frontend/src/pages/FactionDetail.tsx
+++ b/frontend/src/pages/FactionDetail.tsx
@@ -16,14 +16,13 @@ import { useFactionDetail } from "./factionDetail/useFactionDetail";
  * recent-praxis) dispatches the same way, through `factionBody`, falling through
  * to DefaultFactionBody.
  *
- * ONE COMPONENT PER FACTION, AT BOTH WIDTHS (#1314 / ADR-0078). There used to be
- * a `formFactor === "mobile"` early return here that dispatched a whole second
- * registry, `mobileFactionPage`. Those eight skins did not hold a narrow
- * rendering of the body below — they held DIFFERENT COPY, generic chrome in a
- * faction dress, so every faction's manifesto, spotlight and bespoke join flow
- * simply did not exist on a phone. The surface is retired and cannot be
- * re-registered; a skin that needs the viewport reads `useFormFactor()` itself,
- * the way `DefaultFactionBody` does for its pinned action band.
+ * ONE COMPONENT PER FACTION, AT BOTH WIDTHS (#1314 / ADR-0078). There is no
+ * `formFactor === "mobile"` early return here, and a second phone registry is
+ * not the shape to reach for: a parallel set of skins forks the COPY and not
+ * just the width, and every faction's manifesto, spotlight and bespoke join flow
+ * stops existing on a phone. A skin that needs the viewport reads
+ * `useFormFactor()` itself, the way `DefaultFactionBody` does for its pinned
+ * action band.
  *
  * Data + the page backdrop come from useFactionDetail; this component only
  * routes the loading / error / not-found guards and the two dispatches.

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -35,8 +35,8 @@ export default function Factions() {
   // instead of re-requesting it. Both surfaces read this one state.
   const state = useFactionsDirectory()
 
-  // No faction ever claimed `mobileFactionsDirectory`, so the slot and its
-  // dispatch are gone: mobile renders the Default skin directly.
+  // No faction skins the directory on the phone, so mobile renders the Default
+  // skin directly rather than dispatching on the slug.
   if (formFactor === 'mobile') return <DefaultFactionsDirectory state={state} />
 
   return <DesktopFactions state={state} />

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -66,16 +66,15 @@ export default function PraxisDetail() {
     surfaceMap('praxisDetail'),
     state.praxis.task_faction_slug,
   )
-  // NOTHING IS MOUNTED AROUND THE ARCHETYPE ANY MORE. Two pieces of chrome used
-  // to sit here and both moved INTO the page layout:
+  // NOTHING IS MOUNTED AROUND THE ARCHETYPE. The two pieces of chrome that could
+  // sit here both live INSIDE the page layout instead:
   //
   //  - The comment thread. ADR-0061 made comments the page's third region — the
   //    archetype mounts its own via the shared `PraxisDetailComments` slot,
   //    which carries the `visible` gate so a skin cannot forget it (amending
   //    ADR-0006's "neutral chrome below every archetype").
-  //  - The duel cross-link rail (#313/#718). #1090 replaced it with the design's
-  //    duel card in the archetype's aside, and retired the `duelRail` /
-  //    `mobileDuelRail` surfaces with it. A faction now dresses the duel by
-  //    dressing its `praxisDetail`, not by registering a second skin.
+  //  - The duel cross-link (#313/#718, #1090) — the design's duel card, drawn in
+  //    the archetype's own aside. A faction dresses the duel by dressing its
+  //    `praxisDetail`, not by registering a second skin.
   return <Archetype state={state} />
 }

--- a/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
@@ -3,13 +3,9 @@
  * fallback every unregistered slug lands on (#2346).
  *
  * ONE RESPONSIVE COMPONENT, no mobile twin. It reads `useFormFactor()` itself,
- * the way `editPraxis` and the profile bodies do, and the two branches below are
- * the two skins that used to be two files: the desktop two-column form that
- * lived in `pages/CreateCharacter.tsx`, and the first-run phone column that
- * lived in `characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx` (#516).
- * That second file is gone rather than left beside this one — a second mobile
- * path is exactly what the `mobileCreateCharacter` retirement note in
- * `factions/manifest.ts` forbids re-creating.
+ * the way `editPraxis` and the profile bodies do, and both branches below — the
+ * desktop two-column form and the first-run phone column (#516) — are in this
+ * one file. A second mobile path is the thing not to re-create.
  *
  * THE DEFAULT IS THE `na` KIT, NOT UA AND NOT THE VIEWER'S FACTION. An empty
  * `factionSlug` means born unaffiliated and renders this, full stop. The

--- a/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
@@ -31,8 +31,7 @@
  * ## One responsive component, no mobile twin
  *
  * `useComposerSizes()` reads `useFormFactor()` and picks the size set; there is
- * one tree at two widths and no second file — which is also why the retired
- * `mobileCreateCharacter` slot stays retired. Every fixed number here is
+ * one tree at two widths and no second file. Every fixed number here is
  * ornament geometry, never a layout grid (SPEC-faction-ui-profile §1a).
  *
  * ## Copy — none of its own

--- a/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
@@ -1,18 +1,11 @@
 /**
  * The seam: `FactionProfileBody` × `useFormFactor()` (#1319).
  *
- * Before this issue the character profile was TWO dispatches — a
- * `formFactor === 'mobile'` branch in `CharacterProfile.tsx` picking through a
- * `mobileProfile` manifest surface, and `FactionProfileBody` picking through
- * `profileBody` for desktop. The na and WOW mobile skins were reachable only
- * from the first branch, so `FactionProfileBody` itself rendered the desktop
- * markup on a phone.
- *
- * After the collapse (ADR-0056 / ADR-0067 shape) there is ONE responsive
- * component per faction and `FactionProfileBody` is the only dispatcher: a
- * phone-width viewport must reach the SAME two shipped mobile designs it always
- * did, through the `profileBody` surface. That is what this file pins — the
- * surface a caller uses, not the internals of either skin.
+ * There is ONE responsive component per faction (the ADR-0056 / ADR-0067 shape)
+ * and `FactionProfileBody` is the only dispatcher: a phone-width viewport must
+ * reach the two shipped mobile designs through the `profileBody` surface. That
+ * is what this file pins — the surface a caller uses, not the internals of
+ * either skin.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -12,11 +12,9 @@
  * the kept proposed-tasks and friend/foe features.
  *
  * ONE RESPONSIVE COMPONENT (#1319, the ADR-0056 / ADR-0058 / ADR-0067 shape).
- * The phone skin used to be a separate file on a `mobileProfile` manifest
- * surface (`mobileArchetypes/DefaultProfile`, #517, redrawn for #969); that
- * surface is retired and its markup is the `MobileProfile` branch below,
- * unchanged. `useFormFactor()` is read once, at the exported component, which
- * is the only dispatcher — the same call site `<Faction>TaskDetail` uses.
+ * The phone face is the `MobileProfile` branch below, in this file (#517,
+ * redrawn for #969). `useFormFactor()` is read once, at the exported component,
+ * which is the only dispatcher — the same call site `<Faction>TaskDetail` uses.
  *
  * The two branches are separate components rather than one body full of
  * ternaries because they are not one layout at two sizes: the phone stacks a

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -25,15 +25,13 @@
  * `--faction-wow-*` token and both themes come from the cascade.
  *
  * ONE RESPONSIVE COMPONENT (#1319, the ADR-0056 / ADR-0058 / ADR-0067 shape).
- * THE FIELD PAVILION — the phone face, #901 — used to be a separate file on the
- * `mobileProfile` manifest surface (`mobileArchetypes/WowProfile`). That surface
- * is retired and the pavilion is the `MobileProfile` branch below, unchanged:
- * the crested header wash and checker from the kit's one phone screen
- * (`components/factionMarks/wowMobile`), over this archetype's own three marks — burnt-
- * gold figures on near-white plates, honours struck on gilt lozenges, and every
- * row led by a plum rule. Those marks are what make the two form factors read as
- * one page, and they are why the merge folds the pavilion in rather than letting
- * `ProfileSkin` squeeze onto a phone.
+ * THE FIELD PAVILION — the phone face, #901 — is the `MobileProfile` branch
+ * below, in this file: the crested header wash and checker from the kit's one
+ * phone screen (`components/factionMarks/wowMobile`), over this archetype's own
+ * three marks — burnt-gold figures on near-white plates, honours struck on gilt
+ * lozenges, and every row led by a plum rule. Those marks are what make the two
+ * form factors read as one page, and they are why the pavilion is folded in
+ * rather than letting `ProfileSkin` squeeze onto a phone.
  *
  * The pavilion keeps its two deviations from the kit, both of which the desktop
  * page makes too: the CREST does not appear (this is a knight's page, not the

--- a/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx
@@ -90,8 +90,8 @@
  * either would put the society back in the spectrum and un-hide it (ADR-0083 §1,
  * ADR-0027, WORLD_ZERO_STYLE §3).
  *
- * One responsive component, both widths (ADR-0065 §2) — there is no
- * `mobileEditPraxis` surface, so this one row covers the phone too.
+ * One responsive component, both widths (ADR-0065 §2) — no mobile twin, so
+ * this one file covers the phone too.
  */
 import DefaultEditPraxis from "./DefaultEditPraxis";
 import { type EditPraxisState } from "../useEditPraxis";

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -41,8 +41,7 @@
  * ## One responsive component, no mobile twin (ADR-0065 §2)
  *
  * `useComposerSizes()` picks the size set; there is one tree at two widths and
- * no fixed-px grid anywhere below (SPEC-faction-ui-profile §1a). The
- * `mobileEditPraxis` twin and its manifest surface were retired in #1181.
+ * no fixed-px grid anywhere below (SPEC-faction-ui-profile §1a).
  *
  * ## Colour and motion
  *

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -40,11 +40,8 @@
  * ## One responsive component, no mobile twin (ADR-0065 §2)
  *
  * `useComposerSizes()` picks the size set; there is one tree at two widths.
- * `pages/editPraxis/mobileArchetypes/` and the `mobileEditPraxis` manifest
- * surface were retired outright with this issue — superseded by a committed
- * design, not held dormant (ADR-0063's terms, which §2 adopts over
- * ADR-0056/0058's). Mobile stacks with flow; there is no fixed-px grid anywhere
- * below (SPEC-faction-ui-profile §1a).
+ * Mobile stacks with flow; there is no fixed-px grid anywhere below
+ * (SPEC-faction-ui-profile §1a).
  *
  * ## Copy and dress
  *

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -21,10 +21,9 @@
  * ## One responsive component, no mobile twin (ADR-0065 §2)
  *
  * `useComposerSizes()` picks the size set and `sizes.isMobile` picks the
- * conditional ornament; there is one tree at two widths.
- * `mobileArchetypes/EphemeristsEditPraxis.tsx` went with the `mobileEditPraxis`
- * surface in #1181. Nothing below is a fixed-px layout grid
- * (SPEC-faction-ui-profile §1a) — every fixed number here is ornament geometry.
+ * conditional ornament; there is one tree at two widths. Nothing below is a
+ * fixed-px layout grid (SPEC-faction-ui-profile §1a) — every fixed number here
+ * is ornament geometry.
  *
  * ## Copy — none of its own (ADR-0065 §3)
  *

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -18,10 +18,9 @@
  *
  * ## One responsive component, no mobile twin (ADR-0065 §2)
  *
- * `useComposerSizes()` picks the size set; there is one tree at two widths, and
- * `pages/editPraxis/mobileArchetypes/EverymenEditPraxis` went with the
- * `mobileEditPraxis` surface in #1181. Mobile stacks with flow — no fixed-px
- * grid anywhere below (SPEC-faction-ui-profile §1a).
+ * `useComposerSizes()` picks the size set; there is one tree at two widths.
+ * Mobile stacks with flow — no fixed-px grid anywhere below
+ * (SPEC-faction-ui-profile §1a).
  *
  * ## Copy is the shared neutral set (ADR-0065 §3)
  *

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -23,8 +23,7 @@
  * `useComposerSizes()` picks the size set and `sizes.isMobile` gates conditional
  * ornament — one tree at two widths. The phone stacks with flow (the task slip
  * turns its column, the mode keys wrap); there is no fixed-px grid anywhere
- * below (SPEC-faction-ui-profile §1a). `pages/editPraxis/mobileArchetypes/` and
- * the `mobileEditPraxis` surface were retired outright in #1181.
+ * below (SPEC-faction-ui-profile §1a).
  *
  * ## Copy (ADR-0065 §3)
  *

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -23,9 +23,9 @@
  * reference implementation of the same page; the diff between the two files is
  * the whole of WOW's identity on this surface.
  *
- * One responsive component: `useComposerSizes()` picks the size set and
- * `sizes.isMobile` scales the two corner ornaments. There is no mobile twin —
- * `mobileEditPraxis` retired outright with #1181 (ADR-0065 §2).
+ * One responsive component (ADR-0065 §2): `useComposerSizes()` picks the size
+ * set and `sizes.isMobile` scales the two corner ornaments. There is no mobile
+ * twin.
  *
  * ## Copy — none of its own (ADR-0065 §3)
  *

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -1,13 +1,10 @@
 /**
  * Composer dispatch and the mode picker, at BOTH form factors (#1181).
  *
- * Successor to `mobileArchetypes/__tests__/dispatch.test.tsx` and
- * `modePicker.test.tsx`, which went with the `mobileEditPraxis` surface ADR-0065
- * retired. Those two proved the form-factor BRANCH (phone → the mobile twin,
- * desktop → the archetype) and the mode gates as they reached the phone skin.
- * There is no branch left to prove, so what replaces them is the claim the
- * collapse actually makes: **the same archetype answers at both widths, and the
- * shared ModePicker's gates behave identically there.**
+ * There is no form-factor BRANCH to prove (ADR-0065), so what this file proves
+ * instead is the claim one responsive composer makes: **the same archetype
+ * answers at both widths, and the shared ModePicker's gates behave identically
+ * there.**
  *
  * Rendered through `<EditPraxis />` rather than the archetype directly, so the
  * dispatcher is in the path — a regression that re-introduced a form-factor

--- a/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
@@ -3,12 +3,10 @@
  *
  * ONE registry, walked at BOTH form factors — the shape ADR-0069 landed for the
  * duel seal and called strictly stronger than two lists. It is stronger here for
- * a reason specific to this surface: `mobileFactionPage` and `factionBody` were
- * two registries holding two DIFFERENT content sets, so a per-registry test
- * could pass on both while a phone showed generic chrome in a faction dress. On
- * a phone, every faction read `mobile.topMembers` / `mobile.recentPraxis` and
- * exactly one bespoke key (its eyebrow); the manifesto, the spotlight and the
- * faction's own join flow did not exist there at all.
+ * a reason specific to this surface: two registries would hold two DIFFERENT
+ * content sets, so a per-registry test can pass on both while a phone shows
+ * generic chrome in a faction dress — no manifesto, no spotlight, and none of
+ * the faction's own join flow.
  *
  * So the load-bearing assertion is `speaks in its own voice`: at BOTH widths the
  * page must contain the faction's own section headings. That is the whole point

--- a/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
+++ b/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
@@ -231,12 +231,9 @@ describe('mobile factions directory — states (#743)', () => {
 })
 
 /**
- * The container above that view. Carried here from
- * `factionDetail/__tests__/mobileArchetypeSlots.test.tsx`, which walked the
- * retired `mobileFactionPage` registry and kept this one directory assertion as
- * a passenger (#1314). It is thin on purpose — effects never fire in this
- * harness, so the container only ever reaches its loading state — but it is the
- * one thing proving the container wires the view's chrome up at all.
+ * The container above that view. It is thin on purpose — effects never fire in
+ * this harness, so the container only ever reaches its loading state — but it is
+ * the one thing proving the container wires the view's chrome up at all.
  */
 describe('mobile factions directory — the container', () => {
   it('renders the heading and the unaffiliated banner', () => {

--- a/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
@@ -8,9 +8,8 @@ import FactionsDirectoryView from './FactionsDirectoryView'
 const NA_SLUG = 'na'
 
 /**
- * The MOBILE factions-directory skin. It was one of two candidates for a
- * `mobileFactionsDirectory` surface, but no faction ever registered a bespoke
- * directory, so the slot was retired and Factions renders this directly.
+ * The MOBILE factions-directory skin. No faction skins the directory, so
+ * `Factions` renders this one directly rather than dispatching on a slug.
  *
  * It used to self-fetch. That made `/factions` remount its data every time the
  * viewport crossed 767px, because the fetch sat below the form-factor switch;

--- a/frontend/src/pages/praxes/MobilePraxisFeed.tsx
+++ b/frontend/src/pages/praxes/MobilePraxisFeed.tsx
@@ -19,8 +19,7 @@ import type { PraxesFeedState } from './usePraxes'
  * now an explicit choice on both surfaces (or the chip's ×).
  *
  * The results list renders the SHARED `<PraxisCard>` (ADR-0067) — the same
- * component the desktop feed renders. There is no mobile twin: the
- * `mobilePraxisCard` surface and its ten cards are deleted, so a faction's
+ * component the desktop feed renders. There is no mobile twin: a faction's
  * praxis card is one responsive file under `components/praxisCard/desktop/`.
  *
  * The list is a WRAPPING FLEX ROW, not a column, because that is what the

--- a/frontend/src/pages/praxisDetail/DuelCard.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCard.tsx
@@ -1,7 +1,7 @@
 /**
  * The praxis-detail duel card (#1090, epic #1085; design project bebdf7c7,
  * `Unaffiliated Praxis Detail.dc.html`). Successor to `DuelCrossLink` and the
- * twelve `*DuelRail` skins.
+ * duel rail.
  *
  * ## Detail narrates OUTCOMES, not the run-up
  *

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -21,10 +21,7 @@ import ProposeTaskLink from '../ProposeTaskLink'
  * ADR-0056 turned on. Each faction card sizes itself for the phone via
  * `useFormFactor()`, and mobile inherits the inline signup CTA (gated on
  * `can_sign_up` exactly as desktop is), the in-progress count and the
- * multiplier badge, none of which the old mobile-only cards had. That was
- * shipped as a reversible experiment; the owner's hands-on verdict accepted it,
- * so the `mobileTaskCard` dispatcher and its nine cards are now deleted and
- * there is no second task-card implementation to revert to.
+ * multiplier badge. There is one task-card implementation, not a phone twin.
  */
 export default function DefaultTasks({ state }: { state: TasksState }) {
   const { t } = useTranslation('tasks')

--- a/frontend/src/utils/__tests__/praxisModeLabel.test.tsx
+++ b/frontend/src/utils/__tests__/praxisModeLabel.test.tsx
@@ -96,8 +96,6 @@ describe("card mode chips gate on duel presence (#992)", () => {
     ).toBe("");
   });
 
-  // The mobile twins of these two cases are gone with the `mobilePraxisCard`
-  // surface (ADR-0067): `MobileModeChip` was a second chip drawing the same
-  // `isDuelPraxis` verdict, and the desktop cases above now cover both form
-  // factors because `PraxisModeChip` is what a phone renders too.
+  // `PraxisModeChip` is what a phone renders too (ADR-0067), so the cases above
+  // cover both form factors and there is no second chip to twin them against.
 });


### PR DESCRIPTION
Closes #2758

Part of #2533. Comment-only across 52 files, plus one new guard test.

## The seam

**The guard is the seam, and it can genuinely go red.** `frontend/src/__tests__/retiredSurfaces.test.ts`
was written first and committed red (`cf8e7fb2`) against the un-swept tree — **55 findings in 33
shipped files**. The six sweep commits after it are what turn it green.

## Half 1 — the sweep

Re-measured on `origin/main` after #2768 landed: **72 occurrences in 51 files**, including
`mobileTaskCard` on ten lines the issue body did not count. The distinction was made per line:

- **Archaeology → cut.** *"#1313 retired the `mobileDuelSeal` twin. Its rail skins went with the
  `duelRail` surfaces themselves."*
- **A live rule citing a dead surface → rewritten, not deleted.** Every one of these survives with
  the clause naming the retired surface removed:
  - "ONE RESPONSIVE COMPONENT (ADR-0056) — no mobile twin, this file serves both form factors" (8 task cards)
  - "Skins own the FRAME only — every figure and every branch lives in `duel/shared.tsx`"
  - "one tree at two widths, no fixed-px grid anywhere below (SPEC-faction-ui-profile §1a)" (7 composers)
  - "a faction dresses the duel by dressing its `praxisDetail`, not by registering a second skin"
  - `FactionDetail`'s reason a phone registry is the wrong shape: *a parallel set of skins forks the
    COPY and not just the width* — kept, and now stated as a rule rather than as a post-mortem.

Two judgement calls worth checking:

1. **`pages/praxisDetail/DuelCard.tsx`** names "the rail" in four later paragraphs that are about
   live design decisions (why `declined` draws nothing, why no row is "You", where the opponent-ink
   guard now lives). Cutting its antecedent outright would orphan all four, so line 3 keeps
   *"Successor to `DuelCrossLink` and the duel rail"* and only the twelve-`*DuelRail`-skin register
   goes. I did **not** rewrite the four downstream paragraphs — that is a larger prose pass, not
   this lane's rule.
2. **`components/duel/__tests__/wowSealAccent.test.tsx:4`** names `wowDuelRail.test.tsx` — a retired
   **test file**, not a surface key, and it is why that file exists. Left alone.

## Half 2 — the guard

> No shipped source file may name a surface key retired from `SURFACE_KEYS`.

**Where it lives — a sibling, not a row.** `__tests__/retiredIdentities.test.ts` says *"a fourth
retirement is a row, not a file"*, so I checked. It does not fit: that table runs one
`describe.each` over `readStripped`, and its header states the opposite premise — *"Only a draw call
counts."* A row would mean adding a per-row reader knob to a three-row table purely so one row could
invert the premise the table is built on. Two files, two premises.

**It reads RAW source — the one place this deviates from its neighbours.** Every other guard on
`test/sourceScan.ts` strips comments because it hunts a draw call. Here the register **is** comments:
not one of the 72 occurrences was code, so a comment-stripping scan would police nothing and pass on
day one.

**Scope is `sourceFiles()`'s defaults, unmodified** — `frontend/src`, TS/TSX, `__tests__` excluded.
Taking that default is what keeps the four blessed assertions alive for free:

```
components/duel/__tests__/duelSealFormFactor.test.tsx:122-123
pages/characterProfile/__tests__/profileFormFactor.test.tsx:150-151
```

Those are `expect(SURFACE_KEYS).not.toContain(...)` plus their `it(...)` names — #2533's own
prescription that *"if a rule must survive its surface, it belongs in an ADR or a test name."* They
are untouched; only the archaeology around them moved. `docs/` is out of scope entirely, including
`docs/kit-structure.md`'s two `mobileFactionPage` lines, which teach a live rule through a historical
example.

`factionCard` is **not** swept (a live name, not a retired key). `mobileFieldDesk` is **not** in the
denylist (a live `SURFACE_KEYS` entry, and the suite proves the guard leaves it alone).

The denylist is hand-maintained and carries a `ponytail:` marking the ceiling: the repo holds no list
of retired keys, a key's removal leaves nothing to derive from, and the upgrade path is one appended
line — or a `RETIRED_SURFACE_KEYS` export from `manifest.ts` if it ever stops being cheap.

## Proof the guard fails on a reintroduction

Planted `// The \`mobileProfile\` surface was retired by #1319.` in `pages/CharacterProfile.tsx`:

```
FAIL  src/__tests__/retiredSurfaces.test.ts > a retired surface stays retired (#2758) > no shipped source file names one
AssertionError: expected [ Array(1) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "pages/CharacterProfile.tsx:417 names `mobileProfile`",
+ ]
```

Reverted before the push.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally on vite 8.2.2 / vitest
4.1.11 / tsc 5.9.3:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **454 files, 9296 passed**, 1 skipped |
| `npm run build` | clean |
| `npm run budget` | **byte-identical to `origin/main`** |

**Comment-only, proven mechanically** rather than asserted — every added and removed line across all
52 swept files, with the new test excluded, begins with `*`, `//`, `/*` or `*/`:

```
git diff origin/main -U0 -- frontend/src ':!frontend/src/__tests__/retiredSurfaces.test.ts' \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | sed 's/^[+-][[:space:]]*//' \
  | grep -vE '^(\*|//|/\*|\*/)'
→ (no output)
```

**Budget is unchanged, checked against a baseline build rather than assumed.** I built `origin/main`
detached and rebuilt this branch: same figures *and the same content hashes* —
`assets/index-BnTqLzgF.js` 44.0 KB, `assets/index-s3yOQWkV.css` 21.6 KB, JS 141.0 KB / CSS 21.6 KB.
The `WARN JS 141.0 KB` the budget prints is **main's pre-existing state, not this PR's** — comments
do not ship.

## Visual QA is outstanding

I have no browser and no dev stack. Nothing here changes a rendered byte — the diff contains zero
non-comment lines and the built assets hash identically to main's — but that is a build-level
argument, not an eyeball.

## What to eyeball

- **The rewritten rules, not the deletions.** Does each still say something true about what exists
  now? Densest: `factions/wow.ts` (4 sites), `factions/__tests__/surfaceDispatch.test.ts` (5),
  `components/duel/*DuelSealConfirm.tsx` (8 files + the dispatcher).
- **`pages/FactionDetail.tsx`** — the reason a second phone registry is wrong is now phrased in the
  present tense. Confirm it still lands as a prohibition and not as trivia.
- **`factions/wow.ts:87`** — I dropped `createCharacter` from the "not skinned here" list, because
  WOW *does* register `createCharacter` (responsively). Confirm that reading.
- **`pages/praxisDetail/DuelCard.tsx`** — judgement call 1 above. Is keeping "the duel rail" as an
  antecedent right, or should the four downstream paragraphs be swept in a follow-up?
- **`components/duel/__tests__/duelSealFormFactor.test.tsx:7-9`** — the docblock bullet that used to
  name `mobileDuelSeal` now points at the blessed assertion instead. Check the cross-reference reads
  as intended.
- **The `ponytail:` in the new guard** — is a hand-maintained denylist the right ceiling, or should
  `manifest.ts` export `RETIRED_SURFACE_KEYS` now rather than later?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
