### PR TITLE
One ellipsis character across the catalogs — and A4 was already built, at a path nobody could find

### DIFF
--- a/frontend/scripts/i18nKeyRefs.py
+++ b/frontend/scripts/i18nKeyRefs.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 """Per-key i18n reference check (the #1039 / #1068 method).
 
-Usage:  python scripts/i18nKeyRefs.py <namespace>          e.g. praxis
+Usage:  python frontend/scripts/i18nKeyRefs.py <namespace>   e.g. praxis
+
+THE PATH IS `frontend/scripts/`, NOT `scripts/`. It resolves its catalog and its
+source roots from `__file__`, so it runs from any cwd — but the repo ALSO has a
+top-level `scripts/`, and this tool has never lived there. #2598 was measured
+twice against `scripts/i18nKeyRefs.py`, found nothing, and both times concluded
+the TEST-ONLY column below was unbuilt when it had already shipped. Spelling the
+path out here is cheaper than a third re-measure.
 
 For EVERY leaf key in `src/locales/en/<namespace>.json`, search the source tree
 for an ANCHORED reference to that key's full dotted path:

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -30,7 +30,7 @@
     "detailError": "Could not load account detail.",
     "suspendError": "Could not update account.",
     "banError": "Could not update character.",
-    "searchPlaceholder": "Search by email...",
+    "searchPlaceholder": "Search by email…",
     "empty": "No accounts found.",
     "idLabel": "ID #{{id}}",
     "suspend": "suspend",
@@ -127,7 +127,7 @@
       "flags_other": "{{count}} flags",
       "viewPraxis": "View praxis →",
       "viewThread": "View thread →",
-      "failNotePlaceholder": "Reason for failure (visible to player)...",
+      "failNotePlaceholder": "Reason for failure (visible to player)…",
       "actions": {
         "keep": "keep",
         "remove": "remove",

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -22,7 +22,7 @@
     "na": "Not yet sworn to a faction."
   },
   "index": {
-    "loading": "Loading...",
+    "loading": "Loading…",
     "loggedOutHint": "Everyone starts unaffiliated. Earn an invitation through task work to join a faction."
   },
   "detail": {

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -57,7 +57,7 @@
     "basedPlaceholder": "City, region…",
     "basedCount": "{{count}}/100",
     "optional": "· optional",
-    "saveBusy": "Saving...",
+    "saveBusy": "Saving…",
     "saveIdle": "Save Changes",
     "cancel": "Cancel",
     "mobile": {
@@ -374,7 +374,7 @@
       "propose": "Could not propose task."
     },
     "submit": {
-      "busy": "Submitting...",
+      "busy": "Submitting…",
       "meta": "Propose Metatask",
       "task": "Submit proposal",
       "cancel": "Cancel",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -5,7 +5,7 @@
   },
   "listPage": {
     "title": "Praxis",
-    "loading": "Loading praxis...",
+    "loading": "Loading praxis…",
     "empty": "No praxis yet. Be the first.",
     "emptyFiltered": "Nothing filed under those terms. Clear the search or pick a different faction.",
     "emptyCaughtUp": "All caught up",
@@ -111,7 +111,7 @@
       "hide": "hide",
       "fail": "fail",
       "restore": "restore",
-      "failReasonPlaceholder": "Reason for failure (visible to player)...",
+      "failReasonPlaceholder": "Reason for failure (visible to player)…",
       "confirm": "confirm"
     },
     "owner": {

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -2,7 +2,7 @@
   "listPage": {
     "count": "{{count}} shown",
     "countWindowed": "Showing first {{count}}",
-    "loading": "Loading tasks...",
+    "loading": "Loading tasks…",
     "empty": "No tasks match your filters.",
     "emptyFiltered": "Nothing open under those terms. Clear the search or pick a different faction.",
     "emptyCaughtUp": "Nothing open to you",

--- a/frontend/src/locales/en/taunts.json
+++ b/frontend/src/locales/en/taunts.json
@@ -11,7 +11,7 @@
     ],
     "praxis_complete": [
       "{{from_name}} just completed a task. {{to_name}} is still thinking about it.",
-      "{{from_name}} submitted praxis. {{to_name}}... did not."
+      "{{from_name}} submitted praxis. {{to_name}}… did not."
     ]
   },
   "ua": {


### PR DESCRIPTION
Closes #2598

Two jobs were briefed. **One of them was already done**, and proving that is most of this PR's value; the other is a nine-value punctuation sweep.

## The seam

`i18nKeyRefs.py` — specifically, *does a key whose only reader is a test report as dead?*

That seam can genuinely go red, so I drove it before writing anything: I extracted the pre-#2614 version of the script from `85a26785^` and ran both versions against today's tree.

## Job 1 (A4) — already shipped in #2614. No code change needed.

**A4 is built and working. The file is `frontend/scripts/i18nKeyRefs.py`.** The issue body and its re-measure comment both cite `scripts/i18nKeyRefs.py` at the repo root, which has never existed — so the measurement found no file, and a missing file reads exactly like a missing feature. That happened twice.

This is the same failure mode the issue keeps documenting about itself: a scan pointed at the wrong surface reports a clean absence.

### Proof, not assertion — before/after on `common`

| | `common:praxisType.solo` / `.collab` (only reader is a test) | summary |
|---|---|---|
| **pre-#2614** (`85a26785^`) | absent from output → counted **KEPT/alive** | `316 kept, 3 deletable` |
| **on `main` today** | `TEST-ONLY praxisType.solo` / `.collab` | `314 kept, 2 test-only, 3 deletable` |
| **`--ignore-tests`** | folded into `DELETABLE` | `314 kept, 5 deletable` |

### Proof the dynamic families did not regress

I diffed both versions' verdicts for **every key in all 14 catalogs**. Last column is "keys whose verdict #2614 changed":

| namespace | kept | test-only | deletable | verdict changed |
|---|---|---|---|---|
| `errors` | 0 | 0 | 77 | **0** |
| `taunts` | 0 | 0 | 24 | **0** |
| `progression` | 5 | 0 | 50 | **0** |
| `forms` (incl. `editPraxis.collab`'s 90 runtime keys) | 215 | 0 | 101 | **0** |
| `admin` (incl. every `*.status.*`) | 89 | 0 | 19 | **0** |
| `common` | 314 | 2 | 3 | 2 |
| `feed` | 212 | 13 | 31 | 13 |
| `factions` | 122 | 1 | 47 | 1 |
| `home` | 33 | 1 | 5 | 1 |
| `votes` | 4 | 1 | 39 | 1 |
| `praxis` / `tasks` / `glosses` / `onboarding` | — | 0 | — | **0** |

Every one of the five docstring-warned dynamic families is **untouched** — same verdict, same count, before and after. All 18 keys that moved went `KEPT → TEST-ONLY`, which is the intended direction. **Nothing moved the wrong way.**

The only change I made here is a docstring line: the `Usage:` path now reads `frontend/scripts/`, with the trap named once. No behaviour change.

## Job 2 (A2/B3) — one ellipsis character

**Re-measured on `b5d9cf06`: `...` in 9 values, `…` in 33.** B3's "17 and 26" predates everything that has shipped since.

**Decision: `…` (U+2026).** Majority by 33 to 9; it is the correct typographic character; and three periods can be broken across a line where the single glyph cannot. The repo already treats it as canonical in prose — `TaskFilterBar.tsx:198`'s comment describes its own surface as printing `"Loading tasks…"` while the catalog it read said `"Loading tasks..."`.

### Every value changed — 9 values, 0 keys

| key | before | after |
|---|---|---|
| `admin:accounts.searchPlaceholder` | `Search by email...` | `Search by email…` |
| `admin:praxis.failNotePlaceholder` | `Reason for failure (visible to player)...` | `Reason for failure (visible to player)…` |
| `factions:index.loading` | `Loading...` | `Loading…` |
| `forms:editCharacter.saveBusy` | `Saving...` | `Saving…` |
| `forms:proposeTask.submit.busy` | `Submitting...` | `Submitting…` |
| `praxis:listPage.loading` | `Loading praxis...` | `Loading praxis…` |
| `praxis:detail.admin.failReasonPlaceholder` | `Reason for failure (visible to player)...` | `Reason for failure (visible to player)…` |
| `tasks:listPage.loading` | `Loading tasks...` | `Loading tasks…` |
| `taunts:wow.praxis_complete[1]` | `{{to_name}}... did not.` | `{{to_name}}… did not.` |

**No key was deleted, renamed, added or repointed.** Values only — every string renders the same words, one character differently. Three of these now match a same-file twin that already used `…` (`forms:...submitBusy` "Submitting…", `praxis:...submitting` "Submitting…", `admin:...saving` "saving…") — that adjacent drift is exactly what the issue names.

`praxis:listPage.loading` and `tasks:listPage.loading` **stay voiced** and were not collapsed onto `common:loading` — they name *what* is loading, which a bare spinner label does not carry.

## Held to the exclusions

- **B0 untouched**: `common:leaderboard.roster.colLevel` / `.colPoints`, `praxis:card.stamp.pointsShort` / `.points_one` / `_other`.
- **`PLACEHOLDER` values ship unchanged** — six faction descriptions, four `onboarding:*.note`.
- `factions` touched only at `index.loading`, the one key the brief put in scope.
- `frontend/e2e/*` and `frontend/src/pages/onboarding/*` not touched (other agents own them).

## Verification

Ran every step `.github/workflows/test.yml` names for the `frontend` job:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **454 files, 9296 passed, 1 skipped** |
| `npm run build` | built |
| `npm run budget` | JS `WARN 141.0 KB`, CSS `ok` |

`tsc --version` reports 5.9.3, vite 8.2.2, vitest 4.1.11 — the toolchain is real, not a stale junction reporting a false pass.

**The budget `WARN` is pre-existing, not from this change.** `...` and `…` are both 3 bytes in UTF-8, so the diff is byte-neutral — measured per file against `origin/main`, total delta **+0 bytes**.

`api-schema` is not implicated: no route, `response_model` or Pydantic schema was touched.

## What to eyeball

**Visual QA is outstanding — I have no browser and no dev stack. Everything below is unverified on screen.**

1. **The three loading labels** — `/factions`, `/praxis`, `/tasks` list pages. Confirm the trailing glyph renders as a single `…` and not a tofu box in whichever font each surface uses.
2. **`taunts:wow.praxis_complete[1]`** — the only mid-sentence one. `{{to_name}}… did not.` Check the spacing reads right after a long character name.
3. **The two admin placeholders** — account search, and the praxis fail-note box. Placeholder text is often the smallest type on a surface, so the ellipsis is where a font gap shows first.
4. **`forms:editCharacter.saveBusy` / `proposeTask.submit.busy`** — busy-state button labels, sitting in fixed-width buttons beside their idle twins ("Save Changes", "Submit proposal"). Byte-identical, but worth one glance that nothing reflows.

## Open question for you

The brief called A4 "the main job". It was done before I started. **If you want more from the tool than #2614 gave it, say what** — the obvious candidate is wiring it into CI, since right now it has no test and no workflow step, and nothing stops the TEST-ONLY column from silently regressing. I did not add that on my own initiative; it is a new gate on a shared surface, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
