### PR TITLE
The praxis-detail suites mount through one harness

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
@@ -29,35 +29,22 @@
  * a pure `[data-theme]` cascade with no branch in either component, so there is
  * nothing here to assert about it — it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import type { DuelDetailOut, DuelSideOut } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
-import { aMember, aPraxis, aTask } from '../../../test/fixtures'
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis, aTask } from "../../../test/fixtures";
+import {
+  CO_MEMBER,
+  MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
-
-// Imported after the mock so both archetypes pick it up.
-const { default: DefaultPraxisDetail } = await import("../archetypes/DefaultPraxisDetail");
-const { default: AlbescentPraxisDetail } = await import("../archetypes/AlbescentPraxisDetail");
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Ada",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Beth",
-  joined_at: "2026-01-02T00:00:00Z",
-});
 
 const PRAXIS = aPraxis({
   task_title: "A Chore Nobody Logged",
@@ -82,111 +69,36 @@ const SEAL = aTask({
   eligible_for_current_user: false,
 });
 
-const MINE: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 3,
-  display_name: "Ada",
-  faction_slug: "albescent",
-  avatar_url: "",
-  points_from_votes: 18,
-  is_submitted: true,
-  nudged_at: null,
-};
+const DUEL = aDuel({
+  challenger: aDuelSide({ faction_slug: "albescent", points_from_votes: 18 }),
+  opponent: aDuelSide({
+    praxis_id: 2,
+    character_id: 4,
+    display_name: "Rax",
+    faction_slug: "snide",
+    points_from_votes: 15.4,
+  }),
+});
 
-const RIVAL: DuelSideOut = {
-  praxis_id: 2,
-  character_id: 4,
-  display_name: "Rax",
-  faction_slug: "snide",
-  avatar_url: "",
-  points_from_votes: 15.4,
-  is_submitted: true,
-  nudged_at: null,
-};
+const VIEWER = aCurrentUser({
+  character: aCharacter({ faction_slug: "albescent", level: 4 }),
+});
 
-const DUEL: DuelDetailOut = {
-  id: 5,
-  task_id: 7,
-  status: "settled",
-  forfeited_by_character_id: null,
-  challenger: MINE,
-  opponent: RIVAL,
-  winner_character_id: null,
-  challenger_final_points: null,
-  opponent_final_points: null,
-};
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  email: "ada@example.com",
-  display_name: "Ada",
-  is_admin: false,
-  can_comment: true,
-  character: {
-    id: 3,
-    display_name: "Ada",
-    faction_slug: "albescent",
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
-
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
-
-type Skin = typeof DefaultPraxisDetail;
-
+/**
+ * Both skins come out of the same registry, named by slug: `na` is the
+ * undressed page this one is claimed to BE underneath its three layers, and
+ * comparing the two by slug is the comparison the dispatcher would make.
+ */
 function render(
-  Archetype: Skin,
+  slug: "na" | "albescent",
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): string {
   mocks.formFactor = formFactor;
-  return renderToStaticMarkup(
-    <MemoryRouter>
-      <Archetype state={next} />
-    </MemoryRouter>,
-  );
+  return renderPraxisDetail(slug, next).html;
 }
 
 /**
@@ -241,8 +153,8 @@ describe("Albescent praxis detail is Default plus light", () => {
       it(`${axis} (${formFactor}) renders Default byte for byte once undressed`, () => {
         // `render` mutates the shared form-factor mock, so take Default's
         // markup first and re-set the factor for the second render.
-        const plain = render(DefaultPraxisDetail, next, formFactor);
-        const dressed = render(AlbescentPraxisDetail, next, formFactor);
+        const plain = render("na", next, formFactor);
+        const dressed = render("albescent", next, formFactor);
         expect(undress(dressed)).toBe(plain);
       });
     }
@@ -255,7 +167,7 @@ describe("Albescent praxis detail — where the light sits", () => {
     // the window. The layers arrive through `DefaultPraxisDetail`'s `ornament`
     // slot, so they sit after the 1200 sheet's own style and inherit its
     // `overflow: hidden` — the site background still shows around the page.
-    const html = render(AlbescentPraxisDetail, state());
+    const html = render("albescent", state());
     const sheet = html.indexOf("max-width:1200px");
     expect(sheet, "the sheet renders").toBeGreaterThan(-1);
 
@@ -267,7 +179,7 @@ describe("Albescent praxis detail — where the light sits", () => {
   });
 
   it("never reaches for a full-viewport ground", () => {
-    const html = render(AlbescentPraxisDetail, state());
+    const html = render("albescent", state());
     expect(html, "no full-page wash").not.toContain("na-backdrop");
     expect(html, "no fixed inset ground").not.toContain("position:fixed");
   });
@@ -282,7 +194,7 @@ describe("Albescent praxis detail — where the light sits", () => {
     // carrying an `alb-` class would mean a block had been skinned — the report
     // card and the steward bar above all, which ADR-0061 keeps outside the
     // costume.
-    const html = render(AlbescentPraxisDetail, state({ showAdminBar: true, user: VIEWER }));
+    const html = render("albescent", state({ showAdminBar: true, user: VIEWER }));
     expect(
       [...new Set(html.match(/alb-[\w-]+/g))].sort(),
       "wrapper + prism + two layers + the dispatched stamp, nothing else",
@@ -304,7 +216,7 @@ describe("Albescent praxis detail — where the light sits", () => {
   it("writes no inline animation, so reduced motion is honoured by the cascade", () => {
     // index.css owns every keyframe and the `no-preference` gate; a component
     // may not inject a stylesheet or an inline `animation:` (#911).
-    expect(render(AlbescentPraxisDetail, state())).not.toContain("animation");
+    expect(render("albescent", state())).not.toContain("animation");
   });
 });
 
@@ -326,7 +238,7 @@ describe("Albescent praxis detail keeps the light and loses the words", () => {
 
   it("speaks the shared neutral copy on every state", () => {
     for (const [axis, next] of AXES) {
-      const text = render(AlbescentPraxisDetail, next).replace(/<[^>]*>/g, "").toLowerCase();
+      const text = render("albescent", next).replace(/<[^>]*>/g, "").toLowerCase();
       for (const word of UNBUILT_VOICE) {
         expect(text, `${axis} must not speak "${word}"`).not.toContain(word);
       }
@@ -334,7 +246,7 @@ describe("Albescent praxis detail keeps the light and loses the words", () => {
   });
 
   it("keeps the neutral headings the shared page owns", () => {
-    const text = render(AlbescentPraxisDetail, state()).replace(/<[^>]*>/g, "");
+    const text = render("albescent", state()).replace(/<[^>]*>/g, "");
     expect(text, "the write-up heading").toContain("Write-up");
     expect(text, "the proof heading").toContain("Proof");
     expect(text, "the score heading").toContain("Score");
@@ -349,8 +261,8 @@ describe("Albescent praxis detail keeps the light and loses the words", () => {
     // form-factor gated, and it is still the one canonical `TaskCrown`.
     const crown = `title="${i18n.t("feed:taskCrown.title")}"`;
     const crowned = state({ praxis: { ...PRAXIS, is_top_for_task: true } });
-    expect(render(AlbescentPraxisDetail, crowned, "desktop")).toContain(crown);
-    expect(render(AlbescentPraxisDetail, crowned, "mobile")).toContain(crown);
-    expect(render(AlbescentPraxisDetail, state(), "mobile")).not.toContain(crown);
+    expect(render("albescent", crowned, "desktop")).toContain(crown);
+    expect(render("albescent", crowned, "mobile")).toContain(crown);
+    expect(render("albescent", state(), "mobile")).not.toContain(crown);
   });
 });

--- a/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
@@ -32,7 +32,7 @@
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis, aTask } from "../../../test/fixtures";
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMetatask, aPraxis } from "../../../test/fixtures";
 import {
   CO_MEMBER,
   MEMBER,
@@ -55,19 +55,7 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const SEAL = aTask({
-  id: 501,
-  title: "Composting",
-  point_value: 60,
-  level_required: 0,
-  task_type: "metatask",
-  created_by: 9,
-  metatask_faction_slug: "snide",
-  created_by_display_name: "",
-  can_sign_up: false,
-  allowed_modes: [],
-  eligible_for_current_user: false,
-});
+const SEAL = aMetatask({ metatask_faction_slug: "snide" });
 
 const DUEL = aDuel({
   challenger: aDuelSide({ faction_slug: "albescent", points_from_votes: 18 }),

--- a/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
@@ -33,13 +33,7 @@ import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMetatask, aPraxis } from "../../../test/fixtures";
-import {
-  CO_MEMBER,
-  MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, RIVAL, VOTERS, aPraxisDetailState, renderPraxisDetail } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -59,13 +53,7 @@ const SEAL = aMetatask({ metatask_faction_slug: "snide" });
 
 const DUEL = aDuel({
   challenger: aDuelSide({ faction_slug: "albescent", points_from_votes: 18 }),
-  opponent: aDuelSide({
-    praxis_id: 2,
-    character_id: 4,
-    display_name: "Rax",
-    faction_slug: "snide",
-    points_from_votes: 15.4,
-  }),
+  opponent: RIVAL,
 });
 
 const VIEWER = aCurrentUser({

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -31,7 +31,7 @@ import i18n from "../../../i18n";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
 import { PraxisStatusBanners } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import { aPraxis, aTask } from '../../../test/fixtures'
+import { aMetatask, aPraxis } from '../../../test/fixtures'
 import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
 // `markup` tag-strips into `text` — several archetypes split the finding across
@@ -201,19 +201,7 @@ function multiplierState(): PraxisDetailState {
 // faction (here `snide`), not the host archetype's — a UA-hosted page shows a
 // Snide-issued seal. Its condition line is the metatask title, the anchor below.
 
-const SEAL_METATASK = aTask({
-  id: 501,
-  title: "Composting",
-  point_value: 60,
-  level_required: 0,
-  task_type: "metatask",
-  created_by: 9,
-  metatask_faction_slug: "snide",
-  created_by_display_name: "",
-  can_sign_up: false,
-  allowed_modes: [],
-  eligible_for_current_user: false,
-});
+const SEAL_METATASK = aMetatask({ metatask_faction_slug: "snide" });
 
 /** Same praxis, now carrying one applied metatask seal. */
 function sealedState(): PraxisDetailState {

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -24,10 +24,7 @@
  * throwing. We assert the structural anchors each slot leaves behind: the
  * finding text, the "re:" task link, and the author-byline character link.
  */
-import { renderToStaticMarkup } from "react-dom/server";
 import { surfaceMap } from "../../../factions";
-import { MemoryRouter } from "react-router-dom";
-import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 // Initialize the i18n catalog so shared-chrome copy keys resolve to English text.
 import i18n from "../../../i18n";
@@ -35,14 +32,13 @@ import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
 import { PraxisStatusBanners } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import { aPraxis, aTask } from '../../../test/fixtures'
+import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
-function render(element: ReactElement): { html: string; text: string } {
-  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
-  // Tag-stripped text — several archetypes split the finding across spans
-  // (the Ephemerists' lapis last-word), so the headline only reads contiguously
-  // once the wrapping tags are removed.
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
+// `markup` tag-strips into `text` — several archetypes split the finding across
+// spans (the Ephemerists' lapis last-word), so the headline only reads
+// contiguously once the wrapping tags are removed.
+const render = markup;
+
 
 const PRAXIS = aPraxis({
   task_title: "Mangrove",
@@ -67,41 +63,9 @@ const PRAXIS = aPraxis({
  *  praxis payload (`scoreBreakdown`, ADR-0053); behavior-slot state is left in
  *  its default (anonymous, non-owner) shape. */
 function state(): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-  };
+  });
 }
 
 // Default fallback is a registered renderable too — guard it alongside the map.

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -31,8 +31,8 @@ import i18n from "../../../i18n";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
 import { PraxisStatusBanners } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import { aMetatask, aPraxis } from '../../../test/fixtures'
-import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
+import { aMetatask } from '../../../test/fixtures'
+import { aPraxisDetailState, aWalkedPraxis, markup } from '../../../test/praxisDetail'
 
 // `markup` tag-strips into `text` — several archetypes split the finding across
 // spans (the Ephemerists' lapis last-word), so the headline only reads
@@ -40,24 +40,8 @@ import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 const render = markup;
 
 
-const PRAXIS = aPraxis({
-  task_title: "Mangrove",
-  task_point_value: 30,
-  task_level_required: 3,
-  task_faction_slug: "ua",
-  title: "Reforestation",
-  body_text: "Seedlings planted along the estuary.",
-  submitted_at: "2026-01-02T00:00:00Z",
-  created_by_id: 3,
-  created_by_display_name: "Ada",
-  created_by_faction_slug: "ua",
-  updated_at: "2026-01-02T00:00:00Z",
-  members: [],
-  media_items: [],
-  // score = (base 30 + meta 0) × 1.0 + vote points 16 = 46 — the common case.
-  score: 46,
-  points_from_votes: 16,
-});
+const PRAXIS = aWalkedPraxis();
+
 
 /** Minimal state — the read archetypes take every number they show off the
  *  praxis payload (`scoreBreakdown`, ADR-0053); behavior-slot state is left in

--- a/frontend/src/pages/praxisDetail/__tests__/bylinePortrait.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/bylinePortrait.test.tsx
@@ -23,18 +23,16 @@
  * framed plate, Singularity's terminal cell. What travels is the RULE, drawn
  * inside each archetype's existing frame.
  */
-import { renderToStaticMarkup } from 'react-dom/server'
-import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
-// Initialize the catalog so shared-chrome copy keys resolve to English.
-import '../../../i18n'
 import { surfaceMap } from '../../../factions'
 import DefaultPraxisDetail from '../archetypes/DefaultPraxisDetail'
 import { bylineFaces } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import { aPraxis, aMember, AUTHOR } from '../../../test/fixtures'
+import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 import { mediaUrl } from '../../../utils/media'
+
 
 /** A two-word name so the monogram is a distinctive pair a substring can find. */
 const NAME = 'Zev Quist'
@@ -43,13 +41,11 @@ const PORTRAIT = 'avatars/zev.png'
 /** A second member, who since #2318 carries a portrait of their own. */
 const CREWMATE = { id: 44, name: 'Ilse Ronan', portrait: 'avatars/ilse.png' }
 
-function render(element: ReactElement): string {
-  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
-}
+const render = (element: ReactElement): string => markup(element).html
+
 
 function state(over: Partial<Parameters<typeof aPraxis>[0]> = {}): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: aPraxis({
       created_by_display_name: NAME,
       // The author's own member row carries the same portrait the top-level
@@ -65,38 +61,7 @@ function state(over: Partial<Parameters<typeof aPraxis>[0]> = {}): PraxisDetailS
       ],
       ...over,
     }),
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-  }
+  })
 }
 
 function occurrences(haystack: string, needle: string): number {

--- a/frontend/src/pages/praxisDetail/__tests__/bylinePortrait.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/bylinePortrait.test.tsx
@@ -29,6 +29,7 @@ import { surfaceMap } from '../../../factions'
 import DefaultPraxisDetail from '../archetypes/DefaultPraxisDetail'
 import { bylineFaces } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisMemberOut } from '../../../api/praxis'
 import { aPraxis, aMember, AUTHOR } from '../../../test/fixtures'
 import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 import { mediaUrl } from '../../../utils/media'
@@ -64,7 +65,24 @@ function state(over: Partial<Parameters<typeof aPraxis>[0]> = {}): PraxisDetailS
   })
 }
 
+/** The author's own member row, carrying the same portrait the byline reads. */
+const AUTHOR_FACE = aMember({
+  character_display_name: NAME,
+  character_avatar_url: PORTRAIT,
+})
+
+/** The second member. The portrait is the axis: '' is the monogram fallback. */
+const crewmate = (portrait: string): PraxisMemberOut =>
+  aMember({
+    id: 102,
+    character_id: CREWMATE.id,
+    character_display_name: CREWMATE.name,
+    character_avatar_url: portrait,
+    joined_at: '2026-01-02T00:00:00Z',
+  })
+
 function occurrences(haystack: string, needle: string): number {
+
   return haystack.split(needle).length - 1
 }
 
@@ -105,19 +123,8 @@ describe('collab byline: every member wears their own face (#2318)', () => {
           state={state({
             type: 'collab',
             created_by_avatar_url: PORTRAIT,
-            members: [
-              aMember({
-                character_display_name: NAME,
-                character_avatar_url: PORTRAIT,
-              }),
-              aMember({
-                id: 102,
-                character_id: CREWMATE.id,
-                character_display_name: CREWMATE.name,
-                character_avatar_url: CREWMATE.portrait,
-                joined_at: '2026-01-02T00:00:00Z',
-              }),
-            ],
+            members: [AUTHOR_FACE, crewmate(CREWMATE.portrait)],
+
           })}
         />,
       )
@@ -145,19 +152,8 @@ describe('collab byline: every member wears their own face (#2318)', () => {
         state={state({
           type: 'collab',
           created_by_avatar_url: PORTRAIT,
-          members: [
-            aMember({
-              character_display_name: NAME,
-              character_avatar_url: PORTRAIT,
-            }),
-            aMember({
-              id: 102,
-              character_id: CREWMATE.id,
-              character_display_name: CREWMATE.name,
-              character_avatar_url: '',
-              joined_at: '2026-01-02T00:00:00Z',
-            }),
-          ],
+          members: [AUTHOR_FACE, crewmate('')],
+
         })}
       />,
     )
@@ -176,19 +172,8 @@ describe('bylineFaces', () => {
       aPraxis({
         created_by_display_name: NAME,
         created_by_avatar_url: PORTRAIT,
-        members: [
-          aMember({
-            character_display_name: NAME,
-            character_avatar_url: PORTRAIT,
-          }),
-          aMember({
-            id: 102,
-            character_id: CREWMATE.id,
-            character_display_name: CREWMATE.name,
-            character_avatar_url: CREWMATE.portrait,
-            joined_at: '2026-01-02T00:00:00Z',
-          }),
-        ],
+        members: [AUTHOR_FACE, crewmate(CREWMATE.portrait)],
+
       }),
     )
     expect(faces).toEqual([

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -31,121 +31,48 @@ import type {
   PraxisMemberOut,
   PraxisStatus,
 } from "../../../api/praxis";
-import type { CharacterOut, CurrentUser } from "../../../api/auth";
+import type { CurrentUser } from "../../../api/auth";
+import { aCharacter, aCurrentUser, aMember, aPraxis } from "../../../test/fixtures";
 import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
 const text = (element: ReactElement): string => markup(element).text;
 
-
-function member(
+const member = (
   characterId: number,
   name: string,
   hasSubmitted: boolean,
-): PraxisMemberOut {
-  return {
+): PraxisMemberOut =>
+  aMember({
     id: characterId * 10,
-    praxis_id: 1,
     character_id: characterId,
     character_display_name: name,
-    character_avatar_url: "",
     has_submitted: hasSubmitted,
-    is_done: false,
-    joined_at: "2026-01-01T00:00:00Z",
-    nudged_at: null,
-    submitted_at: null,
-  };
-}
+  });
 
-function praxis(
+const praxis = (
   members: PraxisMemberOut[],
   status: PraxisStatus,
   submitProposedAt: string | null,
-): PraxisOut {
-  return {
-    id: 1,
-    task_id: 7,
-    task_title: "Mangrove",
-    task_point_value: 30,
-    task_level_required: 3,
-    task_faction_slug: null,
+): PraxisOut =>
+  aPraxis({
     type: "collab",
     status,
-    title: "Reforestation",
-    body_text: "Seedlings.",
-    moderation_status: "visible",
-    admin_note: null,
-    flagged_at: null,
     submitted_at: null,
     submit_proposed_at: submitProposedAt,
     created_by_id: 1,
-    created_by_display_name: "Ada",
-    created_by_avatar_url: "",
-    created_by_faction_slug: null,
-    created_at: "2026-01-01T00:00:00Z",
-    updated_at: "2026-01-02T00:00:00Z",
-    members,
-    invites: [],
     media_items: [],
-    score: 0,
-    metatask_points: 0,
-    display_multiplier: 1.0,
-    points_from_votes: 0,
-    habit_bonus_points: 0,
-    is_top_for_task: false,
-    duel_id: null,
-    can_flag: true,
-    applied_metatasks: [],
-    viewer_can_vote: true,
-    viewer_vote: null,
-    voter_count: 0,
-  };
-}
+    members,
+  });
 
-function character(id: number): CharacterOut {
-  return {
-    id,
-    username: `u${id}`,
-    display_name: `Player ${id}`,
-    bio: '',
-    tagline: '',
-    avatar_url: '',
-    location: '',
-    level: 5,
-    score: 0,
-    all_time_score: 0,
-    faction_slug: "na",
-    status: "active",
-    created_at: "2026-01-01T00:00:00Z",
-    badges: [],
-    invitations: [],
-  };
-}
+const user = (characterId: number): CurrentUser =>
+  aCurrentUser({
+    character: aCharacter({
+      id: characterId,
+      username: `u${characterId}`,
+      display_name: `Player ${characterId}`,
+    }),
+  });
 
-function user(characterId: number): CurrentUser {
-  return {
-    account_id: 1,
-    email: 'wz_pilgrim@example.com',
-    provider: 'google',
-    character: character(characterId),
-    is_admin: false,
-    can_create_additional_character: false,
-    can_start_as_albescent: false,
-    albescent_revealed: false,
-    albescent_glimpsed: false,
-    can_propose_task: false,
-    can_propose_metatask: false,
-    can_apply_metatask: false,
-    can_see_retired_tasks: false,
-    can_see_pending_tasks: false,
-    can_comment: true,
-    albescent_level_required: 8,
-    second_character_level_required: 5,
-    era_name: "Era 1",
-    level_jump_reach: 0,
-    level_jump_available: false,
-    task_browse_defaults_to_eligible: false,
-  };
-}
 
 /** Minimal PraxisDetailState — only the fields the two slots read matter; the
  *  rest are stubbed with inert defaults. */

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -21,8 +21,6 @@
  *
  * Rendered to static markup; the catalog is initialized so copy keys resolve.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 import "../../../i18n";
@@ -34,11 +32,10 @@ import type {
   PraxisStatus,
 } from "../../../api/praxis";
 import type { CharacterOut, CurrentUser } from "../../../api/auth";
+import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
-function text(element: ReactElement): string {
-  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
-  return html.replace(/<[^>]*>/g, "");
-}
+const text = (element: ReactElement): string => markup(element).text;
+
 
 function member(
   characterId: number,
@@ -153,42 +150,10 @@ function user(characterId: number): CurrentUser {
 /** Minimal PraxisDetailState — only the fields the two slots read matter; the
  *  rest are stubbed with inert defaults. */
 function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: null,
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
     ...overrides,
-  };
+  });
 }
 
 const ADA = () => member(1, "Ada", true);

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -27,6 +27,7 @@ import type { PraxisDetailState } from '../usePraxisDetail'
 import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
 import type { CurrentUser } from '../../../api/auth'
 import { aMember, aPraxis, aTask } from '../../../test/fixtures'
+import { aPraxisDetailState } from '../../../test/praxisDetail'
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
 vi.mock('../../../hooks/useFormFactor', () => ({
@@ -133,45 +134,14 @@ const VIEWER: CurrentUser = {
 } as unknown as CurrentUser
 
 function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
     voters: [
       { character_id: 11, display_name: 'Cy', avatar_url: '', faction_slug: '', value: 5 },
       { character_id: 12, display_name: 'Dov', avatar_url: '', faction_slug: '', value: 3 },
     ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
     ...overrides,
-  }
+  })
 }
 
 function render(

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -24,7 +24,7 @@ import i18n from '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { DuelDetailOut } from '../../../api/duel'
 import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMetatask, aPraxis } from '../../../test/fixtures'
-import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
+import { CO_MEMBER, MEMBER, RIVAL, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
 
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
@@ -53,13 +53,7 @@ const PRAXIS = aPraxis({
 const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
   aDuel({
     challenger: aDuelSide({ faction_slug: 'coven', points_from_votes: 18 }),
-    opponent: aDuelSide({
-      praxis_id: 2,
-      character_id: 4,
-      display_name: 'Rax',
-      faction_slug: 'snide',
-      points_from_votes: 15.4,
-    }),
+    opponent: RIVAL,
     ...overrides,
   })
 

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -19,15 +19,13 @@
  * candle/haze/wheel motions live in index.css behind
  * `prefers-reduced-motion` — neither is assertable here; both are eyeball checks.
  */
-import { renderToStaticMarkup } from 'react-dom/server'
-import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import i18n from '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
-import type { CurrentUser } from '../../../api/auth'
-import { aMember, aPraxis, aTask } from '../../../test/fixtures'
-import { aPraxisDetailState } from '../../../test/praxisDetail'
+import type { DuelDetailOut } from '../../../api/duel'
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis, aTask } from '../../../test/fixtures'
+import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
+
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
 vi.mock('../../../hooks/useFormFactor', () => ({
@@ -43,22 +41,8 @@ vi.mock('../../../hooks/useTheme', () => ({
   useTheme: () => ({ theme: 'dark' as const, toggle: () => {} }),
 }))
 
-// Imported after the mock so the archetype picks it up.
-const { default: CovenPraxisDetail } = await import('../archetypes/CovenPraxisDetail')
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: 'Ada',
-})
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: 'Beth',
-  joined_at: '2026-01-02T00:00:00Z',
-})
-
 const PRAXIS = aPraxis({
+
   task_faction_slug: 'coven',
   created_by_id: 3,
   created_by_display_name: 'Ada',
@@ -66,42 +50,19 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 })
 
-const MINE: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 3,
-  display_name: 'Ada',
-  faction_slug: 'coven',
-  avatar_url: '',
-  points_from_votes: 18,
-  is_submitted: true,
-  nudged_at: null,
-}
-
-const RIVAL: DuelSideOut = {
-  praxis_id: 2,
-  character_id: 4,
-  display_name: 'Rax',
-  faction_slug: 'snide',
-  avatar_url: '',
-  points_from_votes: 15.4,
-  is_submitted: true,
-  nudged_at: null,
-}
-
-function duel(overrides: Partial<DuelDetailOut> = {}): DuelDetailOut {
-  return {
-    id: 5,
-    task_id: 7,
-    status: 'settled',
-    forfeited_by_character_id: null,
-    challenger: MINE,
-    opponent: RIVAL,
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
+const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
+  aDuel({
+    challenger: aDuelSide({ faction_slug: 'coven', points_from_votes: 18 }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 4,
+      display_name: 'Rax',
+      faction_slug: 'snide',
+      points_from_votes: 15.4,
+    }),
     ...overrides,
-  }
-}
+  })
+
 
 const SEAL_METATASK = aTask({
   id: 501,
@@ -117,52 +78,13 @@ const SEAL_METATASK = aTask({
   eligible_for_current_user: false,
 })
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  email: 'ada@example.com',
-  display_name: 'Ada',
-  is_admin: false,
-  can_comment: true,
-  character: {
-    id: 3,
-    display_name: 'Ada',
-    faction_slug: 'coven',
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser
+const VIEWER = aCurrentUser({ character: aCharacter({ faction_slug: 'coven', level: 4 }) })
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return aPraxisDetailState({
-    praxis: PRAXIS,
-    voters: [
-      { character_id: 11, display_name: 'Cy', avatar_url: '', faction_slug: '', value: 5 },
-      { character_id: 12, display_name: 'Dov', avatar_url: '', faction_slug: '', value: 3 },
-    ],
-    ...overrides,
-  })
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides })
 
-function render(
-  next: PraxisDetailState,
-  formFactor: 'desktop' | 'mobile' = 'desktop',
-): { html: string; text: string } {
-  mocks.formFactor = formFactor
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <CovenPraxisDetail state={next} />
-    </MemoryRouter>,
-  )
-  return { html, text: html.replace(/<[^>]*>/g, '') }
-}
+const render = skinRenderer('coven', mocks)
 
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle)
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1)
-  return at
-}
 
 /** Every opening `<a>` tag in the markup, attributes and all. */
 function anchors(html: string): string[] {

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -23,7 +23,7 @@ import { describe, it, expect, vi } from 'vitest'
 import i18n from '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { DuelDetailOut } from '../../../api/duel'
-import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis, aTask } from '../../../test/fixtures'
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMetatask, aPraxis } from '../../../test/fixtures'
 import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
 
 
@@ -64,19 +64,7 @@ const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
   })
 
 
-const SEAL_METATASK = aTask({
-  id: 501,
-  title: 'Composting',
-  point_value: 60,
-  level_required: 0,
-  task_type: 'metatask',
-  created_by: 9,
-  metatask_faction_slug: 'coven',
-  created_by_display_name: '',
-  can_sign_up: false,
-  allowed_modes: [],
-  eligible_for_current_user: false,
-})
+const SEAL_METATASK = aMetatask({ metatask_faction_slug: 'coven' })
 
 const VIEWER = aCurrentUser({ character: aCharacter({ faction_slug: 'coven', level: 4 }) })
 

--- a/frontend/src/pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx
@@ -25,8 +25,6 @@
  */
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { renderToStaticMarkup } from 'react-dom/server'
-import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
 import '../../../i18n'
@@ -37,6 +35,7 @@ import {
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut } from '../../../api/praxis'
+import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
 const SHARED_SOURCE = readFileSync(
   fileURLToPath(new URL('../shared.tsx', import.meta.url)),
@@ -100,46 +99,15 @@ function praxis(overrides: Partial<PraxisOut> = {}): PraxisOut {
 }
 
 function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: praxis(),
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
     isOwner: true,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
     ...overrides,
-  } as PraxisDetailState
+  })
 }
 
-function html(element: ReactElement): string {
-  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
-}
+const html = (element: ReactElement): string => markup(element).html
+
 
 describe('the praxis detail wall carries its own alarm ink (#1451)', () => {
   it.each(WALL_ALARM)('%s: the failed banner reads its wall', (slug, token) => {

--- a/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
@@ -26,7 +26,7 @@ import '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { DuelDetailOut } from '../../../api/duel'
 import { aDuel, aDuelSide, aPraxis } from '../../../test/fixtures'
-import { MEMBER, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
+import { MEMBER, RIVAL, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
 
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
@@ -51,13 +51,6 @@ const PRAXIS = aPraxis({
 
 /** This page's side. Its `praxis_id` is what makes it "mine" rather than the rival. */
 const MINE = aDuelSide({ faction_slug: 'coven', points_from_votes: 18 })
-const RIVAL = aDuelSide({
-  praxis_id: 2,
-  character_id: 4,
-  display_name: 'Rax',
-  faction_slug: 'snide',
-  points_from_votes: 15.4,
-})
 
 const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
   aDuel({ challenger: MINE, opponent: RIVAL, ...overrides })

--- a/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
@@ -26,6 +26,7 @@ import '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
 import { aMember, aPraxis } from '../../../test/fixtures'
+import { aPraxisDetailState } from '../../../test/praxisDetail'
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
 vi.mock('../../../hooks/useFormFactor', () => ({
@@ -90,42 +91,11 @@ function duel(overrides: Partial<DuelDetailOut> = {}): DuelDetailOut {
 }
 
 function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [],
     duel: duel(),
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
     ...overrides,
-  }
+  })
 }
 
 function render(

--- a/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
@@ -24,24 +24,21 @@ import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
-import { aMember, aPraxis } from '../../../test/fixtures'
-import { aPraxisDetailState } from '../../../test/praxisDetail'
+import type { DuelDetailOut } from '../../../api/duel'
+import { aDuel, aDuelSide, aPraxis } from '../../../test/fixtures'
+import { MEMBER, aPraxisDetailState, indexOf, skinRenderer } from '../../../test/praxisDetail'
+
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
 vi.mock('../../../hooks/useFormFactor', () => ({
   useFormFactor: () => mocks.formFactor,
 }))
 
-const { default: DefaultPraxisDetail } = await import('../archetypes/DefaultPraxisDetail')
 const { DuelCard } = await import('../DuelCard')
 
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: 'Ada',
-})
 
 const PRAXIS = aPraxis({
+
   task_title: 'A Chore Nobody Logged',
   type: 'duel',
   created_by_id: 3,
@@ -53,70 +50,24 @@ const PRAXIS = aPraxis({
 })
 
 /** This page's side. Its `praxis_id` is what makes it "mine" rather than the rival. */
-const MINE: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 3,
-  display_name: 'Ada',
-  faction_slug: 'coven',
-  avatar_url: '',
-  points_from_votes: 18,
-  is_submitted: true,
-  nudged_at: null,
-}
-
-const RIVAL: DuelSideOut = {
+const MINE = aDuelSide({ faction_slug: 'coven', points_from_votes: 18 })
+const RIVAL = aDuelSide({
   praxis_id: 2,
   character_id: 4,
   display_name: 'Rax',
   faction_slug: 'snide',
-  avatar_url: '',
   points_from_votes: 15.4,
-  is_submitted: true,
-  nudged_at: null,
-}
+})
 
-function duel(overrides: Partial<DuelDetailOut> = {}): DuelDetailOut {
-  return {
-    id: 5,
-    task_id: 7,
-    status: 'settled' as DuelStatus,
-    forfeited_by_character_id: null,
-    challenger: MINE,
-    opponent: RIVAL,
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
-    ...overrides,
-  }
-}
+const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
+  aDuel({ challenger: MINE, opponent: RIVAL, ...overrides })
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return aPraxisDetailState({
-    praxis: PRAXIS,
-    duel: duel(),
-    ...overrides,
-  })
-}
 
-function render(
-  next: PraxisDetailState,
-  formFactor: 'desktop' | 'mobile' = 'desktop',
-): { html: string; text: string } {
-  mocks.formFactor = formFactor
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <DefaultPraxisDetail state={next} />
-    </MemoryRouter>,
-  )
-  return { html, text: html.replace(/<[^>]*>/g, '') }
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, duel: duel(), ...overrides })
 
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle)
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1)
-  return at
-}
+const render = skinRenderer('na', mocks)
+
 
 describe('duel card — the three readings', () => {
   it('settled: both totals, the margin, and never a decided verdict', () => {

--- a/frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx
@@ -51,6 +51,7 @@ import DefaultPraxisDetail from '../archetypes/DefaultPraxisDetail'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
 import { aPraxis } from '../../../test/fixtures'
+import { aPraxisDetailState } from '../../../test/praxisDetail'
 
 /**
  * Three genuinely different opponents — the same three the retired rail guard
@@ -112,41 +113,10 @@ function duelAgainst(hostSlug: string, rivalSlug: string): DuelDetailOut {
 }
 
 function state(duel: DuelDetailOut): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [],
     duel,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-  }
+  })
 }
 
 // The Default fallback is a registered renderable too — guard it beside the map,

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -21,17 +21,15 @@
  * un-relocation: the owner controls render it for a duel praxis and an ordinary
  * one alike, which is still exactly one mount site (the #646 rule).
  */
-import { renderToStaticMarkup } from 'react-dom/server'
-import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import { describe, it, expect, vi } from 'vitest'
-import '../../../i18n'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut } from '../../../api/praxis'
-import type { CharacterOut, CurrentUser } from '../../../api/auth'
-import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
+import type { CurrentUser } from '../../../api/auth'
+import type { DuelDetailOut, DuelStatus } from '../../../api/duel'
 import type { GameConfigOut, FactionConfigOut } from '../../../api/gameConfig'
-import { aMember } from '../../../test/fixtures'
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMember, aPraxis } from '../../../test/fixtures'
+import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
 function faction(slug: string, win: number, lose: number): FactionConfigOut {
   return {
@@ -56,175 +54,47 @@ vi.mock('../../../hooks/useGameConfig', () => ({ useGameConfig: () => CONFIG }))
 
 const { PraxisOwnerActions, PraxisSubmitControls } = await import('../shared')
 
-function text(element: ReactElement): string {
-  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>).replace(/<[^>]*>/g, '')
-}
+const text = (element: ReactElement): string => markup(element).text
 
-const MEMBER = aMember({
-  id: 10,
-  character_id: 1,
-  character_display_name: 'Ada',
-})
+const MEMBER = aMember({ id: 10, character_id: 1 })
 
-function praxis(): PraxisOut {
-  return {
-    id: 1,
-    task_id: 7,
+const praxis = (): PraxisOut =>
+  aPraxis({
     task_title: 'Mangrove',
     task_point_value: 30,
     task_level_required: 3,
-    task_faction_slug: null,
-    type: 'solo',
-    status: 'submitted',
     title: 'Reforestation',
     body_text: 'Seedlings.',
-    moderation_status: 'visible',
-    admin_note: null,
-    flagged_at: null,
     submitted_at: '2026-01-02T00:00:00Z',
-    submit_proposed_at: null,
     created_by_id: 1,
-    created_by_display_name: 'Ada',
-    created_by_avatar_url: '',
     created_by_faction_slug: 'snide',
-    created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-02T00:00:00Z',
     members: [MEMBER],
-    invites: [],
     media_items: [],
     score: 0,
-    metatask_points: 0,
-    display_multiplier: 1.0,
     points_from_votes: 0,
-    habit_bonus_points: 0,
-    is_top_for_task: false,
     duel_id: 5,
-    can_flag: true,
-    applied_metatasks: [],
-    viewer_can_vote: true,
-    viewer_vote: null,
-    voter_count: 0,
-  }
-}
+  })
 
-const ME: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 1,
-  display_name: 'Ada',
-  faction_slug: 'snide',
-  avatar_url: '',
-  points_from_votes: 4,
-  is_submitted: true,
-  nudged_at: null,
-}
-const FOE: DuelSideOut = {
-  praxis_id: 2,
-  character_id: 2,
-  display_name: 'Rax',
-  faction_slug: 'wow',
-  avatar_url: '',
-  points_from_votes: 9,
-  is_submitted: true,
-  nudged_at: null,
-}
-
-function duel(status: DuelStatus, foeSubmitted: boolean): DuelDetailOut {
-  return {
-    id: 5,
-    task_id: 7,
+const duel = (status: DuelStatus, foeSubmitted: boolean): DuelDetailOut =>
+  aDuel({
     status,
-    forfeited_by_character_id: null,
-    challenger: ME,
-    opponent: { ...FOE, is_submitted: foeSubmitted },
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
-  }
-}
+    challenger: aDuelSide({ character_id: 1, faction_slug: 'snide', points_from_votes: 4 }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 2,
+      display_name: 'Rax',
+      faction_slug: 'wow',
+      points_from_votes: 9,
+      is_submitted: foeSubmitted,
+    }),
+  })
 
-function character(): CharacterOut {
-  return {
-    id: 1,
-    username: 'ada',
-    display_name: 'Ada',
-    bio: '',
-    tagline: '',
-    avatar_url: '',
-    location: '',
-    level: 5,
-    score: 0,
-    all_time_score: 0,
-    faction_slug: 'snide',
-    status: 'active',
-    created_at: '2026-01-01T00:00:00Z',
-    badges: [],
-    invitations: [],
-  }
-}
+const user = (): CurrentUser =>
+  aCurrentUser({ character: aCharacter({ id: 1, faction_slug: 'snide' }) })
 
-function user(): CurrentUser {
-  return {
-    account_id: 1,
-    email: 'wz_pilgrim@example.com',
-    provider: 'google',
-    character: character(),
-    is_admin: false,
-    can_create_additional_character: false,
-    can_start_as_albescent: false,
-    albescent_revealed: false,
-    albescent_glimpsed: false,
-    can_propose_task: false,
-    can_propose_metatask: false,
-    can_apply_metatask: false,
-    can_see_retired_tasks: false,
-    can_see_pending_tasks: false,
-    can_comment: true,
-    albescent_level_required: 8,
-    second_character_level_required: 5,
-    era_name: 'Era 1',
-    level_jump_reach: 0,
-    level_jump_available: false,
-    task_browse_defaults_to_eligible: false,
-  }
-}
-
-function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: praxis(),
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
-    isOwner: true,
-    showAdminBar: false,
-    user: user(),
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    ...overrides,
-  } as PraxisDetailState
-}
+const state = (overrides: Partial<PraxisDetailState>): PraxisDetailState =>
+  aPraxisDetailState({ praxis: praxis(), isOwner: true, user: user(), ...overrides })
 
 describe('forfeit escalation (#718)', () => {
   it('settled duel: the confirm warns, names the winner, and quotes the cost', () => {

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -28,8 +28,9 @@ import type { PraxisOut } from '../../../api/praxis'
 import type { CurrentUser } from '../../../api/auth'
 import type { DuelDetailOut, DuelStatus } from '../../../api/duel'
 import type { GameConfigOut, FactionConfigOut } from '../../../api/gameConfig'
-import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMember, aPraxis } from '../../../test/fixtures'
-import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
+import { aDuel, aDuelSide } from '../../../test/fixtures'
+import { anOwnedPraxis, anOwner, aPraxisDetailState, markup } from '../../../test/praxisDetail'
+
 
 function faction(slug: string, win: number, lose: number): FactionConfigOut {
   return {
@@ -56,25 +57,9 @@ const { PraxisOwnerActions, PraxisSubmitControls } = await import('../shared')
 
 const text = (element: ReactElement): string => markup(element).text
 
-const MEMBER = aMember({ id: 10, character_id: 1 })
-
 const praxis = (): PraxisOut =>
-  aPraxis({
-    task_title: 'Mangrove',
-    task_point_value: 30,
-    task_level_required: 3,
-    title: 'Reforestation',
-    body_text: 'Seedlings.',
-    submitted_at: '2026-01-02T00:00:00Z',
-    created_by_id: 1,
-    created_by_faction_slug: 'snide',
-    updated_at: '2026-01-02T00:00:00Z',
-    members: [MEMBER],
-    media_items: [],
-    score: 0,
-    points_from_votes: 0,
-    duel_id: 5,
-  })
+  anOwnedPraxis({ created_by_faction_slug: 'snide', duel_id: 5 })
+
 
 const duel = (status: DuelStatus, foeSubmitted: boolean): DuelDetailOut =>
   aDuel({
@@ -90,8 +75,8 @@ const duel = (status: DuelStatus, foeSubmitted: boolean): DuelDetailOut =>
     }),
   })
 
-const user = (): CurrentUser =>
-  aCurrentUser({ character: aCharacter({ id: 1, faction_slug: 'snide' }) })
+const user = (): CurrentUser => anOwner({ faction_slug: 'snide' })
+
 
 const state = (overrides: Partial<PraxisDetailState>): PraxisDetailState =>
   aPraxisDetailState({ praxis: praxis(), isOwner: true, user: user(), ...overrides })

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -20,7 +20,7 @@ import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import { aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
-import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, RIVAL, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -45,13 +45,7 @@ const PRAXIS = aPraxis({
 /** A settled duel this praxis is the challenger side of. */
 const DUEL = aDuel({
   challenger: aDuelSide({ faction_slug: "ephemerists", points_from_votes: 18 }),
-  opponent: aDuelSide({
-    praxis_id: 2,
-    character_id: 4,
-    display_name: "Rax",
-    faction_slug: "snide",
-    points_from_votes: 15.4,
-  }),
+  opponent: RIVAL,
 });
 
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -16,35 +16,27 @@
  * this component, so there is nothing to assert about it here; it is an eyeball
  * check, as is the cornice glow (a CSS animation).
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import type { DuelDetailOut } from "../../../api/duel";
-import { aMember, aPraxis } from '../../../test/fixtures'
+import { aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
+import {
+  CO_MEMBER,
+  MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
 
-// Imported after the mock so the archetype picks it up.
-const { default: EphemeristsPraxisDetail, voterMetalWordFits } = await import(
-  "../archetypes/EphemeristsPraxisDetail"
-);
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Ada",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Beth",
-  joined_at: "2026-01-02T00:00:00Z",
-});
+// `voterMetalWordFits` is a pure export of the archetype module, imported after
+// the mock so the module picks it up.
+const { voterMetalWordFits } = await import("../archetypes/EphemeristsPraxisDetail");
 
 const PRAXIS = aPraxis({
   task_title: "The Sunk Causeway",
@@ -58,96 +50,28 @@ const PRAXIS = aPraxis({
 });
 
 /** A settled duel this praxis is the challenger side of. */
-const DUEL: DuelDetailOut = {
-  id: 5,
-  task_id: 7,
-  status: "settled",
-  forfeited_by_character_id: null,
-  challenger: {
-    praxis_id: 1,
-    character_id: 3,
-    display_name: "Ada",
-    faction_slug: "ephemerists",
-    avatar_url: "",
-    points_from_votes: 18,
-    is_submitted: true,
-    nudged_at: null,
-  },
-  opponent: {
+const DUEL = aDuel({
+  challenger: aDuelSide({ faction_slug: "ephemerists", points_from_votes: 18 }),
+  opponent: aDuelSide({
     praxis_id: 2,
     character_id: 4,
     display_name: "Rax",
     faction_slug: "snide",
-    avatar_url: "",
     points_from_votes: 15.4,
-    is_submitted: true,
-    nudged_at: null,
-  },
-  winner_character_id: null,
-  challenger_final_points: null,
-  opponent_final_points: null,
-};
+  }),
+});
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
+// The skin comes from the real registry, resolved at render time — inside the
+// test, so after both the `vi.mock` above and the archetype preload.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <EphemeristsPraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("ephemerists", next);
 }
 
 describe("Ephemerists praxis detail — the inherited layout contract", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -20,14 +20,7 @@ import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import { aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
-import {
-  CO_MEMBER,
-  MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -64,15 +57,7 @@ const DUEL = aDuel({
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// The skin comes from the real registry, resolved at render time — inside the
-// test, so after both the `vi.mock` above and the archetype preload.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("ephemerists", next);
-}
+const render = skinRenderer("ephemerists", mocks);
 
 describe("Ephemerists praxis detail — the inherited layout contract", () => {
   it("gives the desktop aside a 330px track and drops the track on mobile", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -25,7 +25,7 @@
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import { aCharacter, aCurrentUser, aPraxis, aTask } from "../../../test/fixtures";
+import { aCharacter, aCurrentUser, aMetatask, aPraxis } from "../../../test/fixtures";
 import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 import { collabCopy } from "../../../components/collab/collabCopy";
 
@@ -34,19 +34,7 @@ vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
 
-const METATASK = aTask({
-  id: 501,
-  title: "Composting",
-  point_value: 60,
-  level_required: 0,
-  task_type: "metatask",
-  created_by: 9,
-  metatask_faction_slug: "everymen",
-  created_by_display_name: "",
-  can_sign_up: false,
-  allowed_modes: [],
-  eligible_for_current_user: false,
-});
+const METATASK = aMetatask({ metatask_faction_slug: "everymen" });
 
 const PRAXIS = aPraxis({
   task_title: "Sweep The Long Corridor",

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -26,14 +26,7 @@ import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import { aCharacter, aCurrentUser, aPraxis, aTask } from "../../../test/fixtures";
-import {
-  CO_MEMBER,
-  MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 import { collabCopy } from "../../../components/collab/collabCopy";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
@@ -73,15 +66,7 @@ const VIEWER = aCurrentUser({
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// The skin comes from the real registry, resolved at render time — inside the
-// test, so after both the `vi.mock` above and the archetype preload.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("everymen", next);
-}
+const render = skinRenderer("everymen", mocks);
 
 describe("Everymen praxis detail — the layout contract it may not restyle", () => {
   it("gives the desktop aside the shared 330px track and drops it on mobile", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -22,37 +22,24 @@
  * is a pure `[data-theme]` cascade with no branch in the component, so there is
  * nothing here to assert about it — it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import type { DuelDetailOut } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
-import { aMember, aPraxis, aTask } from '../../../test/fixtures'
+import { aCharacter, aCurrentUser, aPraxis, aTask } from "../../../test/fixtures";
+import {
+  CO_MEMBER,
+  MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 import { collabCopy } from "../../../components/collab/collabCopy";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
-
-// Imported after the mock so the archetype picks it up.
-const { default: EverymenPraxisDetail } = await import(
-  "../archetypes/EverymenPraxisDetail"
-);
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Ada",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Beth",
-  joined_at: "2026-01-02T00:00:00Z",
-});
 
 const METATASK = aTask({
   id: 501,
@@ -79,82 +66,21 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  email: "ada@example.com",
-  display_name: "Ada",
-  is_admin: false,
-  can_comment: true,
-  character: {
-    id: 3,
-    display_name: "Ada",
-    faction_slug: "everymen",
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
+const VIEWER = aCurrentUser({
+  character: aCharacter({ faction_slug: "everymen", level: 4 }),
+});
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
+// The skin comes from the real registry, resolved at render time — inside the
+// test, so after both the `vi.mock` above and the archetype preload.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <EverymenPraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("everymen", next);
 }
 
 describe("Everymen praxis detail — the layout contract it may not restyle", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts
+++ b/frontend/src/pages/praxisDetail/__tests__/isViewerMember.test.ts
@@ -9,62 +9,20 @@
 import { describe, it, expect } from "vitest";
 import { isViewerMember } from "../usePraxisDetail";
 import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
+import { aMember, aPraxis } from "../../../test/fixtures";
 
-function member(characterId: number): PraxisMemberOut {
-  return {
+const member = (characterId: number): PraxisMemberOut =>
+  aMember({
     id: characterId * 10,
-    praxis_id: 1,
     character_id: characterId,
     character_display_name: `Character ${characterId}`,
-    character_avatar_url: "",
     has_submitted: false,
-    is_done: false,
-    joined_at: "2026-01-01T00:00:00Z",
-    nudged_at: null,
-    submitted_at: null,
-  };
-}
+  });
 
-function praxis(members: PraxisMemberOut[]): PraxisOut {
-  return {
-    id: 1,
-    task_id: 7,
-    task_title: "Mangrove",
-    task_point_value: 30,
-    task_level_required: 3,
-    task_faction_slug: "ua",
-    type: "collab",
-    status: "in_progress",
-    title: "Reforestation",
-    body_text: "Seedlings planted along the estuary.",
-    moderation_status: "visible",
-    admin_note: null,
-    flagged_at: null,
-    submitted_at: null,
-    submit_proposed_at: null,
-    created_by_id: 3,
-    created_by_display_name: "Ada",
-    created_by_avatar_url: "",
-    created_by_faction_slug: "ua",
-    created_at: "2026-01-01T00:00:00Z",
-    updated_at: "2026-01-02T00:00:00Z",
-    members,
-    invites: [],
-    media_items: [],
-    score: 0,
-    metatask_points: 0,
-    display_multiplier: 1.0,
-    points_from_votes: 0,
-    habit_bonus_points: 0,
-    is_top_for_task: false,
-    duel_id: null,
-    can_flag: true,
-    applied_metatasks: [],
-    viewer_can_vote: true,
-    viewer_vote: null,
-    voter_count: 0,
-  };
-}
+/** An unfinished collab — the only shape with a roster the guard reads. */
+const praxis = (members: PraxisMemberOut[]): PraxisOut =>
+  aPraxis({ type: "collab", status: "in_progress", submitted_at: null, members });
+
 
 describe("isViewerMember (#348)", () => {
   it("is true for the creator (always seeded as a member)", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/memberByline.test.tsx
@@ -4,78 +4,45 @@
  * order; `MemberByline` renders the ordered names Oxford-style
  * (Ada / Ada & Beth / Ada, Beth & Cy), each name linked to its character.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect } from "vitest";
+
 // Initialize the catalog so the collab submit-state markers resolve to English.
 import "../../../i18n";
 import { orderedMembers, MemberByline } from "../shared";
 import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
+import { aMember, aPraxis } from "../../../test/fixtures";
+import { markup } from "../../../test/praxisDetail";
 
-function member(
+const member = (
   characterId: number,
   name: string,
   joinedAt: string,
   hasSubmitted = false,
-): PraxisMemberOut {
-  return {
+): PraxisMemberOut =>
+  aMember({
     id: characterId * 10,
-    praxis_id: 1,
     character_id: characterId,
     character_display_name: name,
-    character_avatar_url: "",
     has_submitted: hasSubmitted,
-    is_done: false,
     joined_at: joinedAt,
-    nudged_at: null,
-    submitted_at: null,
-  };
-}
+  });
 
-function praxis(
+const praxis = (
   members: PraxisMemberOut[],
   createdById: number,
   status: PraxisOut["status"] = "submitted",
-): PraxisOut {
-  return {
-    id: 1,
-    task_id: 7,
-    task_title: "Mangrove",
-    task_point_value: 30,
-    task_level_required: 3,
+): PraxisOut =>
+  aPraxis({
     task_faction_slug: "ua",
     type: "collab",
     status,
-    title: "Reforestation",
-    body_text: "Seedlings planted along the estuary.",
-    moderation_status: "visible",
-    admin_note: null,
-    flagged_at: null,
     submitted_at: null,
-    submit_proposed_at: null,
     created_by_id: createdById,
-    created_by_display_name: "Ada",
-    created_by_avatar_url: "",
     created_by_faction_slug: "ua",
-    created_at: "2026-01-01T00:00:00Z",
-    updated_at: "2026-01-02T00:00:00Z",
-    members,
-    invites: [],
     media_items: [],
-    score: 0,
-    metatask_points: 0,
-    display_multiplier: 1.0,
-    points_from_votes: 0,
-    habit_bonus_points: 0,
-    is_top_for_task: false,
-    duel_id: null,
-    can_flag: true,
-    applied_metatasks: [],
-    viewer_can_vote: true,
-    viewer_vote: null,
-    voter_count: 0,
-  };
-}
+    members,
+  });
+
 
 // Creator (id 1 = "Ada") joined last on purpose, to prove creator-first
 // overrides join order for the creator specifically.
@@ -87,12 +54,9 @@ function bylineText(
   members: PraxisMemberOut[],
   status: PraxisOut["status"] = "submitted",
 ): string {
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <MemberByline praxis={praxis(members, 1, status)} />
-    </MemoryRouter>,
-  );
+  const { html } = markup(<MemberByline praxis={praxis(members, 1, status)} />);
   return html.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&");
+
 }
 
 describe("orderedMembers (#387)", () => {
@@ -125,11 +89,8 @@ describe("MemberByline join format (#387)", () => {
   });
 
   it("links each name to its character profile", () => {
-    const html = renderToStaticMarkup(
-      <MemoryRouter>
-        <MemberByline praxis={praxis([ADA, BETH], 1)} />
-      </MemoryRouter>,
-    );
+    const { html } = markup(<MemberByline praxis={praxis([ADA, BETH], 1)} />);
+
     expect(html).toContain('href="/characters/1"');
     expect(html).toContain('href="/characters/2"');
   });

--- a/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
@@ -20,180 +20,63 @@
  * confirm → `PraxisDetail` redirects the now-`in_progress` praxis straight into
  * the composer. So the unsubmit trigger must survive everywhere the link went.
  */
-import { renderToStaticMarkup } from 'react-dom/server'
-import { MemoryRouter } from 'react-router-dom'
-import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
-import '../../../i18n'
 import { PraxisOwnerActions } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import type { PraxisOut, PraxisMemberOut, PraxisStatus } from '../../../api/praxis'
-import type { CharacterOut, CurrentUser } from '../../../api/auth'
-import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
+import type { PraxisOut, PraxisMemberOut } from '../../../api/praxis'
+import type { CurrentUser } from '../../../api/auth'
+import type { DuelDetailOut, DuelStatus } from '../../../api/duel'
+import {
+  aCharacter,
+  aCurrentUser,
+  aDuel,
+  aDuelSide,
+  aMember,
+  aPraxis,
+} from '../../../test/fixtures'
+import { aPraxisDetailState, markup as render } from '../../../test/praxisDetail'
 
 const EDIT_HREF = 'href="/praxis/1/edit"'
 
-function render(element: ReactElement): { html: string; text: string } {
-  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
-  return { html, text: html.replace(/<[^>]*>/g, '') }
-}
+const member = (characterId: number, name: string): PraxisMemberOut =>
+  aMember({ id: characterId * 10, character_id: characterId, character_display_name: name })
 
-function member(characterId: number, name: string): PraxisMemberOut {
-  return {
-    id: characterId * 10,
-    praxis_id: 1,
-    character_id: characterId,
-    character_display_name: name,
-    character_avatar_url: '',
-    has_submitted: true,
-    is_done: false,
-    joined_at: '2026-01-01T00:00:00Z',
-    nudged_at: null,
-    submitted_at: null,
-  }
-}
-
-function praxis(overrides: Partial<PraxisOut> = {}): PraxisOut {
-  return {
-    id: 1,
-    task_id: 7,
+// EVERY case here is submitted: ADR-0062 means nothing else reaches the page.
+const praxis = (overrides: Partial<PraxisOut> = {}): PraxisOut =>
+  aPraxis({
     task_title: 'Mangrove',
     task_point_value: 30,
     task_level_required: 3,
-    task_faction_slug: null,
-    type: 'solo',
-    // EVERY case here is submitted: ADR-0062 means nothing else reaches the page.
-    status: 'submitted' as PraxisStatus,
     title: 'Reforestation',
     body_text: 'Seedlings.',
-    moderation_status: 'visible',
-    admin_note: null,
-    flagged_at: null,
     submitted_at: '2026-01-02T00:00:00Z',
-    submit_proposed_at: null,
     created_by_id: 1,
-    created_by_display_name: 'Ada',
     created_by_faction_slug: 'wow',
-    created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-02T00:00:00Z',
     members: [member(1, 'Ada')],
-    invites: [],
     media_items: [],
     score: 0,
-    metatask_points: 0,
-    display_multiplier: 1.0,
     points_from_votes: 0,
-    is_top_for_task: false,
-    duel_id: null,
-    can_flag: true,
-    applied_metatasks: [],
     ...overrides,
-  } as PraxisOut
-}
-
-function duel(status: DuelStatus): DuelDetailOut {
-  const side = (praxisId: number, characterId: number, name: string): DuelSideOut => ({
-    praxis_id: praxisId,
-    character_id: characterId,
-    display_name: name,
-    faction_slug: 'wow',
-    avatar_url: '',
-    points_from_votes: 0,
-    is_submitted: true,
-    nudged_at: null,
   })
-  return {
-    id: 5,
-    task_id: 7,
+
+const duel = (status: DuelStatus): DuelDetailOut =>
+  aDuel({
     status,
-    forfeited_by_character_id: null,
-    challenger: side(1, 1, 'Ada'),
-    opponent: side(2, 2, 'Rax'),
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
-  }
-}
+    challenger: aDuelSide({ character_id: 1, faction_slug: 'wow' }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 2,
+      display_name: 'Rax',
+      faction_slug: 'wow',
+    }),
+  })
 
-function user(): CurrentUser {
-  const character: CharacterOut = {
-    id: 1,
-    username: 'ada',
-    display_name: 'Ada',
-    bio: '',
-    tagline: '',
-    avatar_url: '',
-    location: '',
-    level: 5,
-    score: 0,
-    all_time_score: 0,
-    faction_slug: 'wow',
-    status: 'active',
-    created_at: '2026-01-01T00:00:00Z',
-    badges: [],
-    invitations: [],
-  }
-  return {
-    account_id: 1,
-    email: 'wz_pilgrim@example.com',
-    provider: 'google',
-    character,
-    is_admin: false,
-    can_create_additional_character: false,
-    can_start_as_albescent: false,
-    albescent_revealed: false,
-    albescent_glimpsed: false,
-    can_propose_task: false,
-    can_propose_metatask: false,
-    can_apply_metatask: false,
-    can_see_retired_tasks: false,
-    can_see_pending_tasks: false,
-    can_comment: true,
-    albescent_level_required: 8,
-    second_character_level_required: 5,
-    era_name: 'Era 1',
-    level_jump_reach: 0,
-    level_jump_available: false,
-    task_browse_defaults_to_eligible: false,
-  }
-}
+const user = (): CurrentUser =>
+  aCurrentUser({ character: aCharacter({ id: 1, faction_slug: 'wow' }) })
 
-function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: praxis(),
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
-    isOwner: true,
-    showAdminBar: false,
-    user: user(),
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  } as PraxisDetailState
-}
+const state = (overrides: Partial<PraxisDetailState>): PraxisDetailState =>
+  aPraxisDetailState({ praxis: praxis(), isOwner: true, user: user(), ...overrides })
 
 const COLLAB_MEMBERS = [member(1, 'Ada'), member(2, 'Beth')]
 

--- a/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
@@ -26,15 +26,8 @@ import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut, PraxisMemberOut } from '../../../api/praxis'
 import type { CurrentUser } from '../../../api/auth'
 import type { DuelDetailOut, DuelStatus } from '../../../api/duel'
-import {
-  aCharacter,
-  aCurrentUser,
-  aDuel,
-  aDuelSide,
-  aMember,
-  aPraxis,
-} from '../../../test/fixtures'
-import { aPraxisDetailState, markup as render } from '../../../test/praxisDetail'
+import { aDuel, aDuelSide, aMember } from '../../../test/fixtures'
+import { anOwnedPraxis, anOwner, aPraxisDetailState, markup as render } from '../../../test/praxisDetail'
 
 const EDIT_HREF = 'href="/praxis/1/edit"'
 
@@ -43,22 +36,8 @@ const member = (characterId: number, name: string): PraxisMemberOut =>
 
 // EVERY case here is submitted: ADR-0062 means nothing else reaches the page.
 const praxis = (overrides: Partial<PraxisOut> = {}): PraxisOut =>
-  aPraxis({
-    task_title: 'Mangrove',
-    task_point_value: 30,
-    task_level_required: 3,
-    title: 'Reforestation',
-    body_text: 'Seedlings.',
-    submitted_at: '2026-01-02T00:00:00Z',
-    created_by_id: 1,
-    created_by_faction_slug: 'wow',
-    updated_at: '2026-01-02T00:00:00Z',
-    members: [member(1, 'Ada')],
-    media_items: [],
-    score: 0,
-    points_from_votes: 0,
-    ...overrides,
-  })
+  anOwnedPraxis({ created_by_faction_slug: 'wow', ...overrides })
+
 
 const duel = (status: DuelStatus): DuelDetailOut =>
   aDuel({
@@ -72,8 +51,8 @@ const duel = (status: DuelStatus): DuelDetailOut =>
     }),
   })
 
-const user = (): CurrentUser =>
-  aCurrentUser({ character: aCharacter({ id: 1, faction_slug: 'wow' }) })
+const user = (): CurrentUser => anOwner({ faction_slug: 'wow' })
+
 
 const state = (overrides: Partial<PraxisDetailState>): PraxisDetailState =>
   aPraxisDetailState({ praxis: praxis(), isOwner: true, user: user(), ...overrides })

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -19,36 +19,24 @@
  * pure `[data-theme]` cascade with no branch in this component, so there is
  * nothing here to assert about it; it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import type { DuelDetailOut, DuelSideOut, DuelStatus } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
-import { aMember, aPraxis } from '../../../test/fixtures'
+import type { DuelDetailOut, DuelStatus } from "../../../api/duel";
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
+import {
+  CO_MEMBER,
+  MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
-
-// Imported after the mock so the archetype picks it up.
-const { default: SingularityPraxisDetail } = await import(
-  "../archetypes/SingularityPraxisDetail"
-);
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Ada",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Beth",
-  joined_at: "2026-01-02T00:00:00Z",
-});
 
 const PRAXIS = aPraxis({
   task_title: "Recover The Lost Array",
@@ -61,120 +49,35 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  email: "ada@example.com",
-  display_name: "Ada",
-  is_admin: false,
-  can_comment: true,
-  character: {
-    id: 3,
-    display_name: "Ada",
-    faction_slug: "singularity",
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
+const VIEWER = aCurrentUser({
+  character: aCharacter({ faction_slug: "singularity", level: 4 }),
+});
 
-/** This page's side of a duel; `praxis_id` is what makes it "mine". */
-const MINE: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 3,
-  display_name: "Ada",
-  faction_slug: "singularity",
-  avatar_url: "",
-  points_from_votes: 18,
-  is_submitted: true,
-  nudged_at: null,
-};
-
-const RIVAL: DuelSideOut = {
-  praxis_id: 2,
-  character_id: 4,
-  display_name: "Rax",
-  faction_slug: "snide",
-  avatar_url: "",
-  points_from_votes: 15.4,
-  is_submitted: true,
-  nudged_at: null,
-};
-
-function duel(overrides: Partial<DuelDetailOut> = {}): DuelDetailOut {
-  return {
-    id: 5,
-    task_id: 7,
-    status: "settled" as DuelStatus,
-    forfeited_by_character_id: null,
-    challenger: MINE,
-    opponent: RIVAL,
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
+/** `praxis_id: 1` on the challenger is what makes that side "mine". */
+const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
+  aDuel({
+    challenger: aDuelSide({ faction_slug: "singularity", points_from_votes: 18 }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 4,
+      display_name: "Rax",
+      faction_slug: "snide",
+      points_from_votes: 15.4,
+    }),
     ...overrides,
-  };
-}
+  });
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
+// The skin comes from the real registry, resolved at render time — inside the
+// test, so after both the `vi.mock` above and the archetype preload.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <SingularityPraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("singularity", next);
 }
 
 describe("Singularity praxis detail — the inherited layout contract", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -24,7 +24,7 @@ import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut, DuelStatus } from "../../../api/duel";
 import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
-import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, RIVAL, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -50,13 +50,7 @@ const VIEWER = aCurrentUser({
 const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
   aDuel({
     challenger: aDuelSide({ faction_slug: "singularity", points_from_votes: 18 }),
-    opponent: aDuelSide({
-      praxis_id: 2,
-      character_id: 4,
-      display_name: "Rax",
-      faction_slug: "snide",
-      points_from_votes: 15.4,
-    }),
+    opponent: RIVAL,
     ...overrides,
   });
 

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -24,14 +24,7 @@ import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut, DuelStatus } from "../../../api/duel";
 import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
-import {
-  CO_MEMBER,
-  MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -70,15 +63,7 @@ const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// The skin comes from the real registry, resolved at render time — inside the
-// test, so after both the `vi.mock` above and the archetype preload.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("singularity", next);
-}
+const render = skinRenderer("singularity", mocks);
 
 describe("Singularity praxis detail — the inherited layout contract", () => {
   it("gives the desktop aside the eight designs' 330px track, not the outlier 340", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -20,34 +20,24 @@
  * a pure `[data-theme]` cascade with no branch in this component, so there is
  * nothing here to assert about it — it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import type { DuelDetailOut, DuelSideOut } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
-import { aMember, aPraxis } from '../../../test/fixtures'
+import type { DuelDetailOut } from "../../../api/duel";
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
+import {
+  CO_MEMBER,
+  MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
-
-// Imported after the mock so the archetype picks it up.
-const { default: SnidePraxisDetail } = await import("../archetypes/SnidePraxisDetail");
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Ada",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Beth",
-  joined_at: "2026-01-02T00:00:00Z",
-});
 
 const PRAXIS = aPraxis({
   task_title: "A Chore Nobody Logged",
@@ -58,119 +48,32 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  email: "ada@example.com",
-  display_name: "Ada",
-  is_admin: false,
-  can_comment: true,
-  character: {
-    id: 3,
-    display_name: "Ada",
-    faction_slug: "snide",
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
+const VIEWER = aCurrentUser({ character: aCharacter({ faction_slug: "snide", level: 4 }) });
 
-const MINE: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 3,
-  display_name: "Ada",
-  faction_slug: "snide",
-  avatar_url: "",
-  points_from_votes: 18,
-  is_submitted: true,
-  nudged_at: null,
-};
-
-const RIVAL: DuelSideOut = {
-  praxis_id: 2,
-  character_id: 4,
-  display_name: "Rax",
-  faction_slug: "coven",
-  avatar_url: "",
-  points_from_votes: 15.4,
-  is_submitted: true,
-  nudged_at: null,
-};
-
-function duel(overrides: Partial<DuelDetailOut> = {}): DuelDetailOut {
-  return {
-    id: 5,
-    task_id: 7,
-    status: "settled",
-    forfeited_by_character_id: null,
-    challenger: MINE,
-    opponent: RIVAL,
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
+const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
+  aDuel({
+    challenger: aDuelSide({ faction_slug: "snide", points_from_votes: 18 }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 4,
+      display_name: "Rax",
+      faction_slug: "coven",
+      points_from_votes: 15.4,
+    }),
     ...overrides,
-  };
-}
+  });
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
+// The skin comes from the real registry, resolved at render time — inside the
+// test, so after both the `vi.mock` above and the archetype preload.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <SnidePraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("snide", next);
 }
 
 describe("S.N.I.D.E. praxis detail — the inherited layout contract", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -25,14 +25,7 @@ import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
 import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
-import {
-  CO_MEMBER,
-  MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -66,15 +59,7 @@ const duel = (overrides: Partial<DuelDetailOut> = {}): DuelDetailOut =>
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// The skin comes from the real registry, resolved at render time — inside the
-// test, so after both the `vi.mock` above and the archetype preload.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("snide", next);
-}
+const render = skinRenderer("snide", mocks);
 
 describe("S.N.I.D.E. praxis detail — the inherited layout contract", () => {
   it("draws no navigation of its own, at either width (#2102)", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -24,7 +24,7 @@ import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
-import { aCharacter, aCurrentUser, aDuel, aDuelSide, aPraxis } from "../../../test/fixtures";
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMetatask, aPraxis } from "../../../test/fixtures";
 import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
@@ -156,30 +156,7 @@ describe("S.N.I.D.E. praxis detail — copy is neutral (ADR-0061)", () => {
         type: "collab",
         members: [MEMBER, CO_MEMBER],
         applied_metatasks: [
-          {
-            id: 501,
-            title: "Composting",
-            description: '',
-            point_value: 60,
-            level_required: 0,
-            status: "active",
-            task_type: "metatask",
-            created_by: 9,
-            primary_faction_slug: 'na',
-            metatask_faction_slug: "snide",
-            created_at: "2026-01-01T00:00:00Z",
-            in_progress_count: 0,
-            created_by_display_name: "",
-            created_by_avatar_url: "",
-            created_by_faction_slug: null,
-            created_by_level: 0,
-            signup_reason: null,
-            in_progress_praxis_id: null,
-            can_sign_up: false,
-            allowed_modes: [],
-            eligible_for_current_user: false,
-            start_here: false,
-          },
+          aMetatask({ metatask_faction_slug: "snide" }),
         ],
       },
     });

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -41,13 +41,7 @@ import {
   aMember,
   aPraxis,
 } from "../../../test/fixtures";
-import {
-  CO_MEMBER as SHARED_CO_MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER as SHARED_CO_MEMBER, VOTERS, aPraxisDetailState, indexOf, renderPraxisDetail, skinRenderer } from "../../../test/praxisDetail";
 import { resolveRoleReads } from "../../../test/sourceScan";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
@@ -100,15 +94,7 @@ const duel = (status: DuelDetailOut["status"]): DuelDetailOut =>
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// The skin comes from the real registry, resolved at render time — inside the
-// test, so after both the `vi.mock` above and the archetype preload.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("ua", next);
-}
+const render = skinRenderer("ua", mocks);
 
 describe("UA claims the praxis-detail surface (#1119)", () => {
   it("registers a praxisDetail archetype", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -33,14 +33,7 @@ import { surfaceMap } from "../../../factions";
 import { resolvedArchetype } from "../../../factions/lazyArchetype";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
-import {
-  aCharacter,
-  aCurrentUser,
-  aDuel,
-  aDuelSide,
-  aMember,
-  aPraxis,
-} from "../../../test/fixtures";
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMember, aMetatask, aPraxis } from "../../../test/fixtures";
 import { CO_MEMBER as SHARED_CO_MEMBER, VOTERS, aPraxisDetailState, indexOf, renderPraxisDetail, skinRenderer } from "../../../test/praxisDetail";
 import { resolveRoleReads } from "../../../test/sourceScan";
 
@@ -129,30 +122,7 @@ describe("UA praxis detail — copy is neutral (ADR-0061)", () => {
           type: "collab",
           members: [MEMBER, CO_MEMBER],
           applied_metatasks: [
-            {
-              id: 501,
-              title: "Composting",
-              description: '',
-              point_value: 6,
-              level_required: 0,
-              status: "active",
-              task_type: "metatask",
-              created_by: 9,
-              primary_faction_slug: 'na',
-              metatask_faction_slug: "ua",
-              created_at: "2026-01-01T00:00:00Z",
-              in_progress_count: 0,
-              created_by_display_name: "",
-              created_by_avatar_url: "",
-              created_by_faction_slug: null,
-              created_by_level: 0,
-              signup_reason: null,
-              in_progress_praxis_id: null,
-              can_sign_up: false,
-              allowed_modes: [],
-              eligible_for_current_user: false,
-              start_here: false,
-            },
+            aMetatask({ metatask_faction_slug: "ua" }),
           ],
         },
       }),

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -27,16 +27,27 @@
  * pure `[data-theme]` cascade with no branch in the component, so there is
  * nothing here to assert about it; it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import { surfaceMap } from "../../../factions";
 import { resolvedArchetype } from "../../../factions/lazyArchetype";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
-import { aMember, aPraxis } from '../../../test/fixtures'
+import {
+  aCharacter,
+  aCurrentUser,
+  aDuel,
+  aDuelSide,
+  aMember,
+  aPraxis,
+} from "../../../test/fixtures";
+import {
+  CO_MEMBER as SHARED_CO_MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 import { resolveRoleReads } from "../../../test/sourceScan";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
@@ -44,21 +55,12 @@ vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
 
-// Imported after the mock so the archetype picks it up.
+// Imported after the mock. The identity check below needs the MODULE, not the
+// deferred wrapper the registry hands back — everything else renders by slug.
 const { default: UaPraxisDetail } = await import("../archetypes/UaPraxisDetail");
-const { default: DefaultPraxisDetail } = await import("../archetypes/DefaultPraxisDetail");
 
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Wren Abalone",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Bram Quilling",
-  joined_at: "2026-01-02T00:00:00Z",
-});
+const MEMBER = aMember({ character_display_name: "Wren Abalone" });
+const CO_MEMBER = { ...SHARED_CO_MEMBER, character_display_name: "Bram Quilling" };
 
 // No apostrophes in the fixtures: `renderToStaticMarkup` escapes them to
 // `&#x27;`, which survives the tag-strip and breaks a plain substring check.
@@ -73,106 +75,39 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  display_name: "Wren Abalone",
-  is_admin: false,
-  character: {
-    id: 3,
-    display_name: "Wren Abalone",
-    faction_slug: "ua",
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
-
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const VIEWER = aCurrentUser({
+  character: aCharacter({ display_name: "Wren Abalone", faction_slug: "ua", level: 4 }),
+});
 
 /** A two-sided duel at a given status; this praxis is the challenger's. */
-function duel(status: DuelDetailOut["status"]): DuelDetailOut {
-  const side = (praxisId: number | null, id: number, name: string, votes: number) => ({
-    praxis_id: praxisId,
-    character_id: id,
-    display_name: name,
-    faction_slug: "ua",
-    avatar_url: "",
-    points_from_votes: votes,
-    habit_bonus_points: 0,
-    is_submitted: true,
-    nudged_at: null,
-  });
-  return {
-    id: 5,
-    task_id: 7,
+const duel = (status: DuelDetailOut["status"]): DuelDetailOut =>
+  aDuel({
     status,
-    forfeited_by_character_id: null,
-    challenger: side(1, 3, "Wren Abalone", 18),
-    opponent: side(2, 4, "Bram Quilling", 15.4),
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
-  };
-}
+    challenger: aDuelSide({
+      display_name: "Wren Abalone",
+      faction_slug: "ua",
+      points_from_votes: 18,
+    }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 4,
+      display_name: "Bram Quilling",
+      faction_slug: "ua",
+      points_from_votes: 15.4,
+    }),
+  });
 
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
+
+// The skin comes from the real registry, resolved at render time — inside the
+// test, so after both the `vi.mock` above and the archetype preload.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <UaPraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("ua", next);
 }
 
 describe("UA claims the praxis-detail surface (#1119)", () => {
@@ -184,11 +119,7 @@ describe("UA claims the praxis-detail surface (#1119)", () => {
     // Two different components, so the tell has to be the dress rather than a
     // green render.
     const ua = render(state());
-    const na = renderToStaticMarkup(
-      <MemoryRouter>
-        <DefaultPraxisDetail state={state()} />
-      </MemoryRouter>,
-    );
+    const { html: na } = renderPraxisDetail("na", state());
     expect(ua.html, "the toothed leaf").toContain("ua-praxis-leaf");
     expect(na, "which the na page has no notion of").not.toContain("ua-praxis-leaf");
     expect(na, "na's page is the spectrum").toContain("--faction-default-rainbow");

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -13,36 +13,26 @@
  * cascade with no branch in this component, so there is nothing here to assert
  * about it; it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import type { DuelDetailOut } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
 import type { CommentOut } from "../../../api/comments";
 import { PraxisFlagBlock } from "../shared";
-import { aMember, aPraxis } from '../../../test/fixtures'
+import { aCharacter, aCurrentUser, aPraxis } from "../../../test/fixtures";
+import {
+  CO_MEMBER,
+  MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  markup,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
-
-// Imported after the mock so the archetype picks it up.
-const { default: DefaultPraxisDetail } = await import("../archetypes/DefaultPraxisDetail");
-
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Ada",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Beth",
-  joined_at: "2026-01-02T00:00:00Z",
-});
 
 const PRAXIS = aPraxis({
   task_title: "A Chore Nobody Logged",
@@ -51,21 +41,7 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  email: "ada@example.com",
-  display_name: "Ada",
-  is_admin: false,
-  can_comment: true,
-  character: {
-    id: 3,
-    display_name: "Ada",
-    faction_slug: null,
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
+const VIEWER = aCurrentUser({ character: aCharacter({ level: 4 }) });
 
 /** One row the page fetched alongside the praxis (#1281). */
 const COMMENT: CommentOut = {
@@ -86,66 +62,17 @@ const COMMENT: CommentOut = {
   mentions: [],
 };
 
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
+// `na` is a manifest row like the other eight since #2530, so the unaffiliated
+// page comes out of the same registry lookup every faction's does.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <DefaultPraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("na", next);
 }
 
 describe("Unaffiliated praxis detail — layout contract", () => {
@@ -223,11 +150,7 @@ describe("Unaffiliated praxis detail — layout contract", () => {
     // neutral in every faction's dress. The card must not pick up the page's
     // faction tokens — including by INHERITING the sheet's text colour, which
     // is why every text node inside it carries its own neutral token.
-    const html = renderToStaticMarkup(
-      <MemoryRouter>
-        <PraxisFlagBlock state={state()} />
-      </MemoryRouter>,
-    );
+    const { html } = markup(<PraxisFlagBlock state={state()} />);
     expect(html, "renders at all").toContain("Flag this praxis");
     expect(html, "neutral card chrome").toContain("sidebar-card");
     expect(html, "no faction dress anywhere inside").not.toContain("--faction-");

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -19,15 +19,7 @@ import type { PraxisDetailState } from "../usePraxisDetail";
 import type { CommentOut } from "../../../api/comments";
 import { PraxisFlagBlock } from "../shared";
 import { aCharacter, aCurrentUser, aPraxis } from "../../../test/fixtures";
-import {
-  CO_MEMBER,
-  MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  markup,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER, MEMBER, VOTERS, aPraxisDetailState, indexOf, markup, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -65,15 +57,7 @@ const COMMENT: CommentOut = {
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// `na` is a manifest row like the other eight since #2530, so the unaffiliated
-// page comes out of the same registry lookup every faction's does.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("na", next);
-}
+const render = skinRenderer("na", mocks);
 
 describe("Unaffiliated praxis detail — layout contract", () => {
   it("draws no navigation of its own, at either width (#2102)", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -29,15 +29,9 @@ import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut, PraxisMemberOut, PraxisStatus } from '../../../api/praxis'
 import type { CurrentUser } from '../../../api/auth'
 import type { DuelDetailOut, DuelStatus } from '../../../api/duel'
-import {
-  aCharacter,
-  aCurrentUser,
-  aDuel,
-  aDuelSide,
-  aMember,
-  aPraxis,
-} from '../../../test/fixtures'
-import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
+import { aDuel, aDuelSide, aMember } from '../../../test/fixtures'
+import { anOwnedPraxis, anOwner, aPraxisDetailState, markup } from '../../../test/praxisDetail'
+
 
 /**
  * Rendered text with tags stripped and the entities React escapes (`&`, `'`)
@@ -63,22 +57,8 @@ const member = (
   })
 
 const praxis = (overrides: Partial<PraxisOut> = {}): PraxisOut =>
-  aPraxis({
-    task_title: 'Mangrove',
-    task_point_value: 30,
-    task_level_required: 3,
-    title: 'Reforestation',
-    body_text: 'Seedlings.',
-    submitted_at: '2026-01-02T00:00:00Z',
-    created_by_id: 1,
-    created_by_faction_slug: 'wow',
-    updated_at: '2026-01-02T00:00:00Z',
-    members: [member(1, 'Ada', true)],
-    media_items: [],
-    score: 0,
-    points_from_votes: 0,
-    ...overrides,
-  })
+  anOwnedPraxis({ created_by_faction_slug: 'wow', ...overrides })
+
 
 /** The opponent has NOT cast, which is what makes a live duel a free reopen. */
 const duel = (status: DuelStatus): DuelDetailOut =>
@@ -94,8 +74,8 @@ const duel = (status: DuelStatus): DuelDetailOut =>
     }),
   })
 
-const user = (): CurrentUser =>
-  aCurrentUser({ character: aCharacter({ id: 1, faction_slug: 'wow' }) })
+const user = (): CurrentUser => anOwner({ faction_slug: 'wow' })
+
 
 const state = (overrides: Partial<PraxisDetailState>): PraxisDetailState =>
   aPraxisDetailState({

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -22,197 +22,90 @@
  * The `settled` duel forfeit dialog is covered by `duelForfeitWarning.test.tsx`
  * and is unchanged here — it is caught before this copy table is reached.
  */
-import { renderToStaticMarkup } from 'react-dom/server'
-import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
-import '../../../i18n'
 import { PraxisSubmitControls, unsubmitCase } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut, PraxisMemberOut, PraxisStatus } from '../../../api/praxis'
-import type { CharacterOut, CurrentUser } from '../../../api/auth'
-import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
+import type { CurrentUser } from '../../../api/auth'
+import type { DuelDetailOut, DuelStatus } from '../../../api/duel'
+import {
+  aCharacter,
+  aCurrentUser,
+  aDuel,
+  aDuelSide,
+  aMember,
+  aPraxis,
+} from '../../../test/fixtures'
+import { aPraxisDetailState, markup } from '../../../test/praxisDetail'
 
 /**
  * Rendered text with tags stripped and the entities React escapes (`&`, `'`)
  * put back, so an assertion can quote the catalog string as an editor wrote it.
  */
 function text(element: ReactElement): string {
-  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
-    .replace(/<[^>]*>/g, '')
-    .replace(/&#x27;|&#39;/g, "'")
+  return markup(element)
+    .text.replace(/&#x27;|&#39;/g, "'")
     .replace(/&quot;/g, '"')
     .replace(/&amp;/g, '&')
 }
 
-function member(characterId: number, name: string, hasSubmitted: boolean): PraxisMemberOut {
-  return {
+const member = (
+  characterId: number,
+  name: string,
+  hasSubmitted: boolean,
+): PraxisMemberOut =>
+  aMember({
     id: characterId * 10,
-    praxis_id: 1,
     character_id: characterId,
     character_display_name: name,
-    character_avatar_url: '',
     has_submitted: hasSubmitted,
-    is_done: false,
-    joined_at: '2026-01-01T00:00:00Z',
-    nudged_at: null,
-    submitted_at: null,
-  }
-}
+  })
 
-function praxis(overrides: Partial<PraxisOut> = {}): PraxisOut {
-  return {
-    id: 1,
-    task_id: 7,
+const praxis = (overrides: Partial<PraxisOut> = {}): PraxisOut =>
+  aPraxis({
     task_title: 'Mangrove',
     task_point_value: 30,
     task_level_required: 3,
-    task_faction_slug: null,
-    type: 'solo',
-    status: 'submitted' as PraxisStatus,
     title: 'Reforestation',
     body_text: 'Seedlings.',
-    moderation_status: 'visible',
-    admin_note: null,
-    flagged_at: null,
     submitted_at: '2026-01-02T00:00:00Z',
-    submit_proposed_at: null,
     created_by_id: 1,
-    created_by_display_name: 'Ada',
     created_by_faction_slug: 'wow',
-    created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-02T00:00:00Z',
     members: [member(1, 'Ada', true)],
-    invites: [],
     media_items: [],
     score: 0,
-    metatask_points: 0,
-    display_multiplier: 1.0,
     points_from_votes: 0,
-    is_top_for_task: false,
-    duel_id: null,
-    can_flag: true,
-    applied_metatasks: [],
     ...overrides,
-  } as PraxisOut
-}
+  })
 
-const ME: DuelSideOut = {
-  praxis_id: 1,
-  character_id: 1,
-  display_name: 'Ada',
-  faction_slug: 'wow',
-  avatar_url: '',
-  points_from_votes: 0,
-  is_submitted: true,
-  nudged_at: null,
-}
-const FOE: DuelSideOut = {
-  praxis_id: 2,
-  character_id: 2,
-  display_name: 'Rax',
-  faction_slug: 'snide',
-  avatar_url: '',
-  points_from_votes: 0,
-  is_submitted: false,
-  nudged_at: null,
-}
-
-function duel(status: DuelStatus): DuelDetailOut {
-  return {
-    id: 5,
-    task_id: 7,
+/** The opponent has NOT cast, which is what makes a live duel a free reopen. */
+const duel = (status: DuelStatus): DuelDetailOut =>
+  aDuel({
     status,
-    forfeited_by_character_id: null,
-    challenger: ME,
-    opponent: FOE,
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
-  }
-}
+    challenger: aDuelSide({ character_id: 1, faction_slug: 'wow' }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 2,
+      display_name: 'Rax',
+      faction_slug: 'snide',
+      is_submitted: false,
+    }),
+  })
 
-function user(): CurrentUser {
-  const character: CharacterOut = {
-    id: 1,
-    username: 'ada',
-    display_name: 'Ada',
-    bio: '',
-    tagline: '',
-    avatar_url: '',
-    location: '',
-    level: 5,
-    score: 0,
-    all_time_score: 0,
-    faction_slug: 'wow',
-    status: 'active',
-    created_at: '2026-01-01T00:00:00Z',
-    badges: [],
-    invitations: [],
-  }
-  return {
-    account_id: 1,
-    email: 'wz_pilgrim@example.com',
-    provider: 'google',
-    character,
-    is_admin: false,
-    can_create_additional_character: false,
-    can_start_as_albescent: false,
-    albescent_revealed: false,
-    albescent_glimpsed: false,
-    can_propose_task: false,
-    can_propose_metatask: false,
-    can_apply_metatask: false,
-    can_see_retired_tasks: false,
-    can_see_pending_tasks: false,
-    can_comment: true,
-    albescent_level_required: 8,
-    second_character_level_required: 5,
-    era_name: 'Era 1',
-    level_jump_reach: 0,
-    level_jump_available: false,
-    task_browse_defaults_to_eligible: false,
-  }
-}
+const user = (): CurrentUser =>
+  aCurrentUser({ character: aCharacter({ id: 1, faction_slug: 'wow' }) })
 
-function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
-  return {
-    loading: false,
+const state = (overrides: Partial<PraxisDetailState>): PraxisDetailState =>
+  aPraxisDetailState({
     praxis: praxis(),
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
     isOwner: true,
-    showAdminBar: false,
     user: user(),
-    withdrawing: false,
+    // The confirm is what this file reads — every case opens it.
     showWithdrawConfirm: true,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: '',
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: '',
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
     ...overrides,
-  } as PraxisDetailState
-}
+  })
 
 const COLLAB_MEMBERS = [member(1, 'Ada', true), member(2, 'Beth', true)]
 

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -38,29 +38,13 @@ import { AuthContext } from "../../../auth/AuthContext";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { CurrentUser } from "../../../api/auth";
-import { aPraxis } from '../../../test/fixtures'
-import { aPraxisDetailState } from '../../../test/praxisDetail'
+import { aPraxisDetailState, aWalkedPraxis } from '../../../test/praxisDetail'
 
 const HEADING = "Cast your vote";
 const PROMPT = "How much did this move you?";
 
-const PRAXIS = aPraxis({
-  task_title: "Mangrove",
-  task_point_value: 30,
-  task_level_required: 3,
-  task_faction_slug: "ua",
-  title: "Reforestation",
-  body_text: "Seedlings planted along the estuary.",
-  submitted_at: "2026-01-02T00:00:00Z",
-  created_by_id: 3,
-  created_by_display_name: "Ada",
-  created_by_faction_slug: "ua",
-  updated_at: "2026-01-02T00:00:00Z",
-  members: [],
-  media_items: [],
-  score: 46,
-  points_from_votes: 16,
-});
+const PRAXIS = aWalkedPraxis();
+
 
 function viewer(): CurrentUser {
   return {

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -39,6 +39,7 @@ import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { CurrentUser } from "../../../api/auth";
 import { aPraxis } from '../../../test/fixtures'
+import { aPraxisDetailState } from '../../../test/praxisDetail'
 
 const HEADING = "Cast your vote";
 const PROMPT = "How much did this move you?";
@@ -105,41 +106,10 @@ function viewer(): CurrentUser {
 
 /** Detail state for one viewer, carrying the backend's eligibility answer. */
 function state(user: CurrentUser | null, viewerCanVote: boolean): PraxisDetailState {
-  return {
-    loading: false,
+  return aPraxisDetailState({
     praxis: { ...PRAXIS, viewer_can_vote: viewerCanVote },
-    fetchError: null,
-    comments: null,
-    voters: [],
-    duel: null,
-    isOwner: false,
-    showAdminBar: false,
     user,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-  };
+  });
 }
 
 function render(element: ReactElement, user: CurrentUser | null): string {

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -28,14 +28,7 @@ import { surfaceMap } from "../../../factions";
 import { resolvedArchetype } from "../../../factions/lazyArchetype";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
-import {
-  aCharacter,
-  aCurrentUser,
-  aDuel,
-  aDuelSide,
-  aMember,
-  aPraxis,
-} from "../../../test/fixtures";
+import { aCharacter, aCurrentUser, aDuel, aDuelSide, aMember, aMetatask, aPraxis } from "../../../test/fixtures";
 import { CO_MEMBER as SHARED_CO_MEMBER, VOTERS, aPraxisDetailState, indexOf, renderPraxisDetail, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
@@ -121,30 +114,7 @@ describe("WOW praxis detail — copy is neutral (ADR-0061)", () => {
           type: "collab",
           members: [MEMBER, CO_MEMBER],
           applied_metatasks: [
-            {
-              id: 501,
-              title: "Composting",
-              description: '',
-              point_value: 6,
-              level_required: 0,
-              status: "active",
-              task_type: "metatask",
-              created_by: 9,
-              primary_faction_slug: 'na',
-              metatask_faction_slug: "wow",
-              created_at: "2026-01-01T00:00:00Z",
-              in_progress_count: 0,
-              created_by_display_name: "",
-              created_by_avatar_url: "",
-              created_by_faction_slug: null,
-              created_by_level: 0,
-              signup_reason: null,
-              in_progress_praxis_id: null,
-              can_sign_up: false,
-              allowed_modes: [],
-              eligible_for_current_user: false,
-              start_here: false,
-            },
+            aMetatask({ metatask_faction_slug: "wow" }),
           ],
         },
       }),

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -22,37 +22,39 @@
  * pure `[data-theme]` cascade with no branch in the component, so there is
  * nothing here to assert about it; it is an eyeball check.
  */
-import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import i18n from "../../../i18n";
 import { surfaceMap } from "../../../factions";
 import { resolvedArchetype } from "../../../factions/lazyArchetype";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { DuelDetailOut } from "../../../api/duel";
-import type { CurrentUser } from "../../../api/auth";
-import { aMember, aPraxis } from '../../../test/fixtures'
+import {
+  aCharacter,
+  aCurrentUser,
+  aDuel,
+  aDuelSide,
+  aMember,
+  aPraxis,
+} from "../../../test/fixtures";
+import {
+  CO_MEMBER as SHARED_CO_MEMBER,
+  VOTERS,
+  aPraxisDetailState,
+  indexOf,
+  renderPraxisDetail,
+} from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
 
-// Imported after the mock so the archetype picks it up.
+// Imported after the mock. The identity check below needs the MODULE, not the
+// deferred wrapper the registry hands back — everything else renders by slug.
 const { default: WowPraxisDetail } = await import("../archetypes/WowPraxisDetail");
-const { default: DefaultPraxisDetail } = await import("../archetypes/DefaultPraxisDetail");
 
-const MEMBER = aMember({
-  character_id: 3,
-  character_display_name: "Wren Abalone",
-});
-
-const CO_MEMBER = aMember({
-  id: 102,
-  character_id: 4,
-  character_display_name: "Bram Quilling",
-  joined_at: "2026-01-02T00:00:00Z",
-});
+const MEMBER = aMember({ character_display_name: "Wren Abalone" });
+const CO_MEMBER = { ...SHARED_CO_MEMBER, character_display_name: "Bram Quilling" };
 
 // No apostrophes in the fixtures: `renderToStaticMarkup` escapes them to
 // `&#x27;`, which survives the tag-strip and breaks a plain substring check.
@@ -65,106 +67,39 @@ const PRAXIS = aPraxis({
   members: [MEMBER],
 });
 
-const VIEWER: CurrentUser = {
-  id: 50,
-  display_name: "Wren Abalone",
-  is_admin: false,
-  character: {
-    id: 3,
-    display_name: "Wren Abalone",
-    faction_slug: "wow",
-    level: 4,
-    points: 120,
-    avatar_url: null,
-  },
-} as unknown as CurrentUser;
-
-function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
-  return {
-    loading: false,
-    praxis: PRAXIS,
-    fetchError: null,
-    comments: null,
-    voters: [
-      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
-      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
-    ],
-    duel: null as DuelDetailOut | null,
-    isOwner: false,
-    showAdminBar: false,
-    user: null,
-    withdrawing: false,
-    showWithdrawConfirm: false,
-    setShowWithdrawConfirm: () => {},
-    withdrawError: null,
-    adminFailNote: "",
-    setAdminFailNote: () => {},
-    showFailInput: false,
-    setShowFailInput: () => {},
-    moderating: false,
-    moderateError: null,
-    showFlagForm: false,
-    setShowFlagForm: () => {},
-    flagReason: null,
-    setFlagReason: () => {},
-    flagDetail: "",
-    setFlagDetail: () => {},
-    flagging: false,
-    flagError: null,
-    setFlagError: () => {},
-    flagSubmitted: false,
-    handleModerate: async () => {},
-    handleWithdraw: async () => {},
-    handleFlag: async () => {},
-    handleKickMember: async () => {},
-    ...overrides,
-  };
-}
+const VIEWER = aCurrentUser({
+  character: aCharacter({ display_name: "Wren Abalone", faction_slug: "wow", level: 4 }),
+});
 
 /** A two-sided duel at a given status; this praxis is the challenger's. */
-function duel(status: DuelDetailOut["status"]): DuelDetailOut {
-  const side = (praxisId: number | null, id: number, name: string, votes: number) => ({
-    praxis_id: praxisId,
-    character_id: id,
-    display_name: name,
-    faction_slug: "wow",
-    avatar_url: "",
-    points_from_votes: votes,
-    habit_bonus_points: 0,
-    is_submitted: true,
-    nudged_at: null,
-  });
-  return {
-    id: 5,
-    task_id: 7,
+const duel = (status: DuelDetailOut["status"]): DuelDetailOut =>
+  aDuel({
     status,
-    forfeited_by_character_id: null,
-    challenger: side(1, 3, "Wren Abalone", 18),
-    opponent: side(2, 4, "Bram Quilling", 15.4),
-    winner_character_id: null,
-    challenger_final_points: null,
-    opponent_final_points: null,
-  };
-}
+    challenger: aDuelSide({
+      display_name: "Wren Abalone",
+      faction_slug: "wow",
+      points_from_votes: 18,
+    }),
+    opponent: aDuelSide({
+      praxis_id: 2,
+      character_id: 4,
+      display_name: "Bram Quilling",
+      faction_slug: "wow",
+      points_from_votes: 15.4,
+    }),
+  });
 
+const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
+  aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
+
+// The skin comes from the real registry, resolved at render time — inside the
+// test, so after both the `vi.mock` above and the archetype preload.
 function render(
   next: PraxisDetailState,
   formFactor: "desktop" | "mobile" = "desktop",
 ): { html: string; text: string } {
   mocks.formFactor = formFactor;
-  const html = renderToStaticMarkup(
-    <MemoryRouter>
-      <WowPraxisDetail state={next} />
-    </MemoryRouter>,
-  );
-  return { html, text: html.replace(/<[^>]*>/g, "") };
-}
-
-/** Where a marker sits in the markup — the seam the responsive move is about. */
-function indexOf(html: string, needle: string): number {
-  const at = html.indexOf(needle);
-  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
-  return at;
+  return renderPraxisDetail("wow", next);
 }
 
 describe("WOW claims the praxis-detail surface (#951)", () => {
@@ -176,11 +111,7 @@ describe("WOW claims the praxis-detail surface (#951)", () => {
     // The bug this closes was invisible: WOW *rendered*, it just rendered the
     // generic Default. Two different components, so the tell is the dress.
     const wow = render(state());
-    const na = renderToStaticMarkup(
-      <MemoryRouter>
-        <DefaultPraxisDetail state={state()} />
-      </MemoryRouter>,
-    );
+    const { html: na } = renderPraxisDetail("na", state());
     expect(wow.html, "the parchment field").toContain("wow-detail-field");
     expect(na, "which the na page has no notion of").not.toContain("wow-detail-field");
     expect(na, "na's page is the spectrum").toContain("--faction-default-rainbow");

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -36,13 +36,7 @@ import {
   aMember,
   aPraxis,
 } from "../../../test/fixtures";
-import {
-  CO_MEMBER as SHARED_CO_MEMBER,
-  VOTERS,
-  aPraxisDetailState,
-  indexOf,
-  renderPraxisDetail,
-} from "../../../test/praxisDetail";
+import { CO_MEMBER as SHARED_CO_MEMBER, VOTERS, aPraxisDetailState, indexOf, renderPraxisDetail, skinRenderer } from "../../../test/praxisDetail";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -92,15 +86,7 @@ const duel = (status: DuelDetailOut["status"]): DuelDetailOut =>
 const state = (overrides: Partial<PraxisDetailState> = {}): PraxisDetailState =>
   aPraxisDetailState({ praxis: PRAXIS, voters: VOTERS, ...overrides });
 
-// The skin comes from the real registry, resolved at render time — inside the
-// test, so after both the `vi.mock` above and the archetype preload.
-function render(
-  next: PraxisDetailState,
-  formFactor: "desktop" | "mobile" = "desktop",
-): { html: string; text: string } {
-  mocks.formFactor = formFactor;
-  return renderPraxisDetail("wow", next);
-}
+const render = skinRenderer("wow", mocks);
 
 describe("WOW claims the praxis-detail surface (#951)", () => {
   it("registers a praxisDetail archetype", () => {

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -71,6 +71,31 @@ export const aTask = (over: Partial<TaskOut> = {}): TaskOut => ({
   ...over,
 })
 
+/**
+ * A metatask — the seal a praxis applies, not a task anyone signs up for.
+ *
+ * Same wire shape as {@link aTask}; the fields that differ are exactly the ones
+ * that follow from `task_type: 'metatask'`, so a suite that only needs "a seal
+ * to hang on a praxis" says `aMetatask({ metatask_faction_slug: 'coven' })` and
+ * nothing else. `metatask_faction_slug` has no default: which faction's seal it
+ * is is the only thing a caller ever means by it.
+ */
+export const aMetatask = (over: Partial<TaskOut> = {}): TaskOut =>
+  aTask({
+    id: 501,
+    title: 'Composting',
+    point_value: 60,
+    level_required: 0,
+    task_type: 'metatask',
+    created_by: 9,
+    created_by_display_name: '',
+    // A metatask is applied to a praxis, never signed up for (#1093).
+    can_sign_up: false,
+    allowed_modes: [],
+    eligible_for_current_user: false,
+    ...over,
+  })
+
 export const aMember = (over: Partial<PraxisMemberOut> = {}): PraxisMemberOut => ({
   id: 101,
   praxis_id: 1,

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -22,6 +22,8 @@
  * assertion cannot collide with incidental markup. Every id is stable, because
  * several suites assert on hrefs built from them.
  */
+import type { CharacterOut, CurrentUser } from '../api/auth'
+import type { DuelDetailOut, DuelSideOut } from '../api/duel'
 import type { PraxisCardOut, PraxisMemberOut, PraxisOut } from '../api/praxis'
 import type { TaskOut } from '../api/tasks'
 
@@ -191,6 +193,104 @@ export const aPraxisCard = (over: Partial<PraxisCardOut> = {}): PraxisCardOut =>
   viewer_can_vote: true,
   viewer_vote: null,
   voted_by_name: null,
+  ...over,
+})
+
+/**
+ * The signed-in character.
+ *
+ * Defaults to {@link AUTHOR} — the praxis author every detail suite signs in as
+ * when it wants an OWNER's view, so `aCurrentUser()` is already the owner of
+ * `aPraxis()` and a suite that wants a visitor overrides `id`.
+ *
+ * `faction_slug` is a bare `string` on the wire, never null: `na` is the
+ * identity every player starts in (ADR-0030), which is why it is the default
+ * here rather than an empty string.
+ */
+export const aCharacter = (over: Partial<CharacterOut> = {}): CharacterOut => ({
+  id: AUTHOR.id,
+  username: 'ada',
+  display_name: AUTHOR.name,
+  bio: '',
+  tagline: '',
+  avatar_url: '',
+  location: '',
+  level: 5,
+  score: 0,
+  all_time_score: 0,
+  faction_slug: 'na',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+  badges: [],
+  invitations: [],
+  ...over,
+})
+
+/**
+ * The `/auth/me` payload — the viewer, not the character.
+ *
+ * Every capability flag defaults FALSE, which is the wire default too, so a
+ * suite that renders a control has to say which flag opened it. `can_comment`
+ * is the one exception: the comment region is on the page for an ordinary
+ * signed-in player, and defaulting it false would silently delete a section
+ * from every detail render.
+ */
+export const aCurrentUser = (over: Partial<CurrentUser> = {}): CurrentUser => ({
+  account_id: 1,
+  email: 'wz_pilgrim@example.com',
+  provider: 'google',
+  character: aCharacter(),
+  is_admin: false,
+  can_create_additional_character: false,
+  can_start_as_albescent: false,
+  albescent_revealed: false,
+  albescent_glimpsed: false,
+  can_propose_task: false,
+  can_propose_metatask: false,
+  can_apply_metatask: false,
+  can_see_retired_tasks: false,
+  can_see_pending_tasks: false,
+  can_comment: true,
+  albescent_level_required: 8,
+  second_character_level_required: 5,
+  era_name: 'Era 1',
+  level_jump_reach: 0,
+  level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
+  ...over,
+})
+
+/** One side of a duel. Defaults to THIS page's side — praxis 1, {@link AUTHOR}. */
+export const aDuelSide = (over: Partial<DuelSideOut> = {}): DuelSideOut => ({
+  praxis_id: 1,
+  character_id: AUTHOR.id,
+  display_name: AUTHOR.name,
+  faction_slug: 'na',
+  avatar_url: '',
+  points_from_votes: 0,
+  is_submitted: true,
+  nudged_at: null,
+  ...over,
+})
+
+/**
+ * A settled duel — both sides cast, no verdict frozen yet.
+ *
+ * `settled` is the status the detail suites exercise most, because it is the
+ * one where unsubmitting forfeits (ADR-0011 §Forfeit); `active` and `declined`
+ * are one override away. The frozen-outcome trio stays null: it is populated at
+ * era close (ADR-0052), and a live duel that carried one would be a lie.
+ */
+export const aDuel = (over: Partial<DuelDetailOut> = {}): DuelDetailOut => ({
+  id: 5,
+  task_id: 7,
+  status: 'settled',
+  forfeited_by_character_id: null,
+  challenger: aDuelSide(),
+  opponent: aDuelSide({ praxis_id: 2, character_id: 4, display_name: 'Rax' }),
+  winner_character_id: null,
+  challenger_final_points: null,
+  opponent_final_points: null,
   ...over,
 })
 

--- a/frontend/src/test/praxisDetail.tsx
+++ b/frontend/src/test/praxisDetail.tsx
@@ -1,0 +1,157 @@
+/**
+ * The praxis-detail render harness (#2692).
+ *
+ * Twenty of the twenty-two files in `pages/praxisDetail/__tests__` opened with
+ * the same forty-line `PraxisDetailState` literal, the same MemoryRouter mount
+ * and the same tag-stripping `render()`. A 2026-08-25 duplication audit put the
+ * directory at 42.9% duplicated on an 8-line window — against 1-2% everywhere
+ * else in the repo. None of that setup was a premise any of those tests were
+ * making; it was the cost of getting a page onto the page.
+ *
+ * WHY THIS IS NOT IN `fixtures.ts`
+ * -------------------------------
+ * `fixtures.ts` is pure wire shapes with no imports but types, and forty-eight
+ * test files import it. Putting a MOUNT there would drag `react-dom/server`,
+ * the router, the i18n catalog and — through `surfaceMap` — the entire faction
+ * manifest graph into every one of them. The data builders this harness leans
+ * on (`aPraxis`, `aMember`, `aCurrentUser`, `aDuel`) do live there; only the
+ * rendering lives here.
+ *
+ * WHAT IS DELIBERATELY *NOT* HERE
+ * ------------------------------
+ * The `useFormFactor` mock. `vi.mock` is hoisted into the file it is written
+ * in, so a mock registered from this module would not be registered for the
+ * test file that imports it. Each suite keeps its own four-line mock, and its
+ * own `render()` wrapper sets the value before delegating here — which also
+ * keeps the mocking local and visible where the mobile assertions are made.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ComponentType, ReactElement } from 'react'
+import { expect } from 'vitest'
+import { surfaceMap } from '../factions'
+// Initialise the catalog so shared-chrome copy keys resolve to English text.
+import '../i18n'
+import type { PraxisDetailState } from '../pages/praxisDetail/usePraxisDetail'
+import type { VoterDetail } from '../api/votes'
+import { aMember, aPraxis } from './fixtures'
+
+/**
+ * Mount anything under the router and hand back both readings of it.
+ *
+ * `text` is the tag-stripped markup: several archetypes split a heading across
+ * spans (the Ephemerists' lapis last word), so a phrase only reads contiguously
+ * once the wrapping tags are gone. `html` is what a class, an href or a token
+ * name is asserted against.
+ */
+export function markup(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+/** The author's own membership row — the solo case, and `aPraxis()`'s default. */
+export const MEMBER = aMember()
+
+/** A second member, so a collab has someone to credit besides the author. */
+export const CO_MEMBER = aMember({
+  id: 102,
+  character_id: 4,
+  character_display_name: 'Beth',
+  joined_at: '2026-01-02T00:00:00Z',
+})
+
+/**
+ * Two voters at different rungs, which is what the who-voted panel is for: the
+ * page lists each voter's own star value and must never average them.
+ */
+export const VOTERS: VoterDetail[] = [
+  { character_id: 11, display_name: 'Cy', avatar_url: '', faction_slug: '', value: 5 },
+  { character_id: 12, display_name: 'Dov', avatar_url: '', faction_slug: '', value: 3 },
+]
+
+/**
+ * The whole `PraxisDetailState` a detail archetype takes, in its neutral shape:
+ * loaded, anonymous, non-owner, no duel, nothing in flight, every setter and
+ * handler a no-op.
+ *
+ * A suite passes ONLY the axis it is asserting on — `{ isOwner: true }`,
+ * `{ duel }`, `{ praxis: { ...PRAXIS, moderation_status: 'flagged' } }` — so
+ * the call site reads as the test's premise rather than burying it. The
+ * handlers are no-ops because `renderToStaticMarkup` never runs an effect and
+ * never fires an event: nothing in this harness can call one.
+ */
+export function aPraxisDetailState(
+  over: Partial<PraxisDetailState> = {},
+): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: aPraxis(),
+    fetchError: null,
+    comments: null,
+    voters: [],
+    duel: null,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+    ...over,
+  }
+}
+
+/**
+ * Render the praxis-detail page a faction actually gets, named by SLUG.
+ *
+ * The archetype is looked up in the real `surfaceMap('praxisDetail')` registry
+ * rather than imported by hand, so a suite renders what the dispatcher would
+ * render — de-register a faction and its own suite says so. The lookup happens
+ * at call time, inside the test, because the manifest entries are code-split
+ * thunks warmed by `src/test/preloadArchetypes.ts` in a `beforeAll`; resolving
+ * at module scope would find them unwarmed and render null.
+ *
+ * The second argument is a `Partial<PraxisDetailState>`, so a suite that has
+ * already built a full state can pass it straight through.
+ */
+export function renderPraxisDetail(
+  slug: string,
+  over: Partial<PraxisDetailState> = {},
+): { html: string; text: string } {
+  const Archetype = surfaceMap('praxisDetail')[slug] as
+    | ComponentType<{ state: PraxisDetailState }>
+    | undefined
+  if (!Archetype) throw new Error(`no praxisDetail archetype registered for "${slug}"`)
+  return markup(<Archetype state={aPraxisDetailState(over)} />)
+}
+
+/**
+ * Where a marker sits in the markup — the seam every responsive-move assertion
+ * is about. Fails loudly on a missing marker, because `indexOf` returning -1
+ * would otherwise make "rides above" trivially true.
+ */
+export function indexOf(html: string, needle: string): number {
+  const at = html.indexOf(needle)
+  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1)
+  return at
+}

--- a/frontend/src/test/praxisDetail.tsx
+++ b/frontend/src/test/praxisDetail.tsx
@@ -35,7 +35,9 @@ import '../i18n'
 import type { PraxisDetailState } from '../pages/praxisDetail/usePraxisDetail'
 import type { FormFactor } from '../hooks/useFormFactor'
 import type { VoterDetail } from '../api/votes'
-import { aMember, aPraxis } from './fixtures'
+import type { PraxisOut } from '../api/praxis'
+import type { CharacterOut, CurrentUser } from '../api/auth'
+import { aCharacter, aCurrentUser, aMember, aPraxis } from './fixtures'
 
 /**
  * Mount anything under the router and hand back both readings of it.
@@ -69,6 +71,38 @@ export const VOTERS: VoterDetail[] = [
   { character_id: 11, display_name: 'Cy', avatar_url: '', faction_slug: '', value: 5 },
   { character_id: 12, display_name: 'Dov', avatar_url: '', faction_slug: '', value: 3 },
 ]
+
+/**
+ * The praxis the OWNER-CONTROL suites act on, and the viewer who owns it.
+ *
+ * `ownerEditLink`, `unsubmitConfirmCopy` and `duelForfeitWarning` all render a
+ * part of the page rather than an archetype, and all three need the same
+ * premise: a submitted solo whose single member is the signed-in character.
+ * Character 1 rather than {@link AUTHOR}, because the whole point of these
+ * suites is that ownership is read off the MEMBER row (ADR-0013), so the id
+ * that proves it should not be the fixture's default.
+ *
+ * Scoreless on purpose: none of the three reads a number, and a zero says so.
+ */
+export const anOwner = (over: Partial<CharacterOut> = {}): CurrentUser =>
+  aCurrentUser({ character: aCharacter({ id: 1, ...over }) })
+
+export const anOwnedPraxis = (over: Partial<PraxisOut> = {}): PraxisOut =>
+  aPraxis({
+    task_title: 'Mangrove',
+    task_point_value: 30,
+    task_level_required: 3,
+    title: 'Reforestation',
+    body_text: 'Seedlings.',
+    submitted_at: '2026-01-02T00:00:00Z',
+    created_by_id: 1,
+    updated_at: '2026-01-02T00:00:00Z',
+    members: [aMember({ id: 10, character_id: 1 })],
+    media_items: [],
+    score: 0,
+    points_from_votes: 0,
+    ...over,
+  })
 
 /**
  * The whole `PraxisDetailState` a detail archetype takes, in its neutral shape:

--- a/frontend/src/test/praxisDetail.tsx
+++ b/frontend/src/test/praxisDetail.tsx
@@ -33,6 +33,7 @@ import { surfaceMap } from '../factions'
 // Initialise the catalog so shared-chrome copy keys resolve to English text.
 import '../i18n'
 import type { PraxisDetailState } from '../pages/praxisDetail/usePraxisDetail'
+import type { FormFactor } from '../hooks/useFormFactor'
 import type { VoterDetail } from '../api/votes'
 import { aMember, aPraxis } from './fixtures'
 
@@ -154,4 +155,26 @@ export function indexOf(html: string, needle: string): number {
   const at = html.indexOf(needle)
   expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1)
   return at
+}
+
+/**
+ * A per-suite `render(state, formFactor)` for one faction's skin.
+ *
+ * The faction detail suites each opened with the same eight-line wrapper: set
+ * the mocked form factor, mount the archetype, strip the tags. Only the SLUG
+ * differed.
+ *
+ * `mocks` is the suite's own `vi.hoisted` cell, passed in rather than owned
+ * here, because the mock REGISTRATION cannot move: `vi.mock` is hoisted into
+ * the file it is written in, so a call from this module would not register for
+ * the suite that imports it.
+ */
+export function skinRenderer(slug: string, mocks: { formFactor: FormFactor }) {
+  return (
+    next: Partial<PraxisDetailState>,
+    formFactor: FormFactor = 'desktop',
+  ): { html: string; text: string } => {
+    mocks.formFactor = formFactor
+    return renderPraxisDetail(slug, next)
+  }
 }

--- a/frontend/src/test/praxisDetail.tsx
+++ b/frontend/src/test/praxisDetail.tsx
@@ -37,7 +37,7 @@ import type { FormFactor } from '../hooks/useFormFactor'
 import type { VoterDetail } from '../api/votes'
 import type { PraxisOut } from '../api/praxis'
 import type { CharacterOut, CurrentUser } from '../api/auth'
-import { aCharacter, aCurrentUser, aMember, aPraxis } from './fixtures'
+import { aCharacter, aCurrentUser, aDuelSide, aMember, aPraxis } from './fixtures'
 
 /**
  * Mount anything under the router and hand back both readings of it.
@@ -71,6 +71,48 @@ export const VOTERS: VoterDetail[] = [
   { character_id: 11, display_name: 'Cy', avatar_url: '', faction_slug: '', value: 5 },
   { character_id: 12, display_name: 'Dov', avatar_url: '', faction_slug: '', value: 3 },
 ]
+
+/**
+ * The other side of a duel: praxis 2, a S.N.I.D.E. character, just behind on
+ * votes so "leads by" has a margin to print and no reading is a tie by
+ * accident. A suite whose page is itself S.N.I.D.E. overrides `faction_slug` —
+ * a rival in the same colours would make an ink assertion vacuous.
+ */
+export const RIVAL = aDuelSide({
+  praxis_id: 2,
+  character_id: 4,
+  display_name: 'Rax',
+  faction_slug: 'snide',
+  points_from_votes: 15.4,
+})
+
+/**
+ * The praxis the two REGISTRY WALKS render through every archetype
+ * (`archetypeSlots`, `voteRegionGate`).
+ *
+ * Solo, submitted, with votes already cast and no media: every skin has each
+ * invariant slot to draw, and none of them has an upload to lay out. The score
+ * is the arithmetic those walks read — (base 30 + meta 0) × 1.0 + 16 = 46.
+ */
+export const aWalkedPraxis = (over: Partial<PraxisOut> = {}): PraxisOut =>
+  aPraxis({
+    task_title: 'Mangrove',
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: 'ua',
+    title: 'Reforestation',
+    body_text: 'Seedlings planted along the estuary.',
+    submitted_at: '2026-01-02T00:00:00Z',
+    created_by_id: 3,
+    created_by_display_name: 'Ada',
+    created_by_faction_slug: 'ua',
+    updated_at: '2026-01-02T00:00:00Z',
+    members: [],
+    media_items: [],
+    score: 46,
+    points_from_votes: 16,
+    ...over,
+  })
 
 /**
  * The praxis the OWNER-CONTROL suites act on, and the viewer who owns it.


### PR DESCRIPTION
Closes #2692

`frontend/src/pages/praxisDetail/__tests__` carried the same forty-line
`PraxisDetailState` literal, the same MemoryRouter mount and the same
tag-stripping `render()` in **twenty of its twenty-two files** — not the eleven
the issue named. None of it was a premise any of those tests were making; it
was the cost of getting a page onto the page.

## The seam

`aPraxisDetailState()` + `renderPraxisDetail(slug, state)` in a new
`frontend/src/test/praxisDetail.tsx`: the state a detail archetype takes, and
the mount that puts it under a router with the i18n catalog loaded. The
archetype is looked up in the real `surfaceMap('praxisDetail')` registry rather
than imported by hand, so a suite now renders what the dispatcher would render.

The failing-test-first loop does not apply — this is a pure refactor with no
defect underneath it. What stands in for it is the assertion accounting below,
and one real catch it produced: `unsubmitConfirmCopy` defaulted
`showWithdrawConfirm: true` where every other suite defaulted it false. Six
tests went red on the shared default and are green again on an explicit one.

## Where the helper lives, and why not in `fixtures.ts`

The issue says "add `renderPraxisDetail` beside `aTask`/`aMember`/`aPraxis`".
The pure wire shapes did go there — `aCharacter`, `aCurrentUser`, `aDuelSide`,
`aDuel`, `aMetatask`. The **mount** did not, and that is a deliberate departure:
`fixtures.ts` is imported by forty-eight test files and has no imports but
types. Putting `react-dom/server`, the router, the i18n catalog and — through
`surfaceMap` — the whole faction manifest graph behind that import would charge
every one of those files for a page none of them render.

## The two named traps

- **Wholesale `vi.mock`.** The harness mocks nothing. It cannot: `vi.mock` is
  hoisted into the file it is written in, so a call from the harness would not
  register for the suite that imports it. Each suite keeps its own four-line
  `useFormFactor` mock, and `skinRenderer(slug, mocks)` takes the suite's own
  `vi.hoisted` cell as an argument. That is stated in the module header so the
  next person does not try to move it.
- **Copy-anchored `toHaveCount(0)`.** No helper here makes a negative
  assertion easy — `markup()` returns `{ html, text }` and the suites assert on
  them exactly as before. `indexOf()` is the one helper that asserts, and it
  asserts POSITIVELY (`marker missing: …` fails on -1) precisely so that
  "rides above" cannot pass by both markers being absent.

## Numbers

**Tool:** a purpose-written 8-line-window clone detector, kept in the worktree
and not committed. `jscpd` is not a dependency of this repo and there is no
network install here, so the scan is line-based: whitespace collapsed, blank
and pure-comment lines dropped, every window of 8 consecutive code lines
hashed, a window occurring twice anywhere in the corpus marks its 8 lines
duplicated. The same script produced both columns.

| | before (`origin/main`) | after |
|---|---|---|
| code lines in the directory | 5,331 | 3,568 |
| duplicated, total | 2,285 — **42.86%** | 492 — **13.79%** |
| …of which SETUP (before the first `describe`) | 1,696 — **31.81%** | 56 — **1.57%** |
| …of which TEST BODIES | 589 — 11.05% | 436 — 12.22% |

**The issue's "under 3% for the directory" is met on setup and is not met
overall, and I do not think it can be under this issue's own rules.** The 436
residual lines are duplicated *assertions*: `uaPraxisDetail` and
`wowPraxisDetail` are near-twin suites (100 duplicated lines each), and
`snide` / `singularity` / `everymen` / `unaffiliated` share byte-identical
`it("shows the crown at BOTH form factors")`, `it("shows owner controls to a
member")` and `it("lists who voted")` blocks. Removing those means deleting or
merging tests, which is the thing the brief says to stop at. It wants its own
issue and its own ruling; I have not opened one.

Bodies fell in absolute terms too (589 → 436) because `aMetatask`, `RIVAL` and
the member builders reach into fixture construction *inside* test bodies. That
is still fixture setup, not an assertion.

**Assertions:** static `expect(` sites 682 → 674. The −8 is exact and accounted
for: nine files each carried a byte-identical `indexOf()` helper containing one
`expect`, and those nine became one. Runtime assertions are unchanged — the
call sites are untouched (`indexOf(` tokens 75 → 59 = −18 for nine two-token
helper definitions, +2 for the harness's one).

**Tests:** the directory ran 462 before and 462 after. Nothing was skipped,
renamed or deleted.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean (`tsc --noEmit` after every file, not batched)
- `npm run typecheck:design-sync` — clean
- `npm test` — **461 files, 9,474 passed, 1 skipped**
- `npm run build` — built
- `npm run budget` — JS **WARN** at 137.2 KB (warn > 130.9, fail > 175.8). This
  is pre-existing and untouched by this PR: the diff is 21 test files plus two
  files under `src/test/`, no shipped module imports either of them, and the
  bundle is byte-identical to main's.

The `api-schema` job needs nothing — no route, `response_model` or Pydantic
schema was touched. The backend job is untouched.

## What to eyeball

Nothing visual. The diff contains no shipped source file, so there is no pixel
to check and no visual QA is outstanding — the suite is the proof, and it is
the same 462 tests making the same assertions as before.

The judgement calls worth a reviewer's eye are all in prose, not pixels:

1. **`renderPraxisDetail` resolves by slug through `surfaceMap`** instead of a
   hand-written archetype import. That is a small widening: a suite now also
   fails if its faction stops being registered. `ua`/`wow` keep their direct
   import for the `resolvedArchetype(...) === UaPraxisDetail` identity check,
   which is about the module rather than the wrapper.
2. **The `aCurrentUser` swap changes what the fixture contains.** Seven suites
   built `VIEWER` as `{ id: 50, … } as unknown as CurrentUser` — a shape that
   is not the wire shape. They now get a real one. Superset, and green, but it
   is a fixture behaviour change rather than a pure move.
3. **`anOwnedPraxis` / `aWalkedPraxis` / `RIVAL`** are named for their USE
   ("the praxis the owner-control suites act on", "the praxis the two registry
   walks render through every archetype"). If those names read as contrived,
   the alternative is three suites each keeping their own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
