### PR TITLE
About and Members take the censor bar the other two sections already use (#2807)

### DIFF
--- a/frontend/src/pages/factionDetail/__tests__/snideSectionHeadingVoice.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/snideSectionHeadingVoice.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * S.N.I.D.E.'S FOUR SECTION HEADINGS SPEAK IN ONE VOICE (#2807).
+ *
+ * The page drew its four sections in TWO voices, and the split was not a design
+ * choice — Tasks and Recent went through `SectionHeading` (Impact stencil on the
+ * acid censor plate, barcode rule beside it) and About and Members were still the
+ * marker scrawl they had been before that component existed. Owner ruling,
+ * 2026-08-27: all four take `SectionHeading`.
+ *
+ * WHY THE SEAM IS THE RENDERED MARKUP AND NOT THE SOURCE. The sibling guard in
+ * `factionContrast.test.ts` sweeps this file as TEXT, which is the right seam for
+ * "an acid ink with no plate under it" because a pairing is a fact about a style
+ * object. This is a fact about the TREE: whether the heading a reader meets is
+ * inside a heading row at all, and whether that row is a stacking context. A
+ * source sweep cannot see either, and both are exactly what a naive conversion
+ * gets wrong.
+ *
+ * THE HALFTONE IS THE LANDMINE. Both converted headings sit in a panel that also
+ * mounts `<Halftone />` — `position: absolute; inset: 0`, an 8% dot raster over
+ * the panel's whole box. Every sibling that must paint above it carries
+ * `position: relative` of its own, and the two scrawls did. `SECTION_HEADING_ROW`
+ * did not, so wrapping them dropped both headings UNDER the raster. At 8% that
+ * is a slightly dulled heading rather than a broken one — it ships green and gets
+ * reported three weeks later, which is why it is asserted rather than eyeballed.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+// Initialize the i18n catalog so faction copy keys resolve to English text.
+import "../../../i18n";
+import i18n from "../../../i18n";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+import SnideFactionBody from "../archetypes/SnideFactionBody";
+
+function aCharacter(over: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    all_time_score: 100,
+    avatar_url: "",
+    badges: [],
+    bio: "",
+    created_at: "2026-01-01T00:00:00Z",
+    display_name: "Ada",
+    faction_slug: "snide",
+    id: 1,
+    invitations: [],
+    level: 4,
+    location: "",
+    score: 100,
+    status: "active",
+    tagline: "",
+    username: "ada",
+    ...over,
+  };
+}
+
+/** Two members, so a champion AND a rap sheet below it both render. */
+const MEMBERS: CharacterOut[] = [
+  aCharacter({ id: 1, display_name: "RunnerUp", username: "RunnerUp", all_time_score: 40 }),
+  aCharacter({ id: 2, display_name: "TopScorer", username: "TopScorer", all_time_score: 900 }),
+];
+
+function snideMarkup(): string {
+  const state = {
+    slug: "snide",
+    loading: false,
+    faction: { slug: "snide" },
+    fetchError: null,
+    members: MEMBERS,
+    tasks: [],
+    recentPraxis: [],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    sections: undefined,
+    membership: {
+      state: "eligible",
+      currentFactionSlug: null,
+      join: async () => {},
+      joining: false,
+      joinError: null,
+    },
+  } as unknown as FactionDetailState;
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SnideFactionBody state={state} />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * `SECTION_HEADING_ROW`, as React serializes it — minus `position`, which is the
+ * thing under test and so must not be part of what finds the row.
+ */
+const ROW =
+  "display:flex;align-items:center;gap:var(--space-md);margin-bottom:var(--space-sm);flex-wrap:wrap";
+/** `ACID_PLATE` — the censor bar, the first two declarations of the heading span. */
+const PLATE = "color:var(--faction-snide-acid);background:var(--faction-snide-ink)";
+/** `SECTION_HEADING_RULE` — the green/pink barcode that closes every heading row. */
+const RULE = "repeating-linear-gradient(90deg";
+
+/**
+ * The one heading row that wraps `label`: from its opening `style=` back-searched
+ * from the label, forward to the barcode rule that closes it.
+ */
+function headingRow(markup: string, label: string): string {
+  const at = markup.indexOf(label);
+  expect(at, `"${label}" is drawn on the page at all`).toBeGreaterThan(-1);
+  const open = markup.lastIndexOf(ROW, at);
+  expect(
+    open,
+    `"${label}" is not inside a SectionHeading row — no heading row opens before it.`,
+  ).toBeGreaterThan(-1);
+  const close = markup.indexOf(RULE, at);
+  expect(
+    close,
+    `"${label}" is not inside a SectionHeading row — no barcode rule closes after it.`,
+  ).toBeGreaterThan(-1);
+  const row = markup.slice(open, close);
+  expect(
+    row.indexOf(ROW, 1),
+    `a second heading row opens between "${label}" and the row above it, so this is not its row.`,
+  ).toBe(-1);
+  return row;
+}
+
+const HEADINGS: ReadonlyArray<readonly [string, string]> = [
+  ["About", i18n.t("factions:detail.aboutHeading")],
+  ["Tasks", i18n.t("factions:detail.default.tasksHeading", { total: 0 })],
+  ["Recent", i18n.t("factions:detail.default.recentHeading")],
+  ["Members", i18n.t("factions:detail.default.membersHeading", { total: MEMBERS.length })],
+];
+
+describe("every S.N.I.D.E. section heading is the censor bar (#2807)", () => {
+  for (const [section, label] of HEADINGS) {
+    it(`${section} is an Impact stencil on the acid plate`, () => {
+      // A missing key makes i18next echo the key back, which would make the
+      // search below pass against itself.
+      expect(label, `${section}'s copy key resolves to real copy`).not.toMatch(/^factions:/);
+      expect(
+        headingRow(snideMarkup(), label),
+        `${section} still speaks in its own voice. All four sections take SectionHeading.`,
+      ).toContain(PLATE);
+    });
+
+    it(`${section} paints above its panel's halftone raster`, () => {
+      // `<Halftone />` is `position: absolute; inset: 0` over the whole panel. A
+      // heading row that is not itself positioned renders UNDER an 8% dot screen.
+      expect(
+        headingRow(snideMarkup(), label),
+        `${section}'s heading row declares no \`position\`, so the halftone paints over it.`,
+      ).toContain("position:relative");
+    });
+  }
+
+  it("the marker scrawl has left this surface", () => {
+    // `--faction-snide-wall-credit` was the scrawl's green and had no other
+    // reader here. The TOKEN stays — six other files spend it, `SnideProfileBody`
+    // among them, which is why `factionContrast.test.ts` still measures it bare.
+    expect(
+      snideMarkup(),
+      "a heading is still scrawled in the wall's green rather than plated.",
+    ).not.toContain("--faction-snide-wall-credit");
+  });
+});

--- a/frontend/src/pages/factionDetail/__tests__/snideSectionHeadingVoice.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/snideSectionHeadingVoice.test.tsx
@@ -105,11 +105,14 @@ const RULE = "repeating-linear-gradient(90deg";
 function headingRow(markup: string, label: string): string {
   const at = markup.indexOf(label);
   expect(at, `"${label}" is drawn on the page at all`).toBeGreaterThan(-1);
-  const open = markup.lastIndexOf(ROW, at);
+  const found = markup.lastIndexOf(ROW, at);
   expect(
-    open,
+    found,
     `"${label}" is not inside a SectionHeading row — no heading row opens before it.`,
   ).toBeGreaterThan(-1);
+  // Back to the row's own `style="`, so the slice carries every declaration and
+  // not only the ones that happen to follow the anchor.
+  const open = markup.lastIndexOf('style="', found);
   const close = markup.indexOf(RULE, at);
   expect(
     close,
@@ -117,7 +120,7 @@ function headingRow(markup: string, label: string): string {
   ).toBeGreaterThan(-1);
   const row = markup.slice(open, close);
   expect(
-    row.indexOf(ROW, 1),
+    row.indexOf(ROW, row.indexOf(ROW) + 1),
     `a second heading row opens between "${label}" and the row above it, so this is not its row.`,
   ).toBe(-1);
   return row;

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -65,14 +65,16 @@ const NOTE_MUTED = "var(--faction-snide-note-muted)";
    ground (the join button, 5.38:1 through `-on-accent`) and 2.98:1 as TYPE on
    the light wall. Where pink carries a WORD it takes this one. */
 const NOTE_PINK = "var(--faction-snide-note-pink-ink)";
-/* The marker scrawl's green. `GREEN` above is `-acid-deep`, which was picked
-   because it "reads correctly on the always-dark ink" — the panel is no longer
-   always-dark, and it reaches 2.30:1 on the light wall (#2173 computes the same
-   number for the same reason). `-wall-credit` is the wall-end rung of the same
-   hue, minted by #2177: 7.72:1 light / 11.35:1 dark. `GREEN` keeps the two
+/* NO `WALL_GREEN` ROW. It was the marker scrawl's green — `-wall-credit`, the
+   wall-end rung of the acid hue minted by #2177 (7.72:1 light / 11.35:1 dark) —
+   and its only two readers here were the About and Members headings, which #2807
+   converted to {@link SectionHeading}. The ink came off the file with them. The
+   TOKEN is untouched and six other files spend it, `SnideProfileBody` among
+   them, which is why `factionContrast.test.ts` still measures it BARE on this
+   wall. `GREEN` above stays what it always was: `-acid-deep`, kept for the two
    marks whose ground really is the press — the barcode rule and the mugshot's
-   rim — so this is a second name rather than a repoint. */
-const WALL_GREEN = "var(--faction-snide-wall-credit)";
+   rim — and 2.30:1 as type on the light wall, which is why it never carried a
+   word. */
 /* The wall's alarm ink. The join error printed the GLOBAL `--color-danger`,
    which is measured on `--color-bg-page` and reads 4.08:1 on this wall (it was
    3.93:1 on the ink panel before it — an AA miss that predates this issue and
@@ -162,6 +164,15 @@ function Halftone() {
 const ACID_PLATE: CSSProperties = { color: ACID, background: INK };
 
 const SECTION_HEADING_ROW: CSSProperties = {
+  /* LOAD-BEARING SINCE #2807, when About and Members joined the two sections
+     that already used this row. Those two sit INSIDE a `WALL_PANEL`, which also
+     mounts {@link Halftone} — `position: absolute; inset: 0` over the panel's
+     whole box — and every sibling that must paint above that raster carries its
+     own `position`. The two marker scrawls did; this row did not, so wrapping
+     them dropped both headings under an 8% dot screen. That reads as a slightly
+     dulled heading rather than a broken one, which is the kind that ships green.
+     Inert for Tasks and Recent, which stand on the bare wall. */
+  position: "relative",
   display: "flex",
   alignItems: "center",
   gap: "var(--space-md)",
@@ -342,19 +353,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
               cream, so it is the first place to look if 40% is too heavy. */}
           <div style={{ ...WALL_PANEL, boxShadow: "4px 6px 0 color-mix(in srgb, var(--color-print-offset) 40%, transparent)", padding: "var(--space-xl)" }}>
             <Halftone />
-            <div
-              style={{
-                position: "relative",
-                fontFamily: MARKER,
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: marker scrawl heading on the xerox flyer.
-                fontSize: 26,
-                color: WALL_GREEN,
-                transform: "rotate(-1deg)",
-                marginBottom: "var(--space-md)",
-              }}
-            >
-              {t("detail.aboutHeading")}
-            </div>
+            <SectionHeading>{t("detail.aboutHeading")}</SectionHeading>
             <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
               {paragraphs.length ? (
                 paragraphs.map((para, i) => (
@@ -656,19 +655,9 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                 of the seventeen and the first candidate for a light tier. */}
             <div style={{ ...WALL_PANEL, boxShadow: "4px 5px 0 color-mix(in srgb, var(--color-print-offset) 40%, transparent)", padding: "var(--space-lg) var(--space-lg) var(--space-md)" }}>
               <Halftone />
-              <div
-                style={{
-                  position: "relative",
-                  fontFamily: MARKER,
-                  // eslint-disable-next-line local/no-raw-style-values -- ornament: marker scrawl heading on the rap sheet.
-                  fontSize: 22,
-                  color: WALL_GREEN,
-                  transform: "rotate(-1deg)",
-                  marginBottom: "var(--space-md)",
-                }}
-              >
+              <SectionHeading>
                 {t("detail.default.membersHeading", { total: members.length })}
-              </div>
+              </SectionHeading>
               {rapSheet.length === 0 ? (
                 <p className="content-text" style={{ position: "relative", fontFamily: TYPE, color: NOTE_MUTED }}>
                   {spot

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -770,6 +770,13 @@ const SNIDE_WALL_GROUNDS: { where: string; surface: string; wash?: string }[] = 
  * them BARE: `-wall-credit` as the marker scrawl over the About flyer and the rap
  * sheet, `-wall-alarm` as the join error. A reading through a veil does not vouch
  * for the reading without one, which is #1028 in the direction people forget.
+ *
+ * `-wall-credit` KEEPS ITS ROW ON A DIFFERENT SURFACE (#2807). The two scrawls
+ * named above were the faction page's only bare readers of it and both became
+ * plated `SectionHeading`s, so that page no longer takes this reading. The row
+ * stays because `SnideProfileBody` does: its level numeral is a bare `color:`
+ * knob on the shared renderer, standing on this same wall with no plate it could
+ * carry. Deleting the row would drop live coverage, not stale coverage.
  */
 const SNIDE_WALL_INKS = [
   ["headline and title", "--faction-snide-note-ink"],
@@ -3869,7 +3876,12 @@ describe("the S.N.I.D.E. faction page stands on the wall (#2343)", () => {
       ["NOTE_INK", "--faction-snide-note-ink"],
       ["NOTE_MUTED", "--faction-snide-note-muted"],
       ["NOTE_PINK", "--faction-snide-note-pink-ink"],
-      ["WALL_GREEN", "--faction-snide-wall-credit"],
+      // NO `WALL_GREEN` ROW. The body's two readers of the wall's green rung were
+      // the About and Members marker scrawls, and #2807 converted both to the
+      // plated `SectionHeading` the other two sections already used; the alias
+      // came off the file with them. The TIER is untouched — `SnideProfileBody`
+      // still spends it bare on this same wall, which is what the
+      // `SNIDE_WALL_INKS` row "the marker scrawl, bare" still measures.
       ["WALL_ALARM", "--faction-snide-wall-alarm"],
     ],
     [HERO]: [
@@ -4050,7 +4062,12 @@ describe("the S.N.I.D.E. faction page stands on the wall (#2343)", () => {
       source,
       "`GREEN` is `-acid-deep`, picked because it read on the always-dark panel; on the light wall it is 2.30:1. It keeps the barcode and the mugshot's rim, whose ground really is the press.",
     ).not.toMatch(/color: GREEN[,\s}]/);
-    expect(source, "the marker scrawl takes the wall's own green").toContain("color: WALL_GREEN");
+    // The positive half of this pair — "the marker scrawl takes the wall's own
+    // green" — was retired by #2807 with its subject. This surface has no scrawl
+    // left: About and Members are plated headings now, and the four section
+    // headings are checked as a set by `snideSectionHeadingVoice.test.tsx`. The
+    // negative above is the load-bearing half and is unchanged — `GREEN` is
+    // 2.30:1 on the light wall and still must not carry a word here.
     expect(
       source,
       "the join error printed the GLOBAL `--color-danger`, measured on `--color-bg-page` and 4.08:1 here.",


### PR DESCRIPTION
Closes #2807

S.N.I.D.E.'s faction page drew its four sections in two voices. Tasks and Recent
went through `SectionHeading` — Impact stencil on the acid censor plate, barcode
rule beside it. About and Members were still the marker scrawl they had been
before that component existed. Owner ruling, 2026-08-27: all four take
`SectionHeading`. Both inline heading `<div>`s are gone; no new style constant,
no variant prop.

## The seam I tested at

**The rendered tree, not the source.** The sibling guard in
`factionContrast.test.ts` sweeps this file as text, which is the right seam for
"an acid ink with no plate under it" — a pairing is a fact about a style object.
This defect is a fact about the tree: whether the heading a reader meets is
inside a heading row at all, and whether that row is a stacking context. A source
sweep can see neither, and both are what a naive conversion gets wrong.

`frontend/src/pages/factionDetail/__tests__/snideSectionHeadingVoice.test.tsx`
renders the body with `renderToStaticMarkup` (the pattern
`factionLayoutAudit.test.tsx` already uses) and, for each of the four headings,
finds the one heading row that wraps it and asserts the plate and the position.
It went red first at 7 of 9 — About and Members carried no plate, and all four
rows carried no `position`.

## The landmine, confirmed

The issue's warning holds. `SECTION_HEADING_ROW` declared no `position`, and both
converted headings sit inside a `WALL_PANEL` that also mounts `<Halftone />` —
`position: absolute; inset: 0`, an 8% dot raster over the panel's whole box. The
two scrawls each carried their own `position: relative`; the row did not, so the
wrap would have dropped both headings under the raster. At 8% that is a slightly
dulled heading rather than a broken one — it ships green and gets reported three
weeks later. `SECTION_HEADING_ROW` gains `position: relative`, inert for Tasks
and Recent, which stand on the bare wall with nothing over them.

Two of the nine assertions cover exactly this and fail without that one line.

## `factionContrast.test.ts` could NOT stay untouched — flagging it

The issue's "done when" asks for `WALL_GREEN` gone from the body **and**
`factionContrast.test.ts` untouched. Those two cannot both hold. That file has
two assertions whose only subject was `WALL_GREEN` *in this file*:

- `ALIASES[BODY]` carries `["WALL_GREEN", "--faction-snide-wall-credit"]`, and
  `boundSource(BODY)` requires the `const` to exist — it gates **five** tests in
  that describe block.
- `expect(source, "the marker scrawl takes the wall's own green").toContain("color: WALL_GREEN")`.

Keeping the constant is not an escape either: unused, it fails `npm run lint`.
There is exactly one consistent outcome, so I took it rather than stopping. Both
assertions are removed with tombstone comments, following that file's own
precedent (the `NO NOTE_MUTED ROW` note in `ALIASES[HERO]`, left when #2368 took
the hero's last reader of that tier).

**The negative half of the pair is untouched and is the load-bearing half** —
`GREEN` (`-acid-deep`) is 2.30:1 on the light wall and still must not carry a
word on this surface.

**`"the marker scrawl, bare"` in `SNIDE_WALL_INKS` stays, and I verified why
before leaving it.** `SnideProfileBody.tsx:47` still binds `WALL_GREEN` and
spends it at `:135` as `accent` — the level numeral, a bare `color:` knob on the
shared renderer that cannot carry a plate the way a span can. The row keeps a
live subject. Only the docblock prose above it moved, because it named the two
sites this PR deleted; no pair, floor or measurement changed.

## Contrast: nothing minted, nothing owed

`SECTION_HEADING_TEXT` spreads `ACID_PLATE` — `--faction-snide-acid` on
`--faction-snide-ink`, 16.33:1 in both cascades — and that pairing was already
curated. The two headings move **up** from `-wall-credit`'s 7.72:1 / 11.35:1. The
plate's light-mode-only asymmetry is untouched: it is a censor bar by day and
dissolves into the near-black ground at night, which is ruled and is why the
plate is required rather than decorative.

## The barcode rule on panel stock — checked, no restyle needed

The "done when" asked whether the rule reads as a second loud mark now that two
of them sit on a panel instead of the bare wall. It does not, and the reason is
structural rather than a judgement call: `WALL_PANEL` grounds on
`--faction-snide-wall`, the *same token* the page backdrop takes through
`useFactionBackdrop`. The rule's ground is byte-identical to what it was written
for, so its 2.30:1 / ~2.98:1 readings are unchanged. The only new thing over it
is the panel's halftone, and the `position: relative` above lifts the whole row —
rule included — clear of it. I have not restyled it.

## What to eyeball (visual QA is outstanding — I have no browser or dev stack)

Verified by `lint`, `typecheck`, `typecheck:design-sync`, the full vitest suite
(473 files / 9784 tests), `build`, and `budget` (WARN on JS is pre-existing and
exits 0; this diff only removes lines from a lazily-loaded chunk).

On `/factions/snide`, in **both themes**:

1. **All four section headings — About, Tasks, Recent, Members — speak in one
   voice.** Same Impact stencil, same skew, same plate, same barcode rule beside
   each. No scrawl left anywhere in the four.
2. **About and Members paint ABOVE the halftone raster, not under it.** This is
   the one that fails quietly. Compare the two panel-bound headings against
   Tasks and Recent on the bare wall — the acid must be the same brightness in
   all four, with no dot screen visible across the plate or the barcode.
3. **Dark mode still dissolves the bar.** In light the plate reads as a censor
   bar over the word; in dark it must sink into the wall so the heading reads as
   plain acid. That asymmetry is the ruling, not a defect.
4. **The two converted headings are `white-space: nowrap`** where the scrawls
   wrapped. Worth a look at narrow widths — "Members · N" is short, but the row
   is `flex-wrap: wrap` and the panel is the 322px rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
