### PR TITLE
Two duplicated key families fold onto their canonical sources: the tile's name, the hero's tagline (#2806, #2805)

### DIFF
--- a/frontend/src/components/factionHero/CovenFactionHero.tsx
+++ b/frontend/src/components/factionHero/CovenFactionHero.tsx
@@ -112,7 +112,7 @@ export default function CovenFactionHero({
               color: INK,
             }}
           >
-            {i18n.t("feed:factionHero.coven.motto")}
+            {i18n.t("feed:factionSelect.coven.tagline")}
           </div>
         </div>
 

--- a/frontend/src/components/factionHero/DefaultFactionHero.tsx
+++ b/frontend/src/components/factionHero/DefaultFactionHero.tsx
@@ -30,12 +30,14 @@ import FactionSigil from "../sigil/FactionSigil";
  *   kicker   the shared `detail.eyebrow` — the same word the chrome this
  *            replaces printed above the name.
  *   name     `factionName(slug)`, resolved by the page (ADR-0038).
- *   tagline  the faction's own motto out of the copy catalog, drawn only when
- *            the catalog has one. A LOOKUP, not a branch: the key is built from
- *            the slug, so a faction gets a tagline by having copy rather than by
- *            this file learning its name. (It is therefore invisible to a grep
- *            for `t("…")` literals — `factionCopyCollapse.test.ts` skips
- *            computed keys by design and the render tests are what cover it.)
+ *   tagline  the faction's tagline out of the copy catalog — the same string
+ *            its select tile draws, and since #2805 the same KEY, drawn only
+ *            when the catalog has one. A LOOKUP, not a branch: the key is built
+ *            from the slug, so a faction gets a tagline by having copy rather
+ *            than by this file learning its name. (It is therefore invisible to
+ *            a grep for `t("…")` literals — `factionCopyCollapse.test.ts` skips
+ *            computed keys by design; `heroDrawsTheTileTagline.test.tsx` is
+ *            what covers it, across all nine.)
  *   counts   the three raw numbers the page passes, under the shared labels.
  *            NOT a faction's own words for them: the seven bespoke heroes each
  *            rename `members` in their own voice, and the fall-through has no
@@ -50,7 +52,13 @@ import FactionSigil from "../sigil/FactionSigil";
  * width, so there is no reason to make the browser wait for JS to find that out.
  */
 export default function DefaultFactionHero({ slug, name, members, tasks, praxes }: FactionHeroProps) {
-  const tagline: string = i18n.t(`feed:factionHero.${slug}.motto`, { defaultValue: "" });
+  // ONE STRING, READ FROM THE TILE'S KEY (#2805). The hero's own
+  // `factionHero.{F}.motto` family said exactly what `factionSelect.{F}.tagline`
+  // says — #2782 ruled the two surfaces speak with one voice and then nothing
+  // held them to it. `defaultValue` stays for an unregistered slug; every
+  // faction has a tagline, including `na`, which had no `factionHero` block at
+  // all and so printed nothing here.
+  const tagline: string = i18n.t(`feed:factionSelect.${slug}.tagline`, { defaultValue: "" });
   const counts = [
     { value: members, label: i18n.t("feed:factionHero.stats.members") },
     { value: tasks, label: i18n.t("feed:factionHero.stats.tasks") },

--- a/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
@@ -161,7 +161,7 @@ export default function EphemeristsFactionHero({
               border: `1px solid ${BRASS}`,
             }}
           >
-            {i18n.t("feed:factionHero.ephemerists.motto")}
+            {i18n.t("feed:factionSelect.ephemerists.tagline")}
           </div>
           <p
             className="content-text"

--- a/frontend/src/components/factionHero/EverymenFactionHero.tsx
+++ b/frontend/src/components/factionHero/EverymenFactionHero.tsx
@@ -173,7 +173,7 @@ export default function EverymenFactionHero({
                 padding: "4px 14px",
               }}
             >
-              {i18n.t("feed:factionHero.everymen.motto")}
+              {i18n.t("feed:factionSelect.everymen.tagline")}
             </div>
           </div>
         </div>

--- a/frontend/src/components/factionHero/SingularityFactionHero.tsx
+++ b/frontend/src/components/factionHero/SingularityFactionHero.tsx
@@ -217,7 +217,7 @@ export default function SingularityFactionHero({
               marginBottom: "var(--space-lg)",
             }}
           >
-            {i18n.t("feed:factionHero.singularity.motto")}
+            {i18n.t("feed:factionSelect.singularity.tagline")}
           </div>
 
         </div>

--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -302,7 +302,7 @@ export default function SnideFactionHero({
               boxShadow: "2px 3px 0 var(--faction-snide-pink)",
             }}
           >
-            {i18n.t("feed:factionHero.snide.motto")}
+            {i18n.t("feed:factionSelect.snide.tagline")}
           </div>
         </div>
 

--- a/frontend/src/components/factionHero/UaFactionHero.tsx
+++ b/frontend/src/components/factionHero/UaFactionHero.tsx
@@ -17,6 +17,13 @@ import { factionRoleVars } from "../../utils/factionRoles";
  * are gone, and so is the ruling that kept this surface undimmed: both themes
  * come from the `[data-theme="dark"]` cascade.
  *
+ * THE RIBBON'S REMOVAL DID NOT SETTLE THE TAGLINE, and the sentence above was
+ * read as if it had (#2805). This hero drew no tagline of any kind while the
+ * other seven did, so UA was the one faction page that could not say the line
+ * the catalog held for it. The owner ruled the slot back: a plain line under
+ * the wordmark, in the type step Coven's hero already uses — the RIBBON is
+ * still retired, the LINE is not.
+ *
  * The page passes raw counts; the practice supplies its own labels from the
  * copy catalog (feed:factionHero.ua.stats.*), per ADR-0016 — presentation only,
  * no new fields.
@@ -103,6 +110,26 @@ export default function UaFactionHero({
               >
                 {name}
               </h1>
+              {/* THE TAGLINE, RESTORED AS A LINE AND NOT AS THE RIBBON (#2805,
+                  owner ruling). This hero drew no tagline at all — UA was the
+                  one faction whose page could not say the thing the catalog
+                  held for it. The gilt ribbon the redesign retired is not
+                  coming back; what comes back is the plain line the other six
+                  heroes draw, in Coven's cut (display face, 600,
+                  `--text-title`, 0.02em) so it is the kit's existing step
+                  rather than a new one. Same key as the select tile, which is
+                  the whole of #2805. */}
+              <div
+                style={{
+                  fontFamily: UA_DISPLAY,
+                  fontWeight: 600,
+                  fontSize: "var(--text-title)",
+                  letterSpacing: "0.02em",
+                  color: "var(--leaf-faction-hero-ink)",
+                }}
+              >
+                {i18n.t("feed:factionSelect.ua.tagline")}
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/factionHero/WowFactionHero.tsx
+++ b/frontend/src/components/factionHero/WowFactionHero.tsx
@@ -130,7 +130,7 @@ export default function WowFactionHero({
               margin: "0 0 var(--space-lg)",
             }}
           >
-            {i18n.t("feed:factionHero.wow.motto")}
+            {i18n.t("feed:factionSelect.wow.tagline")}
           </p>
 
 

--- a/frontend/src/components/factionHero/__tests__/heroDrawsTheTileTagline.test.tsx
+++ b/frontend/src/components/factionHero/__tests__/heroDrawsTheTileTagline.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * THE SEAM IS THE HERO'S TAGLINE SLOT (#2805).
+ *
+ * `feed:factionHero.{F}.motto` and `feed:factionSelect.{F}.tagline` were one
+ * string in two keys: #2782 ruled the hero says what the tile says and set all
+ * eight mottos to their faction's tagline, after which nothing held them
+ * together. The first edit to either desynchronises them silently — the faction
+ * page and the select tile start saying different things about the same faction
+ * and no test fails.
+ *
+ * So the motto keys are gone and every hero reads the tile's tagline. This file
+ * is what makes that a property rather than a coincidence: nine surfaces, one
+ * key family, asserted per faction.
+ *
+ * IT IS ALSO THE FILE THAT WENT RED ON THE TWO HOLES THE FOLD CLOSED, which is
+ * why it is a loop over the whole population rather than six repointed strings:
+ *
+ *   - **ua drew no tagline at all.** `UaFactionHero` renders no motto — #2782
+ *     minted `factionHero.ua.motto` for a slot that did not exist, and the UA
+ *     redesign's docblock recorded the Latin motto RIBBON's removal, which a
+ *     reader took as settling the line too. The owner ruled on #2805 that the
+ *     slot is restored: not the ribbon, a line in the hero's own quiet
+ *     treatment, taking Coven's cut.
+ *   - **na drew none either.** `feed:factionHero` has no `na` block, so
+ *     `DefaultFactionHero` resolved its motto to `defaultValue: ""`.
+ *     `factionSelect.na.tagline` has said "We play for the love of the game"
+ *     all along; reading the tagline key mounts it without minting anything.
+ *
+ * Rendered at the COMPONENT the manifest names, not at the page, unlike
+ * `defaultFactionHero.test.tsx`: the dispatch is that file's subject and is
+ * covered there, and this harness has to reach `na`, which has no faction page
+ * the page harness can build (`factions:na.join.*` does not exist).
+ *
+ * The assertion is on the KEY's resolved value rather than a hardcoded literal,
+ * deliberately and in the opposite direction from
+ * `defaultFactionHero.test.tsx`'s Albescent case — that one pins the WORDING
+ * because #2504/#2519 got the wording wrong while reading the right key. This
+ * one pins the KEY, because the wording is now authored in exactly one place
+ * and the failure mode left is a surface that stops reading it.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ComponentType } from "react";
+import { describe, it, expect } from "vitest";
+
+import "../../../i18n";
+import i18n from "../../../i18n";
+import { factionName } from "../../../utils/factions";
+import type { FactionHeroProps } from "../../../pages/FactionDetail";
+import { surfaceMap } from "../../../factions";
+import { resolvedArchetype } from "../../../factions/lazyArchetype";
+
+/**
+ * The population is the MANIFEST's, not a list typed here (#2814/#2815): each
+ * slug's hero is the component the site actually mounts for it, code-split and
+ * warmed by `src/test/preloadArchetypes.ts`. A tenth kit joins this sweep by
+ * registering a `factionHero`, which is the only way a completeness claim about
+ * "every faction" stays true. Seven are bespoke, Albescent's is a WRAPPER over
+ * the fall-through, and `na`'s IS the fall-through.
+ *
+ * The archetype is resolved INSIDE each case and not at module scope: the warm
+ * -up runs in `beforeAll`, so a lazy read up here would hand every case the
+ * `null`-rendering stub and the whole file would assert against empty markup.
+ */
+const HEROES = Object.entries(surfaceMap("factionHero"));
+
+const render = (slug: string, lazy: ComponentType<FactionHeroProps>) => {
+  const Hero = resolvedArchetype(lazy);
+  // Not an `expect`: an unresolved archetype renders `null`, so every assertion
+  // downstream would look like a copy bug instead of a warm-up one.
+  if (!Hero) throw new Error(`${slug}'s hero archetype never resolved`);
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Hero slug={slug} name={factionName(slug)} members={214} tasks={9} praxes={1489} />
+    </MemoryRouter>,
+  );
+};
+
+describe("every faction hero draws its tile's tagline (#2805)", () => {
+  it("finds all nine kits, so the sweep cannot pass by looping nothing", () => {
+    expect(HEROES).toHaveLength(9);
+    expect(HEROES.map(([slug]) => slug)).toContain("na");
+  });
+
+  it.each(HEROES)("%s prints its factionSelect tagline", (slug, Hero) => {
+    // `defaultValue` for the same reason `DefaultFactionHero` passes one: the
+    // generated key union does not accept a computed key without it.
+    const tagline = i18n.t(`feed:factionSelect.${slug}.tagline`, { defaultValue: "" });
+    // Guards against a vacuous pass: a missing key resolves to "" here, and ""
+    // is contained in every string ever rendered.
+    expect(tagline, `${slug} has a tagline to draw`).not.toBe("");
+    expect(render(slug, Hero), `${slug}'s hero prints its tagline`).toContain(tagline);
+  });
+
+  it("keeps the motto key family deleted, so the two cannot re-fork", () => {
+    // The fold is only worth anything while there is ONE string. A re-minted
+    // `factionHero.{F}.motto` would resolve, render, and drift.
+    for (const [slug] of HEROES) {
+      expect(i18n.exists(`feed:factionHero.${slug}.motto`), slug).toBe(false);
+    }
+  });
+});

--- a/frontend/src/components/selectCard/CovenSelectCard.tsx
+++ b/frontend/src/components/selectCard/CovenSelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { CovenSigil } from "../sigil/CovenSigil";
 import {
@@ -134,7 +135,7 @@ export default function CovenSelectCard({ state = "locked", members, onVisit }: 
       <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)", padding: "var(--space-sm) var(--space-xl) 0" }}>
         <CovenSigil size={34} color={DEEP} />
         <div style={{ fontFamily: HAND, fontSize: "var(--text-title)", lineHeight: 1, textTransform: "lowercase", color: INK, whiteSpace: "nowrap" }}>
-          {i18n.t("feed:factionSelect.coven.name")}
+          {redactableText("factions:names.coven")}
         </div>
       </div>
       <div style={{ padding: "var(--space-xs) var(--space-xl) 0", fontFamily: READING, fontStyle: "italic", fontSize: "var(--text-content)", color: SOFT }}>{i18n.t("feed:factionSelect.coven.tagline")}</div>

--- a/frontend/src/components/selectCard/DefaultSelectCard.tsx
+++ b/frontend/src/components/selectCard/DefaultSelectCard.tsx
@@ -157,7 +157,14 @@ export default function DefaultSelectCard({
             marginTop: "var(--space-md)",
           }}
         >
-          {say("name")}
+          {/* The CANONICAL name (ADR-0038), not a copy of it under this tile's
+              own stem (#2806). Still through `say`, so the redaction gate is
+              unchanged: `ALBESCENT_SCOPED_KEY` matches the segment in any
+              namespace, so `factions:names.albescent` redacts exactly as
+              `factionSelect.albescent.name` did. `factionName()` would NOT —
+              it returns the MASKED name, which is a different ruled behaviour
+              (ADR-0082 §2) and would silently reverse this tile. */}
+          {redactableText(`factions:names.${slug}`)}
         </div>
         <div className="content-text" style={{ fontStyle: "italic", marginTop: "var(--space-xs)", color: "var(--na-select-card-quiet, var(--faction-default-card-muted))" }}>
           {say("tagline")}

--- a/frontend/src/components/selectCard/EphemeristsSelectCard.tsx
+++ b/frontend/src/components/selectCard/EphemeristsSelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
 import EphemerisNet from "../factionMarks/EphemerisNet";
@@ -135,7 +136,7 @@ export default function EphemeristsSelectCard({ state = "locked", members, onVis
           </span>
           <div>
             {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the plate’s masthead wordmark — Poiret One letterspaced until the width is the mark */}
-            <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.INK, marginTop: "var(--space-xs)" }}>{i18n.t("feed:factionSelect.ephemerists.name")}</div>
+            <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.INK, marginTop: "var(--space-xs)" }}>{redactableText("factions:names.ephemerists")}</div>
             <div style={{ fontSize: "var(--text-content)", fontStyle: "italic", color: eph.QUIET, marginTop: "var(--space-xs)" }}>{i18n.t("feed:factionSelect.ephemerists.tagline")}</div>
           </div>
         </div>

--- a/frontend/src/components/selectCard/EverymenSelectCard.tsx
+++ b/frontend/src/components/selectCard/EverymenSelectCard.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { EverymenSigil } from "../sigil/EverymenSigil";
 import { EverymenCog } from "../factionMarks/everymenCogs";
@@ -216,7 +217,7 @@ export default function EverymenSelectCard({ state = "locked", members, onVisit 
         </div>
 
         <div style={{ flex: 1, padding: "var(--space-lg) var(--space-xl) 0", textAlign: "center" }}>
-          <div style={{ ...LABEL, fontSize: "var(--text-title)", lineHeight: 1.05 }}>{i18n.t("feed:factionSelect.everymen.name")}</div>
+          <div style={{ ...LABEL, fontSize: "var(--text-title)", lineHeight: 1.05 }}>{redactableText("factions:names.everymen")}</div>
           <div style={{ fontFamily: TYPED, fontSize: "var(--text-content)", color: "var(--everymen-muted)", marginBottom: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.everymen.tagline")}</div>
           <div style={{ ...LABEL, fontSize: "var(--text-display)", letterSpacing: "0.01em", lineHeight: 0.96 }}>
             {i18n.t("feed:factionSelect.everymen.headline")}

--- a/frontend/src/components/selectCard/SingularitySelectCard.tsx
+++ b/frontend/src/components/selectCard/SingularitySelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { SingularitySigil } from "../sigil/SingularitySigil";
 import { factionRoleVars } from "../../utils/factionRoles";
@@ -137,7 +138,7 @@ export default function SingularitySelectCard({ state = "locked", members, onVis
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginTop: "var(--space-md)" }}>
           <SingularitySigil size={30} color={BRIGHT} />
           {/* eslint-disable-next-line local/no-raw-style-values -- ornament: terminal-printout faction name — display-size mono, the archetype's banner */}
-          <span style={{ fontSize: 30, color: BRIGHT, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.singularity.name")}</span>
+          <span style={{ fontSize: 30, color: BRIGHT, letterSpacing: "0.02em" }}>{redactableText("factions:names.singularity")}</span>
         </div>
         <div style={{ fontSize: "var(--text-content)", color: DIM, marginTop: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.singularity.tagline")}</div>
         {/* `--faction-singularity-phosphor-dim` stood here — a fourth green, and

--- a/frontend/src/components/selectCard/SnideSelectCard.tsx
+++ b/frontend/src/components/selectCard/SnideSelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { SnideSigil } from "../sigil/SnideSigil";
 import { WALL } from "../factionMarks/snideAtoms";
@@ -112,7 +113,7 @@ export default function SnideSelectCard({ state = "locked", members, onVisit }: 
         <SnideSigil size={40} color={ACID} />
         <div>
           {/* eslint-disable-next-line local/no-raw-style-values -- ornament: ransom-dispatch wordmark — Anton slammed at 0.85 leading */}
-          <div style={{ fontFamily: IMPACT, fontSize: 34, lineHeight: 0.85, color: ACID, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.snide.name")}</div>
+          <div style={{ fontFamily: IMPACT, fontSize: 34, lineHeight: 0.85, color: ACID, letterSpacing: "0.02em" }}>{redactableText("factions:names.snide")}</div>
           <div style={{ fontSize: "var(--text-base)", letterSpacing: "0.14em", marginTop: "var(--space-xs)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.snide.masthead")}</div>
           <div style={{ fontSize: "var(--text-base)", fontStyle: "italic", marginTop: "var(--space-xs)" }}>{i18n.t("feed:factionSelect.snide.tagline")}</div>
         </div>

--- a/frontend/src/components/selectCard/UaSelectCard.tsx
+++ b/frontend/src/components/selectCard/UaSelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { UaSigil } from "../sigil/UaSigil";
 import UaMandala from "../factionMarks/UaMandala";
@@ -124,7 +125,7 @@ export default function UaSelectCard({ state = "locked", members, onVisit }: Omi
         <div style={{ ...UA_EYEBROW, textTransform: "none", letterSpacing: "0.06em" }}>{i18n.t("feed:factionSelect.ua.banner")}</div>
         <div style={{ ...UA_EYEBROW, letterSpacing: "0.24em" }}>{i18n.t("feed:factionSelect.ua.masthead")}</div>
         <div style={{ fontFamily: UA_DISPLAY, fontWeight: 600, fontSize: "var(--text-display)", lineHeight: 1, letterSpacing: "-0.01em", marginTop: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.ua.wordmark")}</div>
-        <div style={{ fontFamily: UA_DISPLAY, fontWeight: 600, fontSize: "var(--text-title)", lineHeight: 1.1, marginTop: "var(--space-sm)" }}>{i18n.t("feed:factionSelect.ua.name")}</div>
+        <div style={{ fontFamily: UA_DISPLAY, fontWeight: 600, fontSize: "var(--text-title)", lineHeight: 1.1, marginTop: "var(--space-sm)" }}>{redactableText("factions:names.ua")}</div>
         <p className="content-text" style={{ margin: "var(--space-xs) 0 0", fontStyle: "italic", lineHeight: 1.4, color: "var(--leaf-faction-select-card-quiet)" }}>{i18n.t("feed:factionSelect.ua.tagline")}</p>
         {/* #850 made the subtitle a full sentence. A sentence cannot be set in
             0.24em all-caps, so it takes the display cut here rather than the

--- a/frontend/src/components/selectCard/WowSelectCard.tsx
+++ b/frontend/src/components/selectCard/WowSelectCard.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { redactableText } from "../../utils/factions";
 import { factionRoleVars } from "../../utils/factionRoles";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { WowSigil } from "../sigil/WowSigil";
@@ -106,8 +107,10 @@ import { CTA_SELECT_SIZE, WOW_CARD_CTA } from "../taskCard/cardCta";
  * plaque, unit". Gathering a register inherits its measurements, and that no new
  * row was needed is the evidence the register was gathered rather than invented.
  *
- * The wordmark is `feed:factionSelect.wow.name`. #2332 set `descriptions.wow`
- * and `factionHero.wow.motto` to the literal PLACEHOLDER deliberately; this tile
+ * The wordmark is the CANONICAL `factions:names.wow`, read through
+ * `redactableText` like the other eight tiles (#2806) — this surface kept its
+ * own byte-identical copy of the name until then. #2332 set `descriptions.wow`
+ * and the hero's motto to the literal PLACEHOLDER deliberately; this tile
  * renders neither, so no copy here is touched by that.
  */
 export default function WowSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
@@ -153,7 +156,7 @@ export default function WowSelectCard({ state = "locked", members, onVisit }: Om
           <WowSigil size={88} />
         </div>
         <div style={{ fontFamily: "var(--wow-select-card-face)", fontSize: "var(--text-title)", lineHeight: 1.1, color: "var(--wow-select-card-ink)" }}>
-          {i18n.t("feed:factionSelect.wow.name")}
+          {redactableText("factions:names.wow")}
         </div>
         <p className="content-text" style={{ fontStyle: "italic", color: "var(--wow-select-card-accent)", margin: "var(--space-xs) 0 var(--space-md)", lineHeight: 1.4 }}>
           {i18n.t("feed:factionSelect.wow.tagline")}

--- a/frontend/src/components/selectCard/__tests__/factionSelectCardDispatch.test.tsx
+++ b/frontend/src/components/selectCard/__tests__/factionSelectCardDispatch.test.tsx
@@ -81,7 +81,9 @@ describe("FactionSelectCard fallback", () => {
 
   it("renders the na copy slots", () => {
     const text = markup(<DefaultSelectCard {...REST} />).replace(/<[^>]*>/g, "");
-    expect(text).toContain(i18n.t("feed:factionSelect.na.name"));
+    // The name comes from the CANONICAL catalog now, not a per-tile copy of it
+    // (#2806) — the tile's own stem holds every other slot below.
+    expect(text).toContain(i18n.t("factions:names.na"));
     expect(text).toContain(i18n.t("feed:factionSelect.na.blurb"));
     expect(text).toContain(i18n.t("feed:factionSelect.na.status.eligible"));
     expect(text).toContain(i18n.t("feed:factionSelect.na.cta"));

--- a/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
@@ -216,6 +216,12 @@ answer — not by widening this test.`,
       // Resolved, not waived: `ROLE_MAP_PROPS` above adds the nine names this
       // one declares by interpolation to every scan (#2674).
       "../../utils/factionRoles",
+      // Resolved, not waived: the only binding taken from here is
+      // `redactableText`, which reads the copy catalog through the Albescent
+      // gate (#2806). It returns a STRING and names no token — the module's
+      // paint helpers (`factionFill`, `factionCssVar`, `factionSpectrumSheet`)
+      // are not imported, so nothing colour-bearing arrives with it.
+      "../../utils/factions",
       "../sigil/WowSigil",
       // The CTA's paint, which is the TASK CARD's since #2818 and is resolved
       // the same way: the case below reads `WOW_CARD_CTA`'s own body, so the

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -1058,10 +1058,12 @@ describe('no key is named for a word or a name it no longer holds (#1910)', () =
  *
  *   1. Six values are the literal `PLACEHOLDER`. That is deliberate — the
  *      owner's marker for a slot she has not written yet, put there so that
- *      seeing it on the page tells her what is missing. One of them
- *      (`factionHero.wow.motto`) replaced a sentence that stopped mid-clause,
- *      so a trailing comma never reaches a player. `descriptions.wow` was one
- *      of those and is now written, which is why it is off this list.
+ *      seeing it on the page tells her what is missing. Two have since left the
+ *      list by different doors: `descriptions.wow` was written, and
+ *      `factionHero.wow.motto` — the one that replaced a sentence stopping
+ *      mid-clause, so a trailing comma never reached a player — was reworded to
+ *      WOW's tagline in #2782 and then deleted with the whole motto family in
+ *      #2805, which folded the hero onto `factionSelect.{F}.tagline`.
  *   2. S.N.I.D.E.'s three masked-profanity strings are the faction's new punk
  *      register, not a leak and not a typo. Exact characters, exact casing.
  *   3. Two faction names changed shape: `ua` from the two-letter abbreviation

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -926,9 +926,23 @@ describe('the slots the copy audit ruled generic stay deleted (#1909)', () => {
  * ========================================================================== */
 describe('no key is named for a word or a name it no longer holds (#1910)', () => {
   /**
-   * #1864 §3. Two of these seven had no reader at all on `origin/main`
+   * #1864 §3. Two of the first seven had no reader at all on `origin/main`
    * (`frame.albescent.masthead`, `taskCard.everymen.masthead`); the other five
    * now resolve through `factionName(slug)`.
+   *
+   * #2806 added the nine `factionSelect.{F}.name` slots — the same defect, one
+   * surface further out and nine wide. Every value was character-for-character
+   * the canonical `factions:names.{F}` (ADR-0038), four of them minted in #2777
+   * purely to make the tile uniform. The tile reads the canonical name now.
+   *
+   * The select tile is NOT a `factionName()` caller, and that is the one thing
+   * to know before repointing it again: unrevealed, `factionName('albescent')`
+   * returns the MASKED name while this tile must print `[REDACTED]` (ADR-0082
+   * §2). It reads `redactableText('factions:names.<slug>')` instead —
+   * `ALBESCENT_SCOPED_KEY` matches the segment in any namespace, so the gate
+   * already covered the key it moved onto. A tile that later wants to say
+   * something other than its faction's full name adds a `wordmark`, which is
+   * the mechanism `ua` already uses; it does not get a shadow copy of the name.
    */
   const NAME_DUPLICATES = [
     'feed.json:frame.albescent.masthead',
@@ -938,6 +952,15 @@ describe('no key is named for a word or a name it no longer holds (#1910)', () =
     'feed.json:taskCard.coven.masthead',
     'feed.json:taskCard.ephemerists.masthead',
     'feed.json:taskCard.everymen.masthead',
+    'feed.json:factionSelect.albescent.name',
+    'feed.json:factionSelect.coven.name',
+    'feed.json:factionSelect.ephemerists.name',
+    'feed.json:factionSelect.everymen.name',
+    'feed.json:factionSelect.na.name',
+    'feed.json:factionSelect.singularity.name',
+    'feed.json:factionSelect.snide.name',
+    'feed.json:factionSelect.ua.name',
+    'feed.json:factionSelect.wow.name',
   ] as const
 
   /**
@@ -978,9 +1001,10 @@ describe('no key is named for a word or a name it no longer holds (#1910)', () =
   ]
 
   it('has the whole ruling in the list', () => {
-    // 3 keys / 7 strings from #1864 §3, plus the 20 `seal`-named leaves #1863
-    // falsified. A line lost to a bad merge would silently shrink the guard.
-    expect(new Set(NAME_DUPLICATES).size).toBe(7)
+    // 3 keys / 7 strings from #1864 §3 plus #2806's nine, and the 20
+    // `seal`-named leaves #1863 falsified. A line lost to a bad merge would
+    // silently shrink the guard.
+    expect(new Set(NAME_DUPLICATES).size).toBe(16)
     expect(new Set(RENAMED.map(([from]) => from)).size).toBe(20)
   })
 

--- a/frontend/src/locales/__tests__/factionKeyCompleteness.test.ts
+++ b/frontend/src/locales/__tests__/factionKeyCompleteness.test.ts
@@ -53,8 +53,12 @@ const EXEMPT: Record<string, string> = {
   "votes:(root)|albescent":
     "Albescent still has no vote voice and counts in arabic (#783), pinned in voteLadders.test.tsx.",
   "feed:factionHero|na":
-    "#2805 folds the hero's motto onto factionSelect.{F}.tagline, which na does have. " +
-    "Revisit this exemption when that lands — the block may not need an na entry at all.",
+    "Revisited when #2805 landed, and it stays: the hole this exemption was hiding is " +
+    "closed rather than papered over. The motto — the one slot na was missing — is gone " +
+    "from the block entirely and every hero reads factionSelect.{F}.tagline, which na has. " +
+    "What is left under factionHero is each faction's own eyebrow and members noun, and " +
+    "na's hero draws neither: DefaultFactionHero takes the SHARED factions:detail.eyebrow " +
+    "and factionHero.stats.members. So there is no na entry to write.",
   "feed:factionHero|albescent.eyebrow":
     "Albescent's hero is a wrapper over DefaultFactionHero, which reads the SHARED " +
     "factions:detail.eyebrow rather than a per-faction one.",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -201,14 +201,12 @@
     "albescent": {
       "factionLine": "Faction · {{name}}",
       "unrankedLine": "Unranked · By design",
-      "motto": "We play for the love of the game",
       "stats": {
         "members": "Players"
       }
     },
     "ephemerists": {
       "eyebrow": "World Zero · Cartographers",
-      "motto": "One who wanders is never lost",
       "gloss": "† nothing keeps. we keep the record anyway — <1>see †</1>",
       "stats": {
         "members": "wanderers"
@@ -216,13 +214,11 @@
     },
     "everymen": {
       "eyebrow": "World Zero · Hardest Workers",
-      "motto": "Be the best you you can be",
       "stats": {
         "members": "fellows"
       }
     },
     "singularity": {
-      "motto": "// we are one",
       "boot": {
         "faction": "FACTION: {{name}}",
         "status": "STATUS: ACTIVE · ARRAYS ONLINE",
@@ -235,13 +231,11 @@
     },
     "snide": {
       "eyebrow": "World Zero · Arsonists",
-      "motto": "Too cool for taglines",
       "stats": {
         "members": "pranksters"
       }
     },
     "ua": {
-      "motto": "Keep the Practice alive",
       "eyebrow": "World Zero · A daily practice",
       "stats": {
         "members": "Artisans"
@@ -249,14 +243,12 @@
     },
     "coven": {
       "eyebrow": "World Zero · Magic's in the air",
-      "motto": "Community is Magic",
       "stats": {
         "members": "witches"
       }
     },
     "wow": {
       "eyebrow": "World Zero · The Capricious Court",
-      "motto": "Imsy-whay or-fay every-oneway.",
       "stats": {
         "members": "Knights"
       }

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -265,7 +265,6 @@
   "factionSelect": {
     "ua": {
       "banner": "The Unwavering Artisans Want You",
-      "name": "Unwavering Artisans",
       "tagline": "Keep the Practice alive",
       "masthead": "World Zero · Nº I",
       "wordmark": "UA",
@@ -283,7 +282,6 @@
     "coven": {
       "banner": "The Cozy Coven Wants You",
       "tagline": "Community is Magic",
-      "name": "Cozy Coven",
       "blurb": "A little magic, a lot of mischief. World Zero's coven for the soft and the strange — take a task, cast a small spell, let the circle cheer.",
       "status": {
         "locked": "Keep Working Together ✦",
@@ -297,7 +295,6 @@
     "wow": {
       "banner": "THE WARRIORS OF WHIMSY WANT YOU",
       "tagline": "Imsy-whay or-fay every-oneway.",
-      "name": "Warriors of Whimsy",
       "chosen": "CHOSEN",
       "status": {
         "locked": "MORE JOUSTING REQUIRED",
@@ -310,7 +307,6 @@
     },
     "snide": {
       "banner": "S.N.I.D.E. Is Cool With You",
-      "name": "S.N.I.D.E.",
       "tagline": "Too cool for taglines",
       "masthead": "Field Dispatch · Nº 0666",
       "blurb": "Your assignment, should you ignore it. Specialists in gleeful disorder — bounties on the boring, and points for the trouble nobody else will take.",
@@ -325,7 +321,6 @@
     },
     "ephemerists": {
       "banner": "The Ephemerists Want You",
-      "name": "The Ephemerists",
       "tagline": "One who wanders is never lost",
       "blurb": "There is no single here. Wanderers who set down what is true before the road moves on — and keep the record anyway.",
       "status": {
@@ -340,7 +335,6 @@
     "singularity": {
       "banner": "Singularity Wants You",
       "tagline": "// we are one",
-      "name": "Singularity",
       "blurb": "The signal does not sleep. A distributed intelligence resolving noise into signal, one verified task at a time.",
       "status": {
         "locked": "// accrue signal to be granted access",
@@ -352,7 +346,6 @@
       "cta": "visit_node --enter"
     },
     "everymen": {
-      "name": "Everymen",
       "tagline": "Be the best you you can be",
       "banner": "THE EVERYMEN WANT YOU",
       "headline": "PICK UP THE LOAD",
@@ -368,7 +361,6 @@
     },
     "albescent": {
       "tagline": "We play for the love of the game",
-      "name": "Albescent",
       "blurb": "Some work leaves no record. An unranked society that keeps its own counsel — and yours.",
       "status": {
         "locked": "Keep Playing",
@@ -381,7 +373,6 @@
     },
     "na": {
       "tagline": "We play for the love of the game",
-      "name": "Unaffiliated",
       "blurb": "Every path is still open. Unaffiliated players take any task on the board and answer to no banner — pick a side when one of them earns it.",
       "status": {
         "locked": "No faction has claimed you.",

--- a/frontend/src/pages/factionDetail/__tests__/descriptionOnce.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/descriptionOnce.test.tsx
@@ -133,8 +133,9 @@ const BLURB_FLOOR = 'PLACEHOLDER'.length
  * different slots that happened to spell the same word — so that page said it
  * twice while still saying its DESCRIPTION once. The owner wrote the
  * description on 2026-08-26, the two slots no longer collide, and the count is
- * a flat 1 again for every slug. The motto is still `PLACEHOLDER`; nothing
- * needs to know that here.
+ * a flat 1 again for every slug. The motto key is gone outright now — #2805
+ * folded every hero onto `feed:factionSelect.{F}.tagline` — so there is no
+ * second slot left to collide with; nothing here needs to know that either.
  */
 
 describe('a faction page says its description exactly once (#2137)', () => {

--- a/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
+++ b/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
@@ -208,18 +208,24 @@ describe("Albescent's name is masked, and two surfaces redact instead (#2409)", 
     expect(factionDescription("albescent")).not.toBe(REDACTED);
 
     // A SURFACE THAT IS ABOUT THE SOCIETY — the `/factions` select tile and the
-    // leaderboard's eighth lane. They ask, and get the mark.
-    expect(redactableText("feed:factionSelect.albescent.name")).toBe(REDACTED);
+    // leaderboard's eighth lane. They ask, and get the mark. The tile reads the
+    // CANONICAL name key since #2806, which is the same key `factionName`
+    // reads one line above — so the two halves of the ruling now sit on ONE
+    // string, and the split is purely in which function asks for it.
+    expect(redactableText("factions:names.albescent")).toBe(REDACTED);
     expect(isFactionRedacted("albescent")).toBe(true);
   });
 
   it("redacts every Albescent-scoped key, not just the name", () => {
     setAlbescentRevealed(false);
     // The generalisation #2409 asks for. The select tile draws its slots off
-    // `feed:factionSelect.albescent.*`; one gate has to cover all of them or
-    // each is a place a future slot can be forgotten.
+    // `feed:factionSelect.albescent.*` — and, since #2806, its NAME off
+    // `factions:names.albescent` in a second namespace. One gate has to cover
+    // all of them or each is a place a future slot can be forgotten, and the
+    // two namespaces below are what makes "matches the segment, not the
+    // prefix" a tested property rather than a docblock claim.
     for (const key of [
-      "feed:factionSelect.albescent.name",
+      "factions:names.albescent",
       "feed:factionSelect.albescent.blurb",
       "feed:factionSelect.albescent.status.locked",
       "feed:factionSelect.albescent.cta",
@@ -248,7 +254,7 @@ describe("Albescent's name is masked, and two surfaces redact instead (#2409)", 
     // extra frame costs nothing, a name leaked once cannot be taken back.
     expect(factionName("albescent")).toBe(factionName("na"));
     expect(isFactionRedacted("albescent")).toBe(true);
-    expect(redactableText("feed:factionSelect.albescent.name")).toBe(REDACTED);
+    expect(redactableText("factions:names.albescent")).toBe(REDACTED);
   });
 
   it("paints and disables off the SAME answer the words redact on", () => {


### PR DESCRIPTION
Closes #2805
Closes #2806

Two duplicated i18n key families fold onto their canonical sources. One PR because both delete from `frontend/src/locales/en/feed.json`; two separate folds, sharing no abstraction.

## The seams, each red before it was green

**#2806 — the catalog leaf.** `catalog.test.ts`'s *"holds no slot that duplicates a faction name"* (#1910) already policed seven of these from #1864 §3. The nine `feed.json:factionSelect.{F}.name` go in the same list, and it went red on exactly those nine before a line of source moved.

**#2805 — the hero's tagline slot at render.** New `heroDrawsTheTileTagline.test.tsx`: every faction hero prints `feed:factionSelect.{F}.tagline`. It went red on `ua` (drew nothing at all) and `na` (resolved to `""`) — the two holes, not the six mechanical repoints. Re-proven red after the rewrite by blanking UA's new line.

## #2806 — nine tiles read the canonical name

All nine `factionSelect.{F}.name` values were character-for-character `factions:names.{F}` (ADR-0038); four were minted in #2777 purely to make the tile uniform. Deleted; each tile reads the canonical key.

**Read through `redactableText`, NOT `factionName`.** Unrevealed, `factionName("albescent")` returns the *masked* name ("Unaffiliated") while this tile must print `[REDACTED]` — two different ruled behaviours (ADR-0082 §2). `ALBESCENT_SCOPED_KEY` matches the *segment* `albescent` in any namespace, so `factions:names.albescent` was already covered and the gate is unchanged. The redaction fixtures in `factionAlbescentHidesInPlainSight.test.ts` moved onto that key, which makes "matches the segment, not the prefix" a tested property across two namespaces rather than a docblock claim.

`wowWearsTheDecreeRegister`'s import allowlist gains `utils/factions` **resolved, not waived**: the only binding taken is `redactableText`, which returns a string and names no token.

## #2805 — the hero folds onto the tile's tagline

#2782 ruled the two surfaces say one thing and set all eight mottos to their tagline; nothing held them there afterwards. Eight keys deleted, six bespoke heroes and `DefaultFactionHero` repointed.

**UA gains the slot (owner ruling on #2805).** Not the retired gilt ribbon — a plain line under the wordmark in the type step Coven's hero already uses (display face, 600, `--text-title`, `0.02em`) on `--leaf-faction-hero-ink`. No new type step, no new token, no new hex. UA's docblock recorded the *ribbon's* removal and was being read as having settled the *line* too; it now says otherwise.

**na gains one too**, for free: `feed:factionHero` has no `na` block, so the fall-through resolved to `defaultValue: ""`. `factionSelect.na.tagline` has said "We play for the love of the game" all along.

`factionKeyCompleteness`'s `feed:factionHero|na` exemption asked in a comment to be revisited when this landed. It stays, with the reason rewritten: the motto was the only slot na lacked, and what remains in that block is each faction's own eyebrow and members noun, neither of which na's hero draws.

The new test loops the **manifest**, not a typed list (#2814/#2815) — `Object.entries(surfaceMap("factionHero"))`, resolving each archetype inside the case because the warm-up runs in `beforeAll`. A tenth kit joins by registering.

## No copy value changed

Every rendered string is byte-identical, with exactly two intended exceptions: na's hero tagline (empty → its tagline) and UA's (absent → present).

## What to eyeball

Visual QA is outstanding — no browser tools and no dev stack on this run.

1. **UA's faction page — the NEW tagline slot.** This is a visible addition. "Keep the Practice alive" now sits under "Unwavering Artisans" inside the sand plate, above the hairline-ruled counts strip. Check it reads as part of the museum plate rather than crowding the wordmark, at desktop and at 375px where the wordmark wraps to two lines.
2. **The Unaffiliated faction page** (`/factions/na`) — a tagline is now present where the line was blank.
3. **All nine select tiles' names** on `/factions` — every one should read exactly what it read before, in the same face and size. UA still draws its "UA" wordmark *above* the name; that key is untouched and is the divergence mechanism the fold relies on existing.
4. **Albescent's tile, unrevealed** — must still read `[REDACTED]`, **not** "Unaffiliated", with its CTA visibly disabled. This is the trap the whole of #2806 turns on. Revealed, it reads "Albescent" and the door opens.
5. The six other faction pages' taglines — same words as before, same treatment.

## Checks run locally

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (473 files, 9787 passed), `npm run build`, `npm run budget` — all green. The budget's JS **WARN** is pre-existing: `origin/main` measures 137.3 KB and this branch 137.2 KB, so the payload is marginally smaller. No backend, route or schema change, so `api-schema` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
