### PR TITLE
The invitation's deferral is one key and one word; the card announces, it does not preview

### DIFF
--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -345,7 +345,14 @@ export default function InvitationLetterPopup({
           and only the confirm step is the shared control's: this button closes
           the letter and leaves the invitation standing, while the cancel one
           click further in returns to the pitch. Collapsing them would turn
-          "not now" into "never mind" on a letter that survives the dismissal. */}
+          "not now" into "never mind" on a letter that survives the dismissal.
+
+          `invitation.dismiss` is top-level, not per-slug, and since #2620 the
+          feed's invitation CARD reads it too — the one string that card and
+          this letter share, because deferring is one act. Reword it here and
+          every surface follows. Nothing ELSE is shared: the card announces the
+          letter, it does not preview it, so its `feed:invitationLetter.*` copy
+          is meant to differ from the headline, pitch and perks above. */}
       {!confirming ? (
         <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'center' }}>
           <button

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -100,11 +100,22 @@ const QUIET: CSSProperties = {
  *  - **Not now** is the slot's existing archive write, wearing a label. It is
  *    emphatically **not** "Decline": ADR-0070 says archiving never answers
  *    anything, the letter stays valid, the factions page still joins, and
- *    `InvitationLetter` has no status column to decline into.
+ *    `InvitationLetter` has no status column to decline into. Its label is the
+ *    letter's own `factions:invitation.dismiss`, the one key both surfaces read
+ *    for this act (#2620) — the only string this card and the letter share.
  *
  * The confirm step is the inline two-stage idiom `InvitationLetterPopup` already
  * uses for the same act — prose plus [confirm] [cancel] replacing the button
  * row — not a new dialog component.
+ *
+ * **This card ANNOUNCES the letter; it does not PREVIEW it** (owner ruling on
+ * #2620, 2026-08-26). Everything else it says is its own: it reads no
+ * `factions:<slug>.invitation.*` headline, pitch, perk or CTA, and "View
+ * Factions" sends the player to the factions page rather than opening the
+ * letter. So `feed:invitationLetter.*` and the letter's copy are two
+ * independent vocabularies **by design** — when they drift apart in a copy
+ * sweep, that is not a defect to file, and nothing here should be pointed at
+ * the letter's keys to "align" them.
  */
 export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
   const { faction_slug } = item.payload;
@@ -310,7 +321,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
               )}
               {onNotNow && (
                 <button type="button" className="feed-action" data-invitation-not-now onClick={onNotNow} style={QUIET}>
-                  {i18n.t("feed:invitationLetter.notNow")}
+                  {i18n.t("factions:invitation.dismiss")}
                 </button>
               )}
             </>

--- a/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
+++ b/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
@@ -54,7 +54,9 @@ function render(factionSlug: string | null, onNotNow?: () => void): string {
 
 const VIEW_FACTIONS = i18n.t('feed:invitationLetter.viewFactions')
 const ACCEPT = i18n.t('common:actions.accept')
-const NOT_NOW = i18n.t('feed:invitationLetter.notNow')
+// The letter's own dismiss key, which this card now shares (#2620) — the one
+// string the announcement and the letter it announces have in common.
+const NOT_NOW = i18n.t('factions:invitation.dismiss')
 
 describe('acceptMode — the predicate', () => {
   it('suppresses Accept when the letter names the faction you are already in', () => {

--- a/frontend/src/locales/README.md
+++ b/frontend/src/locales/README.md
@@ -137,6 +137,29 @@ The figures arrive as `{{count}}` (or `{{hours}}` for S.N.I.D.E., already
 zero-padded). Reword freely around them; the shape of the number — 1-based
 shifts, three-digit hours — is code, not copy.
 
+### The invitation card announces; the letter is the letter (`feed.json` + `factions.json`)
+
+Two blocks describe the same object and **they are meant to say different
+things**: `feed.json` → `invitationLetter.*` is the activity-feed card, and
+`factions.json` → `<slug>.invitation.*` (plus `albescent.letter.*`) is the
+letter itself.
+
+**The card is a notification, not a preview** (owner ruling on #2620). It
+restates none of the letter's headline, pitch, perks or join CTA for any
+faction, and its own call to action sends the player to the **factions page**
+rather than opening the letter. So the two vocabularies are independent by
+design: when a copy sweep lines them up and finds them saying unrelated things,
+**that is the design, not drift to file.** Do not point the card's keys at the
+letter's.
+
+They share exactly one string, and only because it is one act: the control that
+puts an invitation off without answering it reads **`invitation.dismiss`** on
+both surfaces. It sits at the top level of `factions.json`, not under a slug —
+every faction's letter and the feed card read that one key, so rewording it is
+one edit for all of them. The card had a second key for it (`invitationLetter.
+notNow`) and #2620 deleted it; a test in `__tests__/catalog.test.ts` keeps it
+deleted and keeps both surfaces pointed at the survivor.
+
 ## Embedded markup (`<Trans>`)
 
 Some values contain numbered tags for text that must be partly bold, linked,

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -1255,8 +1255,12 @@ describe('the invitation deferral is one key on both surfaces (#2620)', () => {
     // "Not now", not the shared key's original "Maybe later": three feed source
     // files and ADR-0070 already name this act "Not now" in prose, and
     // `forms:editPraxis.attach.cancel` — the app's other deferral — says it too.
+    //
+    // That sibling is NOT asserted here. It is evidence for the word, not a
+    // promise about it: pinning another surface's copy inside this block would
+    // fail a future reword of the attach control with a message about the
+    // invitation deferral, sending the next reader to the wrong issue.
     expect(i18n.t('factions:invitation.dismiss')).toBe('Not now')
-    expect(i18n.t('forms:editPraxis.attach.cancel')).toBe('Not now')
   })
 
   it('points the feed card at the shared key — a move, not a copy', () => {

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest'
 import i18n from '../../i18n'
 import common from '../en/common.json'
 import factions from '../en/factions.json'
+import feed from '../en/feed.json'
 import forms from '../en/forms.json'
 import praxis from '../en/praxis.json'
 import taunts from '../en/taunts.json'
@@ -1217,5 +1218,54 @@ describe('the Disclaimer is the owner\'s text, character for character (#2789)',
   it('dates the document to the pass that rewrote it', () => {
     // A stale date under a rewritten legal document is worse than no date.
     expect(i18n.t('common:disclaimer.lastUpdated')).toBe('Last updated: August 2026')
+  })
+})
+
+/* -------------------------------------------------------------------------- *
+ * #2620 — the invitation's deferral control is one key, on both surfaces.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * The feed's invitation card ANNOUNCES that a letter arrived; it does not
+ * PREVIEW one (owner ruling, 2026-08-26). It restates none of the letter's
+ * headline, pitch or perks, and its call to action sends the player to the
+ * factions page rather than to the letter — so the two vocabularies are
+ * independent by design, and the drift between them is not a defect.
+ *
+ * The single overlap WAS one: both surfaces offer the same act — put the
+ * invitation off without answering it (ADR-0070) — and each held its own key
+ * with its own word. `feed:invitationLetter.notNow` is gone and the card reads
+ * the letter's shared `factions:invitation.dismiss`.
+ *
+ * The catalog half and the call-site half are both here because neither
+ * catches the other's bug: a deleted key with a live caller throws at render
+ * (`missingKeyHandler`), but only on a surface a DOM-less harness never mounts,
+ * and a caller left behind on a resurrected key passes every render test there
+ * is.
+ */
+describe('the invitation deferral is one key on both surfaces (#2620)', () => {
+  const src = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+  const read = (parts: string) => readFileSync(join(src, ...parts.split('/')), 'utf8')
+
+  it('keeps no second key for the act', () => {
+    expect(feed.invitationLetter).not.toHaveProperty('notNow')
+  })
+
+  it('holds the surviving word on the shared key', () => {
+    // "Not now", not the shared key's original "Maybe later": three feed source
+    // files and ADR-0070 already name this act "Not now" in prose, and
+    // `forms:editPraxis.attach.cancel` — the app's other deferral — says it too.
+    expect(i18n.t('factions:invitation.dismiss')).toBe('Not now')
+    expect(i18n.t('forms:editPraxis.attach.cancel')).toBe('Not now')
+  })
+
+  it('points the feed card at the shared key — a move, not a copy', () => {
+    const card = read('components/feed/FeedCardInvitationLetter.tsx')
+    expect(card).toContain('factions:invitation.dismiss')
+    expect(card).not.toContain('invitationLetter.notNow')
+  })
+
+  it('leaves the letter on the key it always read', () => {
+    expect(read('components/InvitationLetterPopup.tsx')).toContain("t('invitation.dismiss')")
   })
 })

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -346,7 +346,7 @@
     }
   },
   "invitation": {
-    "dismiss": "Maybe later"
+    "dismiss": "Not now"
   },
   "mobile": {
     "loadError": "Couldn't load factions.",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -161,7 +161,6 @@
     "sentence": "You've received an invitation to join <1>{{faction}}</1>.",
     "body": "Complete faction tasks to prove your dedication, or visit the factions page to make your choice.",
     "viewFactions": "View Factions →",
-    "notNow": "Not now",
     "accepted": "Joined {{faction}}",
     "setAside": "Set aside — the invitation still stands",
     "error": "Couldn't answer that invitation.",


### PR DESCRIPTION
Closes #2620

Builds the owner's 2026-08-26 ruling, not the body's second outcome. **Outcome 2 is withdrawn: no key alignment was done, and nothing on the card was pointed at the letter's copy.**

## Verified against the code before building

`FeedCardInvitationLetter.tsx` reads only `feed:invitationLetter.*` (`error`, `viewFactions`, `body`, `sentence`, `confirm.*`, `accepted`, `notNow`), plus `common:actions.accept` and `feed:badge.yourStuff`. It reads no `headline`, `pitch`, `perks` or `cta.join` from any faction, and its call to action links to the factions page. The card **announces**; it does not **preview**. So the drift between the two vocabularies is not a defect.

Also confirmed, and left alone: `albescent.letter.cta.joined` is genuinely rendered by `AlbescentInvitation.tsx` after accepting, and the `albescent.letter.*` → `albescent.invitation.*` rename stays parked (#2600).

## The seam

The copy catalog **and** the call site, together, in `frontend/src/locales/__tests__/catalog.test.ts` — the same seam #1911 / #2299 / #2586 pin their collapses at. Neither half catches the other's bug: a deleted key with a live caller throws through `missingKeyHandler`, but only on a surface a DOM-less harness never mounts; a caller left on a resurrected key passes every render test there is.

The loop went red on the real defect first — three of the four new assertions failed on `origin/main` (`notNow` present, shared key reading "Maybe later", card on the wrong key), the fourth passed because the letter's call site never had to move.

## The one defect: two words for one act

`feed:invitationLetter.notNow` is **deleted**. Its single caller moved to the shared `factions:invitation.dismiss` — a move, not a copy. The letter's call site is untouched.

**Which value survived: "Not now".** The ruling settled the key and left the word open, and there is a basis to prefer one:

- Three feed source files (`FeedCardInvitationLetter.tsx`, `FeedCardRouter.tsx`, `FeedItemSlot.tsx`, plus `feedItemLabels.ts`) and ADR-0070's vocabulary already name this act **"Not now"** in prose — including `InvitationLetterPopup.tsx`'s own dismiss comment, which calls the *letter's* control "not now" while the catalog said "Maybe later".
- `forms:editPraxis.attach.cancel`, the app's other deferral control, is already "Not now".
- "Maybe later" was never chosen by a copy pass: it dates to the original letter pop-up (#486) and no owner ruling has touched it since.

So "Not now" makes three deferral controls say one word and keeps four docblocks true. One value edit in `factions.json`, every surface follows.

## Note recorded — the catalogs have **no** note convention

Flagging this because the brief anticipated it: `en/*.json` are strict JSON with no comment mechanism and **zero** meta/underscore keys anywhere. Adding a `_note` leaf would have meant adding a copy key no code reads — dead copy, which is exactly what this run of issues has been deleting, and it would enter the catalog-leaf sweeps as if it were copy.

The convention these catalogs *do* use for a note of this genre is `frontend/src/locales/README.md` — the "Do not add a `comments.time.albescent` branch" note is the same shape of decision-on-the-record. The note went there, in a new section covering **both** namespaces, plus at the two call sites where a reader of these keys actually lands:

- `frontend/src/locales/README.md` — "The invitation card announces; the letter is the letter", naming `feed.json` → `invitationLetter.*` and `factions.json` → `<slug>.invitation.*`, and the one string they share.
- `FeedCardInvitationLetter.tsx` docblock — the card announces, does not preview; do not point its keys at the letter's.
- `InvitationLetterPopup.tsx` dismiss comment — `invitation.dismiss` is top-level and now shared with the feed card; nothing else is.

If a note inside the JSON itself is wanted anyway, say so and I will add it — it just costs a key the code never reads.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally: `lint` clean, `typecheck` clean, `typecheck:design-sync` clean, `npm test` **461 files / 9478 passed**, `build` clean, `budget` exit 0. The budget's JS **WARN is pre-existing** — this diff removes a catalog leaf and adds no runtime bytes. No backend file, route or schema was touched, so `test` and `api-schema` are unaffected.

**Visual QA is outstanding** — no browser tools and no dev stack in this worktree.

## What to eyeball

1. **The feed's invitation card** (Requests queue, on an account holding a current-era invitation) — the second control beside **Accept** should read **"Not now"**, unchanged from what shipped, now sourced from the shared key. Confirm it is still absent in the **Archived** tab, where the slot's action is restore.
2. **A faction's invitation letter** (`InvitationLetterPopup`, any of the seven) — the control beside the join CTA previously read "Maybe later" and now reads **"Not now"**. That is the one intended visible change in this PR. Worth a glance in at least two faction voices, since the button wears each letter's own skin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
