### PR TITLE
The arc says the owner's words, and the ring holds its caption

### DIFF
--- a/frontend/src/components/StartHereMark.tsx
+++ b/frontend/src/components/StartHereMark.tsx
@@ -33,8 +33,13 @@ import { useTranslation } from 'react-i18next'
  * earns the mark it would wear na's ink over that faction's skin; the upgrade
  * is a `slug` prop through `factionCssVar`, and it is not worth a prop today.
  *
- * The copy is a PLACEHOLDER, like every string in this arc — the owner writes
- * the words (`locales/en/onboarding.json`).
+ * THE MARK SHOUTS, THE CATALOG DOES NOT (#2766). `mark.label` is stored as
+ * `Start here` and this surface uppercases it, so the player reads START HERE.
+ * The stored casing is therefore the sentence-case one; the home page's
+ * `home:hero.cta.loggedOut` says `Start Here` because THAT button does not
+ * uppercase and its Title Case is its own. Same phrase deliberately — the
+ * promise made on the marketing page is repeated where it pays off — and the
+ * two differ in the catalog only because one of the two surfaces shouts.
  */
 export default function StartHereMark() {
   const { t } = useTranslation('onboarding')

--- a/frontend/src/locales/en/home.json
+++ b/frontend/src/locales/en/home.json
@@ -10,7 +10,7 @@
     "tagline": "a collaborative production game played in the real world",
     "cta": {
       "loggedIn": "Find a Task",
-      "loggedOut": "PLACEHOLDER — the way in, for a stranger"
+      "loggedOut": "Start Here"
     },
     "devLogin": "dev login (no OAuth)"
   },

--- a/frontend/src/locales/en/onboarding.json
+++ b/frontend/src/locales/en/onboarding.json
@@ -1,40 +1,36 @@
 {
   "card": {
-    "stepCaption": "PLACEHOLDER — STEP",
-    "lookAround": "PLACEHOLDER — let me just look around first"
+    "stepCaption": "Step",
+    "lookAround": "I just want to look around"
   },
   "intro": {
-    "title": "PLACEHOLDER — the title of the pitch",
+    "title": "What is World Zero?",
     "paragraph": {
-      "game": "PLACEHOLDER (slot 1 of 6 — say that this is a game).",
-      "realWorld": "PLACEHOLDER (slot 2 of 6 — say that the things you do happen in the real world, away from the screen).",
-      "proof": "PLACEHOLDER (slot 3 of 6 — say that you photograph what you did, as proof).",
-      "rated": "PLACEHOLDER (slot 4 of 6 — say that other players rate that photo, and that is how you score).",
-      "free": "PLACEHOLDER (slot 5 of 6 — say that it is free).",
-      "maker": "PLACEHOLDER (slot 6 of 6 — say that a person made this, and that it is small and a bit silly)."
+      "game": "World Zero is a game you play in real life.",
+      "character": "Like many games, you will start by creating a character. This character doesn't need to be you.",
+      "tasks": "Like in many games, you will have a variety of tasks you can complete (such as \"slay a dragon\" or \"collect high fives\").",
+      "proof": "Complete them and post proof (in the form of photos, videos or audio) in order to get points.",
+      "levels": "When you get enough points, you can level up and have access to more interesting, more difficult tasks, and vote to give points to tasks others have completed well.",
+      "ahead": "Along the way there will be warring organizations, mysteries and most likely character development. World Zero will always be free and have no ads."
     },
-    "note": "PLACEHOLDER — one line, set beside the tick",
-    "continue": "PLACEHOLDER — go on then"
+    "continue": "I'm in"
   },
   "auth": {
-    "title": "PLACEHOLDER — the title of the sign-in stop",
-    "body": "PLACEHOLDER — one or two lines saying why a score needs somewhere to live. No provider is named here; the buttons name themselves.",
-    "note": "PLACEHOLDER — one line, set beside the tick"
+    "title": "Login Logistics",
+    "body": "World Zero doesn't store any personal information except your email and whatever you post yourself. This means we ask someone else to confirm that your email belongs to you. Choose your way in."
   },
   "terms": {
-    "title": "PLACEHOLDER — the title of the agreement stop",
-    "body": "PLACEHOLDER — one or two lines framing the document below and saying what agreeing binds you to. The document itself is the real Disclaimer and is not a placeholder.",
-    "note": "PLACEHOLDER — one line, set beside the tick",
-    "accept": "PLACEHOLDER — I agree",
-    "error": "PLACEHOLDER — that did not save; try again"
+    "title": "Terms and Conditions",
+    "body": "You understand and agree to the following",
+    "accept": "Yeah yeah, let me play",
+    "error": "Whoops! That didn't work. Try again?"
   },
   "mark": {
-    "label": "PLACEHOLDER — START HERE"
+    "label": "Start here"
   },
   "returning": {
     "title": "Welcome back",
     "body": "You deleted your World Zero account on {{date}}. Nothing from it carries over — your characters, praxis, votes and comments are gone. Start fresh as a new player?",
-    "note": "PLACEHOLDER — one line, set beside the tick",
     "confirm": "Start fresh",
     "error": "That didn't go through. Try again."
   }

--- a/frontend/src/pages/__tests__/homeLoginNotice.test.tsx
+++ b/frontend/src/pages/__tests__/homeLoginNotice.test.tsx
@@ -17,6 +17,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import '../../i18n'
+import home from '../../locales/en/home.json'
 
 vi.mock('../../auth/AuthContext', () => ({
   useAuth: () => ({ user: null, refetch: () => {} }),
@@ -72,5 +73,15 @@ describe('Home, ?login=', () => {
     expect(markup).toContain('data-testid="home-hero-cta"')
     expect(markup).not.toContain('data-testid="sign-in-google"')
     expect(markup).not.toContain('data-testid="sign-in-discord"')
+  })
+
+  // #2766 — the door into the arc was itself a placeholder. It is the first
+  // line of copy a stranger meets on the public marketing page, under the
+  // wordmark and the tagline, and `main` auto-deploys.
+  it('says the written words on that CTA, not a placeholder', () => {
+    const markup = render('')
+
+    expect(markup).toContain(home.hero.cta.loggedOut)
+    expect(home.hero.cta.loggedOut).not.toContain('PLACEHOLDER')
   })
 })

--- a/frontend/src/pages/__tests__/onboardingCards.test.tsx
+++ b/frontend/src/pages/__tests__/onboardingCards.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../../api/auth', () => ({ loginWith: () => {} }))
 import IntroCard from '../onboarding/IntroCard'
 import AuthCard from '../onboarding/AuthCard'
 import TermsCard from '../onboarding/TermsCard'
+import { RING_CAPTION_MAX_CHARS } from '../onboarding/OnboardingCard'
 
 const render = (node: React.ReactNode): string =>
   renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>)
@@ -212,5 +213,67 @@ describe('the terms card', () => {
     const markup = render(<TermsCard onAccepted={() => {}} />)
 
     expect(markup).toContain('data-testid="onboarding-accept-terms"')
+  })
+})
+
+/* ========================================================================== *
+ * #2766 — THE COPY IS WRITTEN, and #2765 — THE RING HOLDS ITS CAPTION.
+ *
+ * These are one block because they are one seam: what the catalog holds and
+ * what the ring can draw are the same question. The arc is public with no
+ * `ProtectedRoute` and `main` auto-deploys, so a slot that slips back to
+ * `PLACEHOLDER` is placeholder text in front of a stranger.
+ * ========================================================================== */
+describe('the arc a stranger actually reads', () => {
+  for (const [name, card] of CARDS) {
+    it(`${name} shows a stranger no placeholder`, () => {
+      const words = render(card).replace(/<[^>]*>/g, ' ')
+
+      expect(words).not.toContain('PLACEHOLDER')
+    })
+
+    it(`${name} wraps an over-long ring caption INSIDE the circle (#2765)`, () => {
+      // 0.2em tracking is the ring caption's alone on this sheet once the note
+      // slot is gone — the control is 0.14em and the title carries none.
+      const ring = (render(card).match(/style="[^"]*"/g) ?? []).filter((style) =>
+        style.includes('letter-spacing:0.2em'),
+      )
+
+      expect(ring).toHaveLength(1)
+      // Without these the caption ran out past the conic band on both sides and
+      // the second line ragged left. `text-align` centres the LINES;
+      // `overflow-wrap` is what lets a too-long word break at all. The <h1>
+      // two elements down has carried the same pair for the same reason.
+      expect(ring[0]).toContain('text-align:center')
+      expect(ring[0]).toContain('overflow-wrap:anywhere')
+    })
+
+    it(`${name} stands its tick alone, the note slot retired (#2766)`, () => {
+      // The tick is kit furniture — "the 3px band, the conic ring, and one
+      // tick" — not a completion state, so nothing is set beside it and the
+      // `note` prop is gone rather than optional.
+      expect(render(card)).toMatch(/<span aria-hidden="true"[^>]*><\/span><\/div>/)
+    })
+  }
+
+  it('keeps the ring caption inside the characters the ring can draw', () => {
+    // Geometry, not preference: 76px of usable width at 11px with 0.2em
+    // tracking in a 0.6em-advance monospace. The constant carries the working.
+    expect(onboarding.card.stepCaption.length).toBeLessThanOrEqual(RING_CAPTION_MAX_CHARS)
+  })
+
+  it('stores the four CSS-uppercased strings unshouted', () => {
+    // `text-transform: uppercase` does the shouting — the caption style for the
+    // first two, `controlBase` for the last two. A catalog holding pre-shouted
+    // text gives the next editor no way to tell whether the caps are the design
+    // or the copy (#2598 §B2b removed exactly that trap from another catalog).
+    for (const shouted of [
+      onboarding.card.stepCaption,
+      onboarding.card.lookAround,
+      onboarding.intro.continue,
+      onboarding.terms.accept,
+    ]) {
+      expect(shouted).not.toBe(shouted.toUpperCase())
+    }
   })
 })

--- a/frontend/src/pages/__tests__/onboardingCards.test.tsx
+++ b/frontend/src/pages/__tests__/onboardingCards.test.tsx
@@ -16,9 +16,10 @@
  *   2. **Neither provider privileged.** Two buttons that drift apart in size,
  *      class or ink is how one quietly becomes the recommended way in. The
  *      assertion compares the rendered tags rather than eyeballing the source.
- *   3. **The real Disclaimer.** `main` auto-deploys. Every other string on this
- *      route is a placeholder and must be; the document is not, and the check
- *      reads `common.json` so a swap to placeholder legal text fails here.
+ *   3. **The real Disclaimer.** `main` auto-deploys, and the check reads
+ *      `common.json` so a swap to placeholder legal text fails here. Since
+ *      #2766 the copy around it is written too, and the block below holds the
+ *      whole route to that.
  *   4. **Rainbow in exactly three places.** The restraint IS the design, which
  *      makes it the one visual rule a test can hold: three references per card,
  *      counted in the markup.
@@ -200,9 +201,10 @@ describe('the terms card', () => {
   it('reads the document from the same keys the Disclaimer page does', () => {
     const markup = render(<TermsCard onAccepted={() => {}} />)
 
-    // The document block holds no PLACEHOLDER — the framing line above it does,
-    // and that is the boundary: `main` auto-deploys, so provisional legal text
-    // would ship to production.
+    // No PLACEHOLDER in the document block: `main` auto-deploys, so provisional
+    // legal text would ship to production. The framing line above it used to be
+    // the placeholder side of that boundary and is written now (#2766), so the
+    // whole card is held to it by the block at the foot of this file.
     const document = /data-testid="onboarding-terms-document"[^>]*>([\s\S]*?)<\/div>/.exec(markup)?.[1]
 
     expect(document).toBeTruthy()

--- a/frontend/src/pages/onboarding/AuthCard.tsx
+++ b/frontend/src/pages/onboarding/AuthCard.tsx
@@ -42,7 +42,6 @@ export default function AuthCard() {
     <OnboardingCard
       step={2}
       title={t('auth.title')}
-      note={t('auth.note')}
       // `className=''` drops `.btn-primary`: on this sheet the primary control
       // is na's card ink, and the app-wide button skin would put a second
       // identity on the card.

--- a/frontend/src/pages/onboarding/AuthCard.tsx
+++ b/frontend/src/pages/onboarding/AuthCard.tsx
@@ -23,8 +23,15 @@ import OnboardingCard, { primaryControl } from './OnboardingCard'
  * SKIPPED ENTIRELY WHEN A SESSION EXISTS — the flow's one asymmetry, and it is
  * `Onboarding.tsx` that applies it, not this card.
  *
- * EVERY STRING HERE IS A PLACEHOLDER except the two button labels, which are
- * the shipped `common:signIn.*` copy this card reuses.
+ * THE BODY IS A FACTUAL CLAIM ON A CONSENT SURFACE (#2766). It names what is
+ * stored — the email, and whatever the player posts — so it is the sentence
+ * that would be quoted if it were ever disputed; the carve-out is worded to
+ * cover proof media and comments, which hang off the praxis rather than the
+ * character. `OAuthProvider.provider_user_id` is the one stored item it does
+ * not reach, recorded on #2766 as a known gap rather than a discovered one.
+ * The slot's job moved with the wording: it answers what happens to your data
+ * rather than why a score needs somewhere to live, which is what the old
+ * placeholder's brief and `SPEC-onboarding.md` describe.
  */
 
 const prose: CSSProperties = {

--- a/frontend/src/pages/onboarding/IntroCard.tsx
+++ b/frontend/src/pages/onboarding/IntroCard.tsx
@@ -9,21 +9,32 @@ import OnboardingCard, { primaryControl } from './OnboardingCard'
  * The paragraph is assembled from six named slots and rendered as a single
  * `<p>`: the slots are what make each of the six a thing the owner can write
  * *into* rather than a thing to remember, and the join is what keeps it one
- * paragraph rather than three beats. The order front-loads the ask — what the
- * game will actually cost you is sentences two and three, never the end.
+ * paragraph rather than three beats.
  *
  * The six are called out one call site each rather than mapped over a key list,
  * so the catalog stays greppable from here (`SignInOptions` makes the same
  * trade for the same reason).
+ *
+ * THE SIX ARE NOT THE SIX THEY WERE (#2766). The owner's written pitch lands a
+ * different six — character, tasks, levels, what lies ahead — so four keys were
+ * RENAMED with it (`realWorld`→`character`, `rated`→`tasks`, `free`→`levels`,
+ * `maker`→`ahead`). A key called `free` holding a sentence about levelling is
+ * the trap #2598 spent a pass removing from another catalog.
  *
  * VOCABULARY. "Praxis" does not appear on this card, or on any card before
  * auth — the player meets the word once they have one. "Sign up" is not used
  * for account creation either; a Character *signs up for* a task, and that is
  * the only thing it means. Factions are cut entirely: invitation-gated
  * (ADR-0022) and unreachable at level 0, so naming them here sells something
- * the game cannot deliver for a long time.
+ * the game cannot deliver for a long time — which is why the written copy says
+ * "warring organizations" and not the word the guard test forbids.
  *
- * EVERY STRING IS A PLACEHOLDER. The owner writes the words.
+ * WHAT THE PITCH KNOWINGLY UNDERSTATES, ruled and recorded on #2766 rather than
+ * overlooked: voting is NOT level-gated (`services/vote.py::viewer_can_vote`
+ * refuses only on self-vote and duel), and the budget starts full, so the
+ * levels slot reads as though voting unlocks with level when a new character
+ * can already vote. The failure mode is a pleasant surprise, not a broken
+ * promise, so the owner's wording stands.
  */
 
 const prose: CSSProperties = {
@@ -39,18 +50,17 @@ export default function IntroCard({ onContinue }: { onContinue: () => void }) {
 
   const paragraph = [
     t('intro.paragraph.game'),
-    t('intro.paragraph.realWorld'),
+    t('intro.paragraph.character'),
+    t('intro.paragraph.tasks'),
     t('intro.paragraph.proof'),
-    t('intro.paragraph.rated'),
-    t('intro.paragraph.free'),
-    t('intro.paragraph.maker'),
+    t('intro.paragraph.levels'),
+    t('intro.paragraph.ahead'),
   ].join(' ')
 
   return (
     <OnboardingCard
       step={1}
       title={t('intro.title')}
-      note={t('intro.note')}
       actions={
         <button type="button" onClick={onContinue} style={primaryControl} data-testid="onboarding-continue">
           {t('intro.continue')}

--- a/frontend/src/pages/onboarding/OnboardingCard.tsx
+++ b/frontend/src/pages/onboarding/OnboardingCard.tsx
@@ -20,7 +20,14 @@ import { useTranslation } from 'react-i18next'
  *   1. the 3px band that IS the border — a transparent frame with the gradient
  *      painted into the border box, never a decorative stripe;
  *   2. the conic ring the step numeral sits inside;
- *   3. one tick, beside the card's single caption line.
+ *   3. one tick.
+ *
+ * THE TICK STANDS ALONE (#2766). It used to sit beside a `note` caption, and
+ * the note slot is retired outright — the owner cut all four of its strings, so
+ * the prop came off rather than becoming optional. The tick is kit furniture
+ * (`SPEC-onboarding.md`: "the 3px band that is the border, the conic ring, and
+ * one tick"), not a completion state, so it needs nothing beside it and this
+ * chassis carries no branch for a slot that is never filled.
  *
  * A card therefore cannot add a fourth by accident; it supplies words and a
  * control, and the sheet is not negotiable from outside.
@@ -44,6 +51,24 @@ const LORA = 'var(--font-display)'
 const RING_SIZE = 84
 /** The sheet stays one column at every width; no form-factor branch to drift. */
 const SHEET_WIDTH = 560
+
+/**
+ * How long `card.stepCaption` may be. GEOMETRY, NOT PREFERENCE (#2765) — the
+ * ring is drawn to hold a numeral and one short word, and the number is
+ * derivable rather than a taste:
+ *
+ *   84px outer, less `--space-xs` of conic band on each side  = 76px usable
+ *   `--text-md` is 11px, `--font-body` is a monospace at 0.6em = 6.6px advance
+ *   plus `letterSpacing: '0.2em'`                             = 2.2px tracking
+ *   76 / 8.8                                                  = 8.6 characters
+ *
+ * So eight fit and the ninth clips. `PLACEHOLDER` measured ~105px and spilled
+ * out of the circle on both sides, which is what filed the bug; the caption
+ * below now also degrades rather than overflowing, but a caption that needs the
+ * degradation is a copy problem and this constant is where that is written
+ * down. `pages/__tests__/onboardingCards.test.tsx` holds the catalog to it.
+ */
+export const RING_CAPTION_MAX_CHARS = 8
 
 /** Label-tier caption voice, shared by every small mark on the sheet. */
 const caption: CSSProperties = {
@@ -112,15 +137,12 @@ const secondaryControl: CSSProperties = {
 export default function OnboardingCard({
   step,
   title,
-  note,
   actions,
   children,
 }: {
   /** Which stop this is. Renders as the numeral inside the conic ring. */
   step: number
   title: string
-  /** The one caption line, set beside the card's single rainbow tick. */
-  note: string
   /** The card's own control(s). The look-around escape is not one of these. */
   actions: ReactNode
   children: ReactNode
@@ -194,7 +216,22 @@ export default function OnboardingCard({
               <span style={{ fontFamily: LORA, fontWeight: 600, fontSize: 'var(--text-title)' }}>
                 {step}
               </span>
-              <span style={{ ...caption, marginTop: 'var(--space-xs)' }}>
+              {/* #2765: the caption has to DEGRADE inside the circle. Without
+                  these two it wrapped to two lines that were each wider than
+                  the ring, and the second hung left. `overflow-wrap` is what
+                  lets a too-long word break at all; `text-align` is what
+                  centres the lines it breaks into — the <h1> below has carried
+                  the same pair for the same reason. Neither replaces
+                  RING_CAPTION_MAX_CHARS: this is the failure being legible
+                  rather than the failure being prevented. */}
+              <span
+                style={{
+                  ...caption,
+                  marginTop: 'var(--space-xs)',
+                  textAlign: 'center',
+                  overflowWrap: 'anywhere',
+                }}
+              >
                 {t('card.stepCaption')}
               </span>
             </div>
@@ -223,11 +260,12 @@ export default function OnboardingCard({
           style={{
             display: 'flex',
             alignItems: 'center',
-            gap: 'var(--space-sm)',
             margin: 'var(--space-lg) 0',
           }}
         >
-          {/* 3 of 3 — one tick. */}
+          {/* 3 of 3 — one tick, and nothing beside it (#2766 retired the note
+              slot). The row survives the caption it used to seat, so the mark
+              keeps the height and the spacing it always had. */}
           <span
             aria-hidden="true"
             style={{
@@ -239,7 +277,6 @@ export default function OnboardingCard({
               flex: 'none',
             }}
           />
-          <span style={{ ...caption, letterSpacing: '0.04em' }}>{note}</span>
         </div>
 
         <div

--- a/frontend/src/pages/onboarding/ReturningCard.tsx
+++ b/frontend/src/pages/onboarding/ReturningCard.tsx
@@ -132,7 +132,6 @@ export default function ReturningCard() {
     <OnboardingCard
       step={1}
       title={t('returning.title')}
-      note={t('returning.note')}
       actions={
         <button
           type="button"

--- a/frontend/src/pages/onboarding/TermsCard.tsx
+++ b/frontend/src/pages/onboarding/TermsCard.tsx
@@ -98,7 +98,6 @@ export default function TermsCard({ onAccepted }: { onAccepted: () => void }) {
     <OnboardingCard
       step={3}
       title={t('terms.title')}
-      note={t('terms.note')}
       actions={
         <button type="button" onClick={accept} style={primaryControl} data-testid="onboarding-accept-terms">
           {t('terms.accept')}

--- a/frontend/src/pages/onboarding/TermsCard.tsx
+++ b/frontend/src/pages/onboarding/TermsCard.tsx
@@ -6,8 +6,17 @@ import i18n from '../../i18n'
 import OnboardingCard, { primaryControl } from './OnboardingCard'
 
 /**
- * Stop 3 — the agreement, and the only card on this route whose document is
- * real copy rather than a placeholder.
+ * Stop 3 — the agreement.
+ *
+ * THE FRAME POINTS AT THE DOCUMENT, IT DOES NOT SUMMARISE IT (#2766).
+ * `terms.body` is an affirmative acknowledgement of understanding and the
+ * control beneath it is `Yeah yeah, let me play`, so the card asserts
+ * comprehension in its frame and performs the opposite in its control. Both
+ * were ruled, one pass apart; if either ever moves they move together. Recorded
+ * with it: the Disclaimer's copyright expectation ("submit no material … you
+ * have not created") reaches a player only if they read the legalese, which
+ * `SPEC-onboarding.md`'s "withholding the cost is a bait-and-switch" rule has
+ * an interest in. Raised and overruled — decisions, not oversights.
  *
  * THE DOCUMENT IS THE DISCLAIMER, VERBATIM (`common:disclaimer.*`) — the same
  * three paragraphs `pages/Disclaimer.tsx` renders, read from the same keys so


### PR DESCRIPTION
Part of #2766
Closes #2765

The onboarding arc stops saying `PLACEHOLDER` to strangers, and the step ring stops
spilling its caption. One PR because they edit the same five files.

## The seam

**The catalog and the rendered card, together.** What the catalog holds and what the ring
can draw are the same question — the spill was a copy defect wearing a layout costume — so
both halves are pinned in `pages/__tests__/onboardingCards.test.tsx`, at
`renderToStaticMarkup` over each card. The loop went red first on all five real defects
(placeholder text in the markup, no `text-align`/`overflow-wrap` on the ring caption, a note
beside the tick, a caption over the ring's character budget, shouted values in the catalog),
then green.

## What landed

**18 values written, verbatim from the owner's rulings on #2766.** The four short chassis
strings, the six-slot pitch, and both bodies.

**Stored unshouted.** `card.stepCaption`, `card.lookAround`, `intro.continue` and
`terms.accept` are uppercased by `text-transform` — the caption style for the first two,
`controlBase` for the last two — so `I'm in` ships as **I'M IN** from a catalog that says
`I'm in`. A guard asserts none of the four equals its own uppercase, because a catalog
holding pre-shouted text gives the next editor no way to tell whether the caps are the
design or the copy (#2598 §B2b).

**`mark.label` — the check the ruling asked for, and the answer.** `StartHereMark` sets
`textTransform: 'uppercase'` (`components/StartHereMark.tsx:49`), so the mark's own surface
*does* shout and `Start here` is stored sentence-case as ruled. The home button does **not**
uppercase — `home:hero.cta.loggedIn` ships as `Find a Task` in Title Case — so
`hero.cta.loggedOut` is `Start Here`, its own casing. Same phrase, deliberately; they differ
in the catalog only because one of the two surfaces shouts. Recorded in the component.

**Four keys renamed with the pitch:** `realWorld`→`character`, `rated`→`tasks`,
`free`→`levels`, `maker`→`ahead`, and `IntroCard`'s array reordered to match. A key called
`free` holding a sentence about levelling is the drift #2598 exists to stop. Both guard tests
iterate `Object.values(...)`, so they survived the rename untouched.

**The note slot is retired outright.** `intro.note`, `auth.note`, `terms.note` and
`returning.note` are gone, and the `note` prop came **off** `OnboardingCard` rather than
becoming optional — `tsc` then named all four call sites for me. The tick survives as kit
furniture (`SPEC-onboarding.md`: "the 3px band that is the border, the conic ring, and one
tick") and stands alone; its flex row is kept so the mark holds exactly the height and
spacing it always had.

**The ring (#2765), both halves.** `card.stepCaption` is `Step`, and the caption span now
carries `textAlign: 'center'` + `overflowWrap: 'anywhere'` so one word too long wraps
*inside* the circle instead of crossing the conic band. The geometry is written down as
`RING_CAPTION_MAX_CHARS = 8`, verified on disk rather than taken on trust: `RING_SIZE` 84
less `--space-xs` (4px) each side = 76px usable; `--text-md` is 11px and `--font-body` is
Courier Prime at 0.6em advance, so 6.6px + 0.2em tracking = 8.8px per character, and
76 / 8.8 = 8.6. Eight fit, the ninth clips. A test holds the catalog to the constant.

## ⚠️ The brief I was dispatched with was one ruling stale

I was told 8 slots stayed reserved (`intro.paragraph.*`, `auth.body`, `terms.body`) and that
this PR should therefore be partial. **#2766 has four owner comments after the 20:00:45Z
ruling** — 20:27, 20:40, 21:28 and 21:36 — that write all eight, rename the four keys, and
close with *"#2766 is fully ruled … Now dispatchable."* Nothing conflicts: the 10 values and
4 cuts in my brief are character-identical to the final state, it simply stops short.

I built the **later** ruling, because the earlier one says in terms that *"a PR that writes
ten values and leaves eight `PLACEHOLDER`s next to them is worse than one that waits"* —
and shipping "What is World Zero?" above six `PLACEHOLDER (slot N of 6 …)` paragraphs is
exactly that.

**This leaves `Part of #2766`, not `Closes`, on purpose.** All 22 placeholders it tracks are
now addressed, so it is closable — but the dispatch asked for `Part of`, PR-to-issue linkage
is fixed at creation time and cannot be edited off, and closing an issue the orchestrator
believes is partial is the one move here that is not cheaply reversible. **Close it by hand
once you agree the copy landed as ruled.**

## Out of scope, left alone

`factions:wow.join.memberStanding`, `feed:factionHero.wow.motto` and Albescent's two perk
names (#2774); the five faction About `descriptions.*` (deliberate, #2598); `returning.title`
/ `.body` / `.confirm` / `.error` (already written). The Disclaimer is untouched — this
branch is based on `origin/main` **after** #2790, so it renders the owner's three paragraphs
and no `p4`. Rebased again mid-work onto #2791.

## Decisions recorded in code, not re-litigated

Three things were raised on #2766 and overruled; each is now a docblock note so the next
reader meets a decision rather than an oversight, and can reverse it without re-deriving the
argument:

- `TermsCard` — the frame asserts *understanding* while the button says `Yeah yeah, let me
  play`; and the Disclaimer's copyright expectation reaches a player only through the
  legalese.
- `IntroCard` — the pitch reads as though voting unlocks with level. It does not:
  `viewer_can_vote` refuses only on self-vote and duel, and the budget starts full.
- `AuthCard` — `OAuthProvider.provider_user_id` is stored and the body's carve-out does not
  reach it.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally, on the rebased base:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 460 files, 9460 passed, 1 skipped |
| `npm run build` | built |
| `npm run budget` | JS `WARN` — **pre-existing**, not this branch: the catalog got 274 bytes *smaller* (2071 → 1797) and no code was added to the initial chunk. CSS ok. |

No backend, no route, no schema — `api-schema` has nothing to regenerate. No CSS file and no
`index.css` touched; no hex, no theme ternary, all colour still through
`--faction-default-*`.

**Visual QA is outstanding** — I have no browser and no dev stack, so the ring was verified
by arithmetic and by the rendered style attribute, not by eye.

## What to eyeball

- The four onboarding stops — `/start` intro, auth, terms, and `/start/again` — at **375px**
  and **560px**. The pitch is now ~110 words, roughly double the old draft and the longest
  string in the arc; the phone is where it earns or loses.
- The **step ring** at each of those stops: numeral and `STEP` entirely inside the circle,
  nothing crossing the conic band, at both widths.
- The **tick with nothing beside it** — it used to seat a caption; check the row still reads
  as a deliberate mark rather than a stray dot.
- `YEAH YEAH, LET ME PLAY` on a 375px phone — it was cut from 33 characters to 22 to fit a
  control that no longer needs to wrap. Confirm it does not.
- The **public marketing home page, signed out**: `Start Here` under the wordmark and
  tagline, in the slot that reads `Find a Task` signed in. It renders as stored —
  `markerButton` sets `textTransform: 'none'` — so this is the one of the two *Start Here*s
  that is not shouted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
