### PR TITLE
The redaction mark outranks a slot that names its own ink

### DIFF
--- a/frontend/src/__tests__/redactionOutranksInlineInk.test.ts
+++ b/frontend/src/__tests__/redactionOutranksInlineInk.test.ts
@@ -1,0 +1,137 @@
+/**
+ * THE REDACTION MARK MUST OUTRANK A SLOT THAT NAMES ITS OWN INK (#2646).
+ *
+ * `.redacted, .redacted * { color: transparent }` is a stylesheet rule, and a
+ * slot that declares `color` in the STYLE ATTRIBUTE outranks it by
+ * specification — as surely as an inline value outranks an inherited one. The
+ * directory tile draws five such slots, so before this guard the mark painted
+ * the one slot that inherits (the display name) and lost to the other four:
+ * four visible `[REDACTED]` markers and one blank gap, which reads as a
+ * rendering bug rather than as a device. The owner ruled shape 1 — `!important`
+ * on the rule, matching `.control-off`'s precedent (#2478, the same wall).
+ *
+ * ── THE SEAM, AND WHY IT IS THIS ONE ────────────────────────────────────────
+ *
+ * The seam is THE SHEET AND THE MOUNTS, READ FROM SOURCE — the `.redacted` rule
+ * as authored in `index.css`, against every component that puts that class on
+ * an element.
+ *
+ * It is not a render, and that is forced rather than lazy: the harness runs
+ * `renderToStaticMarkup` in node, which records the class and the style
+ * attribute side by side and never resolves which of them wins. The exact
+ * question this issue turns on is the one a static render cannot answer, so a
+ * mounted test would go green on the broken sheet and on the fixed one alike. A
+ * computed-style assertion would answer it and needs a real layout engine;
+ * ADR-0082's own e2e path is closed too, because `e2e/contrastScan.ts` skips
+ * `data-redacted="true"` by design.
+ *
+ * So the guard asserts the PAIRING instead, which is the thing that can rot:
+ * for as long as any mount declares its ink inline, the rule must carry the
+ * `!important` that reaches it. Delete the `!important` as a tidy-up and this
+ * goes red naming the mounts it just stopped covering; add a sixth inline slot
+ * and it stays green, because `!important` already covers it.
+ *
+ * `sourceFiles()` skips `__tests__` and `readStripped` drops comments, so the
+ * inventory below reads draw calls only — the prose in `DefaultSelectCard` and
+ * in `index.css` names `.redacted` a dozen times and none of it counts.
+ */
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import { readStripped, sourceFiles, toRelative } from '../test/sourceScan'
+import { stripComments } from '../utils/__tests__/cssVars'
+
+const CSS = stripComments(readFileSync(new URL('../index.css', import.meta.url), 'utf8'))
+
+/** The class token as a className string writes it — never `data-redacted`. */
+const CLASS_TOKEN = /(?<![-\w])redacted(?![-\w])/
+
+/** A `color:` in a style object. Not `backgroundColor`, not `--x-ink`. */
+const INLINE_INK = /(?<![-\w])color\s*:/
+
+/** The body of the one rule whose selector is `.redacted, .redacted *`. */
+const redactionRule = (): string => {
+  const at = CSS.indexOf('.redacted,')
+  expect(at, 'the `.redacted, .redacted *` rule is gone from index.css').toBeGreaterThan(-1)
+  return CSS.slice(CSS.indexOf('{', at) + 1, CSS.indexOf('}', at))
+}
+
+/**
+ * Where a string literal carries the class token: `"redacted"` on its own, or
+ * `' redacted'` appended inside a template. The lookarounds are what keep
+ * `getAttribute("data-redacted")` and the `[REDACTED]` marker out of it.
+ */
+const classTokenSites = (source: string): number[] =>
+  [...source.matchAll(/(['"`])([^'"`]*)\1/g)]
+    .filter(([, , body]) => CLASS_TOKEN.test(body))
+    .map((match) => match.index)
+
+/**
+ * The top-level component that encloses `at` — from its own declaration to the
+ * next `}` in column one.
+ *
+ * Scoping to the component and not to the file is the whole difference between
+ * a useful answer and a misleading one here: `DesktopPlayers.tsx` is a page with
+ * a dozen inline inks on surfaces that have nothing to do with the mark, and
+ * only `FactionLaneName` wears `.redacted`.
+ */
+const enclosingComponent = (source: string, at: number): string => {
+  const starts = [...source.slice(0, at).matchAll(/\n(?=(?:export )?(?:default )?(?:function|const) )/g)]
+  const from = starts.length > 0 ? starts[starts.length - 1].index : 0
+  const closed = source.indexOf('\n}', at)
+  return source.slice(from, closed === -1 ? source.length : closed)
+}
+
+/** Every shipped mount of the mark: its file, and whether it declares its own ink. */
+const mounts = (): { path: string; inlineInk: boolean }[] =>
+  sourceFiles()
+    .map((path) => ({ path: toRelative(path), source: readStripped(path) }))
+    .filter(({ source }) => classTokenSites(source).length > 0)
+    .map(({ path, source }) => ({
+      path,
+      inlineInk: classTokenSites(source).some((at) =>
+        INLINE_INK.test(enclosingComponent(source, at)),
+      ),
+    }))
+
+describe('the redaction mark reaches a slot that declares its own ink (#2646)', () => {
+  it('paints `transparent !important`, on the root and on the subtree', () => {
+    // Both arms in one rule, so both take the flag. The descendant arm plus the
+    // flag is what lets ONE mark redact a whole surface — the arm alone catches
+    // the subtree in the cascade and still loses to it in the style attribute.
+    expect(redactionRule().replace(/\s+/g, ' ').trim()).toBe('color: transparent !important;')
+    expect(CSS).toContain('.redacted,\n.redacted * {')
+  })
+
+  it('covers every mount there is, and says which of them needs the flag', () => {
+    // Three mounts: the directory tile, and the players-page faction lane on
+    // each form factor. `true` is what makes the `!important` above load-bearing
+    // rather than decorative; `false` is the issue body's feared blast radius,
+    // asserted absent rather than assumed — the lane declares `fontSize` and
+    // nothing else, so `.redacted` already won there and the flag moves nothing.
+    //
+    // A fourth entry means a surface started wearing the mark: check its slots
+    // before editing this list. An entry flipping to `false` means a mount moved
+    // onto classes (shape 2 of the issue) — the flag has stopped earning its
+    // keep on that one, which is a decision, not a tidy-up.
+    expect(Object.fromEntries(mounts().map(({ path, inlineInk }) => [path, inlineInk]))).toEqual({
+      'components/selectCard/DefaultSelectCard.tsx': true,
+      'pages/players/DesktopPlayers.tsx': false,
+      'pages/players/MobilePlayers.tsx': false,
+    })
+  })
+
+  it('leaves the selection reveal alone — a pseudo-element has its own cascade', () => {
+    // Drag across a redacted tile and `[REDACTED]` lifts out inverted; that
+    // device is ADR-0082's whole aesthetic. `color: transparent !important` on
+    // the element cannot reach it, because importance is not inherited and
+    // `.redacted *` does not match `*::selection`. Forcing these two would be
+    // the fix eating the thing it exists to protect.
+    for (const selector of ['.redacted ::selection', '.redacted::selection']) {
+      const at = CSS.indexOf(selector)
+      expect(at, selector).toBeGreaterThan(-1)
+      expect(CSS.slice(at, CSS.indexOf('}', at))).not.toContain('!important')
+    }
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7700,18 +7700,36 @@
    surface, instead of five wrappers that a future sixth slot can be added
    without.
 
-   KNOWN GAP, RECORDED RATHER THAN FIXED HERE (#2632): those slots declare their
-   ink in the STYLE ATTRIBUTE, which outranks this rule as surely as it outranks
-   inheritance, so the mark is painted for a slot that inherits its colour and is
-   not for one that names it. `.control-off` hit the same wall and answered it
-   with `!important`; doing that here would also change the leaderboard lane's
-   redaction, so it wants a ruling rather than a drive-by.
+   THE `!important` IS LOAD-BEARING TOO, AND IT IS HALF OF THAT SENTENCE
+   (#2646). Those five slots declare their ink in the STYLE ATTRIBUTE, which
+   outranks a class rule as surely as it outranks inheritance — so the arm added
+   for exactly these slots caught them in the cascade and lost to them in the
+   style attribute. What a reader got was four `[REDACTED]` markers painted
+   normally and one blank gap where the display-size name should be: a
+   half-struck tile, which reads as a rendering bug rather than as a device.
+   With the flag, the descendant arm reaches an inline declaration too, and the
+   pair — ARM plus FLAG — is what actually lets one mark redact a whole subtree.
+   Neither half does it alone. `.control-off` took the flag at the same wall for
+   the same reason (#2478), so this is the house answer, not a special case.
+
+   DO NOT REMOVE IT AS A TIDY-UP. The blast radius was checked before it went
+   in and it is empty: the only other consumer is the players-page faction lane
+   (`FactionLaneName`, both form factors), whose inline style is `fontSize` and
+   nothing else — this rule already won there, and forcing it moves nothing.
+   `__tests__/redactionOutranksInlineInk.test.ts` pins both facts and names the
+   mounts, because `renderToStaticMarkup` records a class and a style attribute
+   without ever resolving which of them wins.
+
+   THE SELECTION REVEAL BELOW IS DELIBERATELY UNFLAGGED. Importance is not
+   inherited and `.redacted *` does not match `*::selection`, so a pseudo-element
+   keeps its own cascade and the drag-to-reveal survives the flag untouched.
+   Flagging those two would be the fix eating the thing it exists to protect.
 
    No raw value here, so nothing for `no-raw-style-values` to catch — the
    ratchet is satisfied by construction rather than by an exemption. */
 .redacted,
 .redacted * {
-  color: transparent;
+  color: transparent !important;
 }
 
 .redacted ::selection,


### PR DESCRIPTION
Closes #2646

Shape 1, as the owner ruled on 2026-08-27: `!important` on the `.redacted` colour.

> The later AI comment on the issue (22:39) deferred this for a browser look and an
> unmade ruling. It was written without the owner ruling five hours earlier, which
> confirmed the premise from source and picked the shape. This PR builds the ruling.

## The defect

`.redacted, .redacted * { color: transparent }` is a bare class rule. `DefaultSelectCard`
declares `color` inline on **five** slots — the root, the eyebrow, the blurb, the status
row and the CTA — and inline beats a class by specification. The one slot with no inline
ink is the display-size faction name, so the name was the only thing that redacted: four
visible `[REDACTED]` markers and one blank gap. A half-struck tile reads as a rendering
bug rather than as a device.

Nothing was leaking. `say()` routes every slot through `redactableText`, so the real name
and blurb are never in the redacted markup at all — what painted was the marker.

## The seam I tested at

**The sheet and its mounts, read from source** — the `.redacted` rule as authored in
`index.css`, against every component that puts that class on an element.

Not a render, and that is forced rather than lazy: the harness runs `renderToStaticMarkup`
in node, which records the class and the style attribute side by side and never resolves
which of them wins. That is the exact question this issue turns on, so a mounted test goes
green on the broken sheet and the fixed one alike. A computed-style assertion would answer
it and needs a real layout engine — **no browser dependency was added to the unit suite**,
per the ruling — and `e2e/contrastScan.ts` skips `data-redacted="true"` by design, so the
e2e path is closed too.

So `frontend/src/__tests__/redactionOutranksInlineInk.test.ts` asserts the **pairing**,
which is the thing that can rot:

1. the rule paints `transparent !important` on both arms;
2. an inventory of every mount of the mark, discovered by scanning source rather than
   hardcoded, each marked with whether it declares its own ink — scoped to the *enclosing
   component*, not the file, so `DesktopPlayers.tsx`'s dozen unrelated inks stay out of
   the answer;
3. the two `::selection` rules keep their own colours and take **no** `!important`.

It was red on assertion 1 before the CSS change (commit `a5bb4c8c` is the guard alone).

## The blast radius, verified rather than assumed

The inventory finds exactly three mounts, and the test pins them:

| mount | declares inline `color`? |
|---|---|
| `components/selectCard/DefaultSelectCard.tsx` | yes — this is what the flag is for |
| `pages/players/DesktopPlayers.tsx` (`FactionLaneName`) | no |
| `pages/players/MobilePlayers.tsx` (`FactionLaneName`) | no |

The lane's inline style is `{ fontSize: 'var(--text-content)' }` and nothing else, so
`.redacted` already won there and the flag moves nothing. I also swept `index.css`
mechanically for every `color:` declaration whose selector could match the lane element
(`<a class="font-display truncate redacted">` and its ancestors, both cascades, nested
`@media`/`[data-theme]` blocks included): the only hits are `.redacted` / `.redacted *`
themselves, `.markdown-preview a` and `.control-off:disabled *`, neither of which is on
that page. The lane is unchanged.

The tile's mark is unaffected too — `AlbescentSigil` / `DefaultSigil` paint the conic ring
as a `background`, never as `color`, so forcing the ink does not erase the sigil.

## Why the selection reveal survives untouched

Importance is not inherited, and `.redacted *` does not match `*::selection`. A
pseudo-element keeps its own cascade, so `.redacted ::selection`'s
`--color-bg-page` / `--color-text-primary` swap still wins and the drag-to-reveal is
byte-identical. The `::selection` rules were not edited; the guard asserts they carry no
`!important`, so a later "consistency" pass cannot flag them.

## The comment

The `KNOWN GAP … RECORDED RATHER THAN FIXED HERE (#2632)` block is replaced with what the
rule now does: that the descendant arm **plus** the flag is what lets one mark redact a
whole subtree (neither half does it alone), that the blast radius was checked and is
empty, that the guard pins both facts, and that the `::selection` rules are deliberately
unflagged. It now reads as a standing instruction not to remove the flag as a tidy-up.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean (`no-raw-style-values` included; the rule declares no raw value)
- `npm run typecheck` — clean (app + e2e)
- `npm run typecheck:design-sync` — clean
- `npm test` — 463 files, 9552 passed, 1 skipped
- `npm run build` — clean
- `npm run budget` — CSS `ok` at 21.7 KB (`warn>22.2`). The JS `WARN` is pre-existing on
  `main`; this branch adds no JavaScript to the initial payload.

`api-schema` is not in play — no route, `response_model` or Pydantic schema is touched.

**Visual QA is outstanding.** I have no browser and no dev stack; everything above is
source, tests, lint and build.

## What to eyeball

1. **A redacted Albescent directory tile** at `/factions`, light **and** dark — all five
   slots blank, one uniform gap, no stray `[REDACTED]` marker anywhere on the card. The
   conic sigil, the spectrum frame and the `.spectrum-rule` hairline should all still
   draw, and the CTA should still be visibly present and shut.
2. **A redacted players-page faction lane** at `/players`, light **and** dark, desktop and
   mobile — this is the surface the issue body feared. It should look exactly as it did
   before this PR.
3. **Drag-select across the redacted tile**, both themes — `[REDACTED]` must lift out
   inverted in every slot, including the four that now redact for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
