### PR TITLE
Albescent's last perk is Transcendence, and no letter slot says PLACEHOLDER (#2828)

### DIFF
--- a/frontend/src/components/__tests__/invitationPerks.test.tsx
+++ b/frontend/src/components/__tests__/invitationPerks.test.tsx
@@ -273,21 +273,27 @@ describe('the eight real perks ship the corrected copy (#2298 §3)', () => {
     expect(perk.desc).toBe(desc)
   })
 
-  it("Albescent's mechanic is named, and its description is owed back", () => {
-    // It was `perks.duties`, named "Enlightenment", until the owner's copy pass
-    // cut `duties` and `witnessed` and put the name she wrote on `record` — the
-    // only perk the letter carries now. The description that travelled with it
-    // stopped mid-clause ("You know how to task"), so on her call it went back
-    // to a placeholder rather than ship unfinished. This is the ONE Albescent
-    // row still owed, and it is owed a desc, not a name.
+  it("Albescent's mechanic is named and written, and says nothing about levels", () => {
+    // It was `perks.duties`, named "Enlightenment", until #2782's copy pass cut
+    // `duties` and `witnessed` and left `record` the only perk the letter
+    // carries. That pass also sent this description back to a placeholder, for
+    // stopping mid-clause ("You know how to task").
+    //
+    // OWNER, 2026-08-28 (#2828): the description is RESTORED VERBATIM, ending
+    // and all. Shown the mid-clause objection and #2782's own diff, she
+    // re-affirmed it and renamed the perk "Transcendence" — the pitch's word for
+    // those who have "transcended the factional competition". THE ENDING IS
+    // DELIBERATE: do not finish the clause, and do not send it back to a
+    // placeholder. That round trip has now happened once.
     const perk = factions.albescent.letter.perks.record as unknown as Perk
-    expect(perk.name).toBe('Abilities')
-    expect(perk.desc).toMatch(/^PLACEHOLDER — /)
+    expect(perk.name).toBe('Transcendence')
+    expect(perk.desc).not.toMatch(/^PLACEHOLDER/)
+    expect(perk.desc).toMatch(/^You see the value in working together,/)
+    expect(perk.desc).toMatch(/You know how to task$/)
     // The owner's draft opened "From levels 1-7…" and closed on level 8. Both
     // sentences were cut deliberately: `inherits_faction_perks` carries no
     // level condition, and `albescent_level_required` is the door in, not a
-    // point where what you hold changes. Nothing about levels may come back —
-    // including in whatever fills this placeholder.
+    // point where what you hold changes. Nothing about levels may come back.
     expect(perk.desc).not.toMatch(/\blevel/i)
   })
 })
@@ -303,7 +309,7 @@ describe('the eight real perks ship the corrected copy (#2298 §3)', () => {
  * where a placeholder is still the honest state, because a description is copy
  * and the letter would say nothing there without it.
  * -------------------------------------------------------------------------- */
-describe('one perk slot is still owed, and nothing else is (#2298 §4, #2774)', () => {
+describe('no perk slot is owed any more (#2298 §4, #2774, #2828)', () => {
   function allPerks(): Array<[string, Perk]> {
     const shared = SLUGS.flatMap((slug) =>
       perksOf(slug).map((perk, idx) => [`${slug}.invitation.perks.${idx}`, perk] as [string, Perk]),
@@ -314,16 +320,19 @@ describe('one perk slot is still owed, and nothing else is (#2298 §4, #2774)', 
     return [...shared, ...alb]
   }
 
-  it("leaves exactly one owed slot — Albescent's mechanic description", () => {
+  it('leaves no owed slot: every perk name and description is written', () => {
     const owed = allPerks().flatMap(([id, perk]) =>
       (['name', 'desc'] as const)
         .filter((field) => perk[field]?.startsWith('PLACEHOLDER'))
         .map((field) => `${id}.${field}`),
     )
-    expect(owed).toEqual(['albescent.letter.perks.record.desc'])
+    expect(owed).toEqual([])
   })
 
-  it('hints that placeholder, so the file says what it wants', () => {
+  // Vacuous today by design — nothing is owed. It is a forward guard: it costs
+  // nothing while the ledger is empty and bites the moment a bare PLACEHOLDER
+  // is added back.
+  it('hints any placeholder, so the file says what it wants', () => {
     for (const [id, perk] of allPerks()) {
       for (const field of ['name', 'desc'] as const) {
         if (!perk[field]?.startsWith('PLACEHOLDER')) continue

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -75,8 +75,8 @@
       "pitch": "Albescent is a secret society for those who have created meaningful contributions to all factions and transcended the factional competition. It's also a thank you to those who have played this game with dedication.",
       "perks": {
         "record": {
-          "name": "Abilities",
-          "desc": "PLACEHOLDER — desc for: Abilities"
+          "name": "Transcendence",
+          "desc": "You see the value in working together, competing, gathering information, being consistent, trying again, and being in the right place at the right time (even if that involves a little messing around with the timeline). You know how to task"
         }
       },
       "newGamePlus": "Available only for New Game+",


### PR DESCRIPTION
Closes #2828.

Albescent's invitation letter shipped `PLACEHOLDER — desc for: Abilities` as its one perk
description, rendered unconditionally at `AlbescentInvitation.tsx:216`. Found during the
`/planner-bot` visual-QA run of #2626.

## Why #2774 missed it

It was the last of the sixteen letter slots #2774 set out to clear, and it survived because
**Albescent's letter is a forked component on a forked catalog path.** Every other faction
stores letter perks under `<slug>.invitation.perks[]`, read by `InvitationLetterPopup`;
`coven.letter.perks` and `wow.letter.perks` are both `null`. A sweep of the shared path
reported zero owed slots while this one stood.

## The ruling — owner, 2026-08-28

```json
"record": {
  "name": "Transcendence",
  "desc": "You see the value in working together, competing, gathering information, being consistent, trying again, and being in the right place at the right time (even if that involves a little messing around with the timeline). You know how to task"
}
```

The name is the letter's own pitch turned back on the reader — *"those who have created
meaningful contributions to all factions and **transcended the factional competition**"*. It is
neither name this row has carried before (`Enlightenment`, then `Abilities`).

**The description is restored verbatim, and its ending is deliberate.** `c6464fdf` (#2782) sent
it back to a placeholder precisely because it stops mid-clause on *"You know how to task"*.
Shown that history and #2782's own diff, the owner re-affirmed it unchanged. The guard test now
records the re-affirmation, because otherwise the next copy pass reads an unfinished sentence
and "fixes" it back to a placeholder — the round trip that has already happened once.

## Tests

The two guards pinned this slot as *owed*, so they went red the moment the copy landed. They
now assert the opposite, which is the more durable shape:

- `leaves exactly one owed slot` → **`leaves no owed slot`**, asserting the owed list is `[]`.
  It fails on *any* new placeholder in *any* perk slot rather than on a change to this one.
- `Albescent's mechanic is named, and its description is owed back` → asserts the name is
  `Transcendence` and the description is written. **The level constraint is untouched and still
  load-bearing**: `inherits_faction_perks` carries no level condition and
  `albescent_level_required` is the door in, not a point where what you hold changes, so
  nothing about levels may appear here.
- `hints any placeholder` is **kept and relabelled**, not deleted. It is vacuous while the
  ledger is empty, which is the point — it is a forward guard that bites the moment a bare
  placeholder returns.

## Verification

- Full frontend suite **9692 passed / 1 skipped, 469 files**; `npm run lint` clean;
  `tsc --noEmit` clean. Re-run green after rebasing onto `1ad94ed2`.
- `PLACEHOLDER` in `frontend/src/locales/en/*.json` is now **5** — all
  `descriptions.{coven,ephemerists,everymen,singularity,albescent}`, the faction About copy
  already recorded as deliberate. **Zero** in any perk or letter slot.
- Rendered geometry measured with the real face at the letter's 620px width: the row wraps to
  **4 lines** (138px) against a sibling mechanic row's 2 (84px), no horizontal overflow.
  Albescent's letter carries one perk where the others carry three, so its box remains the
  shortest of the eight.

## Not verified in a browser

`AlbescentInvitation` is gated on `user.can_start_as_albescent`, which is false for an account
already in Albescent, so the live letter was not reachable in the QA session. The geometry above
is a faithful offscreen measurement using the component's own styles and the real loaded face,
not a screenshot of the letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
