### PR TITLE
Two captions that cannot share 272px become one component that wraps

### DIFF
--- a/frontend/src/__tests__/levelTrackMetaRow.test.tsx
+++ b/frontend/src/__tests__/levelTrackMetaRow.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * The level track's caption row is ONE component, and it wraps (#2767).
+ *
+ * WHAT BROKE
+ * ----------
+ * At the top of the era's curve the left caption is
+ * `"Nowhere to go from here but the top"` — 35 characters at `--text-base`
+ * (10px), uppercase, `0.12em` tracking, so roughly 262px. The right caption
+ * (`"3,886 all-time"`) is roughly 105px. The rail is about 272px and the mobile
+ * Field Desk's column is narrower still, so the pair has no fitting solution at
+ * any gap. On `align-items: center` the two wrapped blocks interleave and the
+ * 8px gap between them disappears; the captions read as one paragraph.
+ *
+ * The mid-curve branch (`"114 TO LEVEL 9"`, ~105px) fits comfortably, which is
+ * why this survived: the defect appears only when `LevelTrack.nextLevel` is
+ * `null` (`utils/levelTrack.ts`).
+ *
+ * WHY A SOURCE SCAN AND NOT A RENDER
+ * ----------------------------------
+ * This harness is `renderToStaticMarkup` in node. There is no layout, so
+ * NOTHING here can see two captions collide — that check is a pair of eyes at
+ * 320px and 375px, and the PR says which surfaces got them. What a scan CAN
+ * see is the thing that made a three-property fix expensive: the row was
+ * hand-authored in nine files, so nine copies had to be found before any of
+ * them could be fixed, and a tenth could appear tomorrow.
+ *
+ * So the guard pins the seam rather than the pixels:
+ *
+ * - the row's i18n keys are named in exactly one component, so a new caller
+ *   mounts `LevelTrackMeta` instead of copying the row again;
+ * - that component carries the three properties the fix consists of.
+ *
+ * `WowFieldDesk.tsx` is why the scan anchors on the i18n keys and not on
+ * `className="flex items-center gap-2"`: it spelled the same row as an inline
+ * style object, so a class-name census missed it. `AlbescentFieldDesk.tsx` is
+ * NOT a site — it renders `DefaultFieldDesk` whole and inherits whatever that
+ * draws.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import type { CSSProperties } from 'react'
+import '../i18n'
+
+import LevelTrackMeta from '../components/LevelTrackMeta'
+import { levelTrack } from '../utils/levelTrack'
+import { readStripped, sourceFiles, toRelative } from '../test/sourceScan'
+
+/** The component that owns the row. Every other file must go through it. */
+const OWNER = 'components/LevelTrackMeta.tsx'
+
+/** The nine surfaces that mount the row (`AlbescentFieldDesk` inherits it). */
+const SITES = [
+  'components/layout/Sidebar.tsx',
+  'pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx',
+  'pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx',
+]
+
+/**
+ * The captions, by the keys they are drawn from — the spelling-proof anchor.
+ *
+ * `topLevel` is deliberately NOT here. The character profile draws the same
+ * sentence in its own body voice at `--text-content`, where #2383 already gave
+ * it the whole row and there is no all-time span beside it; that is a different
+ * surface, not a tenth copy of this one. These two keys appear nowhere but the
+ * row, so they identify it without help.
+ */
+const CAPTION_KEYS = ['sidebar.characterCard.allTime', 'sidebar.characterCard.toNextLevel']
+
+/** Where the shared `topLevel` sentence is legitimately drawn outside the row. */
+const TOP_LEVEL_ELSEWHERE = [
+  'pages/characterProfile/archetypes/DefaultProfileBody.tsx',
+  'pages/characterProfile/archetypes/profileSkin.tsx',
+]
+
+const filesNaming = (key: string): string[] =>
+  sourceFiles()
+    .filter((path) => readStripped(path).includes(key))
+    .map(toRelative)
+    .sort()
+
+/** A curve with a top: level 8 is the last rung. */
+const THRESHOLDS = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+
+const MARKER: CSSProperties = { letterSpacing: '0.12em' }
+
+describe('one component owns the caption row', () => {
+  for (const key of CAPTION_KEYS) {
+    it(`\`${key}\` is drawn in exactly one file`, () => {
+      expect(filesNaming(key)).toEqual([OWNER])
+    })
+  }
+
+  it('leaves the character profile copy of the top-of-curve sentence alone', () => {
+    expect(filesNaming('sidebar.characterCard.topLevel')).toEqual(
+      [OWNER, ...TOP_LEVEL_ELSEWHERE].sort(),
+    )
+  })
+
+  it('all nine sites mount it', () => {
+    const mounts = sourceFiles()
+      .filter((path) => /<LevelTrackMeta[\s/>]/.test(readStripped(path)))
+      .map(toRelative)
+      .sort()
+
+    expect(mounts).toEqual([...SITES].sort())
+  })
+})
+
+describe('the shared row wraps instead of interleaving', () => {
+  const markup = renderToStaticMarkup(
+    <LevelTrackMeta track={levelTrack(8, 3886, THRESHOLDS)} allTimeScore={3886} style={MARKER} />,
+  )
+
+  // The row keeps the eight desks' Tailwind spelling, so the properties are in
+  // the class list rather than a style attribute — vitest compiles no CSS, so
+  // the class names are as close to the cascade as this harness gets.
+  it('lets the captions wrap onto a second line', () => {
+    expect(markup).toContain('flex-wrap')
+  })
+
+  it('aligns on the baseline, so wrapped lines cannot interleave', () => {
+    expect(markup).toContain('items-baseline')
+    expect(markup).not.toContain('items-center')
+  })
+
+  it('keeps `3,886 ALL-TIME` on one line and flush right', () => {
+    expect(markup).toContain('white-space:nowrap')
+    expect(markup).toContain('margin-left:auto')
+  })
+
+  it('draws the top-of-curve caption, not a level to climb to', () => {
+    expect(markup).toContain('Nowhere to go from here but the top')
+    expect(markup).toContain('3,886')
+  })
+})
+
+describe('the faction voice arrives through the style prop', () => {
+  it('is spread onto both captions, not re-derived', () => {
+    const markup = renderToStaticMarkup(
+      <LevelTrackMeta track={levelTrack(3, 35, THRESHOLDS)} allTimeScore={35} style={MARKER} />,
+    )
+
+    expect(markup.match(/letter-spacing:0\.12em/g)).toHaveLength(2)
+  })
+
+  it('draws only the all-time caption when there is no track', () => {
+    const markup = renderToStaticMarkup(
+      <LevelTrackMeta track={null} allTimeScore={35} style={MARKER} />,
+    )
+
+    expect(markup).not.toContain('to Level')
+    expect(markup).not.toContain('Nowhere to go')
+    expect(markup).toContain('35')
+  })
+})

--- a/frontend/src/components/LevelTrackMeta.tsx
+++ b/frontend/src/components/LevelTrackMeta.tsx
@@ -1,0 +1,70 @@
+/**
+ * The baseline row under the level track: what is owed, and what has ever been
+ * earned (#2767).
+ *
+ * ONE ROW, NINE MOUNTS. This tree used to be hand-authored in nine files — the
+ * rail's character card and all eight mobile Field Desks — with `WowFieldDesk`
+ * spelling it as an inline style object rather than the `flex items-center
+ * gap-2` the other eight used, so a class-name census missed it. Nothing about
+ * the row differs between them: it is TREE, not skin (ADR-0078), and the whole
+ * of each kit's voice arrives through `style`, which is the per-file caption
+ * constant the site already had (`identityMetaStyle` on the rail,
+ * `trackMetaStyle` on each desk — Coven's is `{...CAPTION}` and UA's is
+ * `{...smallCaps}`). Pass that constant; do not re-derive it here.
+ *
+ * WHY IT WRAPS. At the top of the era's curve the left caption is a sentence —
+ * `"Nowhere to go from here but the top"`, ~262px at 10px uppercase with
+ * `0.12em` tracking — and the right one is ~105px, in a rail about 272px wide.
+ * There is no gap at which that pair fits. On `align-items: center` both
+ * captions wrapped and their lines INTERLEAVED, which is what made the two read
+ * as one paragraph. So the row wraps, and it aligns on the baseline: when both
+ * captions fit (the mid-curve `"114 TO LEVEL 9"` branch, which is every
+ * character below the top) it renders exactly as it always did — one line,
+ * all-time flush right on its auto margin — and when they don't, all-time drops
+ * to a line of its own and stays right.
+ *
+ * That is deliberately NOT an unconditional stack, which would spend a line of
+ * vertical space on every card for the sake of the one branch that needs it.
+ *
+ * `whiteSpace: 'nowrap'` on the all-time span is the third property: without it
+ * `3,886 ALL-TIME` breaks between the figure and its label, which is worse than
+ * the overflow it is avoiding.
+ */
+import type { CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { LevelTrack } from '../utils/levelTrack'
+
+interface LevelTrackMetaProps {
+  /** The track, or `null` while the era's curve is still loading. */
+  track: LevelTrack | null
+  /** Era-spanning points, drawn on the right. */
+  allTimeScore: number
+  /** The mounting kit's caption voice — font, size, tracking, colour. */
+  style: CSSProperties
+}
+
+export default function LevelTrackMeta({ track, allTimeScore, style }: LevelTrackMetaProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      className="flex flex-wrap items-baseline gap-2"
+      style={{ marginTop: 'var(--space-sm)' }}
+    >
+      {track && (
+        <span style={style}>
+          {track.nextLevel === null
+            ? t('sidebar.characterCard.topLevel')
+            : t('sidebar.characterCard.toNextLevel', {
+                points: track.pointsToNext.toLocaleString(),
+                level: track.nextLevel,
+              })}
+        </span>
+      )}
+      <span style={{ ...style, marginLeft: 'auto', whiteSpace: 'nowrap' }}>
+        {t('sidebar.characterCard.allTime', { points: allTimeScore.toLocaleString() })}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import FactionSigil from '../sigil/FactionSigil'
 import DefaultSigil from '../sigil/DefaultSigil'
 import { feedKicker, feedItemTitle } from '../feed/feedItemLabels'
 import { normalizeFeedItem } from '../feed/normalizeFeedItem'
+import LevelTrackMeta from '../LevelTrackMeta'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
 
@@ -1052,21 +1053,11 @@ export default function Sidebar() {
           </div>
 
           {/* ── Baseline: what is owed, and what has ever been earned ── */}
-          <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-            {track && (
-              <span style={identityMetaStyle}>
-                {track.nextLevel === null
-                  ? t('sidebar.characterCard.topLevel')
-                  : t('sidebar.characterCard.toNextLevel', {
-                      points: track.pointsToNext.toLocaleString(),
-                      level: track.nextLevel,
-                    })}
-              </span>
-            )}
-            <span style={{ ...identityMetaStyle, marginLeft: 'auto' }}>
-              {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-            </span>
-          </div>
+          <LevelTrackMeta
+            track={track}
+            allTimeScore={character.all_time_score}
+            style={identityMetaStyle}
+          />
         </section>
       ) : (
         <section className={PANEL_FRAME} style={panelStyle}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -32,6 +32,7 @@ import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * Cozy Coven MOBILE FieldDesk home (#500, re-dressed by #1209) — the coven's
@@ -324,21 +325,11 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
             />
           </div>
 
-          <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-            {levelTrack && (
-              <span style={trackMetaStyle}>
-                {levelTrack.nextLevel === null
-                  ? t('sidebar.characterCard.topLevel')
-                  : t('sidebar.characterCard.toNextLevel', {
-                      points: levelTrack.pointsToNext.toLocaleString(),
-                      level: levelTrack.nextLevel,
-                    })}
-              </span>
-            )}
-            <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-              {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-            </span>
-          </div>
+          <LevelTrackMeta
+            track={levelTrack}
+            allTimeScore={character.all_time_score}
+            style={trackMetaStyle}
+          />
         </Plate>
 
         {/* ── The pending row, in all three of its states (#1554) ── */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -14,6 +14,7 @@ import FactionSigil from '../../../components/sigil/FactionSigil'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * Default (na) MOBILE FieldDesk home — the account's carried life at a glance,
@@ -295,21 +296,11 @@ export default function DefaultFieldDesk({
           />
         </div>
 
-        <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-          {levelTrack && (
-            <span style={trackMetaStyle}>
-              {levelTrack.nextLevel === null
-                ? t('sidebar.characterCard.topLevel')
-                : t('sidebar.characterCard.toNextLevel', {
-                    points: levelTrack.pointsToNext.toLocaleString(),
-                    level: levelTrack.nextLevel,
-                  })}
-            </span>
-          )}
-          <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-            {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-          </span>
-        </div>
+        <LevelTrackMeta
+          track={levelTrack}
+          allTimeScore={character.all_time_score}
+          style={trackMetaStyle}
+        />
       </section>
 
       {/* ── The pending row: requests, other news, or a dead-ended "all caught

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -28,6 +28,7 @@ import {
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * The Ephemerists MOBILE FieldDesk home (#527, swept onto the Valley plate by
@@ -247,21 +248,11 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
           />
         </div>
 
-        <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-          {levelTrack && (
-            <span style={trackMetaStyle}>
-              {levelTrack.nextLevel === null
-                ? t('sidebar.characterCard.topLevel')
-                : t('sidebar.characterCard.toNextLevel', {
-                    points: levelTrack.pointsToNext.toLocaleString(),
-                    level: levelTrack.nextLevel,
-                  })}
-            </span>
-          )}
-          <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-            {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-          </span>
-        </div>
+        <LevelTrackMeta
+          track={levelTrack}
+          allTimeScore={character.all_time_score}
+          style={trackMetaStyle}
+        />
       </Leaf>
 
       {/* ── The pending row, in all three of its states (#1554) ── */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -11,6 +11,7 @@ import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * Everymen MOBILE FieldDesk home (#529) — the union broadsheet on a phone. The
@@ -294,21 +295,11 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
           />
         </div>
 
-        <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-          {levelTrack && (
-            <span style={trackMetaStyle}>
-              {levelTrack.nextLevel === null
-                ? t('sidebar.characterCard.topLevel')
-                : t('sidebar.characterCard.toNextLevel', {
-                    points: levelTrack.pointsToNext.toLocaleString(),
-                    level: levelTrack.nextLevel,
-                  })}
-            </span>
-          )}
-          <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-            {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-          </span>
-        </div>
+        <LevelTrackMeta
+          track={levelTrack}
+          allTimeScore={character.all_time_score}
+          style={trackMetaStyle}
+        />
       </Plate>
 
       {/* ── The pending row, in all three of its states (#1554) ── */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -11,6 +11,7 @@ import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * Singularity MOBILE FieldDesk home (#526) — the dark terminal on a phone. The
@@ -247,21 +248,11 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
           />
         </div>
 
-        <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-          {levelTrack && (
-            <span style={trackMetaStyle}>
-              {levelTrack.nextLevel === null
-                ? t('sidebar.characterCard.topLevel')
-                : t('sidebar.characterCard.toNextLevel', {
-                    points: levelTrack.pointsToNext.toLocaleString(),
-                    level: levelTrack.nextLevel,
-                  })}
-            </span>
-          )}
-          <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-            {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-          </span>
-        </div>
+        <LevelTrackMeta
+          track={levelTrack}
+          allTimeScore={character.all_time_score}
+          style={trackMetaStyle}
+        />
       </Panel>
 
       {/* ── The pending row, in all three of its states (#1554) ── */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -12,6 +12,7 @@ import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 import { WALL } from '../../../components/factionMarks/snideAtoms'
 import { factionRoleVars } from '../../../utils/factionRoles'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * S.N.I.D.E. MOBILE FieldDesk home (#530) — the operative's file on a phone.
@@ -328,21 +329,11 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
           />
         </div>
 
-        <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-          {levelTrack && (
-            <span style={trackMetaStyle}>
-              {levelTrack.nextLevel === null
-                ? t('sidebar.characterCard.topLevel')
-                : t('sidebar.characterCard.toNextLevel', {
-                    points: levelTrack.pointsToNext.toLocaleString(),
-                    level: levelTrack.nextLevel,
-                  })}
-            </span>
-          )}
-          <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-            {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-          </span>
-        </div>
+        <LevelTrackMeta
+          track={levelTrack}
+          allTimeScore={character.all_time_score}
+          style={trackMetaStyle}
+        />
       </WallPanel>
 
       {/* ── The pending row, in all three of its states (#1554) ── */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
@@ -13,6 +13,7 @@ import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 import { factionRoleVars } from '../../../utils/factionRoles'
+import LevelTrackMeta from '../../../components/LevelTrackMeta'
 
 /**
  * University of Asthmatics MOBILE FieldDesk home (#525/#852) — "One mark today.
@@ -247,21 +248,11 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
           />
         </div>
 
-        <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
-          {levelTrack && (
-            <span style={trackMetaStyle}>
-              {levelTrack.nextLevel === null
-                ? t('sidebar.characterCard.topLevel')
-                : t('sidebar.characterCard.toNextLevel', {
-                    points: levelTrack.pointsToNext.toLocaleString(),
-                    level: levelTrack.nextLevel,
-                  })}
-            </span>
-          )}
-          <span style={{ ...trackMetaStyle, marginLeft: 'auto' }}>
-            {t('sidebar.characterCard.allTime', { points: character.all_time_score.toLocaleString() })}
-          </span>
-        </div>
+        <LevelTrackMeta
+          track={levelTrack}
+          allTimeScore={character.all_time_score}
+          style={trackMetaStyle}
+        />
       </Sheet>
 
       {/* ── The pending row, in all three of its states (#1554) ── */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -70,6 +70,7 @@ import { formatPoints } from "../../../utils/points";
 import type { FieldDeskHomeState } from "../useFieldDeskHome";
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
+import LevelTrackMeta from "../../../components/LevelTrackMeta";
 
 /** Every tappable row clears the faction's 46px thumb target. */
 const TAP = 46;
@@ -239,30 +240,11 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
               />
             </div>
 
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-sm)",
-                marginTop: "var(--space-sm)",
-              }}
-            >
-              {levelTrack && (
-                <span style={trackMetaStyle}>
-                  {levelTrack.nextLevel === null
-                    ? t("sidebar.characterCard.topLevel")
-                    : t("sidebar.characterCard.toNextLevel", {
-                        points: levelTrack.pointsToNext.toLocaleString(),
-                        level: levelTrack.nextLevel,
-                      })}
-                </span>
-              )}
-              <span style={{ ...trackMetaStyle, marginLeft: "auto" }}>
-                {t("sidebar.characterCard.allTime", {
-                  points: character.all_time_score.toLocaleString(),
-                })}
-              </span>
-            </div>
+            <LevelTrackMeta
+              track={levelTrack}
+              allTimeScore={character.all_time_score}
+              style={trackMetaStyle}
+            />
           </div>
         }
       />


### PR DESCRIPTION
Closes #2767

At the top of the era's curve the two captions under the level bar cannot share the rail. `"Nowhere to go from here but the top"` is 35 characters at `--text-base` (10px), uppercase, `0.12em` tracking — roughly 262px — beside a ~105px `3,886 ALL-TIME`, in about 272px. There is no gap at which that pair fits, and on `align-items: center` both captions wrapped and their lines interleaved, so the two read as one paragraph. The mid-curve branch (`114 TO LEVEL 9`, ~105px) fits comfortably, which is why this survived: it only appears when `LevelTrack.nextLevel === null`.

## The seam

**The row's markup is authored in exactly one file.** That is what the guard tests, because it is the thing that made a three-property fix expensive — the same tree was hand-written in nine files, so nine copies had to be found before any could be fixed.

The failing test came first and went red on the real defect: nine sites still spelling the row, and no component owning it.

## What changed

`frontend/src/components/LevelTrackMeta.tsx` is new and owns the row. It takes `{ track, allTimeScore, style }` — `style` is the seam that keeps this ADR-0078-compatible: the row is **tree**, identical in all nine, and each kit's caption voice arrives through the per-file constant the site already had (`identityMetaStyle` on the rail, `trackMetaStyle` on each desk, which is `{...CAPTION}` for Coven and `{...smallCaps}` for UA). Those constants are passed, not re-derived, so no skin loses anything it drew.

The fix itself is three properties on that one row: `flex-wrap`, `items-baseline` in place of `items-center`, and `whiteSpace: 'nowrap'` on the all-time span so `3,886 ALL-TIME` never breaks between the figure and its label. When both captions fit — every character below the top — it renders exactly as today: one line, all-time flush right on its existing auto margin. When they don't, all-time drops to its own line and stays right. Deliberately *not* an unconditional stack, which would spend a line of vertical space on every card for the one branch that needs it.

Nine mounts: `components/layout/Sidebar.tsx` and the eight mobile Field Desks. `WowFieldDesk.tsx` spelled the row as an inline style object rather than the `flex items-center gap-2` the other eight used — same defect, different spelling — and its copy is gone too. `AlbescentFieldDesk.tsx` is untouched: it renders `DefaultFieldDesk` whole and inherits the fix.

Net −144/+285, of which 161 lines are the guard: the nine copies collapse to one.

## The runnable check

`frontend/src/__tests__/levelTrackMetaRow.test.tsx`, in the shape of the existing source-scan guards on `test/sourceScan.ts`:

- `sidebar.characterCard.allTime` and `…toNextLevel` are drawn in exactly one file. It anchors on the **i18n keys**, not on a class name, because that is precisely what the WOW copy would slip past.
- `…topLevel` is allowlisted to two files besides the row: the character profile draws the same sentence in its own body voice at `--text-content`, where #2383 already gave it the whole row. Different surface, not a tenth copy.
- All nine sites mount `<LevelTrackMeta />` — and no tenth does.
- The rendered row carries the wrap, the baseline, `white-space:nowrap` and `margin-left:auto`, and spreads the caller's `style` onto both captions.

## Verification

- `npm test` — 458 files, 9365 passed, 1 skipped.
- `npm run typecheck` clean; `npm run typecheck:design-sync` clean; `npm run lint` clean; `npm run build` clean.
- `npm run budget` — CSS **21.6 KB, unchanged from `origin/main`**, as an extraction of duplicated markup should be. Initial JS 136.7 → 136.8 KB gzipped: the component lands in the initial chunk because the rail imports it, and the eight copies it replaces were in lazy chunks. The `WARN JS` line is pre-existing on `origin/main` at the same threshold — I measured the baseline by building a detached `origin/main` in the same worktree.

## What to eyeball

**Visual QA is outstanding — I have no browser and no dev stack.** The harness is `renderToStaticMarkup` in node: it has no layout engine, so nothing in this PR proves the collision is gone. I am not claiming it visually.

Please check, per `WORLD_ZERO_STYLE.md:1100`:

- **320px, the rail's character card** — a character at max level (the broken case: the sentence and the all-time figure must sit on separate lines, all-time still flush right), and one level below it (the unchanged case: one line, all-time flush right, identical to today).
- **375px, the mobile Field Desk** — same two characters. This column is narrower than the rail, so it was the worse of the two. Worth a look on at least one of the loud skins (WOW or S.N.I.D.E., whose row was the inline-style copy and Coven's `{...CAPTION}`) to confirm the caption voice survived the extraction.
- Both themes on one of the above, since the captions read a `--*-quiet` ink through the passed constant.

**Left alone deliberately, and not looked at:** the character profile's own top-of-curve line (`DefaultProfileBody`, `profileSkin`) — same string, different surface, its own row since #2383. And `AlbescentFieldDesk`, which is a wrapper; if `DefaultFieldDesk` is right at 375px, it is right too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
