### PR TITLE
guest.spec.ts proves a session by a slot, not by a word that moved

### DIFF
--- a/frontend/e2e/guest.spec.ts
+++ b/frontend/e2e/guest.spec.ts
@@ -41,5 +41,25 @@ test('the dev-login button logs a bot in', async ({ page }) => {
   // named /sign up here/i too, and had been passing vacuously against copy that
   // no longer existed anywhere in the app.
   await expect(page.getByTestId('home-hero-cta')).toHaveCount(0)
-  await expect(page.getByRole('button', { name: /logout/i })).toBeVisible()
+  // ...and that a SESSION exists, proved by an authenticated-only slot rather
+  // than by a control's wording (#2761). This line read /logout/i, which could
+  // not match: #2155 moved sign-out off the bar into the Settings Account card,
+  // and the app has no "logout" string at all — `common.json` says "Sign out".
+  // Swapping the matcher would still fail, because the control is not on this
+  // surface any more; the anchor has to move, not the spelling.
+  //
+  // `nav-settings` is NavBar's `/settings` link. It renders inside `{user && }`
+  // — `/settings` is a ProtectedRoute, so for a guest it would be a link to a
+  // redirect, and the bar hides it rather than disabling it. So its presence IS
+  // a session. It is also the way in to the card that now carries sign-out, it
+  // is on every authenticated route rather than just this one, and it is
+  // outside every gate on FieldDesk's own body.
+  // `components/__tests__/navSettingsSlot.test.tsx` pins both halves of that
+  // `{user && }`, so the slot cannot quietly start rendering for a guest.
+  //
+  // Role AND slot: the slot says which element, the role says what it is, and
+  // neither is copy.
+  const settings = page.getByTestId('nav-settings')
+  await expect(settings).toBeVisible()
+  await expect(settings).toHaveRole('link')
 })

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -184,6 +184,14 @@ export default function NavBar() {
           <NavLink
             to="/settings"
             className="label-caption"
+            /* The e2e suite's proof that a session exists (#2761). Signed-in
+               only, on every route, and outside every page's own gates — so
+               `guest.spec.ts` can assert it instead of the sign-out wording it
+               used to, which #2155 moved off this bar entirely. A slot, not a
+               string: `src/__tests__/e2eAnchors.test.ts` fails if this one is
+               renamed and `__tests__/navSettingsSlot.test.tsx` fails if it
+               escapes the `{user && }` above. */
+            data-testid="nav-settings"
             style={({ isActive }) => ({
               textDecoration: 'none',
               padding: 'var(--space-xs) var(--space-sm)',

--- a/frontend/src/components/__tests__/navSettingsSlot.test.tsx
+++ b/frontend/src/components/__tests__/navSettingsSlot.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * #2761 — the slot `e2e/guest.spec.ts` now uses to prove a session exists.
+ *
+ * THE SEAM is the nav's `{user && ...}` settings link. The spec used to assert
+ * a logout button that #2155 removed from the bar, so it had to re-anchor onto
+ * something authenticated-only; `data-testid="nav-settings"` is that anchor.
+ *
+ * `e2eAnchors.test.ts` already checks the slot still exists SOMEWHERE in the
+ * app — which is the rename it guards against. It cannot check the property the
+ * e2e assertion actually rests on: that the slot is absent for a guest. A slot
+ * that started rendering signed-out would leave `guest.spec.ts` green while
+ * proving nothing, which is the exact failure mode that file was written about.
+ * Both halves of the gate are pinned here, so moving the link out of `{user &&}`
+ * fails in the PR suite rather than in a nightly nobody reads.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import type { CurrentUser } from '../../api/auth'
+
+const authMock = vi.fn()
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => authMock(),
+}))
+
+// Same three stubs as `navCharacterLink.test.tsx`: `useTheme` throws outside its
+// provider by design (#701) and the panels come over the network (#1344).
+vi.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light', toggle: () => {} }),
+}))
+vi.mock('../../hooks/useSidebarPanels', () => ({
+  useSidebarPanels: () => ({
+    pending_requests_count: 0,
+    global_activity: [],
+    active_praxes: [],
+    refetch: vi.fn(),
+    loading: false,
+  }),
+}))
+vi.mock('../../api/auth', () => ({ loginWith: () => {} }))
+
+import NavBar from '../NavBar'
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={['/']}>
+      <NavBar />
+    </MemoryRouter>,
+  )
+}
+
+const SLOT = 'data-testid="nav-settings"'
+
+describe('the nav settings slot is a session, not a decoration (#2761)', () => {
+  it('renders for a signed-in account, as a link to /settings', () => {
+    authMock.mockReturnValue({
+      user: { character: { id: 42, display_name: 'Mollusk' } } as unknown as CurrentUser,
+    })
+    const html = render()
+    expect(html).toContain(SLOT)
+    // The slot's own tag, then its attributes — not one welded pattern. React
+    // and react-router order these however they like (`data-discover` lands in
+    // the middle), and the claim is about the ELEMENT: it is an `<a>`, so
+    // Playwright's `toHaveRole('link')` holds, and it goes to `/settings`.
+    const tag = /<a ([^>]*data-testid="nav-settings"[^>]*)>/.exec(html)?.[1]
+    expect(tag, 'the slot is on an anchor').toBeDefined()
+    expect(tag).toContain('href="/settings"')
+  })
+
+  it('is absent for a guest — otherwise the e2e assertion proves nothing', () => {
+    authMock.mockReturnValue({ user: null })
+    expect(render()).not.toContain(SLOT)
+  })
+})


### PR DESCRIPTION
`guest.spec.ts`'s second assertion looked for a button named `/logout/i`. #2155 moved sign-out
off the nav bar into the Settings Account card, and no catalog in this repo contains the word
"logout" at all (`common.json` says `"signOut": "Sign out"`). So the matcher had nothing to
match on the FieldDesk the dev bot lands on, and the spec has failed every nightly since.

Swapping `/logout/i` for `/sign out/i` would fail identically — the control is not on that
surface. The anchor had to move, not the spelling.

## The seam

**The nav's `{user && }` settings link.** It renders only for a signed-in account, on every
authenticated route, outside every gate on the FieldDesk's own body — `/settings` is a
`ProtectedRoute`, so for a guest the bar hides the link rather than disabling it. Its presence
*is* a session, which is exactly what the test's name claims to check. It is also the way in to
the card that now carries sign-out, so this is options 1 and 2 from the issue at once.

## The loop

1. Red: pointed the spec at `getByTestId('nav-settings')` — `src/__tests__/e2eAnchors.test.ts`
   derives its ids from `frontend/e2e/` and immediately failed with *"frontend/e2e reaches for
   getByTestId('nav-settings') and nothing in frontend/src carries it"*.
2. Red: added `components/__tests__/navSettingsSlot.test.tsx`, which failed on the missing slot
   and passed on the guest half.
3. Green: added `data-testid="nav-settings"` to the `NavLink` in `components/NavBar.tsx`.

## What changed

- `frontend/e2e/guest.spec.ts` — line 44 only. Assertion is now `getByTestId('nav-settings')`
  plus `toHaveRole('link')`: the slot says which element, the role says what it is, and neither
  is copy. **Line 43's `home-hero-cta` `toHaveCount(0)` is untouched**, as is the whole guest
  test above it.
- `frontend/src/components/NavBar.tsx` — one new attribute. **A deliberate test contract**, not
  incidental: it is commented as such, and named in the two tests that guard it.
- `frontend/src/components/__tests__/navSettingsSlot.test.tsx` — new. `e2eAnchors` checks the
  slot still exists *somewhere*, which is the rename it was written for; it cannot check the
  property this e2e assertion actually rests on — that the slot is **absent for a guest**. A
  slot that drifted out of `{user && }` would leave `guest.spec.ts` green while proving nothing,
  which is the failure mode `e2eAnchors`' own docblock is about. Both halves are pinned.

No new API endpoints. No styling decisions; nothing for `frontend-style`.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` (`tsc --noEmit` + `tsconfig.e2e.json`) | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **455 files, 9299 passed**, 1 skipped |
| `npm run build` | ok |
| `npm run budget` | exit 0 — pre-existing JS WARN at 141.0 KB, unchanged by one attribute |

`test` and `api-schema` are untouched: no backend file, no route signature, no schema.

## ⚠️ The e2e run itself is OUTSTANDING

I cannot run Playwright — no live backend, no seeded DB, no browsers in this worktree. **I am not
claiming the spec passes.** What I verified instead is that the slot genuinely exists in the
component I claim renders it (`e2eAnchors` fails if it does not, and it is derived from the spec
file, not from a hand-kept list) and that it is gated on a session. The browser run has to be
confirmed on the owner's machine before this leaves draft.

## What to eyeball

- **The one thing a unit test cannot prove:** that the dev bot really lands on a surface with the
  NavBar. It should — `Desktop Chrome` is 1280x720, `useFormFactor()` reads desktop, and
  `Layout` renders `<NavBar />` rather than `MobileHeader`. But that inference is the load-bearing
  step, and only `npx playwright test guest.spec.ts` settles it.
- Whether `nav-settings` is the anchor you want at all, versus something on the FieldDesk body.
  I chose the bar deliberately: FieldDesk's roster section is gated (`rosterOffersAChoice`), the
  mobile branch dispatches to a per-faction skin, and the page has desktop/mobile halves — the
  bar's link has none of that.
- The comment block I added inside the `NavLink`'s attribute list in `NavBar.tsx` — it renders
  nothing, but it is unusual placement and worth a glance.
- The `MobileHeader` also links to `/settings` (`src/components/layout/MobileHeader.tsx:105`) and
  deliberately does **not** carry the slot. One id, one site — if the suite ever runs a mobile
  project, that is the moment to revisit, not now.

Closes #2761

🤖 Generated with [Claude Code](https://claude.com/claude-code)
