### PR TITLE
Propose a Task wears the faction it is proposed FOR: the chassis and its first registration

### DIFF
--- a/frontend/src/factions/__tests__/defaultManifest.test.tsx
+++ b/frontend/src/factions/__tests__/defaultManifest.test.tsx
@@ -51,6 +51,7 @@ import DefaultEditCharacter from '../../pages/characterPaths/archetypes/DefaultE
 import DefaultFactionHero from '../../components/factionHero/DefaultFactionHero'
 import DefaultFactionBody from '../../pages/factionDetail/archetypes/DefaultFactionBody'
 import DefaultProfileBody from '../../pages/characterProfile/archetypes/DefaultProfileBody'
+import DefaultProposeTask from '../../pages/proposeTask/archetypes/DefaultProposeTask'
 import DefaultFieldDesk from '../../pages/fieldDesk/mobileArchetypes/DefaultFieldDesk'
 
 /**
@@ -79,6 +80,7 @@ const WAS_THE_FALLBACK: Record<string, unknown> = {
   profileBody: DefaultProfileBody,
   createCharacter: DefaultCreateCharacter,
   editCharacter: DefaultEditCharacter,
+  proposeTask: DefaultProposeTask,
   duelSeal: DefaultDuelSealConfirm,
   mobileFieldDesk: DefaultFieldDesk,
 }

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -104,6 +104,10 @@ const AlbescentComment = lazyArchetype(() => import('../components/comments/voic
 const AlbescentCreateCharacter = lazyArchetype(() => import('../pages/characterPaths/archetypes/AlbescentCreateCharacter'))
 const AlbescentEditCharacter = lazyArchetype(() => import('../pages/characterPaths/archetypes/AlbescentEditCharacter'))
 const AlbescentDuelSealConfirm = lazyArchetype(() => import('../components/duel/AlbescentDuelSealConfirm'))
+// #2538 — the propose-task chassis's first registration. Lazy like every
+// wrapper above: it renders the whole na page, which is weight the initial load
+// does not need.
+const AlbescentProposeTask = lazyArchetype(() => import('../pages/proposeTask/archetypes/AlbescentProposeTask'))
 
 export const ALBESCENT_MANIFEST: FactionManifest = {
   slug: 'albescent',
@@ -434,6 +438,23 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * life edits itself in a turning frame, and nobody else's page moves.
    */
   editCharacter: () => AlbescentEditCharacter,
+
+  /**
+   * PASS-THROUGH, and the first registration of the propose-task chassis
+   * (#2538). na's spectrum is all over that page — the card's gradient frame,
+   * the metatask box, the submit pill — and not one of those marks is reachable
+   * from here: every one is an INLINE style computed from the slug in
+   * `pages/proposeTask/factionSurfaces.ts`, so `.alb-moves` has no
+   * `.spectrum-dial` or `.spectrum-rule` to set moving. That is the `comment`
+   * row's finding exactly (#2531), on a second surface.
+   *
+   * The dispatch slug is the TARGET faction — the one the task is proposed FOR
+   * — so this row is reached when anyone, member or not, aims a task at
+   * Albescent. A tell on a chip a non-member can pick would be an un-hiding
+   * rather than a reveal (ADR-0027), which is the `duelSeal` row's second
+   * reason as well.
+   */
+  proposeTask: () => AlbescentProposeTask,
 
   /**
    * PASS-THROUGH. `DefaultDuelSealConfirm` is not the na SPECTRUM kit — it draws

--- a/frontend/src/factions/default.ts
+++ b/frontend/src/factions/default.ts
@@ -1,5 +1,5 @@
 /**
- * na (Unaffiliated) — the ninth faction's twenty-one surfaces (#2530, #2537).
+ * na (Unaffiliated) — the ninth faction's twenty-two surfaces (#2530, #2538).
  *
  * NOT AN OVERRIDE LIST, AND THE ONLY MANIFEST OF WHICH THAT IS TRUE. The other
  * eight declare what they override; this one declares what everything else
@@ -63,6 +63,7 @@ const DefaultFieldDesk = lazyArchetype(() => import('../pages/fieldDesk/mobileAr
 const DefaultPraxisCard = lazyArchetype(() => import('../components/praxisCard/desktop/DefaultPraxisCard'))
 const DefaultPraxisDetail = lazyArchetype(() => import('../pages/praxisDetail/archetypes/DefaultPraxisDetail'))
 const DefaultProfileBody = lazyArchetype(() => import('../pages/characterProfile/archetypes/DefaultProfileBody'))
+const DefaultProposeTask = lazyArchetype(() => import('../pages/proposeTask/archetypes/DefaultProposeTask'))
 const DefaultScoreStamp = lazyArchetype(() => import('../components/praxisCard/scoreStamp/DefaultScoreStamp'))
 const DefaultSeal = lazyArchetype(() => import('../components/metataskSeal/skins/DefaultSeal'))
 const DefaultSelectCard = lazyArchetype(() => import('../components/selectCard/DefaultSelectCard'))
@@ -91,6 +92,7 @@ export const DEFAULT_MANIFEST: FactionManifest = {
   editPraxis: () => DefaultEditPraxis,
   createCharacter: () => DefaultCreateCharacter,
   editCharacter: () => DefaultEditCharacter,
+  proposeTask: () => DefaultProposeTask,
   factionHero: () => DefaultFactionHero,
   factionBody: () => DefaultFactionBody,
   profileBody: () => DefaultProfileBody,

--- a/frontend/src/factions/manifest.ts
+++ b/frontend/src/factions/manifest.ts
@@ -10,7 +10,7 @@
  * declares nothing renders correctly everywhere, including on surfaces that do
  * not exist yet.
  *
- * The exception is `./default.ts`, which IS na's row and must claim all twenty-one.
+ * The exception is `./default.ts`, which IS na's row and must claim all twenty-two.
  * Nothing is behind it: a dispatcher reads `map[resolveSlug(map, slug)]` and
  * names no `Default*` of its own, so an unclaimed na surface renders NOTHING
  * rather than falling further back.
@@ -59,6 +59,7 @@ import type { PraxisDetailState } from '../pages/praxisDetail/usePraxisDetail'
 import type { EditPraxisState } from '../pages/editPraxis/useEditPraxis'
 import type { CreateCharacterState } from '../pages/characterPaths/useCreateCharacter'
 import type { EditCharacterState } from '../pages/characterPaths/useEditCharacter'
+import type { ProposeTaskState } from '../pages/proposeTask/useProposeTask'
 import type { FactionDetailState } from '../pages/factionDetail/useFactionDetail'
 import type { FieldDeskHomeState } from '../pages/fieldDesk/useFieldDeskHome'
 
@@ -152,6 +153,35 @@ export interface FactionManifest {
    */
   readonly editCharacter?: Lazy<Stateful<EditCharacterState>>
 
+  /**
+   * Proposing a task (#2538). ONE responsive component per faction, the same
+   * discipline the two character paths landed with.
+   *
+   * THE SLUG IS THE TARGET FACTION — the one the task is being proposed FOR,
+   * which the form asks for as a first-class field (#1824's chips) — and NOT the
+   * viewer's. Owner ruling, 2026-08-24: "propose a task should have the faction
+   * of the task being proposed". So the semantics are `createCharacter`'s,
+   * deliberately and exactly, because a reader should not have to learn two: the
+   * page reskins LIVE as the chips change, and returns to the Default (na)
+   * archetype when the pick is cleared (`''`) or when "unaffiliated" (`na`) is
+   * picked. An unregistered slug lands there too.
+   *
+   * ADR-0084's test is what licenses the dress at all — a page wears a faction
+   * iff the page as a whole resolves to exactly one, and this one does. The
+   * `Settings` exception (#2539) does not reach here: that page has a landed
+   * neutral DESIGN, and this one has no sheet, which puts it back under the
+   * standing rulings that a surface with no sheet gets DERIVED (2026-08-16)
+   * rather than left generic.
+   *
+   * Each faction's propose dress is derived from that faction's
+   * `createCharacter` page — same register, same geometry, same field furniture.
+   *
+   * `state.isLoggedIn` and `state.canProposeTask` are answered in the DISPATCHER,
+   * above the archetype: an archetype only ever draws the happy-path form, or
+   * its success screen. Eight copies of one gate is what that keeps out.
+   */
+  readonly proposeTask?: Lazy<Stateful<ProposeTaskState>>
+
   // ─── Duel surfaces ─────────────────────────────────────────────────────────
   // The duel SEAL is the only dispatched duel surface. ONE responsive component
   // per faction, both form factors (#1313): the skins hang their interior in
@@ -214,6 +244,7 @@ export const SURFACE_KEYS = [
   'profileBody',
   'createCharacter',
   'editCharacter',
+  'proposeTask',
   'duelSeal',
   'mobileFieldDesk',
 ] as const satisfies readonly FactionSurface[]

--- a/frontend/src/pages/ProposeTask.tsx
+++ b/frontend/src/pages/ProposeTask.tsx
@@ -1,20 +1,44 @@
 /**
- * Propose-task dispatcher.
+ * Propose-task dispatcher (#2538) — the seam, not the dress.
  *
- * Drives all form state via `useProposeTask()` and selects the right
- * faction-archetype form based on the user-selected `factionSlug`. Every
- * archetype consumes the same `ProposeTaskState`; only the visual treatment
- * differs. Mirrors the other page dispatchers. The faction-agnostic login /
- * eligibility gates live here so archetypes only ever render the happy-path
- * form (or its success screen).
+ * The file has claimed to dispatch since the archetypes directory was cut, and
+ * it did not: `pages/proposeTask/archetypes/` held exactly one file and this
+ * page held a direct import of it, so the lookup always returned the same
+ * answer. That is the shape four surfaces died in (#2346). It dispatches now.
+ *
+ * THE SLUG IS THE TARGET FACTION, NOT THE VIEWER'S. `state.factionSlug` is the
+ * faction the task is being proposed FOR — the choice the form already asks for
+ * as a first-class field, since #1824 replaced the pennant picker with chips.
+ * Owner ruling, 2026-08-24: "propose a task should have the faction of the task
+ * being proposed."
+ *
+ * WHICH MAKES THIS `createCharacter`'S SEAM, deliberately and exactly, because a
+ * reader should not have to learn two. Like that page there is no loaded record
+ * to read a faction off — the task does not exist yet — so the slug is the pick
+ * in progress, and the page RESKINS LIVE as the chips change, returning to the
+ * na kit the moment the pick is cleared. "Unaffiliated" (`na`) is a pick like
+ * any other and lands on that same kit, since #2530 made it a manifest row
+ * rather than a fallback named by hand.
+ *
+ * `''`, `na` and any unregistered slug resolve to `DefaultProposeTask`, the na
+ * kit — never UA and never the viewer's own faction. Dispatch has no
+ * cross-faction path at all, which is the guard `FactionSelectCard` did not have
+ * when its `UaSelectCard` fallback "dressed every unaffiliated and unknown slug
+ * in UA's costume" (#796, the third instance of #418/#636).
+ *
+ * `resolveVariant`, not `pickVariant`: since #2530 `na` is a manifest row rather
+ * than a hand-named third argument, so the fallback takes no parameter.
+ *
+ * THE TWO GATES STAY HERE, ABOVE THE ARCHETYPE. Signed-out and under-levelled
+ * are faction-agnostic answers, so an archetype only ever draws the happy-path
+ * form or its success screen — one gate rather than eight copies of it.
  */
 import { useTranslation } from "react-i18next";
 import { useProposeTask } from "./proposeTask/useProposeTask";
 import PageTitle from "../components/ui/PageTitle";
-import DefaultProposeTask from "./proposeTask/archetypes/DefaultProposeTask";
+import { resolveVariant } from "../utils/factionDispatch";
+import { surfaceMap } from "../factions";
 
-// ponytail: no faction has a bespoke proposal form yet — everyone renders
-// DefaultProposeTask. Add a resolveVariant dispatch here when one does.
 export default function ProposeTask() {
   const { t } = useTranslation("tasks");
   const state = useProposeTask();
@@ -42,5 +66,6 @@ export default function ProposeTask() {
     );
   }
 
-  return <DefaultProposeTask state={state} />;
+  const Archetype = resolveVariant(surfaceMap("proposeTask"), state.factionSlug);
+  return <Archetype state={state} />;
 }

--- a/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
@@ -9,70 +9,47 @@
  *     picked faction as `metatask_faction_slug` — including `na`
  *     (Unaffiliated = anyone), which the old faction guard wrongly rejected.
  *
- * The visibility half renders the pure `DefaultProposeTask` (no DOM needed).
- * The routing half exercises the extracted pure planner `planProposalSubmission`
- * — the repo has no DOM/renderHook, so hooks are tested via their pure core.
+ * The visibility half renders each ARCHETYPE as a pure function of state (no DOM
+ * needed). The routing half exercises the extracted pure planner
+ * `planProposalSubmission` — the repo has no DOM/renderHook, so hooks are tested
+ * via their pure core.
+ *
+ * PARAMETERISED OVER ARCHETYPES SINCE #2538, and that is the carry-in rather
+ * than a tidy-up: the page dispatches per faction now, so "the checkbox is gated
+ * off `canProposeMetatask`" is a claim about eight forms and was being made
+ * about one. The roster is DERIVED from `surfaceMap('proposeTask')`, so each
+ * archetype of the seven-faction fan-out inherits this gate the moment it
+ * registers, with nothing to append here.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 import '../../../i18n'
-import DefaultProposeTask from '../archetypes/DefaultProposeTask'
+import { archetypeFor, EVERY_SLUG, proposeTaskState } from './proposeTaskState'
 import {
   UNAFFILIATED_FACTION_SLUG,
   planProposalSubmission,
   type ProposeTaskState,
 } from '../useProposeTask'
 
-function state(overrides: Partial<ProposeTaskState> = {}): ProposeTaskState {
-  return {
-    isLoggedIn: true,
-    canProposeTask: true,
-    canProposeMetatask: false,
-    currentLevel: 6,
-    success: false,
-    factions: [],
-    title: '',
-    setTitle: () => {},
-    description: '',
-    setDescription: () => {},
-    pointValue: '10',
-    setPointValue: () => {},
-    levelRequired: 0,
-    setLevelRequired: () => {},
-    factionSlug: UNAFFILIATED_FACTION_SLUG,
-    setFactionSlug: () => {},
-    notes: '',
-    setNotes: () => {},
-    isMetatask: false,
-    setIsMetatask: () => {},
-    metaBonusValue: '10',
-    setMetaBonusValue: () => {},
-    submitting: false,
-    error: null,
-    handleSubmit: async () => {},
-    handleCancel: () => {},
-    ...overrides,
-  }
-}
-
-function renderText(overrides: Partial<ProposeTaskState> = {}): string {
+function renderText(slug: string, overrides: Partial<ProposeTaskState> = {}): string {
+  const Archetype = archetypeFor(slug)
   return renderToStaticMarkup(
     <MemoryRouter>
-      <DefaultProposeTask state={state(overrides)} />
+      <Archetype state={proposeTaskState({ factionSlug: slug, ...overrides })} />
     </MemoryRouter>,
   ).replace(/<[^>]*>/g, '')
 }
 
-describe('metatask checkbox — capability gate', () => {
+describe.each(EVERY_SLUG)('metatask checkbox — capability gate (%s)', (slug) => {
   it('is hidden below the propose-metatask gate', () => {
-    expect(renderText({ canProposeMetatask: false })).not.toContain(
+    expect(renderText(slug, { canProposeMetatask: false })).not.toContain(
       'Create as Metatask',
     )
   })
 
   it('appears once the proposer is eligible', () => {
-    expect(renderText({ canProposeMetatask: true })).toContain(
+    expect(renderText(slug, { canProposeMetatask: true })).toContain(
       'Create as Metatask',
     )
   })

--- a/frontend/src/pages/proposeTask/__tests__/proposeTaskDispatch.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/proposeTaskDispatch.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Propose-task dispatch (#2538) — the seam, not the dress.
+ *
+ * THE SEAM IS `state.factionSlug` → ARCHETYPE, and the slug is the SELECTED
+ * TARGET FACTION: the faction the task is being proposed FOR, which the form
+ * asks for as a first-class field (#1824's chips). It is not the viewer's
+ * faction, and that is the one thing a green build cannot tell you — a
+ * dispatcher wired to `useAuth()` renders a perfectly good page in the wrong
+ * hand, and the two are the same string for most players most of the time.
+ *
+ * These are `createCharacter`'s semantics deliberately and exactly (owner
+ * ruling, 2026-08-24): the page reskins LIVE as the chips change, and returns to
+ * the na kit when the pick is cleared or when "unaffiliated" is picked. Same
+ * seam, same reasoning — a reader should not have to learn two. So the property
+ * worth pinning is a function of one string and needs no DOM: same state,
+ * different slug, different component.
+ *
+ * THE DEFECT CLASS THIS GUARDS IS #796 / #418 / #636. `FactionSelectCard`'s
+ * fallback used to be `UaSelectCard`, which "dressed every unaffiliated and
+ * unknown slug in UA's costume" — three times before it was caught. `na` and any
+ * unregistered slug MUST land on the na kit, never a faction costume.
+ *
+ * THE GATES ARE NOT HERE, AND THAT IS THE POINT OF THE LAST BLOCK.
+ * `state.isLoggedIn` and `state.canProposeTask` are answered in the DISPATCHER,
+ * above the archetype, so the eight archetypes only ever draw the happy path.
+ * Duplicating that gate into eight files is the thing this chassis exists not to
+ * do, so it is asserted on `ProposeTask` itself rather than on an archetype.
+ *
+ * Nothing here proves a pixel: `renderToStaticMarkup`, no DOM (SPEC-testing.md).
+ * Visual QA is outstanding and stated on the PR.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import { UNAFFILIATED_FACTION_SLUG } from '../../../utils/factions'
+import { archetypeFor, EVERY_SLUG, proposeTaskState } from './proposeTaskState'
+import type { ProposeTaskState } from '../useProposeTask'
+
+// `useProposeTask` reaches for the auth context and the faction resource; the
+// dispatcher block below renders the PAGE rather than an archetype, so the hook
+// is stubbed down to the two fields the gates read. Spread from the original: a
+// bare factory blanks the module's sibling exports (`UNAFFILIATED_FACTION_SLUG`
+// is re-exported from there and read across this file's graph).
+const hookState = vi.hoisted(() => ({ value: {} as ProposeTaskState }))
+vi.mock('../useProposeTask', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useProposeTask')>()),
+  useProposeTask: () => hookState.value,
+}))
+
+const DefaultProposeTask = (await import('../archetypes/DefaultProposeTask')).default
+const AlbescentProposeTask = (await import('../archetypes/AlbescentProposeTask')).default
+const ProposeTask = (await import('../../ProposeTask')).default
+
+/**
+ * The registered slugs, DERIVED rather than listed — the same choice
+ * `createCharacterDispatch.test.tsx` makes and for the same reason.
+ * `surfaceDispatch.test.ts` owns which slugs are bespoke, for every surface in
+ * one place; a second roster here would mean the seven fan-out PRs each append
+ * to TWO files in parallel, which is the shared-registry shape that red-mained
+ * `main` twice (#1162).
+ *
+ * `na` is excluded because since #2530 it is a ROW rather than the fallback
+ * behind the row — every assertion below about "the Default" is about the
+ * component that row points at.
+ */
+const REGISTERED = EVERY_SLUG.filter((slug) => slug !== UNAFFILIATED_FACTION_SLUG)
+
+describe('the faction being proposed FOR chooses the archetype', () => {
+  it('at least one faction fills the slot', () => {
+    // The manifest's own rule (#2346): "a slot no faction fills is not a seam,
+    // it is a lookup that always returns the same answer." Four surfaces died
+    // that way. The chassis may not merge empty, and this is the row that would
+    // go red if a future PR removed the last registration rather than the key.
+    expect(REGISTERED.length).toBeGreaterThan(0)
+  })
+
+  it.each(REGISTERED)('%s reskins the page away from the Default', (slug) => {
+    expect(archetypeFor(slug)).not.toBe(DefaultProposeTask)
+  })
+
+  it('picking "unaffiliated" renders the na kit, never a faction costume (#796)', () => {
+    expect(archetypeFor(UNAFFILIATED_FACTION_SLUG)).toBe(DefaultProposeTask)
+  })
+
+  it('clearing the pick returns the page to the Default', () => {
+    // The live reskin, stated as the round trip it actually is: the same page,
+    // one chip changed.
+    const picked = archetypeFor(REGISTERED[0])
+    const cleared = archetypeFor('')
+    expect(picked).not.toBe(cleared)
+    expect(cleared).toBe(DefaultProposeTask)
+  })
+
+  it('an unknown slug cannot reach Object.prototype (#1821)', () => {
+    // `resolveSlug` is own-property-only; a bracket read would hand back the
+    // `Object` function for React to render.
+    expect(archetypeFor('constructor')).toBe(DefaultProposeTask)
+    expect(archetypeFor('no-such-faction')).toBe(DefaultProposeTask)
+  })
+})
+
+describe('albescent is a PASS-THROUGH here (#2531 kinds)', () => {
+  // na draws its spectrum on this page through INLINE styles computed from the
+  // slug (`proposeTask/factionSurfaces.ts`), not through `.spectrum-dial` or
+  // `.spectrum-rule`, so `.alb-moves` has nothing to reach — the same finding
+  // that made `comment` and `duelSeal` pass-throughs. A pass-through that shifts
+  // a pixel is a bug, so byte-identity IS the acceptance test.
+  it('renders markup byte-identical to the Default', () => {
+    const state = proposeTaskState({ factionSlug: 'albescent' })
+    const wrapped = renderToStaticMarkup(
+      <MemoryRouter><AlbescentProposeTask state={state} /></MemoryRouter>,
+    )
+    const plain = renderToStaticMarkup(
+      <MemoryRouter><DefaultProposeTask state={state} /></MemoryRouter>,
+    )
+    expect(wrapped).toBe(plain)
+  })
+})
+
+describe('the gates live in the dispatcher, above every archetype', () => {
+  // Eight archetypes must never each carry a copy of these two early returns.
+  // Asserting them on the PAGE is what says so: an archetype that grew its own
+  // copy would still pass, but a dispatcher that LOST them fails here.
+  function page(overrides: Partial<ProposeTaskState>): string {
+    hookState.value = proposeTaskState(overrides)
+    return renderToStaticMarkup(<MemoryRouter><ProposeTask /></MemoryRouter>)
+  }
+
+  it('a signed-out visitor is told to sign in, and no archetype renders', () => {
+    const html = page({ isLoggedIn: false })
+    expect(html).not.toContain('role="radiogroup"')
+  })
+
+  it('an under-levelled player is told the level, and no archetype renders', () => {
+    const html = page({ canProposeTask: false, currentLevel: 1 })
+    expect(html).not.toContain('role="radiogroup"')
+  })
+
+  it('an eligible player reaches the form itself', () => {
+    expect(page({})).toContain('role="radiogroup"')
+  })
+})

--- a/frontend/src/pages/proposeTask/__tests__/proposeTaskState.ts
+++ b/frontend/src/pages/proposeTask/__tests__/proposeTaskState.ts
@@ -1,0 +1,93 @@
+/**
+ * The propose-task state fixture, and the archetype roster the suites walk.
+ *
+ * WHY IT IS SHARED (#2538). Every propose-task archetype is a pure function of
+ * `ProposeTaskState` — `metataskProposal` and `unaffiliatedOption` both relied
+ * on that before there was a dispatch seam at all, and the issue's carry-in is
+ * to KEEP that property and parameterise the suites over archetypes rather than
+ * rewrite them. Three files needed the same 30-line literal to do it, so it is
+ * built once here.
+ *
+ * `EVERY_ARCHETYPE` is DERIVED from `surfaceMap('proposeTask')`, never listed.
+ * The seven-faction fan-out (#2538) lands one archetype per PR, and each one
+ * inherits these suites the moment it registers — with nothing to append, and no
+ * second roster for those PRs to contend on (`surfaceDispatch.test.ts` owns the
+ * one that exists).
+ *
+ * Not a `.test.ts` file, so vitest does not collect it, and it sits under
+ * `__tests__/` so the source scans in `archetypeReachability.test.ts` and
+ * `surfaceDispatch.test.ts` skip it the way they skip every other test module.
+ */
+import type { ComponentType } from 'react'
+
+import { resolvedArchetype } from '../../../factions/lazyArchetype'
+import { resolveVariant } from '../../../utils/factionDispatch'
+import { surfaceMap } from '../../../factions'
+import { UNAFFILIATED_FACTION_SLUG, type ProposeTaskState } from '../useProposeTask'
+
+/**
+ * A complete, eligible proposer's state. Defaults to the page's opening
+ * position: signed in, past the gate, nothing typed, unaffiliated picked.
+ */
+export function proposeTaskState(
+  overrides: Partial<ProposeTaskState> = {},
+): ProposeTaskState {
+  return {
+    isLoggedIn: true,
+    canProposeTask: true,
+    canProposeMetatask: false,
+    currentLevel: 6,
+    success: false,
+    factions: [],
+    title: '',
+    setTitle: () => {},
+    description: '',
+    setDescription: () => {},
+    pointValue: '10',
+    setPointValue: () => {},
+    levelRequired: 0,
+    setLevelRequired: () => {},
+    factionSlug: UNAFFILIATED_FACTION_SLUG,
+    setFactionSlug: () => {},
+    notes: '',
+    setNotes: () => {},
+    isMetatask: false,
+    setIsMetatask: () => {},
+    metaBonusValue: '10',
+    setMetaBonusValue: () => {},
+    submitting: false,
+    error: null,
+    handleSubmit: async () => {},
+    handleCancel: () => {},
+    ...overrides,
+  }
+}
+
+type ProposeTaskArchetype = ComponentType<{ state: ProposeTaskState }>
+
+/**
+ * Every registered slug, `na` included — the roster `it.each` walks.
+ *
+ * Read at module scope, which is safe: the MAP is built synchronously. What is
+ * not available yet is the component behind each row, so that is
+ * {@link archetypeFor}'s job.
+ */
+export const EVERY_SLUG: string[] = Object.keys(surfaceMap('proposeTask'))
+
+/**
+ * The archetype a slug resolves to, unwrapped.
+ *
+ * Resolved at CALL time, never at module scope: archetypes are code-split, and
+ * `src/test/preloadArchetypes.ts` warms them in `beforeAll` — after this module
+ * has evaluated. A module-scope read gets the deferred wrapper, which renders
+ * `null` under `renderToStaticMarkup`, so a suite would assert against an empty
+ * string and pass.
+ */
+export function archetypeFor(slug: string): ProposeTaskArchetype {
+  const deferred = resolveVariant(surfaceMap('proposeTask'), slug) as ProposeTaskArchetype
+  const Archetype = resolvedArchetype(deferred)
+  // Only undefined if the chunk never landed, which the setup file rules out —
+  // throwing says that, where rendering `undefined` would not.
+  if (!Archetype) throw new Error(`no proposeTask archetype resolved for "${slug}"`)
+  return Archetype
+}

--- a/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
@@ -4,7 +4,22 @@
  * it defaulted to UA and offered no control that could produce `na`.
  *
  * No jsdom in this repo, so we assert on renderToStaticMarkup output. That is
- * enough here because DefaultProposeTask is a pure function of the state prop.
+ * enough here because every propose-task archetype is a pure function of the
+ * state prop.
+ *
+ * TWO BLOCKS SINCE #2538, AND THE SPLIT IS THE POINT. The page dispatches per
+ * faction now, so "the form offers an unaffiliated choice" is a claim about
+ * eight forms and was being made about one. The first block is what every
+ * archetype must keep — the option exists, the group is one radiogroup of eight,
+ * the metatask control is announceable, the placeholder-only fields are named —
+ * and it is DERIVED from `surfaceMap('proposeTask')`, so each archetype of the
+ * seven-faction fan-out inherits it the moment it registers.
+ *
+ * The second block is the na KIT's dress: which token each surface reads. Those
+ * assertions name `DefaultProposeTask` directly and deliberately, because a
+ * faction archetype draws its own register and would fail them by doing its job.
+ * A fan-out PR adds its own contrast/register test beside this one; it does not
+ * widen these.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
@@ -12,61 +27,38 @@ import { describe, it, expect } from 'vitest'
 // Initialize the i18n catalog so copy keys resolve to English text.
 import '../../../i18n'
 import DefaultProposeTask from '../archetypes/DefaultProposeTask'
-import {
-  UNAFFILIATED_FACTION_SLUG,
-  type ProposeTaskState,
-} from '../useProposeTask'
+import { archetypeFor, EVERY_SLUG, proposeTaskState } from './proposeTaskState'
+import type { ProposeTaskState } from '../useProposeTask'
 
-function state(overrides: Partial<ProposeTaskState> = {}): ProposeTaskState {
-  return {
-    isLoggedIn: true,
-    canProposeTask: true,
-    canProposeMetatask: false,
-    currentLevel: 6,
-    success: false,
-    factions: [],
-    title: '',
-    setTitle: () => {},
-    description: '',
-    setDescription: () => {},
-    pointValue: '10',
-    setPointValue: () => {},
-    levelRequired: 0,
-    setLevelRequired: () => {},
-    factionSlug: UNAFFILIATED_FACTION_SLUG,
-    setFactionSlug: () => {},
-    notes: '',
-    setNotes: () => {},
-    isMetatask: false,
-    setIsMetatask: () => {},
-    metaBonusValue: '10',
-    setMetaBonusValue: () => {},
-    submitting: false,
-    error: null,
-    handleSubmit: async () => {},
-    handleCancel: () => {},
-    ...overrides,
-  }
-}
-
-function render(overrides: Partial<ProposeTaskState> = {}): string {
+/** The archetype the dispatcher would pick for `slug`, rendered. */
+function renderFor(slug: string, overrides: Partial<ProposeTaskState> = {}): string {
+  const Archetype = archetypeFor(slug)
   return renderToStaticMarkup(
     <MemoryRouter>
-      <DefaultProposeTask state={state(overrides)} />
+      <Archetype state={proposeTaskState({ factionSlug: slug, ...overrides })} />
     </MemoryRouter>,
   )
 }
 
-describe('propose task — the faction chips', () => {
+/** The na kit specifically, whatever the slug — the dress block below. */
+function render(overrides: Partial<ProposeTaskState> = {}): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <DefaultProposeTask state={proposeTaskState(overrides)} />
+    </MemoryRouter>,
+  )
+}
+
+describe.each(EVERY_SLUG)('propose task — the faction chips (%s)', (slug) => {
   it('offers an unaffiliated choice alongside the real factions', () => {
-    const text = render().replace(/<[^>]*>/g, '')
+    const text = renderFor(slug).replace(/<[^>]*>/g, '')
     expect(text).toContain('Unaffiliated')
     // The registry factions are still listed.
     expect(text).toContain('Everymen')
   })
 
   it('is one radiogroup of eight radios — na plus the seven factions (#1824)', () => {
-    const markup = render()
+    const markup = renderFor(slug)
     expect(markup).toContain('role="radiogroup"')
     expect(markup.match(/role="radio"/g)).toHaveLength(8)
     // Unaffiliated leads, then the rainbow: everymen is the first faction.
@@ -74,6 +66,22 @@ describe('propose task — the faction chips', () => {
     expect(markup.indexOf('Everymen')).toBeLessThan(markup.indexOf('Cozy Coven'))
   })
 
+  it('leaves the metatask control announceable without a native checkbox', () => {
+    // `accent-color` takes one colour and na's identity is seven (#1824).
+    const markup = renderFor(slug, { canProposeMetatask: true })
+    expect(markup).toContain('role="checkbox"')
+    expect(markup).not.toContain('type="checkbox"')
+  })
+
+  it('names the three placeholder-only fields for a screen reader', () => {
+    const markup = renderFor(slug)
+    expect(markup).toContain('aria-label="Task name"')
+    expect(markup).toContain('aria-label="Description"')
+    expect(markup).toContain('aria-label="Notes to admin (optional)"')
+  })
+})
+
+describe('the na kit reads the selected faction through the whole form', () => {
   it('gives the unaffiliated chip the rainbow, never a borrowed faction hue', () => {
     // ADR-0039: `na` has no hue, so it takes the spectrum as a frame rather
     // than resolving to `default` grey or impersonating UA orange (#749).
@@ -97,19 +105,5 @@ describe('propose task — the faction chips', () => {
     // The card's own frame is the bevelled ramp, over an OPAQUE paper layer.
     expect(markup).toContain('var(--faction-default-card-bg)')
     expect(markup).toContain('background-clip:padding-box, border-box')
-  })
-
-  it('leaves the metatask control announceable without a native checkbox', () => {
-    // `accent-color` takes one colour and na's identity is seven (#1824).
-    const markup = render({ canProposeMetatask: true })
-    expect(markup).toContain('role="checkbox"')
-    expect(markup).not.toContain('type="checkbox"')
-  })
-
-  it('names the three placeholder-only fields for a screen reader', () => {
-    const markup = render()
-    expect(markup).toContain('aria-label="Task name"')
-    expect(markup).toContain('aria-label="Description"')
-    expect(markup).toContain('aria-label="Notes to admin (optional)"')
   })
 })

--- a/frontend/src/pages/proposeTask/archetypes/AlbescentProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/AlbescentProposeTask.tsx
@@ -1,0 +1,39 @@
+/**
+ * Albescent proposing a task (#2538) — A PASS-THROUGH WRAPPER. It renders
+ * `DefaultProposeTask` and changes not one pixel; `renderToStaticMarkup` here is
+ * byte-identical to the Default and `proposeTaskDispatch.test.tsx` asserts it.
+ *
+ * THIS IS NOT THE FAN-OUT. The seven faction propose dresses land one per PR,
+ * derived from each faction's `createCharacter` page. Albescent is here because
+ * `surfaceDispatch.test.ts` requires a row for EVERY key in `SURFACE_KEYS` the
+ * moment the key exists (#2531): "an ABSENT row is not 'renders the Default', it
+ * is a reader left to guess which of those two was meant." A wrapper is six
+ * lines and settles that; a dress is not.
+ *
+ * THERE IS NO na MARK ON THIS SURFACE A WRAPPER CAN REACH, and that is the
+ * finding rather than a shrug. na's spectrum is everywhere on this page — the
+ * card's gradient frame, the metatask box, the submit pill — but every one of
+ * them is an INLINE style computed from the slug in
+ * `proposeTask/factionSurfaces.ts`, and a wrapper cannot reach an inline
+ * `background-image`. Neither `.spectrum-dial` nor `.spectrum-rule` is mounted,
+ * so `.alb-moves` — the dresser both of Albescent's re-cuts hang off — has
+ * nothing to grab. That is exactly the reason `comment` is a pass-through
+ * (#2531: "na's cap is inline and computed from the slug"), and it is the same
+ * finding twice rather than a new one.
+ *
+ * The page's one CLASS-borne faction mark is `FactionSigil`, which for this slug
+ * is already the labyrinth and is "never part of the wrapper" (ADR-0083 §1).
+ *
+ * ADDING MOTION ANYWAY WOULD NEED NEW CSS, which makes it a dress and not a
+ * chassis re-cut: a travelling rainbow frame around a form is a treatment
+ * someone has to design, and it would have to be designed for the ONE case
+ * Albescent is picked as a task's target — a chip a non-member can see. So the
+ * registration exists for the manifest's sake, not the dress's. ADR-0027's edge
+ * is untouched: nothing here is Albescent's own colour, copy or motion.
+ */
+import DefaultProposeTask from './DefaultProposeTask'
+import type { ProposeTaskState } from '../useProposeTask'
+
+export default function AlbescentProposeTask({ state }: { state: ProposeTaskState }) {
+  return <DefaultProposeTask state={state} />
+}


### PR DESCRIPTION
Part of #2538

`/tasks/propose` has claimed to dispatch per faction since the archetypes
directory was cut. It did not: `pages/proposeTask/archetypes/` held exactly one
file and `ProposeTask.tsx` held a direct import of it, so the lookup always
returned the same answer — the shape four surfaces died in (#2346). This is the
chassis and its first registration, in one PR, per that rule.

**This is the chassis half only.** The seven faction archetypes follow one per
PR, derived from each faction's `createCharacter` page, in a later batch.

## The seam I tested at

`state.factionSlug` → archetype — the **target** faction, the one the task is
being proposed FOR (#1824's chips), not the viewer's. That is the owner ruling
of 2026-08-24, and it makes the semantics `createCharacter`'s deliberately and
exactly, so a reader does not have to learn two:

- reskins **live** as the chips change
- returns to the na kit when the pick is cleared (`''`)
- returns to the na kit when "unaffiliated" (`na`) is picked

The property is a function of one string and needs no DOM, which is why
`proposeTaskDispatch.test.tsx` is where the loop went red first — it failed on
`REGISTERED.length > 0` before the manifest key existed, then on the missing
Albescent row, and is green on the real seam now.

The thing a green build cannot tell you is *which* faction a dispatcher read, so
that is asserted rather than inferred: the wrong wire (`useAuth()`) compiles
perfectly and draws a perfectly good page in the wrong hand.

## What changed

| File | What |
|---|---|
| `factions/manifest.ts` | `proposeTask` field + `SURFACE_KEYS` entry (the `satisfies` clause makes the two check each other) |
| `factions/default.ts` | na registers `DefaultProposeTask` |
| `factions/albescent.ts` | Albescent registers a **pass-through** |
| `pages/proposeTask/archetypes/AlbescentProposeTask.tsx` | new, 6 lines |
| `pages/ProposeTask.tsx` | direct import → `resolveVariant(surfaceMap('proposeTask'), state.factionSlug)` |
| `pages/proposeTask/__tests__/proposeTaskDispatch.test.tsx` | new — the seam |
| `pages/proposeTask/__tests__/proposeTaskState.ts` | the shared fixture + the derived archetype roster |
| `metataskProposal` / `unaffiliatedOption` | parameterised over archetypes |
| `factions/__tests__/defaultManifest.test.tsx` | na's `proposeTask` identity row |

`resolveVariant`, not `pickVariant`: the 3-arg signature was retired by #2530
(`na` is a manifest row now), so `pickVariant` today means "is there a *bespoke*
variant". `CreateCharacter.tsx` and `EditCharacter.tsx` both use
`resolveVariant`; this matches them.

## Albescent is a PASS-THROUGH, and that is a finding rather than a shrug

The key cannot exist without an Albescent row — `surfaceDispatch.test.ts` runs
`it.each(SURFACE_KEYS)('claims %s')` for it. The question is which *kind*.

na's spectrum is all over this page — the card's gradient frame, the metatask
box, the submit pill — and not one of those marks is reachable from a wrapper:
every one is an **inline** style computed from the slug in
`proposeTask/factionSurfaces.ts`, so `.alb-moves` has no `.spectrum-dial` or
`.spectrum-rule` to set moving. That is exactly the `comment` row's finding
(#2531: "na's cap is inline and computed from the slug"), on a second surface.
The page's one class-borne faction mark is `FactionSigil`, which for this slug is
already the labyrinth and is "never part of the wrapper" (ADR-0083 §1).

Adding motion anyway would need new CSS, which makes it a dress rather than a
chassis re-cut — and it would have to be a dress designed for the one case where
Albescent is a task's *target*, a chip a non-member can pick, where a tell is an
un-hiding rather than a reveal (ADR-0027). So the byte-identity is asserted
instead: `renderToStaticMarkup` of the wrapper equals the Default's, in
`proposeTaskDispatch.test.tsx`. (`AlbescentEditCharacter` set the precedent of
asserting a new wrapper's kind in its own dispatch suite rather than widening
`albescentWrapperKinds.test.tsx`, which the fan-out lanes would contend on.)

## The carry-ins

- **The gates stay in the dispatcher.** `isLoggedIn` / `canProposeTask` never
  reach an archetype. The last block of the dispatch suite asserts that on
  `ProposeTask` itself, so a dispatcher that *loses* the gates goes red — which
  is the assertion that keeps eight copies of one gate out.
- **The metatask path and the unaffiliated option survive, in every archetype.**
  Both suites already rendered `DefaultProposeTask` as a pure function of state.
  That property is kept and they are **parameterised**, not rewritten: the roster
  is derived from `surfaceMap('proposeTask')`, so every fan-out archetype
  inherits the metatask gate, the eight-chip radiogroup and the three
  aria-labelled fields the moment it registers — nothing to append, and no second
  registry for seven parallel PRs to collide on.
  `unaffiliatedOption`'s **token** assertions stay on `DefaultProposeTask` by
  name, split into their own block: a faction archetype draws its own register
  and would fail those by doing its job.

## Byte budget

`npm run budget`, before → after:

```
before   WARN JS  137.2 KB   warn>130.9 KB     ok  CSS  21.7 KB   warn>22.2 KB
after    WARN JS  137.3 KB   warn>130.9 KB     ok  CSS  21.7 KB   warn>22.2 KB
```

CSS is **22,256 B → 22,256 B** at gzip -9, measured on the emitted
`dist/assets/index-*.css`: not one byte, because this PR adds no CSS at all. The
JS WARN is pre-existing (#2469); the +0.1 KB is one string in `SURFACE_KEYS` and
two manifest rows in the blocking `factions` chunk. Both archetypes are
`lazyArchetype` dynamic imports and stay out of the entry chunk.

## Blockers named on the issue, both verified clear today

- **#2534** — `factions/__tests__/wowRendersDefault.test.tsx` no longer exists on
  `main`, so the hand-maintained `WOW_SKINNED` set the third comment worried
  about cannot mis-answer for a new key. Sequencing note is spent.
- **#2489** — moot here regardless: this page never mounts `PortraitPicker`.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:
`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(**462 files, 9547 passed, 1 skipped**), `npm run build`, `npm run budget`.
No backend, route signature or Pydantic schema touched, so `api-schema` has
nothing to regenerate.

**Visual QA is outstanding** — no browser or dev stack in this environment.
Nothing here proves a pixel: `renderToStaticMarkup`, no DOM (SPEC-testing.md).

`.design-sync/config.json` / `.ds-kit/index.tsx` are untouched, matching #2788,
which did not register `AlbescentEditCharacter` there either. They also sit
outside `frontend/`.

## What to eyeball

The propose-a-task page at `/tasks/propose`, as an eligible proposer:

1. **With a faction chip selected** — pick, say, Cozy Coven. The card frame, the
   task-name face, the level nodes and the submit pill should all take Coven's
   hue, and they should change *the instant the chip changes*, with no route
   change and no flash of the previous faction.
2. **With the pick cleared / "Unaffiliated" picked** — the page should be exactly
   the spectrum form it opens in. Nothing about it should have moved. This is the
   #796 case: it must never land on UA's costume or the viewer's own faction.
3. **With "albescent" picked**, if it is offered — it must be indistinguishable
   from (2). The wrapper is asserted byte-identical, so any visible difference is
   a bug in the assertion's premise, not in the dress.
4. **The two gates** — signed out, and signed in below `level_to_propose_task`
   (level 3 / 70 points). Each should show its own message and no form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
