### PR TITLE
Three completeness guards: a gap becomes a red test instead of an audit finding

### DIFF
--- a/frontend/src/locales/__tests__/factionKeyCompleteness.test.ts
+++ b/frontend/src/locales/__tests__/factionKeyCompleteness.test.ts
@@ -1,0 +1,198 @@
+/**
+ * A faction-keyed catalog block is complete, or it says why not (#2814).
+ *
+ * Every gap this repo has found in the copy catalogs was the same shape: a block
+ * keyed by faction slug where one faction is quietly absent, or holds one fewer
+ * key than its siblings. #2805 found `feed:factionHero` has no `na` block, so the
+ * Unaffiliated faction page printed no tagline while every other faction's did.
+ * #2806 found the reverse — nine identical copies of a string that already had a
+ * canonical home. Neither was caught by a test, because nothing enumerated the
+ * population they were absent from.
+ *
+ * THE DENOMINATOR IS THE POINT. "Is a key missing?" is unanswerable. "Is a key
+ * missing from this block, whose members are the nine slugs?" is a test. The
+ * blocks are discovered by walking the catalogs rather than listed here, so a
+ * block added next month is covered the moment it exists.
+ *
+ * TWO KINDS OF BLOCK, AND THE DATA TELLS THEM APART. A block with a `default`
+ * sibling is an OVERRIDE block: a faction declares an entry only where it differs
+ * and the default catches the rest, so absence is the design (taunts, vote
+ * chrome, praxis comment times). A block without one must be COMPLETE. Nothing
+ * needs to declare which kind it is — `default` is the marker, and it is already
+ * how the readers behave.
+ *
+ * Deliberate absences live in EXEMPT below, each with its reason. An exemption is
+ * cheap to add and is the point of the guard: it turns "nobody noticed" into
+ * "someone decided", and the reason is there for whoever asks next.
+ */
+import { describe, expect, it } from "vitest";
+import factions from "../en/factions.json";
+import feed from "../en/feed.json";
+import praxis from "../en/praxis.json";
+import taunts from "../en/taunts.json";
+import votes from "../en/votes.json";
+import { ALBESCENT_FACTION_SLUG, FACTION_RAINBOW_ORDER } from "../../utils/factions";
+
+/**
+ * The nine kits, derived. `FACTION_RAINBOW_ORDER` is the seven that carry a hue;
+ * `na` and Albescent sit outside it for reasons of their own, which is why every
+ * loop in the repo prepends them by hand rather than reaching for one list.
+ */
+const SLUGS: readonly string[] = ["na", ALBESCENT_FACTION_SLUG, ...FACTION_RAINBOW_ORDER];
+
+/** `<catalog>:<path>` → why a slug or key is allowed to be absent. */
+const EXEMPT: Record<string, string> = {
+  "factions:(root)|na":
+    "Unaffiliated has no faction-detail block: no invitation, no join, no spotlight to write.",
+  "factions:(root)|albescent.invitation":
+    "Albescent is a secret society — it is not joined by invitation letter (ADR-0082).",
+  "factions:(root)|albescent.join":
+    "Albescent is not joined; the reveal admits you (#2409).",
+  "factions:(root)|albescent.spotlight":
+    "Albescent does not advertise itself on the directory (ADR-0088).",
+  "votes:(root)|albescent":
+    "Albescent still has no vote voice and counts in arabic (#783), pinned in voteLadders.test.tsx.",
+  "feed:factionHero|na":
+    "#2805 folds the hero's motto onto factionSelect.{F}.tagline, which na does have. " +
+    "Revisit this exemption when that lands — the block may not need an na entry at all.",
+  "feed:factionHero|albescent.eyebrow":
+    "Albescent's hero is a wrapper over DefaultFactionHero, which reads the SHARED " +
+    "factions:detail.eyebrow rather than a per-faction one.",
+  "feed:factionHero|singularity.eyebrow":
+    "Reads the shared factions:detail.eyebrow, like the Default hero it follows here.",
+  "feed:factionSelect|albescent.banner":
+    "Albescent and na both wear DefaultSelectCard, which draws no banner slot.",
+  "feed:factionSelect|na.banner":
+    "DefaultSelectCard draws no banner slot.",
+  "feed:factionSelect|wow.blurb":
+    "WowSelectCard draws a banner and no blurb — the decree design has no blurb slot.",
+  "feed:factionSelect|everymen.blurb":
+    "EverymenSelectCard draws a banner and no blurb — the bill design has no blurb slot.",
+};
+
+const CATALOGS: readonly [string, Record<string, unknown>][] = [
+  ["factions", factions as Record<string, unknown>],
+  ["feed", feed as Record<string, unknown>],
+  ["praxis", praxis as Record<string, unknown>],
+  ["taunts", taunts as Record<string, unknown>],
+  ["votes", votes as Record<string, unknown>],
+];
+
+type Block = {
+  id: string;
+  entries: Record<string, unknown>;
+  slugs: string[];
+  isOverride: boolean;
+};
+
+/** Every object in a catalog keyed by three or more faction slugs. */
+function blocksIn(catalog: string, node: unknown, path: string, found: Block[]): void {
+  if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+  const entries = node as Record<string, unknown>;
+  const slugs = Object.keys(entries).filter((k) => SLUGS.includes(k));
+  if (slugs.length >= 3) {
+    found.push({
+      id: `${catalog}:${path || "(root)"}`,
+      entries,
+      slugs,
+      isOverride: "default" in entries,
+    });
+  }
+  for (const [k, v] of Object.entries(entries)) {
+    blocksIn(catalog, v, path ? `${path}.${k}` : k, found);
+  }
+}
+
+const BLOCKS: Block[] = CATALOGS.flatMap(([name, cat]) => {
+  const found: Block[] = [];
+  blocksIn(name, cat, "", found);
+  return found;
+});
+
+const COMPLETE = BLOCKS.filter((b) => !b.isOverride);
+
+describe("faction-keyed catalog blocks are complete, or exempt with a reason", () => {
+  // The tripwire. A walker that silently stops matching would otherwise report a
+  // clean board by scanning nothing at all — the failure mode that scored one
+  // faction at zero assertions during #2814's audit.
+  it("finds the faction-keyed blocks at all, so nothing passes by vacuum", () => {
+    expect(BLOCKS.length).toBeGreaterThanOrEqual(7);
+    expect(COMPLETE.map((b) => b.id)).toEqual(
+      expect.arrayContaining(["factions:names", "factions:descriptions", "feed:factionSelect"]),
+    );
+    expect(BLOCKS.some((b) => b.isOverride)).toBe(true);
+  });
+
+  it.each(COMPLETE.map((b) => [b.id, b] as const))(
+    "%s declares every faction",
+    (id, block) => {
+      const missing = SLUGS.filter(
+        (s) => !block.slugs.includes(s) && !(`${id}|${s}` in EXEMPT),
+      );
+      expect(missing, `${id} is a complete block — add the slug, or exempt it in EXEMPT`).toEqual(
+        [],
+      );
+    },
+  );
+
+  /**
+   * THE AMBIGUOUS MIDDLE IS THE WHOLE POINT, and the threshold took a try to get
+   * right. A first cut flagged only the all-but-one case and missed
+   * `factionSelect.blurb` at 7 of 9 — which is exactly the shape worth catching.
+   *
+   * The keys cluster: universal (9 of 9 — the contract), bespoke (1 or 2 — a
+   * wordmark, a plaque), and a middle that is always either a decision nobody
+   * wrote down or a hole nobody noticed. So: a key held by MORE THAN HALF but not
+   * all must be named in EXEMPT with its reason. Bespoke slots never trip it, and
+   * a key that quietly stops being universal always does.
+   */
+  it.each(COMPLETE.map((b) => [b.id, b] as const))(
+    "%s gives every faction the keys its siblings share",
+    (id, block) => {
+      const keysets = new Map<string, Set<string>>();
+      for (const slug of block.slugs) {
+        const entry = block.entries[slug];
+        if (typeof entry === "object" && entry !== null && !Array.isArray(entry)) {
+          keysets.set(slug, new Set(Object.keys(entry as object)));
+        }
+      }
+      if (keysets.size < 3) return;
+
+      const held = new Map<string, number>();
+      for (const keys of keysets.values()) {
+        for (const k of keys) held.set(k, (held.get(k) ?? 0) + 1);
+      }
+
+      const holes: string[] = [];
+      for (const [key, count] of held) {
+        if (count <= keysets.size / 2 || count === keysets.size) continue;
+        for (const [slug, keys] of keysets) {
+          if (!keys.has(key) && !(`${id}|${slug}.${key}` in EXEMPT)) {
+            holes.push(`${slug} lacks '${key}' (${count}/${keysets.size} siblings have it)`);
+          }
+        }
+      }
+      expect(holes, `${id}: add the key, or exempt it in EXEMPT with a reason`).toEqual([]);
+    },
+  );
+
+  it("keeps no exemption for a block or slug that no longer exists", () => {
+    const live = new Set<string>();
+    for (const b of BLOCKS) {
+      for (const s of SLUGS) live.add(`${b.id}|${s}`);
+      for (const s of b.slugs) {
+        const entry = b.entries[s];
+        if (typeof entry === "object" && entry !== null) {
+          for (const k of Object.keys(entry as object)) live.add(`${b.id}|${s}.${k}`);
+        }
+      }
+    }
+    // An exemption names either a slug (block|slug) or a key (block|slug.key).
+    // Both are addressable above; a stale one is an exemption for something gone.
+    const stale = Object.keys(EXEMPT).filter((e) => {
+      const [blockId] = e.split("|");
+      return !BLOCKS.some((b) => b.id === blockId);
+    });
+    expect(stale, "these exemptions name a block that no longer exists — delete them").toEqual([]);
+  });
+});

--- a/frontend/src/pages/praxisDetail/__tests__/kitInvariants.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/kitInvariants.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * What every praxis-detail kit must do, asserted for every kit (#2814, #2801).
+ *
+ * THE POPULATION IS THE POINT. Nine of these behaviours were written out by hand
+ * across the kit suites — one in six files, one in five, one in four — and the
+ * kits that never got a copy were invisible, because nothing enumerated the set
+ * a kit could be missing FROM. "Is a kit missing an assertion?" is unanswerable.
+ * "Is a kit missing one of INVARIANTS?" is this file.
+ *
+ * A behaviour belongs here if it cannot vary by faction. Whether a viewer who
+ * cannot act is shown an action box is not a kit's decision; neither is hiding a
+ * hidden praxis's comments. Everything a kit decides FOR ITSELF — the lotus, the
+ * bunting, the censor bar, the plate register — stays in its own suite, and this
+ * file must never grow an assertion that names a faction.
+ *
+ * BOTH LISTS ARE DERIVED, AND THEY COME FROM DIFFERENT PLACES. The kits come
+ * from `surfaceMap('praxisDetail')`, so a tenth kit joins by existing. The
+ * invariants are hand-authored HERE, which is what keeps this from being a
+ * tautology — `defaultManifest.test.tsx` records the same reasoning: a
+ * denominator derived from its own subject asserts only that the subject equals
+ * itself.
+ *
+ * EVERY INVARIANT ASSERTS ITS POSITIVE CASE FIRST. A bare `not.toContain` passes
+ * the moment the copy it names is deleted, or when the fixture never produced
+ * the thing at all — the vacuous-pass failure #2814's audit kept hitting from
+ * the other side. So each check below proves the thing appears when it should,
+ * then that it does not when it should not.
+ *
+ * This file is phase 1. It does NOT delete the hand-written copies in the kit
+ * suites — that waits on owner QA, per the epic. Adding an invariant here is
+ * expected to make some kit fail; that failure is a finding to file, not a
+ * reason to narrow the list.
+ */
+import { describe, expect, it } from 'vitest'
+import { surfaceMap } from '../../../factions'
+import { aPraxis } from '../../../test/fixtures'
+import { VOTERS, renderPraxisDetail } from '../../../test/praxisDetail'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+/** Every registered praxis-detail kit, derived — a tenth joins by existing. */
+const KITS: string[] = Object.keys(surfaceMap('praxisDetail'))
+
+type Invariant = {
+  /** Reads as the rule, not as the mechanism. */
+  readonly name: string
+  /** Throws (via expect) when this kit breaks the rule. */
+  readonly check: (slug: string) => void
+}
+
+const INVARIANTS: readonly Invariant[] = [
+  {
+    name: 'hides the comment region on a praxis that is not visible',
+    check: (slug) => {
+      const shown = renderPraxisDetail(slug, { comments: [] })
+      expect(shown.text, 'positive case: a visible praxis shows the region').toContain('Discussion')
+
+      const hidden = renderPraxisDetail(slug, {
+        comments: [],
+        praxis: { ...aPraxis(), moderation_status: 'hidden' },
+      } as Partial<PraxisDetailState>)
+      expect(hidden.text).not.toContain('Discussion')
+    },
+  },
+  {
+    name: "lists who voted and each voter's own rung, never an average",
+    check: (slug) => {
+      const voted = renderPraxisDetail(slug, { voters: VOTERS })
+      expect(voted.text).toContain('Who voted')
+      expect(voted.html, 'each voter links to their own character').toContain(
+        'href="/characters/11"',
+      )
+
+      const unvoted = renderPraxisDetail(slug, { voters: [] })
+      expect(unvoted.text, 'no empty voter panel').not.toContain('Who voted')
+    },
+  },
+  {
+    name: 'draws no navigation of its own — the breadcrumb is site chrome',
+    check: (slug) => {
+      const { html } = renderPraxisDetail(slug, {})
+      // The trail's CONTENTS are pinned in pages/__tests__/breadcrumbAcrossSurfaces
+      // for every skin at both widths. What is left to say here is the negative:
+      // no kit re-draws the crumb inside its own sheet, and none grows a phone
+      // back bar of its own.
+      const sheet = html.slice(html.indexOf('</nav>') + 1)
+      expect(sheet, 'no crumb inside the surface').not.toContain('href="/tasks"')
+      expect(html, 'no phone back bar').not.toContain('href="/praxis"')
+    },
+  },
+]
+
+/** invariant × kit — the whole grid, named so a failure says which cell. */
+const GRID: [string, string, Invariant][] = INVARIANTS.flatMap((inv) =>
+  KITS.map((slug): [string, string, Invariant] => [inv.name, slug, inv]),
+)
+
+describe('every praxis-detail kit holds every faction-invariant behaviour', () => {
+  // The tripwire. A harness that stopped resolving kits would otherwise report a
+  // clean grid by asserting nothing at all — the failure that scored one faction
+  // at zero assertions during #2814's audit.
+  it('has kits and invariants to check at all', () => {
+    expect(KITS.length, 'surfaceMap resolved no praxisDetail kits').toBeGreaterThanOrEqual(9)
+    expect(INVARIANTS.length).toBeGreaterThan(0)
+    expect(GRID).toHaveLength(INVARIANTS.length * KITS.length)
+  })
+
+  it.each(GRID)('%s — %s', (_name, slug, invariant) => {
+    invariant.check(slug)
+  })
+})

--- a/frontend/src/test/__tests__/loopListsAreDerived.test.ts
+++ b/frontend/src/test/__tests__/loopListsAreDerived.test.ts
@@ -1,0 +1,127 @@
+/**
+ * A list that DRIVES per-kit iteration is derived, not typed (#2814, #2815).
+ *
+ * A parameterised test looks exhaustive. Whether it is depends entirely on the
+ * list it loops, and a hand-typed list is a population someone has to remember
+ * to update. `pages/fieldDesk/__tests__/homeTrackBand.test.tsx` types eight
+ * slugs under a comment reading "so all eight are checked" — there are nine, and
+ * `AlbescentFieldDesk` is registered on `mobileFieldDesk`. The claim outlived the
+ * list, which is worse than no claim at all.
+ *
+ * WHAT THIS GUARD DOES NOT SAY. Not every slug array is wrong. A fixture, a
+ * contrast pair table, an expected-order assertion — those name slugs because
+ * the slugs ARE the subject. Sixty-one test files hold a slug array; only the
+ * twenty-five below drive a `.each`, and only those are making a completeness
+ * claim. This guard is narrow on purpose.
+ *
+ * TYPING IS SOMETIMES RIGHT, AND THE EXCEPTION MATTERS.
+ * `factions/__tests__/defaultManifest.test.tsx` types its surface list on
+ * purpose, and says why: *"derived from the manifest it would assert that the
+ * manifest equals itself, which is exactly the tautology that let the na kit
+ * drift out of the registry in the first place."* A denominator taken from its
+ * own subject proves nothing. So the rule is not "always derive" — it is
+ * "derive, or be on this list having said why".
+ *
+ * THIS IS A RATCHET. The twenty-five entries below are grandfathered: they exist
+ * today and #2815 converts them. The guard's job is that the twenty-sixth cannot
+ * appear quietly. Removing an entry as it is converted is the intended direction;
+ * adding one needs a reason in the review, not just a green suite.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { sourceFiles, stripComments, toRelative } from '../sourceScan'
+
+/** A quoted faction slug — the nine kits plus the `default` archetype's name. */
+const SLUG_LITERAL =
+  /['"](?:ua|wow|coven|snide|singularity|ephemerists|everymen|albescent|na|default)['"]/g
+
+/** Any read that reaches the manifest rather than restating it. */
+const DERIVED =
+  /surfaceMap|FACTION_MANIFESTS|FACTION_RAINBOW_ORDER|Object\.(?:keys|entries)|CSS_KEY|KIT_MODULES|SURFACE_KEYS|MANIFESTS/
+
+/**
+ * `<path from src/>|<const name>` for every typed list driving a `.each` today.
+ * Shrinks as #2815 converts them; it must never grow without a reason.
+ */
+const GRANDFATHERED: ReadonlySet<string> = new Set([
+  'components/__tests__/feedRow.test.tsx|FILL_SLUGS',
+  'components/__tests__/invitationPerks.test.tsx|MECHANICS',
+  'components/collab/__tests__/collabCopy.test.ts|FACTION_SLUGS',
+  'components/comments/__tests__/commentFootRule.test.tsx|VOICES',
+  'components/comments/__tests__/mentionPopoverClip.test.tsx|VOICES',
+  'components/factionHero/__tests__/factionWordmarkWrap.test.tsx|HEROES',
+  'components/feed/__tests__/feedRowInk.test.tsx|CASES',
+  'components/praxisCard/__tests__/bylineDivider.test.tsx|DASHED',
+  'components/praxisCard/__tests__/praxisMasthead.test.tsx|BANDED',
+  'components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx|UNIFIED',
+  'components/sigil/__tests__/factionSigil.test.tsx|SLUGS',
+  'components/taskCard/__tests__/factionTaskCardsV2.test.tsx|SKINS',
+  'components/taskCard/__tests__/mastheadFactionLink.test.tsx|MASTHEADED',
+  'components/taskCard/__tests__/mobileCardFillsColumn.test.tsx|SKINS',
+  'components/taskCard/__tests__/taskCardsV3.test.tsx|SKINS',
+  'pages/characterPaths/__tests__/placeholderInk.test.ts|FIELDS',
+  'pages/characterPaths/__tests__/singularityCreateCharacterRegister.test.tsx|WIDTHS',
+  'pages/characterProfile/__tests__/factionProfileBody.test.tsx|SLUGS',
+  'pages/characterProfile/__tests__/profileAbout.test.tsx|BRANCHES',
+  'pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx|SLUGS',
+  'pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx|SLUGS',
+  'pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx|SLUGS',
+  'pages/fieldDesk/__tests__/homeTrackBand.test.tsx|SKINS',
+  'pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx|WALL_ALARM',
+  'pages/tasks/__tests__/equalHeightRow.test.tsx|SKINS',
+])
+
+function typedLoopLists(): string[] {
+  const found: string[] = []
+  for (const file of sourceFiles({ includeTests: true })) {
+    if (!/\.test\.tsx?$/.test(file)) continue
+    const source = stripComments(readFileSync(file, 'utf8'))
+    const rel = toRelative(file).replace(/\\/g, '/').replace(/^src\//, '')
+
+    const looped = new Set(
+      [...source.matchAll(/(?:it|describe|test)\.each\(\s*([A-Za-z_]\w*)/g)].map((m) => m[1]),
+    )
+    for (const name of looped) {
+      const decl = new RegExp(
+        `const\\s+${name}\\b[^=]*=\\s*(\\[[\\s\\S]*?\\n\\s*\\]|\\[[^\\]]*\\])`,
+      ).exec(source)
+      if (!decl) continue
+      const body = decl[1]
+      const slugs = body.match(SLUG_LITERAL)?.length ?? 0
+      if (slugs >= 3 && !DERIVED.test(body)) found.push(`${rel}|${name}`)
+    }
+  }
+  return found.sort()
+}
+
+const TYPED = typedLoopLists()
+
+describe('a list driving per-kit iteration is derived from the manifest', () => {
+  // The tripwire. This guard's whole output is a list of things that are WRONG,
+  // so a scanner that silently stopped matching would report a perfect board.
+  it('still finds the typed lists it is meant to be watching', () => {
+    expect(TYPED.length, 'the scan matched nothing — the regexes have drifted').toBeGreaterThan(15)
+    expect(TYPED, 'the known worst case must still be visible to the scan').toContain(
+      'pages/fieldDesk/__tests__/homeTrackBand.test.tsx|SKINS',
+    )
+  })
+
+  it('adds no new typed list', () => {
+    const fresh = TYPED.filter((entry) => !GRANDFATHERED.has(entry))
+    expect(
+      fresh,
+      'Derive this list from surfaceMap()/FACTION_MANIFESTS so a tenth kit joins by existing. ' +
+        'If typing it is deliberate — see defaultManifest.test.tsx on the tautology trap — ' +
+        'add it to GRANDFATHERED with the reason in your PR.',
+    ).toEqual([])
+  })
+
+  it('keeps no grandfathered entry that has already been converted', () => {
+    const live = new Set(TYPED)
+    const stale = [...GRANDFATHERED].filter((entry) => !live.has(entry)).sort()
+    expect(
+      stale,
+      'these lists are derived now (or gone) — delete them from GRANDFATHERED so the ratchet holds',
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Three test-only guards. **No production code changes, and no existing test is deleted or edited.**

Every faction gap this repo has found was the same shape: something absent from a population that
nothing enumerated. #2805 found `feed:factionHero` has no `na` block, so the Unaffiliated faction
page printed no tagline while every other faction's did. #2806 found nine identical copies of a
string that already had a canonical home. Neither was caught by a test, because *"is something
missing?"* is unanswerable — only *"is it missing from **this** list?"* is a test.

Each guard enumerates a population and asserts over it.

## `kitInvariants.test.tsx` — invariants × kits (28 tests)

The invariant list is hand-authored in the file; the kit list comes from
`surfaceMap('praxisDetail')`. **Two different sources on purpose** —
`defaultManifest.test.tsx` already records why: *"derived from the manifest it would assert that
the manifest equals itself, which is exactly the tautology that let the na kit drift out of the
registry in the first place."*

All nine kits already pass all three invariants, so the gap really was in the *assertions*, not the
behaviour — which is what #2801's phase 1 predicted. Every invariant proves its **positive case
before its negative**, so a bare `not.toContain` cannot pass by naming copy that no longer exists.

A failure names the cell: `hides the comment region on a praxis that is not visible — albescent`.

## `factionKeyCompleteness.test.ts` — catalog keys × factions (14 tests)

Blocks are discovered by walking the catalogs, so one added next month is covered the moment it
exists. **The data classifies itself:** a block with a `default` sibling is an *override* block
(absence is the design), one without must be *complete*.

Within a block, a key held by more than half the factions but not all must be exempted with a
reason. A first cut flagged only the all-but-one case and missed `factionSelect.blurb` at 7 of 9 —
which is exactly the shape worth catching.

It surfaced six previously-invisible decisions, now written down: `wow` and `everymen` have no blurb
slot, `DefaultSelectCard` draws no banner, and `DefaultFactionHero` reads the shared
`factions:detail.eyebrow` rather than a per-faction one. It also holds #2805's missing
`factionHero.na`, exempted with a pointer to that issue to revisit when it lands.

## `loopListsAreDerived.test.ts` — the loop layer's populations (3 tests)

A parameterised test *looks* exhaustive; whether it is depends on the list it loops.
`homeTrackBand.test.tsx` types eight slugs under a comment reading "so all eight are checked" —
there are nine, and `AlbescentFieldDesk` is registered on `mobileFieldDesk`.

A ratchet over the **25** typed lists that drive a `.each` today, so the 26th cannot appear quietly.
Converting one means deleting its entry, and a third assertion fails if a grandfathered entry is
already derived — the list cannot rot in the permissive direction.

Scope is deliberately narrow: 61 test files hold a slug array, but most are fixtures, contrast pair
tables and expected-order assertions, where the slugs *are* the subject. Only a list driving
iteration makes a completeness claim.

## Every guard carries a tripwire

`expect(TYPED.length).toBeGreaterThan(15)`, `expect(KITS.length).toBeGreaterThanOrEqual(9)`,
`expect(BLOCKS.length).toBeGreaterThanOrEqual(7)`.

A guard whose whole output is a list of wrong things reports a perfect board the moment its scanner
drifts — and that is not hypothetical. During the #2814 audit a double-quote-only regex scored Coven
at **zero** assertions when it has one of the fullest suites in the directory.

## Verified red before green

Each guard was made to fail on purpose and then restored:

- an injected false invariant fails **nine times**, each naming its kit — including `na` and `albescent`
- removing `factionSelect.wow` and `coven.tagline` fails both halves of the catalog guard with
  actionable messages
- a new typed `.each` list fails the ratchet, pointing at `surfaceMap()` and at the tautology exception

## What this does not do

**No hand-written per-kit copy is deleted.** That is phase 2 and waits on owner QA, per #2814.
These guards are additive: they assert the invariants centrally while the existing kit suites keep
asserting them too.

`archetypeReachability.test.ts` already covers archetype reachability — orphan skins, unread
surfaces, and it excludes tests from its reference set so a retired skin cannot keep itself alive. A
fourth guard there would be redundant, so none was written.

## Checks

Full frontend suite **465 files / 9594 passing, 1 skipped**; `tsc --noEmit` and `eslint` clean.
Adds 45 tests.

Refs #2814, #2801, #2805, #2806, #2815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
