### PR TITLE
The task card offers the praxis you already filed

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -64,6 +64,7 @@ export function makeTask(overrides: Partial<TaskOut> = {}): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: true,
     allowed_modes: ['solo', 'collab'],
     eligible_for_current_user: true,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4417,6 +4417,17 @@
           "status": {
             "$ref": "#/components/schemas/TaskStatus"
           },
+          "submitted_praxis_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Submitted Praxis Id"
+          },
           "task_type": {
             "$ref": "#/components/schemas/TaskType"
           },
@@ -4447,6 +4458,7 @@
           "eligible_for_current_user",
           "signup_reason",
           "in_progress_praxis_id",
+          "submitted_praxis_id",
           "start_here",
           "created_by_name",
           "notes"
@@ -5779,6 +5791,17 @@
           "status": {
             "$ref": "#/components/schemas/TaskStatus"
           },
+          "submitted_praxis_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Submitted Praxis Id"
+          },
           "task_type": {
             "$ref": "#/components/schemas/TaskType"
           },
@@ -5809,6 +5832,7 @@
           "eligible_for_current_user",
           "signup_reason",
           "in_progress_praxis_id",
+          "submitted_praxis_id",
           "start_here"
         ],
         "title": "TaskOut",

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -85,14 +85,42 @@ class TaskOut(WireModel):
     # THE POPULATION IS THE DETAIL PAGE'S, `in_progress` ONLY, and it is
     # deliberately NARROWER than the denial's own (`in_progress`, `pending`,
     # `submitted`). A submitted praxis shuts sign-up with nothing left to edit,
-    # and this field is None there — reachable, not theoretical, and the client
-    # falls back to the plain label for it.
+    # and this field is None there — reachable, not theoretical, and
+    # `submitted_praxis_id` below is what the client reaches for instead
+    # (#2643). Only `pending` still falls through to the plain label.
     #
     # It is also NOT filtered by the Double Dipper carve-out
     # (``active_member_task_ids``). "Do I hold a draft here" is a raw fact no
     # ability changes; sourcing it from the blocking set would have made an
     # Everymen player the one group whose draft the wire refused to name.
     in_progress_praxis_id: Optional[int] = None
+    # The VIEWER'S OWN FILED praxis on this task — the praxis id, or None (#2643).
+    #
+    # The field above's twin, one status further on, and it exists because the
+    # field above left half its own denial unanswered. `already_active_member`
+    # covers a submitted praxis too, and there the card had nothing to offer:
+    # a greyed "Already done" where the task detail says "Read your praxis" and
+    # links to it. The detail reaches that praxis through its own submitted-only
+    # gallery fetch, which a grid of cards cannot make one per card — so the id
+    # rides along on the row, exactly as its twin does.
+    #
+    # VIEWER-SCOPED, and this is the one that would be worth a leak. A popular
+    # task has many submissions and only ONE of them is the requesting
+    # character's: the id comes from `services.praxis.submitted_praxis_ids`,
+    # whose query joins `PraxisMember` on the viewer's own character id, and it
+    # is None for a viewer who has not submitted. It defaults None for anonymous
+    # callers exactly as the flags above do.
+    #
+    # `submitted` ONLY — narrower than the denial's population, like its twin.
+    # A `pending` praxis is awaiting moderation and is nobody's "read your
+    # praxis"; it keeps falling through to the plain label.
+    #
+    # SUBMITTED MORE THAN ONCE, this holds the MOST RECENT. Re-signing up after
+    # a praxis is filed is a live path (`ctaAgain`, Double Dipper), so the case
+    # is real rather than theoretical, and the answer is stated in the query's
+    # ordering rather than left to the default: offering someone a first attempt
+    # they have already superseded is the wrong door.
+    submitted_praxis_id: Optional[int] = None
     # The *start here* mark (#1861, SPEC-onboarding § The hand-off). True iff
     # this is the one game-wide onboarding task AND the viewing character has
     # never completed it — ever, not "not this era".

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -634,7 +634,7 @@ async def gather_signup_facts(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> SignupFacts:
-    """Read one page's worth of :class:`SignupFacts` in seven queries, not seven per row.
+    """Read one page's worth of :class:`SignupFacts` in seven queries, not per row.
 
     ``era`` is threaded into the membership read so a caller evaluating against a
     non-current ruleset gets facts from that same ruleset — precomputed facts

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -622,6 +622,10 @@ class SignupFacts:
     #: (#2359). A third population, and neither of the two above: see
     #: :func:`in_progress_praxis_ids` for why it can be folded into neither.
     in_progress_praxis_ids: Mapping[int, int]
+    #: Task id → the viewer's FILED praxis on it, for ``TaskOut.submitted_praxis_id``
+    #: (#2643). A fourth, for :func:`submitted_praxis_ids`'s reason — the same
+    #: denial, the other side of it.
+    submitted_praxis_ids: Mapping[int, int]
 
 
 async def gather_signup_facts(
@@ -630,7 +634,7 @@ async def gather_signup_facts(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> SignupFacts:
-    """Read one page's worth of :class:`SignupFacts` in six queries, not six per row.
+    """Read one page's worth of :class:`SignupFacts` in seven queries, not seven per row.
 
     ``era`` is threaded into the membership read so a caller evaluating against a
     non-current ruleset gets facts from that same ruleset — precomputed facts
@@ -641,9 +645,12 @@ async def gather_signup_facts(
     mean restating the Double Dipper carve-out outside the SQL that owns it — the
     #1359 defect exactly.
 
-    The sixth is the open-draft map (#2359). It is a *page-wide* query like the
-    other five, so the browse still costs a constant number of reads however
-    many rows are on it — the only property this file's #1377 work defends.
+    The sixth is the open-draft map (#2359) and the seventh its filed twin
+    (#2643). Both are *page-wide* queries like the other five, so the browse
+    still costs a constant number of reads however many rows are on it — the
+    only property this file's #1377 work defends. Seven constant reads is that
+    property held, not spent: what it forbids is a read that scales with the
+    page, and neither of these does.
     """
     era_row = await get_current_era_row(session)
     return SignupFacts(
@@ -659,6 +666,7 @@ async def gather_signup_facts(
         in_progress_praxis_ids=await in_progress_praxis_ids(
             character, task_ids, session
         ),
+        submitted_praxis_ids=await submitted_praxis_ids(character, task_ids, session),
     )
 
 
@@ -1502,6 +1510,55 @@ async def in_progress_praxis_ids(
     A character may hold more than one open draft on one task (Double Dipper);
     the ordering makes the newest one the answer rather than an arbitrary one.
     """
+    return await _own_praxis_ids(character, task_ids, PraxisStatus.in_progress, session)
+
+
+async def submitted_praxis_ids(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+) -> dict[int, int]:
+    """Which of ``task_ids`` ``character`` has FILED a praxis on, and which praxis
+    — ONE query. The source of ``TaskOut.submitted_praxis_id`` (#2643).
+
+    The twin of :func:`in_progress_praxis_ids` one status further on, and it
+    exists for the same reason: ``already_active_member`` is the denial a card
+    spends its only slot on, and for a *submitted* praxis the useful thing —
+    reading it — is one hop away with no id to reach it by. Same viewer scoping,
+    same page-wide shape, same absence of ``era``.
+
+    ``submitted`` ONLY, deliberately narrower than the denial's own population
+    (``in_progress``, ``pending``, ``submitted``). ``pending`` is a praxis
+    awaiting moderation and is nobody's "read your praxis"; it keeps falling
+    through to the plain label, exactly as it did before this field existed.
+
+    A character may have submitted MORE THAN ONCE to one task — re-signing up
+    after a first praxis is filed is a live path (``ctaAgain``, Double Dipper) —
+    so this holds the MOST RECENT one. That is the ordering below and not the
+    query's default: ascending ``Praxis.id`` with a last-write-wins dict leaves
+    the highest id, and ids are monotonic. A stale first attempt would be the
+    wrong door to offer someone who has already filed a second.
+    """
+    return await _own_praxis_ids(character, task_ids, PraxisStatus.submitted, session)
+
+
+async def _own_praxis_ids(
+    character: Character,
+    task_ids: Collection[int],
+    status: PraxisStatus,
+    session: AsyncSession,
+) -> dict[int, int]:
+    """Task id → ``character``'s own praxis in ``status`` on it, newest wins.
+
+    The one query behind both readers above, so the two cannot drift on the part
+    that matters most: **the membership join is what scopes this to the viewer**.
+    Written once, it cannot be dropped from one of them and leak a stranger's
+    praxis id onto a task with many submissions.
+
+    Private because the two named readers are the vocabulary — a caller wanting
+    "the viewer's praxis in status X" for some third X is a population that
+    should arrive with its own docstring saying what it means, as those two do.
+    """
     if not task_ids:
         return {}
     result = await session.execute(
@@ -1509,7 +1566,7 @@ async def in_progress_praxis_ids(
         .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
         .where(
             PraxisMember.character_id == character.id,
-            Praxis.status == PraxisStatus.in_progress,
+            Praxis.status == status,
             Praxis.task_id.in_(task_ids),
         )
         .order_by(Praxis.id)

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -37,6 +37,7 @@ from services.praxis import (
     gather_signup_facts,
     is_task_eligible_for_character,
     signup_reason,
+    submitted_praxis_ids,
     SignupFacts,
 )
 from services.level_jump import available_level_reach
@@ -349,14 +350,21 @@ async def build_task_out_for_viewer(
         viewer, task, eligibility, session, facts=signup_facts
     )
     # The viewer's own open draft on this task, so a card can OFFER it instead of
-    # announcing it (#2359). Carries #1377's fallback property, exactly as
-    # `signup_reason` above does: an id outside the page these facts were
-    # gathered for means "not asked about", never "no draft".
+    # announcing it (#2359) — and its filed twin, so the same card can offer the
+    # praxis to READ when there is nothing left to edit (#2643). Both carry
+    # #1377's fallback property, exactly as `signup_reason` above does: an id
+    # outside the page these facts were gathered for means "not asked about",
+    # never "no praxis". Both are `viewer`-scoped by the query behind them, so
+    # neither can name a praxis that is not this viewer's own.
     if task.id in signup_facts.task_ids:
         base.in_progress_praxis_id = signup_facts.in_progress_praxis_ids.get(task.id)
+        base.submitted_praxis_id = signup_facts.submitted_praxis_ids.get(task.id)
     else:
         base.in_progress_praxis_id = (
             await in_progress_praxis_ids(viewer, [task.id], session)
+        ).get(task.id)
+        base.submitted_praxis_id = (
+            await submitted_praxis_ids(viewer, [task.id], session)
         ).get(task.id)
     base.allowed_modes = [m.value for m in allowed_praxis_modes(viewer, stats.level, era)]
     base.eligible_for_current_user = is_task_eligible_for_character(

--- a/backend/tests/integration/test_task_signup_reason.py
+++ b/backend/tests/integration/test_task_signup_reason.py
@@ -308,3 +308,164 @@ async def test_praxis_id_is_the_same_whether_or_not_the_page_precomputed_facts(
             active_task, character, db_session, signup_facts=uncovered
         )
     ).in_progress_praxis_id == praxis.id
+
+
+# ---------------------------------------------------------------------------
+# #2643 — the same seam again, on the OTHER half of the same denial:
+# `TaskOut.submitted_praxis_id`.
+#
+# `already_active_member` covers a filed praxis as well as an open draft, and
+# for the filed one the field above is null by design — so the card fell all the
+# way back to a greyed "Already done" while the task detail said "Read your
+# praxis" and linked to it. The detail can: it reaches the praxis through its
+# own submitted-only gallery. A grid of cards cannot make that request per card,
+# so this id rides along on the row exactly as its twin does.
+#
+# THE LEAK IS THE CASE WORTH A TEST. A popular task has many submissions and
+# only one of them is the requesting character's, so the assertion that matters
+# is not "the id is right" but "somebody else's id is never here".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_denial_carries_the_filed_praxis_it_is_about(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    some_faction: Faction,
+):
+    """Shut, nothing to edit — and now something to read."""
+    praxis = await _seed_praxis(
+        db_session, character, active_task, PraxisStatus.submitted
+    )
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.signup_reason == SignupDenialReason.already_active_member.value
+    assert out.submitted_praxis_id == praxis.id
+    # The twin stays null: this praxis is filed, and its editor would bounce.
+    assert out.in_progress_praxis_id is None
+
+
+@pytest.mark.asyncio
+async def test_another_characters_submission_is_never_named(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    some_faction: Faction,
+):
+    """THE LEAK CASE. A task with a submission on it hands a stranger nothing.
+
+    ``character2`` has filed a praxis here; ``character`` has not. The viewer
+    sees a task with submissions, an open sign-up, and no id — because the query
+    behind the field joins ``PraxisMember`` on the *requesting* character. Drop
+    that join and this row would name someone else's praxis to every viewer of
+    the task.
+    """
+    other_praxis = await _seed_praxis(
+        db_session, character2, active_task, PraxisStatus.submitted
+    )
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.submitted_praxis_id is None
+    assert out.submitted_praxis_id != other_praxis.id
+    # And the viewer's own sign-up is untouched by a stranger's membership.
+    assert out.can_sign_up is True
+
+
+@pytest.mark.asyncio
+async def test_a_task_never_submitted_to_carries_no_filed_id(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    some_faction: Faction,
+):
+    """The plain null — nobody has submitted anything anywhere."""
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.submitted_praxis_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_pending_praxis_is_not_something_to_read(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    some_faction: Faction,
+):
+    """The population boundary. ``pending`` shuts sign-up and stays label-only.
+
+    It is awaiting moderation, so it is neither a draft to edit nor a filed
+    praxis to read. Widening either field to the denial's full population is
+    what this pins against.
+    """
+    await _seed_praxis(db_session, character, active_task, PraxisStatus.pending)
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.signup_reason == SignupDenialReason.already_active_member.value
+    assert out.submitted_praxis_id is None
+    assert out.in_progress_praxis_id is None
+
+
+@pytest.mark.asyncio
+async def test_the_second_submission_is_the_one_offered(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    some_faction: Faction,
+):
+    """Submitted twice — the docblock promises the MOST RECENT, not the first.
+
+    Re-signing up after filing is a live path, so this is the ordering being an
+    intention rather than the query's default.
+    """
+    first = await _seed_praxis(
+        db_session, character, active_task, PraxisStatus.submitted
+    )
+    second = await _seed_praxis(
+        db_session, character, active_task, PraxisStatus.submitted
+    )
+    assert second.id > first.id
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.submitted_praxis_id == second.id
+
+
+@pytest.mark.asyncio
+async def test_filed_id_is_the_same_whether_or_not_the_page_precomputed_facts(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    some_faction: Faction,
+):
+    """#1377's property once more: absence from the bag is not "no praxis"."""
+    praxis = await _seed_praxis(
+        db_session, character, active_task, PraxisStatus.submitted
+    )
+    other = await _make_task(db_session, character)
+
+    covered = await gather_signup_facts(
+        character, [active_task.id, other.id], db_session
+    )
+    assert (
+        await build_task_out_for_viewer(
+            active_task, character, db_session, signup_facts=covered
+        )
+    ).submitted_praxis_id == praxis.id
+
+    uncovered = await gather_signup_facts(character, [other.id], db_session)
+    assert (
+        await build_task_out_for_viewer(
+            active_task, character, db_session, signup_facts=uncovered
+        )
+    ).submitted_praxis_id == praxis.id

--- a/frontend/src/__tests__/accessibleNameSpacing.test.tsx
+++ b/frontend/src/__tests__/accessibleNameSpacing.test.tsx
@@ -65,6 +65,7 @@ function metatask(): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -3907,6 +3907,8 @@ export interface components {
              */
             start_here: boolean;
             status: components["schemas"]["TaskStatus"];
+            /** Submitted Praxis Id */
+            submitted_praxis_id: number | null;
             task_type: components["schemas"]["TaskType"];
             /** Title */
             title: string;
@@ -4477,6 +4479,8 @@ export interface components {
              */
             start_here: boolean;
             status: components["schemas"]["TaskStatus"];
+            /** Submitted Praxis Id */
+            submitted_praxis_id: number | null;
             task_type: components["schemas"]["TaskType"];
             /** Title */
             title: string;

--- a/frontend/src/components/metataskSeal/__tests__/sealMasthead.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealMasthead.test.tsx
@@ -72,6 +72,7 @@ function metatask(slug: string): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,

--- a/frontend/src/components/metataskSeal/__tests__/sealSkinsA.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealSkinsA.test.tsx
@@ -35,6 +35,7 @@ function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,

--- a/frontend/src/components/metataskSeal/__tests__/sealSkinsB.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealSkinsB.test.tsx
@@ -38,6 +38,7 @@ function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,

--- a/frontend/src/components/metataskSeal/metataskCompose.test.tsx
+++ b/frontend/src/components/metataskSeal/metataskCompose.test.tsx
@@ -41,6 +41,7 @@ function metatask(
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: true,
     allowed_modes: ["solo"],
     eligible_for_current_user: true,

--- a/frontend/src/components/taskCard/__tests__/signupAffordance.test.ts
+++ b/frontend/src/components/taskCard/__tests__/signupAffordance.test.ts
@@ -146,10 +146,12 @@ describe('a draft you already hold', () => {
     expect(onSignup).not.toHaveBeenCalled()
   })
 
-  it('falls back to the plain label when there is no draft to land on', () => {
-    // Reachable, not theoretical: the denial's population includes `submitted`
-    // and `pending` praxes, which shut sign-up with nothing left to edit. A
-    // link to /praxis/null/edit is worse than the label it replaced.
+  it('falls back to the plain label when there is nothing to land on', () => {
+    // Reachable, not theoretical: the denial's population also covers a
+    // `pending` praxis, which shuts sign-up while awaiting moderation — no
+    // draft to edit and nothing filed to read. A link to /praxis/null/edit is
+    // worse than the label it replaced. (`submitted` used to land here too;
+    // #2643 below gave it its own door.)
     const cta = taskCardSignupCta(held({ in_progress_praxis_id: null }), vi.fn())!
     expect(cta.denied).toBe(true)
     expect(cta.href).toBeUndefined()
@@ -172,5 +174,97 @@ describe('a draft you already hold', () => {
       expect(cta.href, reason).toBeUndefined()
       expect(cta.onPress, reason).toBeUndefined()
     }
+  })
+})
+
+/**
+ * #2643 — the other half of the SAME denial.
+ *
+ * `already_active_member` covers a filed praxis as well as an open draft, and
+ * the filed half kept the greyed refusal after #2359 because the wire named no
+ * praxis to reach. It does now, so the slot becomes a link — to the READ page,
+ * because `/edit` redirects a submitted praxis straight back to it (#1164,
+ * #1397) and a button that changes nothing is the thing this issue is about.
+ *
+ * The seam is the same one #2359 uses and for the same reason: no markup
+ * assertion can tell a live link from a dead label, but a value-out `href` can.
+ */
+describe('a praxis you have already filed', () => {
+  const filed = (overrides: Partial<TaskOut> = {}) =>
+    aTask({
+      can_sign_up: false,
+      signup_reason: 'already_active_member',
+      submitted_praxis_id: 91,
+      ...overrides,
+    })
+
+  it('offers the praxis to read instead of refusing', () => {
+    const cta = taskCardSignupCta(filed(), vi.fn())!
+    expect(cta.denied, 'a way in is not a refusal').toBe(false)
+    expect(cta.href).toBe('/praxis/91')
+    expect(cta.label).toBe(i18n.t('tasks:detail.submitted.view'))
+  })
+
+  it('links to the READ page, never to the editor that would bounce', () => {
+    const cta = taskCardSignupCta(filed(), vi.fn())!
+    expect(cta.href).not.toContain('/edit')
+  })
+
+  it('does not sign up — the slot navigates, it does not post', () => {
+    const onSignup = vi.fn()
+    const cta = taskCardSignupCta(filed(), onSignup)!
+    expect(cta.onPress).toBeUndefined()
+    expect(onSignup).not.toHaveBeenCalled()
+  })
+
+  it('says the same words the task detail says', () => {
+    // One table, one copy edit. The detail's submitted block reads this very
+    // key, so the card and the detail cannot say different things about the
+    // same praxis.
+    const cta = taskCardSignupCta(filed(), vi.fn())!
+    expect(cta.label).toBe('Read your praxis')
+  })
+
+  it('prefers the open draft when a viewer somehow holds both', () => {
+    // Double Dipper can leave a filed praxis and a live draft on one task. The
+    // draft is the one with work left in it, so it keeps the slot — and this
+    // is also the no-regression assertion for #2359's behaviour.
+    const cta = taskCardSignupCta(
+      filed({ in_progress_praxis_id: 77 }),
+      vi.fn(),
+    )!
+    expect(cta.href).toBe('/praxis/77/edit')
+    expect(cta.label).toBe(i18n.t('tasks:detail.signup.workOnThis'))
+  })
+
+  it('leaves the other four denials alone — a filed id changes nothing', () => {
+    for (const reason of DENIALS.filter((r) => r !== 'already_active_member')) {
+      const cta = taskCardSignupCta(
+        aTask({
+          can_sign_up: false,
+          signup_reason: reason,
+          submitted_praxis_id: 91,
+          level_required: 4,
+        }),
+        vi.fn(),
+      )!
+      expect(cta.denied, reason).toBe(true)
+      expect(cta.href, reason).toBeUndefined()
+      expect(cta.onPress, reason).toBeUndefined()
+    }
+  })
+
+  it('leaves a PERMITTED sign-up alone — Double Dipper still begins again', () => {
+    // A faction that may hold several memberships gets `multi_membership` and a
+    // live sign-up, filed praxis or not. Turning that into a read link would
+    // take away the claim the server is willing to honour.
+    const cta = taskCardSignupCta(
+      aTask({ signup_reason: 'multi_membership', submitted_praxis_id: 91 }),
+      vi.fn(),
+    )!
+    expect(cta.denied).toBe(false)
+    expect(cta.href).toBeUndefined()
+    expect(cta.onPress).toBeTypeOf('function')
+    expect(cta.label).toBe(i18n.t('tasks:detail.signup.ctaAgain'))
   })
 })

--- a/frontend/src/components/taskCard/__tests__/taskCardsV3.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/taskCardsV3.test.tsx
@@ -303,7 +303,18 @@ const HELD = aTask({
   in_progress_praxis_id: 77,
 })
 
-/** The same shut card with nothing to land on — submitted, or pending. */
+/** The same shut card, the praxis already FILED (#2643) — a door to READ it. */
+const FILED = aTask({
+  can_sign_up: false,
+  signup_reason: 'already_active_member',
+  submitted_praxis_id: 91,
+})
+
+/**
+ * The same shut card with nothing to land on at all: a `pending` praxis, the
+ * one status in the denial's population that is neither editable nor readable.
+ * `submitted` used to live here too, until #2643 gave it `FILED` above.
+ */
 const HELD_WITH_NO_DRAFT = aTask({
   can_sign_up: false,
   signup_reason: 'already_active_member',
@@ -381,4 +392,36 @@ describe.each(SKINS)('$slug offers a draft you already hold (#2359)', (skin) => 
       expect(html).not.toContain('href="/praxis/')
     },
   )
+})
+
+/**
+ * #2643 — the same nine skins, the other half of the same denial.
+ *
+ * The Done-when is "in all nine skins", and the reason that is worth nine
+ * assertions rather than one is the same as #2359's: no skin should have needed
+ * touching, and the way to know is to render all nine and look. `denied` goes
+ * false and `href` is set; `CardCtaControl` does the rest.
+ */
+describe.each(SKINS)('$slug offers a praxis you already filed (#2643)', (skin) => {
+  it('draws the slot as a link to the praxis, on the 44px floor', () => {
+    const html = renderTask(skin, FILED)
+    expect(visible(html)).toContain(i18n.t('tasks:detail.submitted.view'))
+    const slot = html.match(/<a [^>]*href="\/praxis\/91"[^>]*>/)
+    expect(slot, 'the slot is an anchor to the filed praxis').not.toBeNull()
+    expect(slot![0], 'the tap floor').toContain('min-height:44px')
+  })
+
+  it('points at the READ page, not the editor that would bounce', () => {
+    // `/edit` redirects a submitted praxis straight back to `/praxis/:id`
+    // (#1164, #1397), so an edit link here is a control that changes nothing.
+    expect(renderTask(skin, FILED)).not.toContain('/edit')
+  })
+
+  it('replaces the refusal rather than sitting beside it', () => {
+    const html = renderTask(skin, FILED)
+    expect(html).not.toContain('<button')
+    expect(visible(html)).not.toContain(
+      i18n.t('tasks:detail.signup.denied.alreadyActiveMember'),
+    )
+  })
 })

--- a/frontend/src/components/taskCard/signupAffordance.ts
+++ b/frontend/src/components/taskCard/signupAffordance.ts
@@ -4,6 +4,7 @@ import {
   SIGNUP_CTA_KEY,
   SIGNUP_IN_PROGRESS_KEY,
   SIGNUP_REASON_ALREADY_ACTIVE_MEMBER,
+  SIGNUP_SUBMITTED_KEY,
   isSignupDenial,
   signupCtaKey,
 } from "../../pages/taskDetail/signupCta";
@@ -47,10 +48,12 @@ export interface TaskCardSignupCta {
    */
   onPress?: () => void;
   /**
-   * Where the slot GOES instead of what it posts (#2359) — a router path, set
-   * on exactly one reason: `already_active_member` with a draft to land on.
+   * Where the slot GOES instead of what it posts (#2359, #2643) — a router
+   * path, set on exactly one reason: `already_active_member` with a praxis to
+   * land on. Two destinations, one reason: a draft's editor, or a filed
+   * praxis's read page.
    *
-   * Never set together with {@link onPress}. Navigating to your own draft is
+   * Never set together with {@link onPress}. Navigating to your own praxis is
    * not signing up: the server has refused the claim and is right to, and the
    * praxis this reaches already exists.
    */
@@ -92,26 +95,44 @@ export function taskCardSignupCta(
   if (!onSignup) return null;
 
   if (isSignupDenial(task.signup_reason)) {
-    // THE ONE REFUSAL THAT IS A DOOR (#2359). `already_active_member` means the
-    // viewer holds an open draft on this task, so the card was spending its only
-    // slot telling them something they knew, with the useful thing one press
-    // away. The wire carries that draft's id now, and the slot becomes a link to
-    // its editor — pressable, and NOT a sign-up (the server has refused the
+    // THE ONE REFUSAL THAT IS A DOOR (#2359, #2643). `already_active_member`
+    // means the viewer holds a praxis on this task, so the card was spending its
+    // only slot telling them something they knew, with the useful thing one
+    // press away. The wire carries that praxis's id now, and the slot becomes a
+    // link to it — pressable, and NOT a sign-up (the server has refused the
     // claim and is right to; the praxis already exists).
     //
-    // The null branch falls through to the label below, and it is REACHABLE
-    // rather than defensive: the denial's population also covers `submitted`
-    // and `pending` praxes, which shut sign-up with nothing left to edit. A
-    // link to /praxis/null/edit is worse than the sentence it replaced.
-    if (
-      task.signup_reason === SIGNUP_REASON_ALREADY_ACTIVE_MEMBER &&
-      task.in_progress_praxis_id != null
-    ) {
-      return {
-        label: i18n.t(`tasks:${SIGNUP_IN_PROGRESS_KEY}`),
-        denied: false,
-        href: `/praxis/${task.in_progress_praxis_id}/edit`,
-      };
+    // ONE REASON, TWO DOORS, chosen by which id the row carries and never by a
+    // second reason value — the server sends `already_active_member` for a
+    // draft and for a filed praxis alike, because both shut sign-up for the
+    // same rule. The ids are what tell them apart:
+    //
+    // * an OPEN DRAFT goes to its editor, and takes precedence when a viewer
+    //   somehow holds both (Double Dipper can leave one of each): the draft is
+    //   the one with work left in it.
+    // * a FILED praxis goes to its READ page, never `/edit` — that redirects a
+    //   submitted praxis straight back to `/praxis/:id` (#1164, #1397), so an
+    //   edit link here would be a control that changes nothing.
+    //
+    // The null-null branch falls through to the label below, and it is
+    // REACHABLE rather than defensive: the denial's population also covers a
+    // `pending` praxis, which shuts sign-up while awaiting moderation with
+    // nothing to edit and nothing to read.
+    if (task.signup_reason === SIGNUP_REASON_ALREADY_ACTIVE_MEMBER) {
+      if (task.in_progress_praxis_id != null) {
+        return {
+          label: i18n.t(`tasks:${SIGNUP_IN_PROGRESS_KEY}`),
+          denied: false,
+          href: `/praxis/${task.in_progress_praxis_id}/edit`,
+        };
+      }
+      if (task.submitted_praxis_id != null) {
+        return {
+          label: i18n.t(`tasks:${SIGNUP_SUBMITTED_KEY}`),
+          denied: false,
+          href: `/praxis/${task.submitted_praxis_id}`,
+        };
+      }
     }
     // `level` is only read by `denied.belowLevel`; passing it to the others is
     // free and keeps this a single call rather than a branch per reason.

--- a/frontend/src/pages/__tests__/taskCardOffersTheTask.test.tsx
+++ b/frontend/src/pages/__tests__/taskCardOffersTheTask.test.tsx
@@ -73,6 +73,7 @@ function makeTask(overrides: Partial<TaskOut> = {}): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: true,
     allowed_modes: ['solo'],
     eligible_for_current_user: true,

--- a/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
+++ b/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
@@ -29,6 +29,7 @@ function task(overrides: Partial<TaskOut> & { id: number }): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: true,
     allowed_modes: [],
     eligible_for_current_user: true,

--- a/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
@@ -110,6 +110,7 @@ function makeTask(): TaskOut {
     created_by_level: 0,
     signup_reason: null,
     in_progress_praxis_id: null,
+    submitted_praxis_id: null,
     can_sign_up: true,
     allowed_modes: ['solo'],
     eligible_for_current_user: true,

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -287,6 +287,7 @@ describe("S.N.I.D.E. praxis detail — copy is neutral (ADR-0061)", () => {
             created_by_level: 0,
             signup_reason: null,
             in_progress_praxis_id: null,
+            submitted_praxis_id: null,
             can_sign_up: false,
             allowed_modes: [],
             eligible_for_current_user: false,

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -231,6 +231,7 @@ describe("UA praxis detail — copy is neutral (ADR-0061)", () => {
               created_by_level: 0,
               signup_reason: null,
               in_progress_praxis_id: null,
+              submitted_praxis_id: null,
               can_sign_up: false,
               allowed_modes: [],
               eligible_for_current_user: false,

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -223,6 +223,7 @@ describe("WOW praxis detail — copy is neutral (ADR-0061)", () => {
               created_by_level: 0,
               signup_reason: null,
               in_progress_praxis_id: null,
+              submitted_praxis_id: null,
               can_sign_up: false,
               allowed_modes: [],
               eligible_for_current_user: false,

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -194,6 +194,26 @@ describe("task-detail content-slot invariant", () => {
       expect(html, "my-submission slot").toContain('href="/praxis/55"');
     });
 
+    it(`${slug} still draws ONE submitted link once the wire names it too`, () => {
+      // #2643 put the filed praxis's id on `TaskOut`, and `detailSignupCta`
+      // shares the card's resolver — so the detail's sign-up slot can now
+      // resolve to a "Read your praxis" link of its own. It must not: the page
+      // already has that link in its submitted block, and the stand-down in
+      // `shared.tsx` (`state.mySubmission → null`) is what keeps it to one.
+      const { html } = render(
+        <Archetype
+          state={baseState({
+            mySubmission: MY_PRAXIS,
+            task: { ...TASK, submitted_praxis_id: 55 },
+          })}
+        />,
+      );
+      expect(
+        html.match(/href="\/praxis\/55"/g)?.length,
+        "exactly one way in, not two",
+      ).toBe(1);
+    });
+
     it(`${slug} renders the continue control while in progress`, () => {
       const { html } = render(
         <Archetype

--- a/frontend/src/pages/taskDetail/__tests__/signupCta.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/signupCta.test.tsx
@@ -28,10 +28,13 @@ import "../../../i18n"; // real catalogs — a missing key throws rather than pa
 import { surfaceMap } from "../../../factions";
 import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
 import {
+  SIGNUP_IN_PROGRESS_KEY,
   SIGNUP_REASON_MULTI_MEMBERSHIP,
+  SIGNUP_SUBMITTED_KEY,
   canSignUpForTask,
   signupCtaKey,
 } from "../signupCta";
+import i18n from "../../../i18n";
 import type { TaskDetailState } from "../useTaskDetail";
 import { aPraxisCard, aTask } from '../../../test/fixtures'
 
@@ -119,6 +122,37 @@ describe("signupCtaKey — the label follows the server's reason", () => {
     // A future backend reason must not blank the button.
     expect(signupCtaKey("some_reason_from_a_later_era")).toBe(
       "detail.signup.cta",
+    );
+  });
+});
+
+describe("the two doors out of one denial (#2359, #2643)", () => {
+  it("keys both onto copy this build actually has", () => {
+    // The real catalogs are loaded above, so a key that is not in them resolves
+    // to itself — which is what this catches.
+    expect(i18n.t(`tasks:${SIGNUP_IN_PROGRESS_KEY}`)).not.toBe(
+      SIGNUP_IN_PROGRESS_KEY,
+    );
+    expect(i18n.t(`tasks:${SIGNUP_SUBMITTED_KEY}`)).toBe("Read your praxis");
+  });
+
+  it("borrows the task detail's OWN submitted copy rather than a synonym", () => {
+    // The owner ruling (2026-08-24) is that "Read your praxis" is right for both
+    // surfaces. Pointing the card at `detail.submitted.view` — the key the
+    // detail's own submitted block renders — is what makes a future copy edit
+    // land on both at once instead of drifting them apart.
+    expect(SIGNUP_SUBMITTED_KEY).toBe("detail.submitted.view");
+  });
+
+  it("stays out of signupCtaKey — the wire's reason cannot tell them apart", () => {
+    // Neither key is reachable from a `signup_reason`: the server sends
+    // `already_active_member` for a draft and a filed praxis alike. Which door
+    // opens is decided by which praxis id the row carries, in
+    // `components/taskCard/signupAffordance.ts`. If this ever starts returning
+    // one of them, the reason has grown a sixth value and this table needs a
+    // real row rather than a constant.
+    expect(signupCtaKey("already_active_member")).toBe(
+      "detail.signup.denied.alreadyActiveMember",
     );
   });
 });

--- a/frontend/src/pages/taskDetail/archetypes/shared.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/shared.tsx
@@ -266,16 +266,19 @@ export function TaskWorthStamp({ state }: { state: TaskDetailState }) {
  * for the same task offered nothing. It offers the link now.
  *
  * The conjunction from `signupAffordance` is untouched and load-bearing: the
- * reason ALONE is not a door, because it also covers a submitted or pending
- * praxis with nothing left to edit. The link needs `in_progress_praxis_id` too.
+ * reason ALONE is not a door, because it also covers a `pending` praxis, which
+ * shuts sign-up while awaiting moderation with nothing to edit and nothing to
+ * read. The link needs an id — `in_progress_praxis_id`, or since #2643
+ * `submitted_praxis_id`, whose door is the READ page rather than the editor.
  *
  * ### …but only where the page is not already the door
  *
  * The detail page has its own in-progress block — "Continue editing" beside
- * "drop" — gated on the separate `/praxis/mine` read. Where that block draws,
- * this slot stands down: two links to the same editor in one panel is not the
- * gap being closed. The slot is the FALLBACK, for the read where the task's own
- * `signup_reason` knows about a draft that the page's roster fetch does not.
+ * "drop" — gated on the separate `/praxis/mine` read, and its own submitted
+ * block ("Read your praxis") gated on `mySubmission`. Where either draws, this
+ * slot stands down: two links to the same praxis in one panel is not the gap
+ * being closed. The slot is the FALLBACK, for the read where the task's own
+ * `signup_reason` knows about a praxis that the page's own fetches do not.
  *
  * ### The anonymous viewer
  *

--- a/frontend/src/pages/taskDetail/signupCta.ts
+++ b/frontend/src/pages/taskDetail/signupCta.ts
@@ -62,6 +62,27 @@ const CTA_AGAIN_KEY = "detail.signup.ctaAgain" as const;
 export const SIGNUP_IN_PROGRESS_KEY = "detail.signup.workOnThis" as const;
 
 /**
+ * What that SAME denial says when the praxis behind it is already filed (#2643).
+ *
+ * `already_active_member` covers a submitted praxis too, and there the key above
+ * does not apply: there is no draft, and `/edit` redirects a submitted praxis
+ * straight back to its read page (#1164, #1397). What is useful is READING it,
+ * which is what the task detail has always offered on this very key — so the
+ * card borrows the detail's own words rather than minting a card-sized synonym.
+ *
+ * IT IS THE `detail.submitted.*` KEY, not a `detail.signup.*` one, and that is
+ * deliberate: the copy already existed and the owner ruling (2026-08-24) was
+ * that it is the right copy for both surfaces. A second string saying the same
+ * thing is how the two would drift apart on the next edit.
+ *
+ * A ROW, not a branch, for `DENIAL_KEYS`'s reason. This key and the one above
+ * are chosen by which praxis id the wire carries, not by a second reason value
+ * — the server sends one reason for both, and the ids are what distinguish
+ * them.
+ */
+export const SIGNUP_SUBMITTED_KEY = "detail.submitted.view" as const;
+
+/**
  * Every reason sign-up is SHUT, mapped to the copy that says so (#1976).
  *
  * The left column is `services/praxis.py`'s `SignupDenialReason`, value for
@@ -92,6 +113,7 @@ export type SignupCtaKey =
   | typeof SIGNUP_CTA_KEY
   | typeof CTA_AGAIN_KEY
   | typeof SIGNUP_IN_PROGRESS_KEY
+  | typeof SIGNUP_SUBMITTED_KEY
   | SignupDenialKey;
 
 /**

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -59,6 +59,11 @@ export const aTask = (over: Partial<TaskOut> = {}): TaskOut => ({
   created_by_level: 0,
   signup_reason: null,
   in_progress_praxis_id: null,
+  // The viewer's own draft and their own filed praxis on this task (#2359,
+  // #2643) — both null for the modal task, which the viewer has never touched.
+  // The suites that care set one or the other; setting BOTH is a state the
+  // server does not produce for a task that shut sign-up.
+  submitted_praxis_id: null,
   can_sign_up: true,
   allowed_modes: ['solo'],
   eligible_for_current_user: true,


### PR DESCRIPTION
Closes #2643

The task card had no submitted state. `already_active_member` came down the wire, the card looked for a draft id, found none, and drew a greyed **"Already done"** — while the task detail for the same task said **"Read your praxis"** and linked to it. Owner ruling 2026-08-24: that copy is right for both surfaces.

## The seam

`taskCardSignupCta(task, onSignup)` — value-out, in `frontend/src/components/taskCard/signupAffordance.ts`. It is the seam #2359 used and for the same reason: `renderToStaticMarkup` cannot tell a live link from a dead label, but an `href` on a returned object can. The red test was `expected 'Already done' to be 'Read your praxis'`.

The backend guard sits one seam lower, at the wire: `build_task_out_for_viewer` → `TaskOut`.

## One correction to the brief, worth reading

**There is no `submitted` sign-up reason.** `SignupDenialReason` has five values and a filed praxis produces `already_active_member`, exactly as a draft does — `_held_membership_task_ids_subquery` counts `in_progress`, `pending` and `submitted` alike. So "extend the `href` branch to the `submitted` reason" has no reason to extend to.

The shape that *does* exist is #2359's: **one reason, two doors, chosen by which praxis id the row carries.** That is what this builds, and it is the same pattern rather than a second one. `SIGNUP_SUBMITTED_KEY` joins the literal union beside `SIGNUP_IN_PROGRESS_KEY` — which is likewise not reachable from `signupCtaKey`, for the same reason. A row, not a branch, and `DENIAL_KEYS` is untouched.

## Backend

`TaskOut.submitted_praxis_id`, beside its twin, resolved in the same place from the same page-wide precompute — `gather_signup_facts` now reads seven page-wide queries instead of six, so a 50-row browse still costs a constant number of reads. That is the property `#1377` defends; a seventh constant read holds it rather than spending it.

`in_progress_praxis_ids` and the new `submitted_praxis_ids` now share one private query, `_own_praxis_ids`. **That is the leak defence:** the `PraxisMember.character_id == character.id` join is written once, so it cannot be dropped from one reader and hand a stranger an id on a task with many submissions.

**Submitted more than once** — a live path via `ctaAgain` / Double Dipper — resolves to the **most recent**. Ascending `Praxis.id` into a last-write-wins dict leaves the highest id; it is stated in the docblock and pinned by a test rather than left to the query's default. Offering someone a first attempt they have already superseded is the wrong door.

## Frontend

`denied` goes false and `href` is set, which is all `CardCtaControl` ever needed. **No skin was touched** — all nine render the anchor, and the suite proves it rather than asserting it of one.

Two doors, ordered: an open draft still wins (it is the one with work left in it, and that keeps #2359 unregressed); a filed praxis links to `/praxis/:id` — **never `/edit`**, which redirects a submitted praxis straight back (#1164, #1397) and would be a control that changes nothing. A `pending` praxis still falls through to the plain label: awaiting moderation is neither editable nor readable.

The card takes the task detail's **own** `detail.submitted.view` key rather than minting a card-sized synonym, so the owner's words stay one string on both surfaces.

## The task detail is unchanged, and here is why

The issue allowed switching it to the payload field **if that simplification is free**. It is not, on two counts:

1. `mySubmission` is a `PraxisCardOut`, not an id. Nine archetypes gate on `!mySubmission` (the drop control, the in-progress block, `hasActions`), so replacing it with a number is a rewrite of nine files, not a deletion.
2. It **saves no request**. `mySubmission` is `.find()` over `submissions`, the gallery the detail page renders anyway. There is no extra fetch to remove.

So the detail keeps its own copy, its own target, and its own source. Only the card changed.

**One thing this did have to guard, though.** `detailSignupCta` shares the card's resolver, so the detail's sign-up slot can now resolve to a "Read your praxis" link of its own — and the page already draws one. The stand-down in `shared.tsx` (`state.mySubmission → null`) is what keeps the panel to one link, and it turned out to be pinned by nothing: the existing test set `mySubmission` on a task whose wire named no filed praxis, so it never met the case. It does now, across every archetype, asserting **exactly one** `href="/praxis/55"`.

## Verified locally — every step in `.github/workflows/test.yml`

- `pytest --cov=. --cov-fail-under=92` — **1684 passed, 94.23%**
- `api-schema`: `python scripts/regen_api_client.py` then `git diff --exit-code` — clean. Both artifacts are committed, produced by that script and never hand-edited.
- `npm run lint` / `typecheck` / **`typecheck:design-sync`** / `test` (**461 files, 9521 tests**) / `build` / `budget`
- The ruff ratchet caught one new E501; the line got shorter rather than the allowlist longer.

**The `budget` WARN is pre-existing, not this PR.** I measured it: **137.2 KB with my two source files, and 137.2 KB with `origin/main`'s versions swapped in.** The JS warn line has already been crossed on main; this diff moves it by nothing.

**`typecheck:design-sync` fallout:** the generated type makes the field required, so `.design-sync/previews/_fixtures.tsx` and eleven suites that spell a whole `TaskOut` out needed the field. Added, never weakened to optional.

### The two guards the issue asked for by name

- **`submitted` resolves to a link, not a denial** — `signupAffordance.test.ts`, plus all nine skins in `taskCardsV3.test.tsx`.
- **`submitted_praxis_id` is null for a viewer who has not submitted** — `test_another_characters_submission_is_never_named`. I proved it red: deleting the `character_id` filter from the shared query fails **that test and only that test**.

## What to eyeball

Visual QA is outstanding — this was built with no browser and no dev stack, so everything above is tests, `tsc` and lint. Please look at:

1. **A task card for a task you have submitted, in all nine skins.** It should read "Read your praxis" as a live link, where it used to read a greyed "Already done". Albescent especially — its card is the `na` sheet plus drift, and the slot is one of the places that shows.
2. **The link target.** It must land on `/praxis/:id` and *stay* there. If it bounces you back from an editor, it went to `/edit`.
3. **The network panel, on a grid of tasks.** One request for the list, and **no per-card request**. That is the whole reason the id rides on the payload.
4. **A task you have a draft on** — unchanged, still "Work on this?" to the editor. And **an Everymen character** with a filed praxis: still "Begin again", still a live sign-up, not a read link.
5. **The task detail**, to confirm it looks exactly as it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
