### PR TITLE
Six one-cut faces stop being asked for a second cut, and UA's x names the weight it actually draws

### DIFF
--- a/frontend/src/components/duel/EverymenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/EverymenDuelSealConfirm.tsx
@@ -185,7 +185,6 @@ export default function EverymenDuelSealConfirm({
             position: 'relative',
             margin: 0,
             fontFamily: POSTER,
-            fontWeight: 400,
             // The forfeit dialog speaks quieter than the routine one — a tier
             // down, not a raw number. Both sit in the Content ramp (§4a).
             fontSize: onInk ? 'var(--text-heading)' : 'var(--text-display)',

--- a/frontend/src/components/factionHero/SingularityFactionHero.tsx
+++ b/frontend/src/components/factionHero/SingularityFactionHero.tsx
@@ -202,7 +202,6 @@ export default function SingularityFactionHero({
               letterSpacing: "0.04em",
               margin: "0 0 var(--space-md)",
               color: PHOSPHOR,
-              fontWeight: 400,
             }}
           >
             {name}

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -193,6 +193,12 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           // rung covers that case too.
           titleStyle={{
             fontFamily: DECO,
+            // THIS 400 IS LOAD-BEARING — do not sweep it (#2597). Poiret One
+            // ships one cut, so a weight beside it is normally inert and #2597
+            // took twelve such lines off. Not this one: `PraxisTitle` puts a
+            // `font-semibold` CLASS on the same <h2>, and the inline 400 is the
+            // only thing suppressing a 600 the face cannot draw. Removing it
+            // trades an inert declaration for a real fake-bold.
             fontWeight: 400,
             letterSpacing: "0.02em",
             color: INK,

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -375,7 +375,6 @@ export default function EphemeristsTaskCard({
             <h2
               style={{
                 fontFamily: DECO,
-                fontWeight: 400,
                 fontSize: size.titleSize,
                 letterSpacing: "0.02em",
                 lineHeight: 1.24,

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -244,7 +244,6 @@ export default function SingularityTaskCard({
             <h2
               style={{
                 fontFamily: MONO,
-                fontWeight: 400,
                 fontSize: size.titleSize,
                 lineHeight: 1.22,
                 color: BRIGHT,

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -314,7 +314,6 @@ export default function WowTaskCard({
             <h2
               style={{
                 fontFamily: MED,
-                fontWeight: 400,
                 fontSize: size.titleSize,
                 lineHeight: 1.1,
                 margin: "0 0 var(--space-sm)",

--- a/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
@@ -355,7 +355,6 @@ export default function SingularityCreateCharacter({ state }: { state: CreateCha
             <h1
               style={{
                 fontFamily: FACE,
-                fontWeight: 400,
                 fontSize: sizes.titleSize,
                 color: BRIGHT,
                 textShadow: HALO_GREEN,

--- a/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
@@ -313,7 +313,6 @@ export default function WowCreateCharacter({ state }: { state: CreateCharacterSt
             <h1
               style={{
                 fontFamily: MED,
-                fontWeight: 400,
                 fontSize: sizes.titleSize,
                 lineHeight: 1.1,
                 color: INK,

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -718,7 +718,14 @@ function MediaPlate({ children, caption, onRemove }: MediaPlateProps) {
           border: `1px solid ${RULE}`,
           color: ACCENT,
           fontSize: "var(--text-md)",
-          fontWeight: 700,
+          // 600, not 700, and the weight is DELIBERATE (#2597). This button
+          // inherits `pageStyle`'s EB Garamond, which the loader ships at 400
+          // and 600 — so the 700 that stood here was drawn as the real 600 all
+          // along and this is the same pixels, honestly named. Not a #2487
+          // sweep site: synthesis is a defect, substitution is a design call,
+          // and the owner made it. Dropping the weight would render a 22px
+          // control at 400, which is a change to a working button.
+          fontWeight: 600,
           cursor: "pointer",
           lineHeight: 1,
           padding: 0,

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -559,7 +559,6 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
       <h1
         style={{
           fontFamily: DECO,
-          fontWeight: 400,
           fontSize: size.titleSize,
           lineHeight: 1.16,
           letterSpacing: "0.02em",

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -441,7 +441,6 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
       <h1
         style={{
           fontFamily: MONO,
-          fontWeight: 400,
           fontSize: desktop ? "var(--text-display)" : "var(--text-heading)",
           lineHeight: 1.15,
           margin: "0 0 var(--space-lg)",

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -453,7 +453,6 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
       <h1
         style={{
           fontFamily: MED,
-          fontWeight: 400,
           fontSize: size.title,
           lineHeight: 1.08,
           margin: '0 0 var(--space-md)',

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -458,7 +458,6 @@ export default function EphemeristsTaskDetail({
       <h1
         style={{
           fontFamily: DECO,
-          fontWeight: 400,
           fontSize: size.titleSize,
           lineHeight: 1.16,
           letterSpacing: "0.02em",

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -321,7 +321,6 @@ export default function SingularityTaskDetail({
       <h1
         style={{
           fontFamily: MONO,
-          fontWeight: 400,
           fontSize: desktop ? "var(--text-heading)" : "var(--text-title)",
           lineHeight: 1.2,
           color: BRIGHT,

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -523,7 +523,6 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
       <h1
         style={{
           fontFamily: MED,
-          fontWeight: 400,
           fontSize: size.title,
           lineHeight: 1.08,
           margin: 0,

--- a/frontend/src/utils/__tests__/fontsLoaded.test.ts
+++ b/frontend/src/utils/__tests__/fontsLoaded.test.ts
@@ -890,3 +890,130 @@ describe("an inherited page face is not asked to fake a bold (#2487)", () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * The PINNED half of the same axis (#2597), and the rule #2487 established:
+ * a face that ships one cut is never asked for a second one.
+ *
+ * #1294 above asks whether a declared weight can be RENDERED, so it is silent on
+ * every `fontWeight: 400` — 400 is the one weight a single-cut family always
+ * has. That is the shape this catches. A weight declaration on such a family can
+ * only ever be a no-op or a synthesis; either way the source asserts a choice the
+ * family cannot offer, and the next reader has to re-derive that it is inert.
+ * #2487 swept three such families off S.N.I.D.E. and the composer directory;
+ * #2597 swept the other six. This is what stops the tenth arriving unswept.
+ *
+ * ONE-CUT IS DERIVED, NEVER LISTED. A family qualifies when the generated sheets
+ * ship exactly one weight for it, counted across both slants — IM Fell English
+ * has no upright face at all, and a hand-written list would have had to remember
+ * that. `scripts/fetch-fonts.mjs` adding a cut retires a family from this check
+ * by itself, which is the only way the two can stay in step.
+ *
+ * A scope that pins BOTH is the evidence bar, exactly as `declaredFaces` sets
+ * it: a weight beside no family is #2487's business and a comment about one is
+ * nobody's, which is why the source is read with its comments blanked.
+ */
+describe("a one-cut family is never asked for a weight (#2597)", () => {
+  const faces = loadedFaces();
+  const familyNames = new Set(faces.map((face) => face.family));
+
+  /** Families the loader ships exactly one weight for, across both slants. */
+  const oneCut = new Set(
+    [...familyNames].filter(
+      (family) =>
+        new Set(faces.filter((face) => face.family === family).map((face) => face.weight)).size ===
+        1,
+    ),
+  );
+
+  /**
+   * The one scope where a `fontWeight: 400` on a one-cut face is load-bearing.
+   *
+   * `PraxisTitle` hands its `<h2>` a `font-semibold` CLASS as well as the skin's
+   * `titleStyle`, so on that element the inline 400 is not restating the default
+   * — it is the only thing suppressing a 600 the class would otherwise impose,
+   * and Poiret One has no 600 to give. Deleting it swaps an inert declaration
+   * for a real fake-bold, which is the trap #2597's ruling names. Every other
+   * skin routing a one-cut face through that same title inherits the class and
+   * carries no such guard: those are reported on the PR, not fixed here, because
+   * the honest fix repaints UA and Coven and wants an owner's call.
+   */
+  const LOAD_BEARING = new Set(["components/praxisCard/desktop/EphemeristsPraxisCard.tsx"]);
+
+  it("derives the one-cut families from the sheets rather than a list", () => {
+    // Sanity check on the derivation: the six #2597 swept, plus #2487's three.
+    for (const family of [
+      "share tech mono",
+      "permanent marker",
+      "poiret one",
+      "spectral",
+      "medievalsharp",
+      "bebas neue",
+      "anton",
+      "archivo black",
+      "special elite",
+    ]) {
+      expect(oneCut.has(family), `${family} is no longer derived as one-cut`).toBe(true);
+    }
+    // And the negative side, or the check passes by matching nothing: these ship
+    // real cuts, and a weight on them is a design decision rather than a defect.
+    for (const family of ["lora", "courier prime", "cinzel", "eb garamond"]) {
+      expect(oneCut.has(family), `${family} was wrongly derived as one-cut`).toBe(false);
+    }
+  });
+
+  it("names no weight in a scope that pins a single-cut family", () => {
+    const asked: string[] = [];
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      if (FONT_SHEETS.includes(file)) continue;
+      const rel = file.slice(SRC_DIR.length + 1).replace(/\\/g, "/");
+      if (LOAD_BEARING.has(rel)) continue;
+      const raw = readFileSync(file, "utf-8").replace(
+        /(["'`])(?:\\.|(?!\1)[^\\])*\1|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g,
+        (match) => (match.startsWith("/") ? match.replace(/[^\n]/g, " ") : match),
+      );
+      const source = resolveRoleReads(file.endsWith(".css") ? raw : inlineConstants(file, raw));
+
+      for (const match of source.matchAll(/font-?[fF]amily\s*[:=]/g)) {
+        const scope = enclosingScope(source, match.index);
+        if (!/font-?[wW]eight\s*[:=]/.test(scope)) continue;
+        const families = new Set<string>();
+        for (const quoted of scope.matchAll(/["']\s*([A-Za-z][A-Za-z0-9 ]+)\s*["',]/g)) {
+          const family = quoted[1].trim().toLowerCase();
+          if (familyNames.has(family)) families.add(family);
+        }
+        for (const reference of scope.matchAll(/var\((--[a-z0-9-]+)\)/g)) {
+          for (const family of familiesBehindToken(reference[1], familyNames)) families.add(family);
+        }
+        for (const family of families) {
+          if (!oneCut.has(family)) continue;
+          const line = source.slice(0, match.index).split("\n").length;
+          asked.push(`${rel}:${line} — ${family}`);
+        }
+      }
+    }
+
+    expect(
+      [...new Set(asked)].sort(),
+      `These scopes set a weight beside a family that ships exactly one cut, so the
+` +
+        `declaration is either inert or a bold the browser has to smear on itself
+` +
+        `(#2487, #2597). Drop the weight — Tailwind's preflight already resets
+` +
+        `headings and form controls to \`font-weight: inherit\`, so on a bare <h1>
+` +
+        `or <h2> with nothing above it setting one, removing it changes no pixel.
+` +
+        `CHECK THE ANCESTORS FIRST: if anything above the element, or a weight
+` +
+        `UTILITY CLASS on the element itself, declares a weight, the 400 is what
+` +
+        `suppresses it and removing it brings the fake bold straight back — add
+` +
+        `the file to LOAD_BEARING above with the reason instead. Do NOT add the
+` +
+        `cut to the payload; the byte budget is in WARN (#2469).`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2597

Six 400-only faces swept, UA's `×` corrected rather than deleted, and a guard so
the tenth family does not arrive unswept.

## The seam I tested at

A **brace-delimited source scope that pins both a family and a weight** — the
same seam `declaredFaces` in `fontsLoaded.test.ts` already reads for #1294.
#1294 asks whether a declared weight can be *rendered*, so it passes every
`fontWeight: 400`: 400 is the one weight a single-cut family always has. That
silence is exactly the shape #2487 swept by hand and #2597 asked for again.

The new guard, `a one-cut family is never asked for a weight (#2597)`, went red
on **13 sites** before any source changed, and those 13 matched a hand-derived
list built independently. One-cut membership is **derived from the generated
sheets** (a family with exactly one loaded weight across both slants), never
listed — so IM Fell English, which has no upright face at all, is not a special
case anyone has to remember, and `scripts/fetch-fonts.mjs` adding a cut retires
a family from the check by itself.

## The ancestor re-derivation — the brief's fact had rotted

The issue names four weight-setting selectors in `index.css`. **There are seven
today.** `.filter-empty__title`, `.feed-load-more` and `.requests-queue__title`
have joined `.feed-action`, `.level-gem-number`, `.faction-hero-name` and
`.faction-hero-count-value`. The conclusion survives: all seven land on leaf
spans, buttons and headings, none is an ancestor of a card or detail headline,
and each sets its own multi-cut family (Lora or Courier Prime) or none at all.

Also checked and clear: no other stylesheet in the repo declares a `font-weight`
(only `index.css` does); the four `@apply font-bold` rules are
`.markdown-preview h1/h2/h3/strong`, which carry Lora on the same element; and
no shared shell — `TaskCard.tsx`, `ComposerPage`, `duel/shared.tsx`,
`praxisDetail/shared.tsx` — sets an inline weight on anything that contains a
swept headline. Every one of the 13 is a bare `<h1>`/`<h2>` with **no
className**, so Tailwind preflight's `font-weight: inherit` is what actually
applies.

## Sites CHANGED (14)

**Swept — 13 removals. All were `fontWeight: 400`, i.e. all no-ops, not faux
bolds. Zero pixels move.**

| Face | Site |
|---|---|
| Share Tech Mono | `components/factionHero/SingularityFactionHero.tsx` — hero wordmark `<h1>` |
| Share Tech Mono | `components/taskCard/SingularityTaskCard.tsx` — title `<h2>` |
| Share Tech Mono | `pages/taskDetail/archetypes/SingularityTaskDetail.tsx` — title `<h1>` |
| Share Tech Mono | `pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx` — title `<h1>` |
| Share Tech Mono | `pages/characterPaths/archetypes/SingularityCreateCharacter.tsx` — composer `<h1>` |
| MedievalSharp | `components/taskCard/WowTaskCard.tsx` — title `<h2>` |
| MedievalSharp | `pages/taskDetail/archetypes/WowTaskDetail.tsx` — title `<h1>` |
| MedievalSharp | `pages/praxisDetail/archetypes/WowPraxisDetail.tsx` — title `<h1>` |
| MedievalSharp | `pages/characterPaths/archetypes/WowCreateCharacter.tsx` — composer `<h1>` |
| Poiret One | `components/taskCard/EphemeristsTaskCard.tsx` — title `<h2>` |
| Poiret One | `pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx` — title `<h1>` |
| Poiret One | `pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx` — title `<h1>` |
| Bebas Neue | `components/duel/EverymenDuelSealConfirm.tsx` — dialog `<h2>` |

**Corrected, not deleted — 1.** `pages/editPraxis/archetypes/UaEditPraxis.tsx`,
the media tile's `×`: `fontWeight: 700` → `600`, with the reason at the site.
The button inherits `pageStyle`'s EB Garamond, which ships 400 and 600
(`eb-garamond-400to600-latin.woff2`), so 700 was never synthesised — the browser
matched the real 600 and drew it honestly. **This is a zero-pixel diff**: same
used weight, and the source stops naming a cut the family cannot supply.
Deleting it would have rendered a 22px control at 400. Synthesis is a defect;
substitution is a design call.

## Sites CHECKED and LEFT, with the reason

**`components/praxisCard/desktop/EphemeristsPraxisCard.tsx` — the trap, met for
real.** Its `titleStyle` carries `fontFamily: DECO` (Poiret One) and
`fontWeight: 400`, so it looks exactly like the 13. It is **load-bearing**:
`PraxisTitle` puts a `font-semibold` **class** on the same `<h2>`, and the
inline 400 is the only thing suppressing a 600 Poiret One has no cut for.
Deleting it trades an inert declaration for a real fake-bold. Left in place,
annotated at the site, and listed in the guard's `LOAD_BEARING` set with the
reason — so the next sweep does not refile it.

**Permanent Marker and Spectral — swept, nothing found.** No scope anywhere in
`src` pins either family beside a weight. (#2487 had already taken S.N.I.D.E.'s
declarations off, and Spectral is Ephemerists' reading face, which never carried
one.)

**Weights on multi-cut faces — left, they are real cuts, not synthesis.** These
all sit in the same files or right beside a swept line and are *not* defects:
Cinzel 500/600 across `ephemeristsPlate.tsx`, `EphemeristsTaskCard`,
`EphemeristsTaskDetail`, `EphemeristsCreateCharacter`; Lora 600 across
`DefaultTaskCard` and `AlbescentTaskDetail`; Cormorant Garamond 600/700 across
the UA surfaces and `factionBands.tsx`; Caveat 600/700 across the Coven
surfaces; Courier Prime 700 in `VoteShell` (snide treatment),
`EverymenFactionBody`'s cancel button, `TaskCard.tsx`'s two metatask pills,
`proposeTask/factionSurfaces.ts`'s submit pill, and `duel/shared.tsx`.

**`components/duel/EverymenDuelSealConfirm.tsx:260` (the forfeit `<p>`) — left.**
It has no family of its own, but it inherits `DuelSealSheet`'s `ground`, which
is `--font-body` (Courier Prime). 700 is a real cut there.

**`pages/editPraxis/archetypes/EverymenEditPraxis.tsx:821` — left.** Structurally
the same 22px `×` as UA's, and it looked like a second instance. It is not: the
Everymen composer's `pageStyle` is `--font-body` (Courier Prime), not Bebas, so
the button's 700 is a real cut.

**`pages/proposeTask/factionSurfaces.ts:96` — left, but flagged below.** Its
`fontFamily` is `factionCssVar(slug, "card-font")`, i.e. *any* faction's card
font, under a static `fontWeight: 700`. For five slugs that resolves to a
one-cut face. Fixing it is not a deletion — it needs a per-faction answer.

## Found while sweeping — NOT fixed, needs an owner ruling

A second, larger instance of the same defect that the issue's framing does not
reach, because it is a **Tailwind class**, not a `fontWeight` declaration:

`components/praxisCard/shared.tsx:169` — `PraxisTitle`'s `<h2>` carries
`className="content-title font-display font-semibold …"`. Every praxis-card skin
routes its display face through it, and **five of those faces ship one cut**:

- Default → `--faction-default-card-font` → **Bebas Neue**
- Everymen → `--ev-praxis-face` → **Bebas Neue**
- Singularity → `--sg-praxis-card-face` → **Share Tech Mono**
- S.N.I.D.E. → `--snd-pcard-face` → **Permanent Marker**
- WOW → `--wow-praxis-card-face` → **MedievalSharp**

Only Ephemerists overrides it (see above). So five praxis-card titles are
drawing a **synthesised 600 right now** — the visible defect, not a no-op. I did
not touch it because the honest fix (dropping `font-semibold`) repaints the two
skins whose faces *do* have the cut: UA (Cormorant Garamond, real 600) and Coven
(Caveat, which resolves 600 → its real 700). That is a design call, and #2597
authorised a no-judgement sweep.

Same shape, same reason for leaving it: `praxisCard/shared.tsx:450/456`
(`font-semibold` on the byline name, which takes the faction display face) and
`components/avatar/FactionAvatar.tsx:146` (`font-bold` on the monogram, under
`style.fontFamily`).

## Verification

Run locally, from `.github/workflows/test.yml`'s `frontend` job:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 461 files, 9476 passed, 1 skipped
- `npm run build` — clean
- `npm run budget` — CSS **ok** (21.7 KB), JS **WARN** (137.2 KB) — pre-existing
  and untouched by this PR, which is 13 deleted lines plus comments that are
  stripped from the bundle. No font file added; #2469's ceiling is respected.

`api-schema` and the backend `test` job are not reachable from this diff — no
route, `response_model` or Pydantic schema is touched.

**Visual QA is outstanding.** I have no browser and no dev stack. The argument
that the 13 removals are zero-pixel is structural (all `400`; bare `<h1>`/`<h2>`;
Tailwind preflight sets `font-weight: inherit`; the seven weight-setting
selectors re-derived above are all leaves), and the argument that UA's `×` is
zero-pixel is the CSS Fonts 4 matching rule, but neither has been looked at.

## What to eyeball

- **Singularity** — faction hero wordmark, task card title, task detail title,
  praxis detail title, create-character composer heading.
- **WOW** — task card title, task detail title, praxis detail title,
  create-character composer heading.
- **Ephemerists** — task card title, task detail title, praxis detail title. And
  the **praxis card** title, which deliberately did *not* change: it should still
  look identical to the others, i.e. not bolder.
- **Everymen** — duel seal confirm dialog heading.
- **UA** — the media tile's `×` close button in the edit-praxis composer. This
  one must look **exactly** as it does on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
