### PR TITLE
S.N.I.D.E.'s praxis title stops asking Anton for a bold it cannot draw (#2797)

### DIFF
--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -146,6 +146,16 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           }}
           titleStyle={{
             fontFamily: "var(--faction-snide-font-impact)",
+            // THIS 400 IS LOAD-BEARING — do not sweep it (#2797). Anton ships
+            // one cut, so a weight beside it is normally inert: not here.
+            // `PraxisTitle` puts a `font-semibold` CLASS on the same <h2>, and
+            // this inline 400 is the only thing suppressing a 600 the face
+            // cannot draw. The owner looked at all five synthesised titles on
+            // 2026-08-27 and ruled S.N.I.D.E. the one that reads better at 400;
+            // the other four keep the fake bold ON PURPOSE (see LOAD_BEARING in
+            // `utils/__tests__/fontsLoaded.test.ts`). Removing this trades an
+            // inert-looking declaration for a real fake-bold.
+            fontWeight: 400,
             textTransform: "uppercase",
             letterSpacing: "0.04em",
             lineHeight: 1,

--- a/frontend/src/utils/__tests__/fontsLoaded.test.ts
+++ b/frontend/src/utils/__tests__/fontsLoaded.test.ts
@@ -927,18 +927,55 @@ describe("a one-cut family is never asked for a weight (#2597)", () => {
   );
 
   /**
-   * The one scope where a `fontWeight: 400` on a one-cut face is load-bearing.
+   * The scopes where a `fontWeight: 400` on a one-cut face is load-bearing.
    *
    * `PraxisTitle` hands its `<h2>` a `font-semibold` CLASS as well as the skin's
    * `titleStyle`, so on that element the inline 400 is not restating the default
    * — it is the only thing suppressing a 600 the class would otherwise impose,
-   * and Poiret One has no 600 to give. Deleting it swaps an inert declaration
-   * for a real fake-bold, which is the trap #2597's ruling names. Every other
-   * skin routing a one-cut face through that same title inherits the class and
-   * carries no such guard: those are reported on the PR, not fixed here, because
-   * the honest fix repaints UA and Coven and wants an owner's call.
+   * and neither Poiret One nor Anton has a 600 to give. Deleting it swaps an
+   * inert-looking declaration for a real fake-bold, which is the trap #2597's
+   * ruling names.
+   *
+   * FOUR SKINS KEEP THE SYNTHESISED 600 ON PURPOSE (#2797). That is #2487's
+   * rule — *synthesis is a defect, substitution is a design call* — being
+   * knowingly departed from, not satisfied. On 2026-08-27 the owner rendered
+   * every one of these titles at its real cut beside the browser's fake bold and
+   * ruled by eye: **"600 looks better for most of them. S.N.I.D.E. is the only
+   * one that looks better with 400."** So:
+   *
+   * | skin | title face resolves to | verdict |
+   * | --- | --- | --- |
+   * | na (`DefaultPraxisCard`) | `--faction-default-card-font` → Bebas Neue | keep the synthesised 600 |
+   * | Everymen (`EverymenPraxisCard`) | `--ev-praxis-face` → `--faction-everymen-card-font` → Bebas Neue | keep the synthesised 600 |
+   * | Singularity (`SingularityPraxisCard`) | `--font-faction-terminal` → Share Tech Mono | keep the synthesised 600 |
+   * | WOW (`WowPraxisCard`) | `--wow-praxis-card-face` → `--faction-wow-card-font` → MedievalSharp | keep the synthesised 600 |
+   * | S.N.I.D.E. (`SnidePraxisCard`) | `--faction-snide-font-impact` → Anton | inline 400 — below |
+   * | Ephemerists (`EphemeristsPraxisCard`) | Poiret One | inline 400 — below |
+   *
+   * UA and Coven are untouched: Cormorant Garamond and Caveat ship a real 600
+   * and declare it themselves. The shared `font-semibold` stays.
+   *
+   * WHY THE RULING IS RECORDED HERE. This check cannot see those four: it reads
+   * source declarations and cannot follow `className="font-semibold"` → the
+   * `fonts.display` / `titleStyle` prop → a per-skin CSS variable → a faction
+   * token → a face. The day it learns that indirection it will go red on all
+   * four, and that red is a DECISION, not an oversight — do not "fix" it, and do
+   * not add cuts to the payload (the byte budget is in WARN, #2469). Note the
+   * evidence's ceiling: fake-bold is drawn by the browser and the algorithm
+   * differs by engine and platform, so one browser on one OS is a fair basis for
+   * a taste call and not a guarantee. A title that looks wrong on another engine
+   * is new evidence, not a contradiction.
+   *
+   * ponytail: the entries below are files, not elements, so a second weight on a
+   * one-cut face anywhere in an exempted file goes unseen. Two annotated files is
+   * under the bar for a scope-precise exemption; if this set grows, narrow it.
    */
-  const LOAD_BEARING = new Set(["components/praxisCard/desktop/EphemeristsPraxisCard.tsx"]);
+  const LOAD_BEARING = new Set([
+    "components/praxisCard/desktop/EphemeristsPraxisCard.tsx",
+    // #2797, above: Anton ships one cut and the `font-semibold` class is on the
+    // same <h2>, so this 400 is the ruled substitution, not an inert line.
+    "components/praxisCard/desktop/SnidePraxisCard.tsx",
+  ]);
 
   it("derives the one-cut families from the sheets rather than a list", () => {
     // Sanity check on the derivation: the six #2597 swept, plus #2487's three.


### PR DESCRIPTION
Closes #2797

Implements the owner's ruling verbatim: **S.N.I.D.E. alone drops to `fontWeight: 400`; na, Everymen, Singularity and WOW keep the browser-synthesised 600 on purpose; UA and Coven are untouched; the shared `font-semibold` on `PraxisTitle` stays.** One declaration in one file, plus the record.

## The seam I tested at

`frontend/src/utils/__tests__/fontsLoaded.test.ts` → `a one-cut family is never asked for a weight (#2597)` → `it("names no weight in a scope that pins a single-cut family")`.

That guard reads every source scope that sets a `fontFamily`, resolves the family behind a CSS variable, and fails if the scope also names a weight the face cannot draw. Adding the 400 to `SnidePraxisCard`'s `titleStyle` made it go red on the real thing first:

```
+ [
+   "components/praxisCard/desktop/SnidePraxisCard.tsx:148 — anton",
+ ]
```

Adding the file to `LOAD_BEARING` — with the ruling written above it — turns it green. Same shape #2597 built for `EphemeristsPraxisCard`'s 400.

## What changed

- `frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx` — inline `fontWeight: 400` on the praxis title, annotated in the shape `EphemeristsPraxisCard` set: what the class does, why the line is not inert, and who ruled it when.
- `frontend/src/utils/__tests__/fontsLoaded.test.ts` — `SnidePraxisCard.tsx` joins `LOAD_BEARING`, and the docblock above it now carries the ruling: the four skins that keep the synthesis, the face each title actually resolves to, the date the owner looked, the link to #2797, and the caveat that fake-bold is engine- and platform-specific so this is a taste call and not a guarantee. The point of writing it there: the day that guard learns to follow `font-semibold` → `titleStyle`/`fonts.display` → a per-skin variable → a faction token → a face, it goes red on four deliberate decisions, and whoever sees that red needs to find a decision rather than an oversight.

Nothing else moved. No archetype gained a weight declaration it did not have, and `index.css` is untouched (read only).

## One correction to the ruling's table, which does not change the ruling

The ruling lists S.N.I.D.E.'s face as **Permanent Marker**. The praxis card's *title* is not set in the card font — `titleStyle` overrides `fonts.display`, and it names `--faction-snide-font-impact` → **Anton**. Permanent Marker is what `fonts.display` (`--snd-pcard-face` → `--faction-snide-card-font`) hands the rest of the body. Anton is one-cut too — it is in the guard's own derivation list — so the defect, the ruling and the fix are all unaffected; only the face's name in the record is. The guard confirms it by naming `anton` in the failure above.

Also worth recording against the issue's correction: the six `--*-face` hooks are not undeclared after all. Each card spreads `factionRoleVars(slug, prefix)` on its frame, which emits `--<prefix>-face: var(--faction-<slug>-card-font)` at runtime. The fall-through table in the ruling is right; the hooks just get their values from JS rather than from a static CSS rule.

## Verification

Run locally, all green, in this order:

- `npx vitest run src/utils/__tests__/fontsLoaded.test.ts` — red on the real defect first (above), then 16 passed.
- `npm run lint` (includes the `no-raw-style-values` ratchet) — clean.
- `npm run typecheck` and `npm run typecheck:design-sync` — clean.
- `npm test` — 462 files, 9549 passed, 1 skipped.
- `npm run build` — clean.
- `npm run budget` — CSS ok; JS in the pre-existing WARN band (#2469), unchanged by this diff (comments in a lazily-loaded card and a test file).

Backend untouched, so `test` and `api-schema` have nothing to regenerate.

**Visual QA is outstanding.** I have no browser and no dev stack; the ruling itself came from a look, and this diff only carries it out.

## What to eyeball

1. A **S.N.I.D.E.** praxis card title beside an **Everymen** one — on `/praxis`, and again in a task-detail praxis gallery — in **light** and in **dark**. The S.N.I.D.E. title should read as clean Anton with no smeared outline; the Everymen title should look exactly as it does on `main` (the ruled synthesised 600).
2. The S.N.I.D.E. title on a **task-detail** row specifically, where the host repoints `--snd-praxis-*` and the ground goes black — the weight change must not soften the title against the wall.
3. Confirm **na, Singularity and WOW** praxis titles are pixel-unchanged, since nothing in their path moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
