### PR TITLE
The take-the-tie ability moves off a slug branch on BOTH sides of the wire

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -521,6 +521,7 @@ export function makeFactionConfig(overrides: Partial<FactionConfigOut> = {}): Fa
     // neutral config is exactly that, and the perk has no preview surface: it
     // renders nothing at all, it prints to the devtools console.
     reads_the_array: false,
+    takes_duel_ties: false,
     ...overrides,
   }
 }

--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -94,11 +94,21 @@ from game_config import (
 #                                    config in the browser console. Purely
 #                                    client-side — /game-config already ships to
 #                                    everyone, so there is no server door to add
+#   takes_duel_ties               -- "take the tie" (#718/#2664): on a TIED duel
+#                                    this faction takes the win rate and the
+#                                    other side the loss rate. The rule is "the
+#                                    SOLE holder takes it" -- grant it to two
+#                                    factions and a duel between them is a real
+#                                    tie, so it is the one perk the inheritor
+#                                    below does NOT pick up. Rides on
+#                                    /game-config: the browser shows the stakes
+#                                    from this same flag
 #   inherits_faction_perks        -- holds every OTHER faction's perk in this era
 #                                    (#1871). Declare the faction's own floor and
 #                                    EraConfig resolves the union; the duel pair
 #                                    is inherited WHOLE from the highest
-#                                    duel_win_modifier, downside included.
+#                                    duel_win_modifier, downside included, and
+#                                    takes_duel_ties is not inherited at all.
 #
 # ** Perks live in TWO places. ** The fields above are one; the other is the
 # pair of EraConfig frozensets in the ERA_N block below,

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -51,7 +51,7 @@ ERA_1_FACTIONS = {
         collab_other_modifier=1.0,
         duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
         duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
-        takes_duel_ties=True,         # takes the tie, when it is the SOLE holder (#2664)
+        takes_duel_ties=True,         # takes the tie, as SOLE holder (#2664)
     ),
     # Warriors of Whimsy (#811). Its perk is MECHANICAL, not multiplicative: the
     # level jump below is WOW's only perk, so every modifier drops to the Era 1

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -51,6 +51,7 @@ ERA_1_FACTIONS = {
         collab_other_modifier=1.0,
         duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
         duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
+        takes_duel_ties=True,         # takes the tie, when it is the SOLE holder (#2664)
     ),
     # Warriors of Whimsy (#811). Its perk is MECHANICAL, not multiplicative: the
     # level jump below is WOW's only perk, so every modifier drops to the Era 1

--- a/backend/eras/era_2.py
+++ b/backend/eras/era_2.py
@@ -55,7 +55,7 @@ ERA_2_FACTIONS = {
         collab_other_modifier=1.0,
         duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
         duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
-        takes_duel_ties=True,         # takes the tie, when it is the SOLE holder (#2664)
+        takes_duel_ties=True,         # takes the tie, as SOLE holder (#2664)
     ),
     "wow": FactionConfig(
         slug="wow",

--- a/backend/eras/era_2.py
+++ b/backend/eras/era_2.py
@@ -55,6 +55,7 @@ ERA_2_FACTIONS = {
         collab_other_modifier=1.0,
         duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
         duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
+        takes_duel_ties=True,         # takes the tie, when it is the SOLE holder (#2664)
     ),
     "wow": FactionConfig(
         slug="wow",

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -108,6 +108,17 @@ class FactionConfig:
     # read out of the very payload the perk prints. There is deliberately no
     # ``services.`` reader to pair with it and no enforcement to add.
     reads_the_array: bool = False
+    # "Take the tie" (#718, moved off a slug branch in #2664): on a *tied* duel,
+    # does this faction take the win rate while the other side takes the loss
+    # rate? False (the baseline) means a tie is a real tie at 1.0x both ways.
+    # Read via services.scoring.sole_tie_taker_slug -- never branch on a faction
+    # slug in a service. Until #2664 this WAS a slug branch, in scoring.py AND
+    # again in the browser (`useDuelStakes`), so no era could move the ability.
+    #
+    # The rule is "the SOLE holder takes the tie": two holders cancel and the
+    # duel is a real tie. That is why the flag is deliberately NOT inheritable
+    # -- see _NON_INHERITED_PERK_FIELDS.
+    takes_duel_ties: bool = False
     # Albescent's charter (#1871): this faction holds every OTHER faction's perk
     # in its era. Declared here, resolved by ``EraConfig.__post_init__`` — the
     # era file states the faction's own floor and the union is computed, so a
@@ -136,6 +147,18 @@ _ANY_PERK_FIELDS: tuple[str, ...] = (
     "can_apply_metatask_at_any_level",
     "reads_the_array",
 )
+
+#: Perk axes an inheritor does NOT pick up, and the reason each is exempt.
+#:
+#: ``takes_duel_ties`` (#2664) is self-cancelling: the ability is "the *sole*
+#: holder of this perk takes the tie", so a second holder does not gain an
+#: ability -- it *destroys* the first holder's. Unioning it would therefore turn
+#: every Snide-vs-inheritor tie from "Snide takes it" into a real tie, changing
+#: banked points rather than widening a perk. It sits beside the duel pair
+#: (:data:`_DUEL_PERK_FIELDS`) for the same underlying reason: the duel axis is
+#: a relation between two sides, not a per-side quantity, and a naive union gets
+#: it backwards.
+_NON_INHERITED_PERK_FIELDS: tuple[str, ...] = ("takes_duel_ties",)
 
 #: The duel pair — inherited TOGETHER, never field by field. See
 #: :func:`_inherited_faction_config`.

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2303,6 +2303,10 @@
           "slug": {
             "title": "Slug",
             "type": "string"
+          },
+          "takes_duel_ties": {
+            "title": "Takes Duel Ties",
+            "type": "boolean"
           }
         },
         "required": [
@@ -2313,7 +2317,8 @@
           "collab_other_modifier",
           "duel_win_modifier",
           "duel_loss_modifier",
-          "reads_the_array"
+          "reads_the_array",
+          "takes_duel_ties"
         ],
         "title": "FactionConfigOut",
         "type": "object"

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -46,6 +46,7 @@ async def get_game_config(
             duel_win_modifier=faction.duel_win_modifier,
             duel_loss_modifier=faction.duel_loss_modifier,
             reads_the_array=faction.reads_the_array,
+            takes_duel_ties=faction.takes_duel_ties,
         )
         for faction in CURRENT_ERA.factions.values()
     ]

--- a/backend/schemas/game_config.py
+++ b/backend/schemas/game_config.py
@@ -22,6 +22,13 @@ class FactionConfigOut(WireModel):
     # the array can see the flag that grants it — and no `/auth/me` field, no
     # capability flag and no extra request were needed to gate it.
     reads_the_array: bool
+    # "Take the tie" (#2664). Same reason as the flag above, one step further:
+    # the client does not merely *display* this perk, it computes the stakes
+    # tiles from it (`useDuelStakes`). Until #2664 the browser re-derived the
+    # rule from a hardcoded `'snide'`, so the stakes a player was shown and the
+    # points the server banked were two copies of one rule that no era could
+    # move. Emitting the flag makes them one rule with one source.
+    takes_duel_ties: bool
 
 
 class LevelUnlockOut(WireModel):

--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -17,13 +17,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from badges import ALL_BADGES, BadgeContext
+from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.praxis import Praxis
 from schemas.character import BadgeOut
 from services.duel_outcome import duel_winner
-from services.scoring import snide_tie_winner_id
+from services.scoring import sole_tie_taker_id
 from services.vote_tally import get_tally, tally_votes
 
 # Every duel status that can feed the duelist badge. `resolved` is included
@@ -66,6 +67,7 @@ async def _previous_era_id(session: AsyncSession) -> Optional[int]:
 async def _duel_winner_facts(
     character_ids: set[int],
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> DuelWinnerFacts:
     """Both duel facts for the given characters, from one pass over their duels.
 
@@ -186,11 +188,12 @@ async def _duel_winner_facts(
                 challenger_moderation=row.challenger_moderation,
                 opponent_moderation=row.opponent_moderation,
                 forfeited_by_character_id=row.forfeited_by_character_id,
-                tie_break_winner_id=snide_tie_winner_id(
+                tie_break_winner_id=sole_tie_taker_id(
                     faction_by_character.get(row.challenger_character_id, ""),
                     row.challenger_character_id,
                     faction_by_character.get(row.opponent_character_id, ""),
                     row.opponent_character_id,
+                    era,
                 ),
             )
         if winner_character_id is None or winner_character_id not in character_ids:

--- a/backend/services/duel_outcome.py
+++ b/backend/services/duel_outcome.py
@@ -65,7 +65,7 @@ def duel_winner(
        ``VoteTally.points_from_votes`` wins.
     3. **Tiebreak.** Equal points returns ``tie_break_winner_id`` — a winner some
        faction ability grants on a tie (Snide wins ties, #748), pre-resolved from
-       the factions by the caller (:func:`services.scoring.snide_tie_winner_id`)
+       the factions by the caller (:func:`services.scoring.sole_tie_taker_id`)
        so this rule stays plain-ids-in. ``None`` (the default) is a real tie, and
        also the correct answer for a no-contest (a duel that never became votable),
        which callers express by passing equal points.

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -17,7 +17,7 @@ from models.task import Task, TaskStatus
 # task alive in every era (#511); the sweep below only has to recognise it.
 from seed import ONBOARDING_TASK_TITLE
 from services.duel_outcome import duel_winner
-from services.scoring import snide_tie_winner_id
+from services.scoring import sole_tie_taker_id
 from services.vote_tally import get_tally, tally_votes
 
 
@@ -179,6 +179,7 @@ async def resolve_duels_at_era_close(
     session: AsyncSession,
     resolved_at: datetime | None = None,
     closing_era_id: int | None = None,
+    era: EraConfig = CURRENT_ERA,
 ) -> list[Duel]:
     """Freeze every unresolved duel's outcome (ADR-0052). Returns the frozen rows.
 
@@ -286,11 +287,12 @@ async def resolve_duels_at_era_close(
                     opponent_praxis.moderation_status if opponent_praxis else None
                 ),
                 forfeited_by_character_id=duel.forfeited_by_character_id,
-                tie_break_winner_id=snide_tie_winner_id(
+                tie_break_winner_id=sole_tie_taker_id(
                     faction_by_character.get(challenger_character_id, ""),
                     challenger_character_id,
                     faction_by_character.get(duel.opponent_character_id, ""),
                     duel.opponent_character_id,
+                    era,
                 ),
             )
             if is_contest

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 COLLABORATION_MODE_SOLO = "solo"
 COLLABORATION_MODE_COLLAB = "collab"
 COLLABORATION_MODE_DUEL = "duel"
-SNIDE_FACTION_SLUG = "snide"
 
 _WHOLE = Decimal(1)
 
@@ -134,9 +133,10 @@ def compute_duel_multiplier(
 ) -> float:
     """Return the duel outcome multiplier for a single participant.
 
-    Tiebreaker rules:
-    - Tie with one Snide player: Snide gets win rate, other gets loss rate.
-    - Tie with no Snide, or both Snide: both get 1.0×.
+    Tiebreaker rules (#2664 — a config perk, not a faction):
+    - Tie where exactly one side holds ``takes_duel_ties``: that side gets its
+      win rate, the other its loss rate.
+    - Tie where neither side or *both* sides hold it: both get 1.0×.
     """
     if not is_tied:
         faction_config = era.factions.get(character_faction_slug)
@@ -144,47 +144,74 @@ def compute_duel_multiplier(
             return 1.5 if is_winner else 0.5
         return faction_config.duel_win_modifier if is_winner else faction_config.duel_loss_modifier
 
-    # Tied case: Snide wins ties (one shared predicate, see snide_tie_winner_slug).
-    tie_winner_slug = snide_tie_winner_slug(character_faction_slug, opponent_faction_slug)
+    # Tied case: the sole tie-taker wins (one shared predicate, see
+    # sole_tie_taker_slug).
+    tie_winner_slug = sole_tie_taker_slug(
+        character_faction_slug, opponent_faction_slug, era
+    )
     if tie_winner_slug is None:
         return 1.0
 
     faction_config = era.factions.get(character_faction_slug)
     if faction_config is None:
-        return 2.0 if character_faction_slug == tie_winner_slug else 0.5
+        # A slug this era does not know holds no perk (see `_takes_duel_ties`),
+        # so it is never the tie taker here — only the side that loses to one.
+        return 0.5
     if character_faction_slug == tie_winner_slug:
         return faction_config.duel_win_modifier
     return faction_config.duel_loss_modifier
 
 
-def snide_tie_winner_slug(faction_a: str, faction_b: str) -> Optional[str]:
+def _takes_duel_ties(faction_slug: str, era: EraConfig) -> bool:
+    """Does this era grant ``faction_slug`` the take-the-tie perk?
+
+    An unknown slug (a character with no faction, a slug from a closed era)
+    holds no perk — the same answer the old slug comparison gave.
+    """
+    faction = era.factions.get(faction_slug)
+    return faction is not None and faction.takes_duel_ties
+
+
+def sole_tie_taker_slug(
+    faction_a: str, faction_b: str, era: EraConfig = CURRENT_ERA
+) -> Optional[str]:
     """The faction slug that wins a *tied* duel, or ``None`` for a true tie.
 
-    Snide's ability is that it takes ties — but only when it is the *sole* Snide
-    side. Two Snide sides (or no Snide) is a real tie. This is the one definition
-    of the rule; both the live multiplier above and the winner id below read it.
+    The ability is **"the sole holder of ``takes_duel_ties`` takes the tie"** —
+    not "Snide wins ties". Two holders (or none) is a real tie, which is why the
+    perk is not inheritable (``game_config._NON_INHERITED_PERK_FIELDS``).
+
+    This is the one definition of the rule: the live multiplier above, the winner
+    id below, and the stakes the browser shows a player (``useDuelStakes``, via
+    the ``takes_duel_ties`` field on ``/game-config``) all resolve to it. #2664
+    replaced the slug comparison that used to live here — with the rule keyed to
+    a slug on both sides of the wire, no era could move the ability, which is
+    exactly what ``EraConfig`` exists to allow (ADR-0042).
     """
-    a_snide = faction_a == SNIDE_FACTION_SLUG
-    b_snide = faction_b == SNIDE_FACTION_SLUG
-    if a_snide and not b_snide:
+    a_takes = _takes_duel_ties(faction_a, era)
+    b_takes = _takes_duel_ties(faction_b, era)
+    if a_takes and not b_takes:
         return faction_a
-    if b_snide and not a_snide:
+    if b_takes and not a_takes:
         return faction_b
     return None
 
 
-def snide_tie_winner_id(
+def sole_tie_taker_id(
     challenger_faction_slug: str,
     challenger_character_id: Optional[int],
     opponent_faction_slug: str,
     opponent_character_id: Optional[int],
+    era: EraConfig = CURRENT_ERA,
 ) -> Optional[int]:
-    """Character id that wins a tied duel by the Snide tiebreak, else ``None``.
+    """Character id that wins a tied duel by the take-the-tie perk, else ``None``.
 
     Feeds ``duel_winner(..., tie_break_winner_id=...)`` so the single winner rule
     (the badge, the freeze) agrees with what the multiplier has always done.
     """
-    winner_slug = snide_tie_winner_slug(challenger_faction_slug, opponent_faction_slug)
+    winner_slug = sole_tie_taker_slug(
+        challenger_faction_slug, opponent_faction_slug, era
+    )
     if winner_slug is None:
         return None
     return (

--- a/backend/tests/integration/test_duel_era_resolution.py
+++ b/backend/tests/integration/test_duel_era_resolution.py
@@ -24,19 +24,29 @@ from models.praxis import (
 )
 from services.duel_outcome import duel_winner
 from services.era import apply_era_reset
-from services.scoring import SNIDE_FACTION_SLUG
 from tests.integration.factories import (
     cast_vote,
     make_character,
     make_duel,
 )
 
-#: The other side of a lone-Snide tie: a real faction of the live era that is not
-#: Snide. Derived, never named — the live era's first real faction may itself be
-#: Snide, in which case a fixture default would make this a two-Snide tie and
-#: silently change the rule under test (#2708).
-NOT_SNIDE = next(
-    slug for slug in real_faction_slugs(CURRENT_ERA) if slug != SNIDE_FACTION_SLUG
+#: The two sides of a lone-tie-taker tie, derived from the PERK and never named
+#: (#2664, extending #2708). The rule is "the SOLE holder of `takes_duel_ties`
+#: takes the tie", so a fixture that hardcoded "snide" would stop naming the
+#: rule the moment an era moved the ability — and a fixture default could pick
+#: a second holder and silently turn the case under test into a real tie.
+TIE_TAKER = next(
+    (
+        slug
+        for slug in real_faction_slugs(CURRENT_ERA)
+        if CURRENT_ERA.factions[slug].takes_duel_ties
+    ),
+    None,
+)
+NOT_TIE_TAKER = next(
+    slug
+    for slug in real_faction_slugs(CURRENT_ERA)
+    if not CURRENT_ERA.factions[slug].takes_duel_ties
 )
 
 
@@ -172,13 +182,16 @@ async def test_era_reset_freezes_the_snide_tie_to_snide(
     Snide wins ties everywhere the live multiplier applies; the permanent frozen
     record must agree, or `duel_victor` (#823) would lose a win the site showed.
     """
-    # Snide's row (and every other era's) is seeded by ``some_faction``; the
-    # slug is the one ``services.scoring.snide_tie_winner_slug`` keys the
-    # tiebreak on, so naming it here names the rule, not a roster (#2708).
+    # Every era faction's row is seeded by ``some_faction``. The side named
+    # here is the one holding ``takes_duel_ties``, i.e. the faction
+    # ``services.scoring.sole_tie_taker_slug`` picks out — so this names the
+    # rule, not a roster (#2708, #2664).
+    if TIE_TAKER is None:
+        pytest.skip(f"no faction in {CURRENT_ERA.config_key} takes duel ties")
     duel, challenger, _opponent = await make_duel(
         db_session, era, label="snidefreeze", status=DuelStatus.settled,
         challenger_votes=3, opponent_votes=3,
-        challenger_faction=SNIDE_FACTION_SLUG, opponent_faction=NOT_SNIDE,
+        challenger_faction=TIE_TAKER, opponent_faction=NOT_TIE_TAKER,
     )
 
     await _close_the_era(db_session, account)

--- a/backend/tests/integration/test_duelist_badge.py
+++ b/backend/tests/integration/test_duelist_badge.py
@@ -29,19 +29,29 @@ from models.praxis import (
     ModerationStatus,
 )
 from services.badge import build_badge_contexts, list_badges_for_character
-from services.scoring import SNIDE_FACTION_SLUG
 from tests.integration.factories import (
     make_duel,
 )
 
 DUELIST_BADGE = {"key": "duelist", "name": "Duelist"}
 
-#: The other side of a lone-Snide tie: a real faction of the live era that is not
-#: Snide. Derived, never named — the live era's first real faction may itself be
-#: Snide, in which case a fixture default would make this a two-Snide tie and
-#: silently change the rule under test (#2708).
-NOT_SNIDE = next(
-    slug for slug in real_faction_slugs(CURRENT_ERA) if slug != SNIDE_FACTION_SLUG
+#: The two sides of a lone-tie-taker tie, derived from the PERK and never named
+#: (#2664, extending #2708). The rule is "the SOLE holder of `takes_duel_ties`
+#: takes the tie", so a fixture that hardcoded "snide" would stop naming the
+#: rule the moment an era moved the ability — and a fixture default could pick
+#: a second holder and silently turn the case under test into a real tie.
+TIE_TAKER = next(
+    (
+        slug
+        for slug in real_faction_slugs(CURRENT_ERA)
+        if CURRENT_ERA.factions[slug].takes_duel_ties
+    ),
+    None,
+)
+NOT_TIE_TAKER = next(
+    slug
+    for slug in real_faction_slugs(CURRENT_ERA)
+    if not CURRENT_ERA.factions[slug].takes_duel_ties
 )
 
 
@@ -91,17 +101,20 @@ async def test_snide_wins_the_tie_and_earns_the_badge(
     Snide side reads as the duel winner everywhere the tiebreak applies — the
     live multiplier already did this; the badge was the straggler.
     """
-    # Snide's row (and every other era's) is seeded by ``some_faction``; the
-    # slug is the one ``services.scoring.snide_tie_winner_slug`` keys the
-    # tiebreak on, so naming it here names the rule, not a roster (#2708).
+    # Every era faction's row is seeded by ``some_faction``. The side named
+    # here is the one holding ``takes_duel_ties``, i.e. the faction
+    # ``services.scoring.sole_tie_taker_slug`` picks out — so this names the
+    # rule, not a roster (#2708, #2664).
+    if TIE_TAKER is None:
+        pytest.skip(f"no faction in {CURRENT_ERA.config_key} takes duel ties")
     _, challenger, opponent = await make_duel(
         db_session,
         era,
         label="snidetie",
         challenger_votes=3,
         opponent_votes=3,
-        challenger_faction=SNIDE_FACTION_SLUG,
-        opponent_faction=NOT_SNIDE, commit=True)
+        challenger_faction=TIE_TAKER,
+        opponent_faction=NOT_TIE_TAKER, commit=True)
     assert await _badge_keys(db_session, challenger) == ["duelist"]
     assert await _badge_keys(db_session, opponent) == []
 

--- a/backend/tests/integration/test_game_config.py
+++ b/backend/tests/integration/test_game_config.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA
 from models.account import Account
 from services.progression import HIDDEN_UNTIL_REVEALED_UNLOCK_KEY
+from services.scoring import sole_tie_taker_slug
 
 
 @pytest.mark.asyncio
@@ -99,6 +100,60 @@ async def test_game_config_carries_the_array_flag(client: AsyncClient):
     if not holders:
         pytest.skip(f"no faction in {CURRENT_ERA.config_key} reads the array")
     assert {slug for slug, value in served.items() if value} == holders
+
+
+@pytest.mark.asyncio
+async def test_game_config_carries_the_tie_taking_flag(client: AsyncClient):
+    """The seam #2664 exists for: ONE rule, served to the half that displays it.
+
+    The take-the-tie ability is computed twice — once by the server, when it
+    banks a tied duel's points (``services.scoring.sole_tie_taker_slug``), and
+    once by the browser, when it shows a player their stakes before they cast
+    (``useDuelStakes``). Before #2664 both were ``faction == "snide"``: two
+    copies of a rule, consistent only by luck, and neither movable by an era.
+
+    So this asserts more than "the field is emitted". It asserts the flag the
+    client is handed picks out **exactly** the factions the scoring predicate
+    treats as tie takers. Given that, and given the client reads the flag rather
+    than re-deriving the rule, the stakes shown and the points banked cannot
+    disagree — they are one rule with one source.
+    """
+    data = (await client.get("/game-config")).json()
+    served = {
+        faction["slug"]: faction["takes_duel_ties"] for faction in data["factions"]
+    }
+
+    assert served == {
+        slug: faction.takes_duel_ties
+        for slug, faction in CURRENT_ERA.factions.items()
+    }
+
+    # The flag the wire carries IS the rule the scorer applies. Ask the
+    # predicate itself, per faction, against a side that does not hold the perk.
+    holders = {slug for slug, value in served.items() if value}
+    if not holders:
+        pytest.skip(f"no faction in {CURRENT_ERA.config_key} takes duel ties")
+    a_non_holder = next(slug for slug, value in served.items() if not value)
+    scored = {
+        slug
+        for slug in served
+        if sole_tie_taker_slug(slug, a_non_holder, CURRENT_ERA) == slug
+    }
+    assert scored == holders
+
+    # And the perk is self-cancelling: two holders make a real tie, which is why
+    # it is the one perk the inheritor does not pick up (#2664).
+    for slug in holders:
+        assert sole_tie_taker_slug(slug, slug, CURRENT_ERA) is None
+    inheritors = {
+        slug
+        for slug, faction in CURRENT_ERA.factions.items()
+        if faction.inherits_faction_perks
+    }
+    assert not (inheritors & holders), (
+        "an inheritor holding the tie-taking perk would DESTROY the sole "
+        "holder's ability, not gain one"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 642
+RUFF_FINDING_TOTAL = 641
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -182,7 +182,7 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "services/praxis_scoring.py::E501": 3,
     "services/relationship_service.py::E501": 1,
     "services/relationship_service.py::I001": 1,
-    "services/scoring.py::E501": 2,
+    "services/scoring.py::E501": 1,
     "services/task.py::E501": 6,
     "services/task.py::I001": 1,
     "services/vote.py::E501": 3,

--- a/backend/tests/unit/test_faction_perk_inheritance.py
+++ b/backend/tests/unit/test_faction_perk_inheritance.py
@@ -25,6 +25,7 @@ from game_config import (
     _ANY_PERK_FIELDS,
     _DUEL_PERK_FIELDS,
     _MAX_PERK_FIELDS,
+    _NON_INHERITED_PERK_FIELDS,
     ERA_1,
     ERA_2,
     EraConfig,
@@ -269,6 +270,7 @@ def test_every_faction_config_field_is_classified() -> None:
         | set(_MAX_PERK_FIELDS)
         | set(_ANY_PERK_FIELDS)
         | set(_DUEL_PERK_FIELDS)
+        | set(_NON_INHERITED_PERK_FIELDS)
     )
     assert {f.name for f in dataclasses.fields(FactionConfig)} == classified
 

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -439,8 +439,12 @@ def test_duel_multiplier_tie_follows_the_config_not_the_slug():
     era that hands the ability to wow must bank wow the win rate on a tie.
     """
     moved = _era_where_only("wow")
-    wow = compute_duel_multiplier("wow", "snide", is_winner=False, is_tied=True, era=moved)
-    snide = compute_duel_multiplier("snide", "wow", is_winner=False, is_tied=True, era=moved)
+    wow = compute_duel_multiplier(
+        "wow", "snide", is_winner=False, is_tied=True, era=moved
+    )
+    snide = compute_duel_multiplier(
+        "snide", "wow", is_winner=False, is_tied=True, era=moved
+    )
     assert wow == moved.factions["wow"].duel_win_modifier
     assert snide == moved.factions["snide"].duel_loss_modifier
 

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import Decimal
 
 import pytest
 
-from game_config import ERA_1, ERA_2
+from game_config import ERA_1, ERA_2, EraConfig
 from models.praxis import ModerationStatus
 from services.duel_outcome import duel_winner
 from services.scoring import (
@@ -18,8 +18,8 @@ from services.scoring import (
     compute_votes_available,
     exact,
     round_half_up,
-    snide_tie_winner_id,
-    snide_tie_winner_slug,
+    sole_tie_taker_id,
+    sole_tie_taker_slug,
 )
 
 
@@ -377,23 +377,72 @@ def test_duel_tie_both_snide():
     assert result == 1.0
 
 
-def test_snide_tie_winner_slug_sole_snide_wins():
-    assert snide_tie_winner_slug("snide", "wow") == "snide"
-    assert snide_tie_winner_slug("wow", "snide") == "snide"
+def _era_where_only(slug_with_the_perk: str) -> EraConfig:
+    """``ERA_1`` with ``takes_duel_ties`` held by exactly one named faction.
+
+    Inheritance is switched off across the board so the era states the perk
+    literally; ``takes_duel_ties`` is not an inherited axis (see
+    ``game_config._NON_INHERITED_PERK_FIELDS``), but flattening it here keeps
+    the fixture readable rather than implicitly relying on that.
+    """
+    return replace(
+        ERA_1,
+        factions={
+            slug: replace(
+                faction,
+                takes_duel_ties=(slug == slug_with_the_perk),
+                inherits_faction_perks=False,
+            )
+            for slug, faction in ERA_1.factions.items()
+        },
+    )
 
 
-def test_snide_tie_winner_slug_no_or_both_snide_is_a_real_tie():
-    assert snide_tie_winner_slug("wow", "ua") is None
-    assert snide_tie_winner_slug("snide", "snide") is None
+def test_sole_tie_taker_slug_sole_holder_wins():
+    assert sole_tie_taker_slug("snide", "wow", ERA_1) == "snide"
+    assert sole_tie_taker_slug("wow", "snide", ERA_1) == "snide"
 
 
-def test_snide_tie_winner_id_resolves_to_the_snide_side():
-    # Snide is the challenger → the challenger id wins the tie.
-    assert snide_tie_winner_id("snide", 1, "wow", 2) == 1
-    # Snide is the opponent → the opponent id wins the tie.
-    assert snide_tie_winner_id("wow", 1, "snide", 2) == 2
-    # No Snide → nobody wins the tie.
-    assert snide_tie_winner_id("wow", 1, "ua", 2) is None
+def test_sole_tie_taker_slug_two_holders_or_none_is_a_real_tie():
+    assert sole_tie_taker_slug("wow", "ua", ERA_1) is None
+    # The ability is "the SOLE holder takes the tie", not "this faction wins
+    # ties" — two holders cancel (#2664).
+    assert sole_tie_taker_slug("snide", "snide", ERA_1) is None
+
+
+def test_sole_tie_taker_slug_follows_the_config_not_the_slug():
+    """#2664: move the perk and the rule moves with it.
+
+    This is the whole point of the flag. With the ability on wow instead of
+    snide, a snide-vs-wow tie goes to *wow*, and snide-vs-ua is a real tie —
+    outcomes a ``faction == "snide"`` comparison can never produce.
+    """
+    moved = _era_where_only("wow")
+    assert sole_tie_taker_slug("snide", "wow", moved) == "wow"
+    assert sole_tie_taker_slug("wow", "snide", moved) == "wow"
+    assert sole_tie_taker_slug("snide", "ua", moved) is None
+
+
+def test_sole_tie_taker_id_resolves_to_the_holding_side():
+    # The holder is the challenger → the challenger id wins the tie.
+    assert sole_tie_taker_id("snide", 1, "wow", 2, ERA_1) == 1
+    # The holder is the opponent → the opponent id wins the tie.
+    assert sole_tie_taker_id("wow", 1, "snide", 2, ERA_1) == 2
+    # Nobody holds it → nobody wins the tie.
+    assert sole_tie_taker_id("wow", 1, "ua", 2, ERA_1) is None
+
+
+def test_duel_multiplier_tie_follows_the_config_not_the_slug():
+    """The banked multiplier reads the same moved perk the predicate does.
+
+    Guards the seam between the predicate and the number actually scored: an
+    era that hands the ability to wow must bank wow the win rate on a tie.
+    """
+    moved = _era_where_only("wow")
+    wow = compute_duel_multiplier("wow", "snide", is_winner=False, is_tied=True, era=moved)
+    snide = compute_duel_multiplier("snide", "wow", is_winner=False, is_tied=True, era=moved)
+    assert wow == moved.factions["wow"].duel_win_modifier
+    assert snide == moved.factions["snide"].duel_loss_modifier
 
 
 def _winner(**overrides):

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -2871,6 +2871,8 @@ export interface components {
             reads_the_array: boolean;
             /** Slug */
             slug: string;
+            /** Takes Duel Ties */
+            takes_duel_ties: boolean;
         };
         /** FactionOut */
         FactionOut: {

--- a/frontend/src/components/__tests__/theArray.test.ts
+++ b/frontend/src/components/__tests__/theArray.test.ts
@@ -56,6 +56,7 @@ function makeFaction(slug: string, overrides: Record<string, unknown> = {}) {
     duel_win_modifier: 1.5,
     duel_loss_modifier: 0.5,
     reads_the_array: slug === 'singularity',
+    takes_duel_ties: false,
     ...overrides,
   }
 }

--- a/frontend/src/components/duel/__tests__/StakesTiles.test.tsx
+++ b/frontend/src/components/duel/__tests__/StakesTiles.test.tsx
@@ -18,11 +18,16 @@
  * arithmetic on top of the config, not the transport.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import '../../../i18n'
 import type { GameConfigOut, FactionConfigOut } from '../../../api/gameConfig'
 
-function faction(slug: string, win: number, lose: number): FactionConfigOut {
+function faction(
+  slug: string,
+  win: number,
+  lose: number,
+  takesTies = false,
+): FactionConfigOut {
   return {
     slug,
     own_task_modifier: 1.0,
@@ -34,16 +39,35 @@ function faction(slug: string, win: number, lose: number): FactionConfigOut {
     // #1869: Singularity's perk flag. Irrelevant to the duel axis these
     // fixtures exercise, but part of the contract.
     reads_the_array: false,
+    // #2664: the take-the-tie perk. This one IS the duel axis, and it is the
+    // reason the three fixtures below differ only in which ROW carries a flag.
+    takes_duel_ties: takesTies,
   }
 }
 
-// Mirrors era_1.py: snide is the high-risk outlier, wow the ordinary case.
-const CONFIG = {
-  factions: [faction('snide', 2.0, 0.0), faction('wow', 1.5, 0.5)],
+// Mirrors era_1.py: snide is the high-risk outlier and the tie taker, wow the
+// ordinary case.
+const ERA_1_SHAPED = {
+  factions: [faction('snide', 2.0, 0.0, true), faction('wow', 1.5, 0.5)],
 } as unknown as GameConfigOut
 
+// #2664: the SAME numbers with the perk moved to wow. No slug changes — only
+// which row carries the flag. An era is allowed to do exactly this, and before
+// #2664 the browser could not see it happen.
+const PERK_ON_WOW = {
+  factions: [faction('snide', 2.0, 0.0), faction('wow', 1.5, 0.5, true)],
+} as unknown as GameConfigOut
+
+// Both sides hold it. The perk is "the SOLE holder takes the tie", so two
+// holders cancel and the duel is a real tie.
+const BOTH_HOLD = {
+  factions: [faction('snide', 2.0, 0.0, true), faction('wow', 1.5, 0.5, true)],
+} as unknown as GameConfigOut
+
+let mockConfig: GameConfigOut = ERA_1_SHAPED
+
 vi.mock('../../../hooks/useGameConfig', () => ({
-  useGameConfig: () => CONFIG,
+  useGameConfig: () => mockConfig,
 }))
 
 const { StakesTiles } = await import('../shared')
@@ -67,6 +91,10 @@ function text(props: {
 }
 
 describe('StakesTiles', () => {
+  beforeEach(() => {
+    mockConfig = ERA_1_SHAPED
+  })
+
   it('renders a losing Snide duelist 0, not half (#718 correction 2)', () => {
     const t = text({ viewer: 'snide', opponent: 'wow', status: 'active' })
     expect(t).toMatch(/If you win/i)
@@ -83,17 +111,44 @@ describe('StakesTiles', () => {
     expect(t).toMatch(/15/) // 30 × 0.5
   })
 
-  it('pays a tie 1.0x when neither side is Snide', () => {
+  it('pays a tie 1.0x when neither side holds the tie perk', () => {
     const t = text({ viewer: 'wow', opponent: 'wow', status: 'active' })
     expect(t).toMatch(/A tie pays 30\./)
   })
 
-  it('gives Snide the win rate on a tie, and its opponent the loss rate', () => {
+  it('gives the sole tie taker the win rate, and its opponent the loss rate', () => {
     expect(text({ viewer: 'snide', opponent: 'wow', status: 'active' })).toMatch(
       /A tie pays 60\./,
     )
     expect(text({ viewer: 'wow', opponent: 'snide', status: 'active' })).toMatch(
       /A tie pays 15\./,
+    )
+  })
+
+  it('follows the flag, not the slug, when an era moves the perk (#2664)', () => {
+    // The one assertion a `slug === 'snide'` comparison can never satisfy: the
+    // same two factions, the same modifiers, the perk on the other row. Passing
+    // this proves the browser reads `takes_duel_ties` off /game-config — the
+    // very field `services.scoring.sole_tie_taker_slug` banks the points from.
+    mockConfig = PERK_ON_WOW
+    expect(text({ viewer: 'wow', opponent: 'snide', status: 'active' })).toMatch(
+      /A tie pays 45\./, // 30 x wow's own 1.5 win rate
+    )
+    expect(text({ viewer: 'snide', opponent: 'wow', status: 'active' })).toMatch(
+      /A tie pays 0\./, // 30 x snide's own 0.0 loss rate
+    )
+  })
+
+  it('makes a tie between two holders a real tie (#2664)', () => {
+    // Snide vs Snide is a real tie today and stays one for any era that grants
+    // the perk twice: the ability is SOLE-holder, so a second holder cancels it
+    // rather than sharing it.
+    mockConfig = BOTH_HOLD
+    expect(text({ viewer: 'snide', opponent: 'wow', status: 'active' })).toMatch(
+      /A tie pays 30\./,
+    )
+    expect(text({ viewer: 'wow', opponent: 'snide', status: 'active' })).toMatch(
+      /A tie pays 30\./,
     )
   })
 

--- a/frontend/src/components/duel/__tests__/duelSealFormFactor.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSealFormFactor.test.tsx
@@ -42,6 +42,7 @@ function faction(slug: string, win: number, lose: number): FactionConfigOut {
     // #1869: Singularity's perk flag. Irrelevant to the duel axis these
     // fixtures exercise, but part of the contract.
     reads_the_array: false,
+    takes_duel_ties: false,
   }
 }
 

--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -44,6 +44,7 @@ function faction(slug: string, win: number, lose: number): FactionConfigOut {
     // #1869: Singularity's perk flag. Irrelevant to the duel axis these
     // fixtures exercise, but part of the contract.
     reads_the_array: false,
+    takes_duel_ties: false,
   }
 }
 

--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -154,13 +154,14 @@ export interface DuelStakes {
   win: number
   /** Base points if it loses. `0` for Snide — by construction, not by branch. */
   lose: number
-  /** Base points on a tie (1.0×, or the win/loss rate when exactly one side is Snide). */
+  /**
+   * Base points on a tie: 1.0×, or the win/loss rate when exactly one side
+   * holds the take-the-tie perk (`takes_duel_ties`).
+   */
   tie: number
   /** Base points if the duel never happens (declined / no opponent): plain solo. */
   solo: number
 }
-
-const SNIDE_FACTION_SLUG = 'snide'
 
 /**
  * Win / lose / tie / solo-fallback base points for ONE side of a duel.
@@ -182,15 +183,24 @@ export function useDuelStakes(
   const faction = config.factions.find((entry) => entry.slug === viewerFactionSlug)
   if (!faction) return null
 
-  // Tie: 1.0× for both sides, unless exactly one side is Snide — then Snide
-  // takes the win rate and the other side the loss rate.
-  const exactlyOneSnide =
-    (viewerFactionSlug === SNIDE_FACTION_SLUG) !== (opponentFactionSlug === SNIDE_FACTION_SLUG)
-  const tieModifier = !exactlyOneSnide
-    ? 1.0
-    : viewerFactionSlug === SNIDE_FACTION_SLUG
-      ? faction.duel_win_modifier
-      : faction.duel_loss_modifier
+  // Tie: 1.0× for both sides, unless exactly ONE side holds `takes_duel_ties` —
+  // then that side takes its win rate and the other its loss rate.
+  //
+  // #2664: this reads the era's flag off the payload rather than comparing a
+  // slug, and it is the same field the server's `sole_tie_taker_slug` banks the
+  // points from. That is the whole point: the stakes a player is shown here and
+  // the points the server actually banks are now one rule with one source,
+  // rather than two hardcoded copies of `'snide'` that agreed by luck and that
+  // no era could move (ADR-0042).
+  const opponent = config.factions.find((entry) => entry.slug === opponentFactionSlug)
+  const viewerTakesTies = faction.takes_duel_ties
+  const opponentTakesTies = opponent?.takes_duel_ties ?? false
+  const tieModifier =
+    viewerTakesTies === opponentTakesTies
+      ? 1.0
+      : viewerTakesTies
+        ? faction.duel_win_modifier
+        : faction.duel_loss_modifier
 
   return {
     win: taskPointValue * faction.duel_win_modifier,

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -44,6 +44,7 @@ function faction(slug: string, win: number, lose: number): FactionConfigOut {
     // #1869: Singularity's perk flag. Irrelevant to the duel axis these
     // fixtures exercise, but part of the contract.
     reads_the_array: false,
+    takes_duel_ties: false,
   }
 }
 

--- a/frontend/src/utils/__tests__/points.test.ts
+++ b/frontend/src/utils/__tests__/points.test.ts
@@ -33,6 +33,7 @@ function config(
     // #1869: Singularity's perk flag. Grants information, never points, so it
     // is irrelevant to every multiplier here — but part of the contract.
     reads_the_array: false,
+    takes_duel_ties: false,
   }
 }
 


### PR DESCRIPTION
Closes #2664

Snide's take-the-tie ability was computed from a hardcoded `'snide'` on **both**
sides of the wire — `services/scoring.py` for the points banked, `useDuelStakes`
for the stakes a player is shown before they cast. Two copies of one rule,
consistent only by luck, and neither movable by an era (ADR-0042). Both halves
move here, in one PR, because fixing either alone would make the stakes shown
disagree with the points banked.

## The seam I tested at

**`FactionConfig.takes_duel_ties` — one flag, one predicate, carried on the wire
so the displayed stakes and the banked points are the same field.**

The red test came first, at that seam, on both sides:

- `tests/unit/test_scoring.py::test_sole_tie_taker_slug_follows_the_config_not_the_slug`
  — an era with the perk on **wow** instead of snide. A `faction == "snide"`
  comparison can never satisfy it. Went red on `ImportError`, then on the real
  behaviour, then green.
- `StakesTiles.test.tsx` — `follows the flag, not the slug, when an era moves the
  perk` and `makes a tie between two holders a real tie`. Both failed against the
  old `exactlyOneSnide` branch with the actual wrong figures (`A tie pays 60`
  where the moved perk owed 45), then green.

## How the two halves are provably the same rule

`tests/integration/test_game_config.py::test_game_config_carries_the_tie_taking_flag`
does not merely assert the field is emitted. It asserts the flag the client is
handed picks out **exactly** the factions the scoring predicate treats as tie
takers — it asks `sole_tie_taker_slug` itself, per faction, and compares that set
to the served set. Given that, plus a client that reads the flag rather than
re-deriving the rule (the `PERK_ON_WOW` fixture is what proves it does), the
stakes shown and the points banked cannot disagree: they are one rule with one
source.

## What changed

| where | what |
|---|---|
| `backend/game_config.py` | `takes_duel_ties: bool = False` on `FactionConfig`, with the docstring the sibling perks carry |
| `backend/game_config.py` | new `_NON_INHERITED_PERK_FIELDS` bucket — see below |
| `backend/eras/era_1.py`, `era_2.py` | `takes_duel_ties=True` on S.N.I.D.E. |
| `backend/eras/_template.py` | the flag documented beside the other perks |
| `backend/schemas/game_config.py`, `routers/game_config.py` | exposed + populated on `FactionConfigOut` |
| `backend/services/scoring.py` | `snide_tie_winner_slug`/`_id` → `sole_tie_taker_slug`/`sole_tie_taker_id`, reading `era`; `SNIDE_FACTION_SLUG` deleted |
| `backend/services/badge.py`, `services/era.py` | the two callers thread `era: EraConfig = CURRENT_ERA` |
| `frontend/src/components/duel/shared.tsx` | `useDuelStakes` reads `takes_duel_ties` off the rows it already had; `exactlyOneSnide` and the frontend `SNIDE_FACTION_SLUG` deleted |
| `backend/openapi.json`, `frontend/src/api/generated/schema.d.ts` | regenerated by `python scripts/regen_api_client.py` |

### The name

`snide_tie_winner_slug` was renamed, not just re-pointed. A predicate named after
one faction is the same defect one layer up. The rule is **"the sole holder of
this perk takes the tie"** — `sole_tie_taker_slug` says that, and keeps the
semantic exactly: a two-Snide duel is a real tie, not a Snide win.

### Why the perk is deliberately NOT in `_ANY_PERK_FIELDS`

The brief asked me to decide and say. **It must not be inheritable, and this is
not a style call — putting it in `_ANY_PERK_FIELDS` would change banked points
today.**

Albescent carries `inherits_faction_perks=True` in both eras. `takes_duel_ties`
is self-cancelling: a second holder does not *gain* an ability, it *destroys* the
first holder's. So unioning it would flip every Snide-vs-Albescent tie from "Snide
takes it" (today) to a real tie — a scoring change, which #2664 forbids
explicitly. It sits beside `_DUEL_PERK_FIELDS`, exempt for the same underlying
reason #1871 Ruling 1 found: the duel axis is a *relation between two sides*, not
a per-side quantity, and a naive union gets it backwards.

`test_every_faction_config_field_is_classified` still bites — the new bucket is
in its union, so a future perk field cannot be forgotten.

## No scoring change

- Era 1 and Era 2 both grant the flag to S.N.I.D.E., so every pairing banks what
  it banks today, including two-Snide (a real tie) and no-Snide. **Era 2 was set
  too, deliberately**: `eras/era_2.py` is live on `main` and its Snide would
  otherwise have silently lost the ability at the flip.
- Albescent does not inherit it, per above.
- One behaviour *did* narrow, and it is strictly more correct: a faction slug the
  era does not know now holds no perk, where the old literal comparison would have
  granted it to a stray `"snide"` from a closed era. That made
  `compute_duel_multiplier`'s `2.0 if ... else 0.5` fallback half unreachable, so
  it is now `return 0.5` with the reason written down.

## Deliberate non-change

`TheArray.tsx` does not print the new flag. Its docblock states the design — a
perk reaches the console only when someone deliberately writes its name in
`ArrayFactionRow`, and `theArray.test.ts` exists to force that to be a decision.
Whether Singularity gets to read the tie rule is a product call, not part of a
defect fix, so I left it and am naming it here rather than silently deciding it.

## Verification

Every step `.github/workflows/test.yml` names, run locally:

- **test** — `pytest --cov=. --cov-fail-under=92` against a dedicated `wz2664_test`:
  **1687 passed**, coverage 94.23%.
- **api-schema** — `python scripts/regen_api_client.py` then `git diff --exit-code`
  on both artifacts: clean. Both regenerated files are committed.
- **frontend** — `lint` clean; `tsc --noEmit` clean; `typecheck:design-sync` clean
  (`.design-sync/previews/_fixtures.tsx` updated for the new required field);
  `vitest run` **9529 passed / 461 files**; `build` clean.
- **byte budget** — WARN at 137.2 KB JS (`warn>130.9`, `fail>175.8`), i.e. passing.
  Pre-existing, not from this PR: the only bundled source file changed is
  `duel/shared.tsx`, which is not in the initial-load chunk list the budget report
  prints. The rest of the frontend diff is test fixtures and type-only declarations.

**Visual QA is outstanding** — this session has no browser tools and no dev stack.
Everything above is tests, tsc and eslint.

## What to eyeball

1. **A duel composer with one S.N.I.D.E. side.** The tie tile must still read
   *"A tie pays 2× base"* for the Snide duelist and the loss rate for the other
   side — unchanged from today, now sourced from the flag.
2. **A duel composer with two S.N.I.D.E. sides.** The tie tile must read plain
   1.0× base for both. This is the case the rule has always had and that the
   rename is named after; worth seeing it on screen.
3. **A duel with no S.N.I.D.E. side**, as the control: 1.0× both ways.
4. That the tile a player is shown before casting matches the points that land
   after the era freezes a tied duel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
