### PR TITLE
An onboarding control can break its line, and the broken line centres

### DIFF
--- a/frontend/src/pages/__tests__/onboardingCards.test.tsx
+++ b/frontend/src/pages/__tests__/onboardingCards.test.tsx
@@ -76,6 +76,29 @@ describe('every onboarding card', () => {
       expect(markup.match(/--faction-default-rainbow/g)).toHaveLength(3)
     })
 
+    it(`${name} lets a long control label wrap onto a centred second line`, () => {
+      const markup = render(card)
+
+      // #2764: `controlBase` set `white-space:nowrap`, so a label wider than the
+      // 560px sheet ran out past the rainbow border rather than breaking — and
+      // on a 375px phone that bites at much shorter labels. The actions row
+      // already wraps; it was the button that could not.
+      //
+      // Asserted on the MARKUP and not on the exported style object, because
+      // that is what also covers the two provider buttons `SignInOptions`
+      // renders from the style it is handed.
+      expect(markup).not.toContain('white-space:nowrap')
+
+      // `justify-content:center` centres the anonymous flex ITEM inside the
+      // control; once the label wraps that item fills the width and the short
+      // second line still rags left. Centring the LINES is `text-align`'s job,
+      // so every control carries it. `inline-flex` is `controlBase`'s alone on
+      // this surface, which is what makes it the selector.
+      for (const style of markup.match(/style="[^"]*"/g) ?? []) {
+        if (style.includes('display:inline-flex')) expect(style).toContain('text-align:center')
+      }
+    })
+
     it(`${name} states no colour of its own`, () => {
       const markup = render(card)
 

--- a/frontend/src/pages/onboarding/OnboardingCard.tsx
+++ b/frontend/src/pages/onboarding/OnboardingCard.tsx
@@ -54,12 +54,27 @@ const caption: CSSProperties = {
   color: 'var(--faction-default-card-muted)',
 }
 
+/**
+ * A CONTROL MUST BE ABLE TO BREAK ITS LINE (#2764). This carried
+ * `white-space: nowrap`, so a label wider than the sheet had nowhere to go and
+ * ran out past the rainbow border — and the sheet is only 560px, so on a phone
+ * that bit at much shorter labels. The actions row already wraps; it was the
+ * button that could not.
+ *
+ * `text-align` and not `justify-content` is what centres the wrapped line.
+ * `justify-content: center` centres the anonymous flex ITEM inside the control,
+ * but a wrapping item fills the available width, so its short second line still
+ * rags left. Both declarations are load-bearing and neither replaces the other.
+ *
+ * The control keeps its intrinsic width. Stretching it to the sheet would also
+ * end the overflow, and that is a design change rather than this fix.
+ */
 const controlBase: CSSProperties = {
   cursor: 'pointer',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
-  whiteSpace: 'nowrap',
+  textAlign: 'center',
   fontFamily: LORA,
   fontWeight: 600,
   fontSize: 'var(--text-xl)',


### PR DESCRIPTION
Closes #2764

`controlBase` in `frontend/src/pages/onboarding/OnboardingCard.tsx` set `white-space: nowrap`, so a control label wider than the 560px sheet had nowhere to break and ran out past the rainbow border. The actions row already wraps (`flexWrap: 'wrap'`); the *button* was what could not.

**One declaration out, one in, in the one shared object.** Both `primaryControl` and `secondaryControl` spread `controlBase`, so every control on the surface is fixed at once — the intro continue, the terms accept, the returning-player confirm, the look-around escape, and the two provider buttons `SignInOptions` renders from the style `AuthCard` hands it.

### `text-align: center` is not redundant with the flex centring

The issue asked me to confirm this rather than assume it, and it *is* needed. `justify-content: center` centres the anonymous flex **item** inside the control. Once the label wraps, that item is sized to the available width, so its short second line still rags left inside it. Centring the *lines* is `text-align`'s job. Both declarations are load-bearing and neither replaces the other.

### Deliberately not done

- **Controls keep their intrinsic width.** Stretching them to the sheet would also end the overflow, and it is a design change rather than this fix.
- **The placeholder copy is untouched** (#2766). The fix has to hold under whatever the real copy turns out to be, which is why the `nowrap` goes rather than the string.
- **No `overflow-wrap` added.** A flex item's automatic minimum size is its min-content width, so a *single* word longer than the sheet would still overflow. No current or plausible label is one, and the `<h1>` already carries `overflow-wrap: anywhere` if that ever needs matching. Noted, not fixed here.

### The seam

The rendered `style` attribute of every control on every stop, in `frontend/src/pages/__tests__/onboardingCards.test.tsx` — asserted on the **markup**, not on the exported style object, because the markup is what also covers the two provider buttons `SignInOptions` renders. Written first; it went red on all three cards for the real defect (`white-space:nowrap` present in the intro, terms and both auth buttons) before the fix, green after.

What the check cannot see is overflow — the harness is `renderToStaticMarkup` with no layout. It pins the declaration so a future edit cannot silently reintroduce it; it does not prove the pixels.

### Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm run build` all clean. `npm test`: 454 files, 9299 passed / 1 skipped.

`npm run budget` is **byte-identical to baseline** — I rebuilt with `origin/main`'s version of the file to check: JS 141.0 KB, CSS 21.6 KB both ways. The JS `WARN` is pre-existing on `main` and is not from this change (inline styles; the onboarding route is not in the initial payload).

### Visual QA is OUTSTANDING

I have no browser and no dev stack, and the node harness structurally cannot see overflow. **The overflow is not visually confirmed fixed.**

## What to eyeball

At **375px** and **560px**, on each of:

1. **Intro** (`/start`) — the continue button and the look-around escape.
2. **Terms** (`/start`, post-continue) — the accept button and the escape.
3. **Auth** (`/start`, signed out) — **both** provider buttons, Google and Discord, plus the escape.
4. **Returning-player confirm** (`/start/again`) — the start-fresh button and the escape.

Looking for, at each: nothing crossing the rainbow border, no horizontal scroll, and a label that wraps breaking to a **centred** second line rather than one ragged left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
