### PR TITLE
The eager marks barrel drops the ornament: 4.2 KB gzipped off the blocking path

### DIFF
--- a/frontend/src/__tests__/eagerPathImports.test.ts
+++ b/frontend/src/__tests__/eagerPathImports.test.ts
@@ -1,6 +1,6 @@
 /**
- * #1141 — two modules that must not be reached by a static import from an
- * eager path.
+ * #1141 — modules that must not be reached by a static import from an eager
+ * path.
  *
  * `api/admin` — `TaskCard` imported `updateTaskStatus` at module scope, so the
  * built `admin-*.js` chunk was fetched by every logged-out visitor on `/tasks`
@@ -10,6 +10,16 @@
  * `api/gameConfig`'s `getGameConfig` — `hooks/useGameConfig` already dedupes
  * `/game-config` behind a module-level cache plus a shared in-flight promise,
  * so a direct caller costs a second request for a payload already in hand.
+ *
+ * `components/factionMarks` — the ornament (#2779). `Sidebar` draws
+ * `FactionSigil` on every page, `FactionSigil` adapts `UaSigil`, and `UaSigil`
+ * used to take its ensō from the folder's BARREL. A barrel is a static
+ * re-export, so first paint paid for every name in it: `Lotus`,
+ * `PointsRoundel`, and — through a re-export with zero consumers —
+ * `CovenCauldron` and the whole `covenSlip` vocabulary behind it. 4.2 KB
+ * gzipped of Coven and UA ornament, blocking, for one circle. Both rows above
+ * ask "who imports X"; this one has to ask the other direction, because the
+ * offending line was in a file that imports nothing wrong — it was REACHED.
  *
  * WHY A SOURCE SCAN AND NOT THE BUNDLE BUDGET
  * -------------------------------------------
@@ -21,11 +31,16 @@
  * statically") is a property of the source, and CI runs vitest before the
  * build, so this is both the honest seam and the only one available per-PR.
  *
+ * The ornament row is the one case the budget CAN see — 4.2 KB moved. It still
+ * cannot hold it: JS is over WARN (#2605) and WARN exits 0, so the number would
+ * drift back up printing the same block it prints today, and nothing would go
+ * red. A ratchet the budget cannot enforce is one this file can.
+ *
  * Same posture as `noInjectedStylesheets.test.ts`: one assertion covers every
  * module, present and future, without instantiating any of them.
  */
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 // Shipped modules only — `sourceFiles` skips `__tests__` by default, which is
 // what this file needs: a test's imports are never in a visitor's bundle, and
@@ -41,17 +56,68 @@ function valueImportSpecifiers(source: string): string[] {
   const specifiers: string[] = []
   const importClause = /import\s+(type\s+)?([\s\S]*?)\s*from\s*['"]([^'"]+)['"]/g
   for (const [, typeOnly, clause, specifier] of stripComments(source).matchAll(importClause)) {
-    // `import { type A, type B } from` is erased too.
-    const allInlineTypes =
-      clause.trim().startsWith('{') &&
-      clause
-        .replace(/[{}]/g, '')
-        .split(',')
-        .filter((binding) => binding.trim().length > 0)
-        .every((binding) => binding.trim().startsWith('type '))
-    if (!typeOnly && !allInlineTypes) specifiers.push(specifier)
+    if (!typeOnly && !allInlineTypes(clause)) specifiers.push(specifier)
   }
   return specifiers
+}
+
+/** `import { type A, type B } from` is erased by tsc too, and pulls no chunk. */
+function allInlineTypes(clause: string): boolean {
+  return (
+    clause.trim().startsWith('{') &&
+    clause
+      .replace(/[{}]/g, '')
+      .split(',')
+      .filter((binding) => binding.trim().length > 0)
+      .every((binding) => binding.trim().startsWith('type '))
+  )
+}
+
+/**
+ * Everything a module pulls into its own chunk group: its value imports PLUS
+ * its re-exports. `export { x } from './x'` is a static edge exactly like an
+ * import — that is the whole of #2779 — and `valueImportSpecifiers` cannot see
+ * it, so a barrel would otherwise look like a leaf.
+ *
+ * The clause is pinned to `{…}` / `*` rather than matched lazily, because
+ * `export function f()` followed anywhere later by an `… from '…'` would
+ * otherwise match across half a file.
+ */
+function staticEdges(source: string): string[] {
+  const reExport = /export\s+(type\s+)?(\{[^}]*\}|\*(?:\s+as\s+\w+)?)\s*from\s*['"]([^'"]+)['"]/g
+  const reExported = [...stripComments(source).matchAll(reExport)]
+    .filter(([, typeOnly, clause]) => !typeOnly && !allInlineTypes(clause))
+    .map(([, , , specifier]) => specifier)
+  return [...valueImportSpecifiers(source), ...reExported]
+}
+
+/** A relative specifier as tsc resolves it, or null if it is not TS source. */
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  const base = join(dirname(fromFile), specifier)
+  return ['.ts', '.tsx', '/index.ts', '/index.tsx'].map((s) => base + s).find(existsSync) ?? null
+}
+
+/**
+ * Every module the entry reaches WITHOUT crossing an `import()` — the graph the
+ * browser must have in hand before it can paint. Bare specifiers stop the walk:
+ * `node_modules` is not ours to split. `import()` never appears here because
+ * `valueImportSpecifiers` declines to match it, which is the same reason it is
+ * the right primitive for this.
+ */
+function eagerModules(): string[] {
+  const seen = new Set<string>()
+  const queue = [join(SRC_DIR, 'main.tsx')]
+  while (queue.length > 0) {
+    const path = queue.pop() as string
+    if (seen.has(path)) continue
+    seen.add(path)
+    for (const specifier of staticEdges(readFileSync(path, 'utf8'))) {
+      if (!specifier.startsWith('.')) continue
+      const resolved = resolveRelative(path, specifier)
+      if (resolved !== null) queue.push(resolved)
+    }
+  }
+  return [...seen].map(toRelative).sort()
 }
 
 /** Files that legitimately hold a static import of the module under guard. */
@@ -79,6 +145,19 @@ describe('/game-config is fetched once per load (#1141)', () => {
         return /\bgetGameConfig\b/.test(stripComments(source))
       }),
     ).toEqual([])
+  })
+})
+
+describe('the faction ornament stays off the eager path (#2779)', () => {
+  it('reaches one mark from the entry, and never the barrel behind it', () => {
+    // `Enso` is legitimately blocking: `Sidebar` draws the sigil on first paint.
+    // Everything else in the folder belongs to a lazy archetype, so it must be
+    // reached BY PATH from that archetype — never through `factionMarks/index`,
+    // whose every name would then ride along. If this list grows, the mark that
+    // joined it is on the critical path for every visitor of every faction.
+    expect(eagerModules().filter((path) => path.startsWith('components/factionMarks/'))).toEqual([
+      'components/factionMarks/Enso.tsx',
+    ])
   })
 })
 

--- a/frontend/src/components/factionMarks/index.ts
+++ b/frontend/src/components/factionMarks/index.ts
@@ -22,8 +22,15 @@
  * `factionHero/`, `selectCard/` or `factionCard/` when `components/cards/` was
  * split up. They are NOT re-exported here: a second name for a module is the
  * thing that split was undoing, so import them by path.
+ *
+ * NEITHER IS `CovenCauldron`, AND THAT IS A BYTE RULE (#2779). This barrel is on
+ * the EAGER path — `Sidebar` -> `FactionSigil` -> `UaSigil` imports `Enso` from
+ * here on every page — so a name re-exported here is a name every first paint
+ * pays for. The cauldron's re-export had zero consumers (both surfaces already
+ * import it by path) and cost 2.0 KB gzipped of blocking JS, because it dragged
+ * `covenSlip` behind it. Import a faction's own ornament by path; only marks
+ * more than one faction's surfaces share belong in the three lines below.
  */
 export { default as Lotus, type FactionMarkProps } from "./Lotus";
 export { default as Enso } from "./Enso";
 export { default as PointsRoundel, type PointsRoundelProps } from "./PointsRoundel";
-export { default as CovenCauldron, type CovenCauldronProps } from "./CovenCauldron";

--- a/frontend/src/components/sigil/UaSigil.tsx
+++ b/frontend/src/components/sigil/UaSigil.tsx
@@ -1,4 +1,10 @@
-import { Enso } from "../factionMarks";
+// BY PATH, NOT THROUGH THE BARREL (#2779). `Sidebar` imports `FactionSigil`
+// eagerly on every page and it adapts this component, so this line is the ONE
+// import of `components/factionMarks` on the blocking path. Through the barrel
+// it also pulled `Lotus` and `PointsRoundel` — 2.0 KB gzipped that only lazy UA
+// and Everymen archetypes ever draw. The barrel is right for those seven
+// consumers and stays; the eager one takes the path.
+import Enso from "../factionMarks/Enso";
 
 /**
  * Shared UA (University of Asthmatics) identity atoms — the ensō sigil and the


### PR DESCRIPTION
Closes #2779

**Two deleted/rewritten import lines take 4.2 KB gzipped off the blocking path.** No component
changed, no surface was lazified, no byte budget was touched — this is entirely about which chunk
three existing modules land in.

## The seam

**A static-import walk of the entry graph, in `eagerPathImports.test.ts` (#1141).** The defect was
not "a file imports something it shouldn't" — the two rows already in that file ask that question,
and neither would have seen this. `factionMarks/index.ts` was *reached*: `Sidebar` →
`FactionSigil` → `UaSigil` → the barrel, and a barrel is a static re-export, so first paint paid
for every name in it. So the new row asks the other direction: **what does `main.tsx` reach without
crossing an `import()`?**

The loop went red on the real defect first — see the proof below.

## Measured, not predicted

Both builds on **vite 8.2.2** from the lockfile (confirmed via
`node -e "console.log(require('vite/package.json').version)"`), gzip level 9, which is what
`bundle-budget.mjs` uses. Baseline is a clean build of `origin/main` at `33086f46`.

| blocking path | `main` @ `33086f46` | this branch | delta |
|---|---|---|---|
| assets | 18 | **15** | −3 |
| **JS raw** | 447,198 B | **435,351 B** | **−11,847 B** |
| **JS gzip9** | 144,396 B (141.0 KB) | **140,110 B (136.8 KB)** | **−4,286 B (−4.2 KB)** |
| CSS gzip9 | 21.6 KB | 21.6 KB | unchanged |

Per step, so the second one is priced on its own rather than folded into the first:

| step | JS raw | JS gzip9 |
|---|---|---|
| 1 — delete the `CovenCauldron` re-export | −5,351 B | **−2,228 B** (141.0 → 138.8 KB) |
| 2 — `UaSigil` takes `Enso` by path | −6,496 B | **−2,058 B** (138.8 → 136.8 KB) |

**Step 2 was measured before it was kept.** The issue said to consider it and drop it if the win
was small; it is 2.0 KB gzipped for one rewritten import line, which is the same size as step 1, so
it stays. The barrel keeps its seven remaining importers — every one of them a lazy UA or Everymen
archetype — and is not otherwise unpicked.

`dist/index.html`'s modulepreload list before and after:

```
- /assets/factionMarks-wTjLHI3h.js   (7,204 B raw / 2.4 KB gz)
- /assets/covenSlip-UrQS7pym.js      (3,104 B raw / 1.3 KB gz)
- /assets/CovenCauldron-VfEzuZyU.js  (1,738 B raw / 0.7 KB gz)
- /assets/media-u1kkgSjt.js          (0.1 KB gz — rode in behind covenSlip)
+ /assets/Enso-DJcuzPDk.js           (0.3 KB gz)
```

## The guard, proved red

`eagerPathImports.test.ts` gains a walk of the entry's static graph and one row:

```ts
expect(eagerModules().filter((path) => path.startsWith('components/factionMarks/'))).toEqual([
  'components/factionMarks/Enso.tsx',
])
```

`valueImportSpecifiers` could not have seen this on its own — its regex matches `import … from`,
and the offending edge was `export { … } from`. So the walk uses a `staticEdges` that follows
re-exports too, which is the whole of why a barrel looked like a leaf.

**Reverted both fixes locally and ran it.** Not asserted — output:

```
FAIL src/__tests__/eagerPathImports.test.ts > the faction ornament stays off the eager path (#2779)
AssertionError: expected [ …(6) ] to deeply equal [ 'components/factionMarks/Enso.tsx' ]

- Expected
+ Received

  [
+   "components/factionMarks/CovenCauldron.tsx",
    "components/factionMarks/Enso.tsx",
+   "components/factionMarks/Lotus.tsx",
+   "components/factionMarks/PointsRoundel.tsx",
+   "components/factionMarks/covenSlip.tsx",
+   "components/factionMarks/index.ts",
  ]
```

Those five extra names are exactly the five modules the bundler put on the blocking path. The
regression was then reverted and the row is green.

## Not touched

- **`frontend/scripts/bundle-budget.mjs` is unchanged.** #2605's ruling is still the owner's; #2469
  binds. JS is still `WARN` — 136.8 KB against `warn>130.9 KB`. The overage was 10.1 KB and is now
  **5.9 KB**. Current figure posted on #2605.
- No surface was lazified. Every Coven archetype was already lazy via `lazyArchetype()`.
- `CovenCauldron` and `covenSlip` still exist and still render; they are only in a different chunk.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **455 files, 9303 passed, 1 skipped**
- `npm run build` — clean
- `npm run budget` — `WARN JS 136.8 KB` / `ok CSS 21.6 KB` (WARN pre-exists, see above)

No backend, route, `response_model` or Pydantic schema was touched, so `api-schema` and `test` are
not in scope.

## Visual QA is OUTSTANDING

**I have no browser and no dev stack.** Nothing above proves a pixel. The changes move where three
modules are *fetched from*, not what they draw, and no component body changed — but a chunking move
is exactly the kind of change that can surface as a mark that renders a frame late or not at all.

## What to eyeball

1. **The UA ensō in the sidebar, on any page.** This is the import that moved, and it is the only
   ornament left on the blocking path. It should paint as it always has — the mask asset itself is
   unchanged.
2. **The Coven task card's cauldron** (`CovenTaskCard`) — its `CovenCauldron` import is unchanged,
   but the chunk it now arrives in is not.
3. **The Coven praxis score stamp** (`CovenScoreStamp`) — same cauldron, second mount, different
   size.
4. **Any UA surface that draws a lotus** (UA praxis card, task card, task detail, edit praxis,
   create character) and **the Everymen score stamp's roundel** — these still come through the
   barrel, which is now fetched with their lazy archetype rather than at first paint. Watch for a
   pop-in on first navigation to those surfaces.
5. **A cold load with the network throttled**, to confirm nothing that used to be preloaded now
   arrives late enough to flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
