### PR TITLE
The S.N.I.D.E. note's inks and its washes each move half way onto the ground it composites to (#2450)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1309,10 +1309,17 @@
   --faction-snide-note-ink: #14110b; /* headline, level, points numeral (FLIPS) — 9.87:1 in the pink corner */
   /* Brief + in-progress copy. #5f5c50 read 5.93:1 on the stock and 4.23:1 in
      the wall's pink corner; walked until the corner clears — 5.03:1 there,
-     6.75:1 at the top of the ramp. */
-  --faction-snide-note-muted: #545143;
+     6.75:1 at the top of the ramp.
+
+     WALKED AGAIN FOR THE FULL COMPOSITE (#2450). Those readings are the wall's
+     four FLAT ones; the pixel a glyph actually stands on has all five printed
+     layers over the ramp, and #545143 read 3.87:1 there — 36 of the nightly's
+     39 failures. Half the correction is here and half is in the washes below;
+     4.67:1 on the worst-case composite, 6.51:1 flat on the ramp's deep stop.
+     See the composite note beside `-note-scan`. */
+  --faction-snide-note-muted: #4e4a3d;
   --faction-snide-note-rule: rgba(20, 17, 11, 0.28);
-  --faction-snide-note-grain: rgba(20, 17, 11, 0.045); /* the xerox raster */
+  --faction-snide-note-grain: rgba(20, 17, 11, 0.036); /* the xerox raster */
   --faction-snide-note-bar: #14110b; /* the header bar */
   --faction-snide-note-bar-ink: #f4f1e8; /* the ordinal on that bar */
   /* The pink that is TEXT, as opposed to the pink that is a drawn line. Walked
@@ -1323,8 +1330,15 @@
      `--faction-snide-wall-alarm` by measurement rather than by borrowing, and
      stays its own token for #1181's reason — one is the clipping's caption ink,
      the other is the wall's destructive mark, and a shared value today is not a
-     shared contract tomorrow. 4.98:1 in the corner, 6.67:1 at the ramp's top. */
-  --faction-snide-note-pink-ink: #9d174d;
+     shared contract tomorrow. 4.98:1 in the corner, 6.67:1 at the ramp's top.
+
+     WALKED A FOURTH TIME, AND FOR THE SAME REASON A FOURTH TIME (#2450): the
+     value was measured on a ground it does not stand on. Every reading above is
+     a FLAT one, and the wall paints five layers — #9d174d is 3.83:1 on the
+     worst-case composite. #8d1345 is 4.79:1 there with the washes eased below,
+     5.91:1 flat in the pink corner. It no longer shares a hex with
+     `--faction-snide-wall-alarm`, which is what having two tokens was for. */
+  --faction-snide-note-pink-ink: #8d1345;
   /* The headline's four cuts. Cut 2 is knocked out of the near-black ink and
      cut 1 sits on acid: both are stated as their own pair rather than reusing
      `-paper`/`-ink`, because those two SWAP under the dark cascade and a
@@ -1346,10 +1360,29 @@
      jobs, two tokens. Nor is `-note-wall-shadow` a retune of `-note-shadow`
      above — that one is shared with both detail pages (#2066) and stays put.
      The light shadow is a hard printed offset with NO blur: a clipping pasted
-     flat on a wall, not a card floating over one. */
-  --faction-snide-note-scan: rgba(20, 17, 11, 0.05);
-  --faction-snide-note-wash-acid: rgba(111, 174, 0, 0.14);
-  --faction-snide-note-wash-pink: rgba(190, 24, 93, 0.1);
+     flat on a wall, not a card floating over one.
+
+     ── THE WORST-CASE COMPOSITE, AND WHY THESE THREE CAME DOWN (#2450) ──
+     THE BASE OF THE STACK IS THE RAMP, NOT `-note-paper`. That is the fact
+     three rounds of walking this family missed, and it is why the numbers kept
+     coming out flattering: `WALL` in `factionMarks/snideAtoms` is FIVE layers
+     and the bottom one is `WALL_PLAIN`, the `-wall`/`-wall-deep` ramp. Nothing
+     composites onto `-note-paper` — it has had no consumer since #2065.
+
+     Worst case in LIGHT is the darkest pixel: the ramp's deep stop with all
+     four printed layers over it. At the shipped alphas that is rgb(188,181,155)
+     — exactly what the nightly's runner read off the element, and the ground
+     that failed 36 of its 39 tests. Eased to the values below it is
+     rgb(195,188,165). That is only half the fix; the inks above carry the rest,
+     per the owner's ruling of 2026-08-27 — bringing the washes far enough on
+     their own thins the acid and pink tint, and that texture is the register.
+     `utils/__tests__/snideWallComposite.test.ts` holds the model and the
+     arithmetic. Two of the five layers are duty-cycled stripes and two are
+     positional radials, so there is no single ground: the composite varies by
+     pixel and the gate is the worst one. */
+  --faction-snide-note-scan: rgba(20, 17, 11, 0.04);
+  --faction-snide-note-wash-acid: rgba(111, 174, 0, 0.11);
+  --faction-snide-note-wash-pink: rgba(190, 24, 93, 0.08);
   /* The edge and the shadow are LOAD-BEARING, not ornament: the S.N.I.D.E.
      faction page paints its own ground with the same wall recipe through
      `useFactionBackdrop`, so these two are the only thing that separates the
@@ -3384,10 +3417,17 @@
   --faction-snide-note-ink: #f4f1e8;
   --faction-snide-note-muted: #cfcdbf;
   --faction-snide-note-rule: rgba(244, 241, 232, 0.26);
-  --faction-snide-note-grain: rgba(244, 241, 232, 0.05);
+  --faction-snide-note-grain: rgba(244, 241, 232, 0.042);
   --faction-snide-note-bar: #080706;
   --faction-snide-note-bar-ink: #ff2d8b; /* the bar's ordinal goes pink — 5.75:1 */
-  --faction-snide-note-pink-ink: #ff69ac;
+  /* BRIGHTENED PART WAY (#2450). The dark cascade runs BACKWARDS and that is
+     the trap in this fix: this half's paper is #14110b, DARKER than the
+     rgb(71,56,41) the browser paints, so here the washes LIGHTEN the ground
+     instead of darkening it and the correction is the mirror of the light
+     half's — washes down, ink UP. #ff69ac read 4.22:1 on the worst-case
+     composite; #ff71b1 on the eased one is 4.91:1. `-note-muted` needed
+     nothing, at 7.82:1. */
+  --faction-snide-note-pink-ink: #ff71b1;
   --faction-snide-note-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.85);
   /* The wall the clipping is pasted to, lights out (#2065). The scanline still
      darkens — a scan is subtractive in both themes — while the two washes and
@@ -3395,10 +3435,19 @@
      the deep ones composite to nothing. The shadow loses its printed offset and
      becomes a hairline plus a deep drop: an offset in the dark is invisible, and
      the hairline is what keeps the card an object on the faction page's
-     identical ground. */
+     identical ground.
+
+     THE WORST CASE HERE IS THE LIGHTEST PIXEL, not the darkest (#2450): the
+     inks on this half are light, so what gates them is the ramp's TOP stop with
+     the three lightening layers over it and the scanline OFF — a 1px-on/3px-off
+     stripe leaves most pixels in an off-band, and a glyph that lands there gets
+     no help from it. That reads rgb(71,56,41) at the shipped alphas, which is
+     what the nightly measured, and rgb(63,49,37) at the eased ones below. The
+     scan itself does NOT come down: it is the one layer that darkens in this
+     cascade, so easing it would push the ground the wrong way. */
   --faction-snide-note-scan: rgba(0, 0, 0, 0.5);
-  --faction-snide-note-wash-acid: rgba(182, 255, 46, 0.13);
-  --faction-snide-note-wash-pink: rgba(255, 45, 139, 0.14);
+  --faction-snide-note-wash-acid: rgba(182, 255, 46, 0.11);
+  --faction-snide-note-wash-pink: rgba(255, 45, 139, 0.12);
   --faction-snide-note-wall-edge: rgba(182, 255, 46, 0.35);
   --faction-snide-note-wall-shadow:
     0 0 0 1px rgba(0, 0, 0, 0.9), 0 18px 40px -22px rgba(0, 0, 0, 1);

--- a/frontend/src/utils/__tests__/snideWallComposite.test.ts
+++ b/frontend/src/utils/__tests__/snideWallComposite.test.ts
@@ -1,0 +1,219 @@
+/**
+ * THE GROUND S.N.I.D.E.'S NOTE ACTUALLY STANDS ON (#2450).
+ *
+ * WHY THIS FILE EXISTS. `factionContrast.test.ts` measures the flyposted wall
+ * as FOUR FLAT READINGS — the two stops of the `-wall`/`-wall-deep` ramp and
+ * the two corner washes — and deliberately does not model the raster or the
+ * scanline, on the argument that a 2px stripe is a texture and not a surface.
+ * That argument holds for the stripes and not for the stack: a glyph stands on
+ * one pixel, and that pixel carries every layer that covers it. Measured flat,
+ * `-note-muted` cleared AA. Measured on the pixel, it was 3.87:1, and that gap
+ * was 36 of the nightly rendered sweep's 39 failures — one surface (the
+ * S.N.I.D.E. tile on `/factions`, which every faction's route list visits),
+ * counted nine times over two themes and two viewports.
+ *
+ * THE FACT THAT CLOSED IT, and the one three rounds of walking this family
+ * missed: **the base of the composite is the wall ramp, not
+ * `--faction-snide-note-paper`.** `WALL` is five layers and the bottom one is
+ * `WALL_PLAIN`. Compositing the four washes onto `-note-paper` predicts
+ * rgb(206,195,173); onto the ramp it predicts what the browser paints, to
+ * fractions of a unit. `-note-paper` has had no consumer since #2065.
+ *
+ * THERE IS NO SINGLE GROUND. Two of the five layers are `repeating-linear-
+ * gradient` stripes with duty cycles (grain 2-on/5-off, scan 1-on/3-off) and
+ * two are positional radials, so the composite varies by pixel. What a contrast
+ * gate wants is the WORST pixel, and worst runs in opposite directions per
+ * cascade because the inks do: light inks are dark on a light ground, so worst
+ * is the DARKEST composite; dark inks are light on a dark ground, so worst is
+ * the LIGHTEST one — which is also why the scanline drops out of the dark model
+ * (1-on/3-off leaves most pixels unhelped by it).
+ *
+ * WHAT THIS FILE IS NOT. It is not a second contrast manifest.
+ * `factionContrast.test.ts` still owns the flat readings and every other
+ * S.N.I.D.E. pairing; this owns one thing the flat readings cannot express, so
+ * the next person does not have to rediscover the ramp underneath.
+ *
+ * ponytail: gates the three inks the NOTE prints on this ground. The composer's
+ * tiers stand on the same composite and two of them miss there —
+ * `-composer-faint` at 3.82:1 light / 3.94:1 dark, and `-composer-alarm` /
+ * `--faction-snide-wall-alarm` at 4.15:1 light. Neither is on the swept routes
+ * and walking them is a design call the 2026-08-27 ruling did not make; they are
+ * reported on #2450 for a follow-up. Add their rows here when it lands.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AA_NORMAL,
+  compositeOver,
+  contrastRatio,
+  formatRatio,
+  parseColor,
+  relativeLuminance,
+  type Rgba,
+} from "../contrast";
+import { WALL, WALL_PLAIN } from "../../components/factionMarks/snideAtoms";
+import { readThemes, resolveVar, type Theme } from "./cssVars";
+
+const CSS_PATH = fileURLToPath(new URL("../../index.css", import.meta.url));
+const THEMES = readThemes(readFileSync(CSS_PATH, "utf8"));
+
+/**
+ * The worst pixel, per cascade: which ramp stop is under it and which of the
+ * printed layers cover it, BOTTOM-TO-TOP (the order a painter applies them, ie.
+ * the reverse of the order `WALL` lists them in).
+ */
+interface Stack {
+  /** The ramp stop `WALL_PLAIN` supplies at that pixel. */
+  base: string;
+  layers: string[];
+}
+
+const WORST: Record<Theme, Stack> = {
+  // Darkest: the ramp's deep stop, with all four printed layers over it.
+  light: {
+    base: "--faction-snide-wall-deep",
+    layers: [
+      "--faction-snide-note-wash-pink",
+      "--faction-snide-note-wash-acid",
+      "--faction-snide-note-scan",
+      "--faction-snide-note-grain",
+    ],
+  },
+  // Lightest: the ramp's top stop, the two washes and the (cream) grain — and
+  // NO scanline, which is the only layer that darkens in this cascade and is
+  // absent from three pixels in four.
+  dark: {
+    base: "--faction-snide-wall",
+    layers: [
+      "--faction-snide-note-wash-pink",
+      "--faction-snide-note-wash-acid",
+      "--faction-snide-note-grain",
+    ],
+  },
+};
+
+/** The three inks the clipping prints straight on that ground. */
+const NOTE_INKS = [
+  "--faction-snide-note-ink",
+  "--faction-snide-note-muted",
+  "--faction-snide-note-pink-ink",
+] as const;
+
+/** The four flat readings `factionContrast.test.ts` measures, for comparison. */
+const FLAT: Stack[] = [
+  { base: "--faction-snide-wall", layers: [] },
+  { base: "--faction-snide-wall-deep", layers: [] },
+  { base: "--faction-snide-wall", layers: ["--faction-snide-note-wash-acid"] },
+  { base: "--faction-snide-wall-deep", layers: ["--faction-snide-note-wash-pink"] },
+];
+
+function color(name: string, theme: Theme): Rgba {
+  const raw = resolveVar(name, theme, THEMES);
+  expect(raw, `${name} (${theme}) is not declared`).not.toBeNull();
+  const parsed = parseColor(raw!);
+  expect(parsed, `${name} (${theme}) resolved to "${raw}" — not a solid color`).not.toBeNull();
+  return parsed!;
+}
+
+function paint(stack: Stack, theme: Theme): Rgba {
+  return stack.layers.reduce((ground, layer) => compositeOver(color(layer, theme), ground), color(stack.base, theme));
+}
+
+/** `rgb(r, g, b)` at the rounding a browser reports, so a failure reads like the runner's log. */
+function show(ground: Rgba): string {
+  return `rgb(${[ground.r, ground.g, ground.b].map((channel) => Math.round(channel)).join(", ")})`;
+}
+
+/** Split a `background` shorthand into its layers — commas inside `()` are not separators. */
+function layersOf(background: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < background.length; index += 1) {
+    const character = background[index];
+    if (character === "(") depth += 1;
+    else if (character === ")") depth -= 1;
+    else if (character === "," && depth === 0) {
+      parts.push(background.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  parts.push(background.slice(start).trim());
+  return parts;
+}
+
+describe("the S.N.I.D.E. wall's worst-case composite", () => {
+  /**
+   * THE ANCHOR. Every other assertion here trusts the model; this one proves it,
+   * against numbers no one in this repo chose — the two grounds the nightly's
+   * browser read off the element, quoted on #2450, with the alphas that shipped
+   * before this fix. If a refactor breaks the model, this goes red with it.
+   */
+  it("reproduces the grounds the rendered sweep measured, from the alphas that shipped before #2450", () => {
+    const composite = (base: string, layers: string[]) =>
+      layers.reduce((ground, layer) => compositeOver(parseColor(layer)!, ground), parseColor(base)!);
+
+    const light = composite("#e0ddd1", [
+      "rgba(190, 24, 93, 0.1)",
+      "rgba(111, 174, 0, 0.14)",
+      "rgba(20, 17, 11, 0.05)",
+      "rgba(20, 17, 11, 0.045)",
+    ]);
+    expect(show(light)).toBe("rgb(188, 181, 155)");
+    expect(contrastRatio(parseColor("#545143")!, light)).toBeCloseTo(3.87, 1);
+    expect(contrastRatio(parseColor("#9d174d")!, light)).toBeCloseTo(3.83, 1);
+
+    const dark = composite("#0a0a0b", [
+      "rgba(255, 45, 139, 0.14)",
+      "rgba(182, 255, 46, 0.13)",
+      "rgba(244, 241, 232, 0.05)",
+    ]);
+    expect(show(dark)).toBe("rgb(71, 56, 41)");
+    expect(contrastRatio(parseColor("#ff69ac")!, dark)).toBeCloseTo(4.22, 1);
+  });
+
+  /**
+   * The model above names layers; `snideAtoms` paints them. This is the seam
+   * between the two, and it is where the model would rot silently — a sixth
+   * layer, or a re-ordering, and every ratio below would measure a ground the
+   * app stopped painting.
+   */
+  it("still describes the stack snideAtoms paints", () => {
+    const painted = layersOf(WALL);
+    expect(painted).toHaveLength(5);
+    expect(painted[4], "the BASE of the stack is the ramp — that is the whole finding of #2450").toBe(WALL_PLAIN);
+    // `WALL` lists top-to-bottom; the model lists bottom-to-top.
+    expect(painted.slice(0, 4).map((layer) => /--faction-snide-note-[\w-]+/.exec(layer)?.[0])).toEqual(
+      [...WORST.light.layers].reverse(),
+    );
+    expect(WALL_PLAIN).toContain(WORST.light.base);
+    expect(WALL_PLAIN).toContain(WORST.dark.base);
+  });
+
+  it("is the DARKEST reading in light and the LIGHTEST in dark", () => {
+    const flatLight = FLAT.map((stack) => relativeLuminance(paint(stack, "light")));
+    expect(relativeLuminance(paint(WORST.light, "light"))).toBeLessThan(Math.min(...flatLight));
+
+    const flatDark = FLAT.map((stack) => relativeLuminance(paint(stack, "dark")));
+    expect(relativeLuminance(paint(WORST.dark, "dark"))).toBeGreaterThan(Math.max(...flatDark));
+  });
+
+  for (const theme of ["light", "dark"] as Theme[]) {
+    describe(theme, () => {
+      for (const ink of NOTE_INKS) {
+        it(`${ink} clears AA on the composite`, () => {
+          const ground = paint(WORST[theme], theme);
+          const ratio = contrastRatio(color(ink, theme), ground);
+          expect(
+            ratio,
+            `${ink} (${resolveVar(ink, theme, THEMES)}) on ${show(ground)} = ${formatRatio(ratio)}, needs ${AA_NORMAL}:1. ` +
+              `Both the ink and the washes may move — see the ruling on #2450.`,
+          ).toBeGreaterThanOrEqual(AA_NORMAL);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #2450

Hybrid, per the owner's ruling of 2026-08-27: the washes come down part way and the inks move part way, measured separately in each cascade because the dark one runs backwards.

## The seam I tested at

**Token values composited through the real five-layer `WALL` stack, not the four flat readings.** `factionContrast.test.ts` measures this wall as two ramp stops and two corner washes, and says in its own docblock that it deliberately does not model the raster or the scanline. That is why every one of these three inks was green in Part A while Part B failed 36 times: a glyph does not stand on a *reading*, it stands on a *pixel*, and that pixel carries every layer covering it.

New file: `frontend/src/utils/__tests__/snideWallComposite.test.ts`. It goes **red on the pre-#2450 stylesheet with exactly the nightly's three findings** — 3.87:1 and 3.83:1 on `rgb(188, 181, 155)`, 4.22:1 on `rgb(71, 56, 41)` — and green after.

## The missing layer: the base of the composite is the ramp, not `-note-paper`

The issue and the ruling both derive the ground by compositing the four washes onto `--faction-snide-note-paper` `#f4f1e8`, get ~`rgb(206,195,173)`, and conclude "something else is in the stack". There is, and it is the bottom layer:

`WALL` in `frontend/src/components/factionMarks/snideAtoms.tsx` is **five** layers, and the fifth is `WALL_PLAIN` — `linear-gradient(180deg, var(--faction-snide-wall) 0%, var(--faction-snide-wall-deep) 100%)`. **The composite sits on the wall ramp.** `-note-paper` has had no consumer since #2065.

So the browser was reachable by arithmetic after all, and no browser reading was needed:

| | base | layers over it (bottom to top) | predicted | runner read |
|---|---|---|---|---|
| light | `--faction-snide-wall-deep` `#e0ddd1` (ramp's bottom stop) | wash-pink .10, wash-acid .14, scan .05, grain .045 | `rgb(188.1, 180.7, 155.0)` | `rgb(188, 181, 155)` |
| dark | `--faction-snide-wall` `#0a0a0b` (ramp's top stop) | wash-pink .14, wash-acid .13, grain .05 — **scan omitted** | `rgb(71.3, 55.9, 41.2)` | `rgb(71, 56, 41)` |

Both to well under a unit, and the inks on them reproduce the log's 3.89 / 3.85 / 4.22 to rounding.

**There is no single ground.** Two of the five layers are duty-cycled stripes (grain 2px-on/5px-off at 115deg, scan 1px-on/3px-off) and two are positional radials, so the composite varies by pixel and what a gate wants is the *worst* one — which runs in opposite directions per cascade, because the inks do. Light inks are dark on a light ground, so worst is the **darkest** composite (deep stop, all four layers). Dark inks are light on a dark ground, so worst is the **lightest** one (top stop, the three lightening layers, and the scanline off — 1-on/3-off leaves three pixels in four unhelped by the one layer that darkens there).

## What changed, and the ratios

Grounds move to `rgb(195, 188, 165)` = `#c3bca5` (light) and `rgb(63, 49, 37)` = `#3f3125` (dark).

**Light** — `frontend/src/index.css` ~1320-1385

| token | from | to |
|---|---|---|
| `--faction-snide-note-grain` | `.045` | `.036` |
| `--faction-snide-note-scan` | `.05` | `.04` |
| `--faction-snide-note-wash-acid` | `.14` | `.11` |
| `--faction-snide-note-wash-pink` | `.10` | `.08` |
| `--faction-snide-note-muted` | `#545143` (3.87:1) | `#4e4a3d` — **4.67:1** |
| `--faction-snide-note-pink-ink` | `#9d174d` (3.83:1) | `#8d1345` — **4.79:1** |

**Dark** — ~3420-3449. The washes come down and the ink goes **up**; the scanline does not move, since it is the only layer that darkens in this cascade.

| token | from | to |
|---|---|---|
| `--faction-snide-note-grain` | `.05` | `.042` |
| `--faction-snide-note-wash-acid` | `.13` | `.11` |
| `--faction-snide-note-wash-pink` | `.14` | `.12` |
| `--faction-snide-note-pink-ink` | `#ff69ac` (4.22:1) | `#ff71b1` — **4.91:1** |

`--faction-snide-note-muted` dark was already clear and is untouched: 7.04:1 before, 7.82:1 now. `--faction-snide-note-ink` is 9.92:1 light / 11.07:1 dark.

**Neither half would have done it alone**, which is the ruling's "split the correction" as arithmetic: the eased washes with the old inks read 4.20:1 / 4.15:1 / 4.69:1 (two still fail), and the new inks on the old washes read 4.30:1 / 4.41:1 / 4.42:1 (all three still fail).

Every flat reading improved too, so no `factionContrast.test.ts` row moved the wrong way: light `-note-muted` 5.02-6.75 becomes 5.77-7.50 and `-note-pink-ink` 4.79-6.68 becomes 5.91-7.69 across the wall's four readings.

## The surface

The faction-invariant ground is the **S.N.I.D.E. tile on `/factions`** (`SnideSelectCard`), which `routesFor()` visits for every faction: blurb in `-note-muted`, status line in `-note-pink-ink`, both on `WALL`. That is one surface counted 9 factions x 2 themes x 2 viewports, not nine defects — as the issue said.

## Verified

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (475 files, 9805 passed), `npm run build`, `npm run budget` — all green locally, with `vite 8.2.2` confirmed (not a stale junction).

Byte-neutral on CSS to the resolution the budget prints: `21.9 KB` both on `origin/main` and on this branch, measured back to back in the same tree (comments are stripped; the diff is a handful of alpha digits). The JS WARN is `main`'s and pre-existing.

## NOT verified — owed to the owner

- **`e2e/contrast.spec.ts` has not been run.** It needs a running stack and a browser; I have neither. The claim here is that the three pairings clear 4.5:1 against a composite that reproduces the runner's own measurements to a fraction of a unit — it is not a green nightly.
- **No visual check.** Whether the note still reads as a xeroxed clipping is unverified. The washes carry roughly half the correction (a uniform ~20% ease in light, ~15% in dark); if the texture has visibly flattened, the answer is to push more onto the inks — the composite test will tell you instantly whether a re-balance still clears.

## One finding for a follow-up, deliberately not fixed here

The same worst-case composite gates the **composer's** tiers and the wall's alarm, and three of them miss there — none is on the swept routes, and walking them is a design call the ruling did not make:

- `--faction-snide-composer-faint` — 3.82:1 light, 3.94:1 dark
- `--faction-snide-composer-alarm` and `--faction-snide-wall-alarm` (both `#9d174d`) — 4.15:1 light

`-note-pink-ink` no longer shares a hex with `-wall-alarm`, which is what having two tokens was for (#1181). A `ponytail:` note in the new test names this ceiling.

## What to eyeball

- `/factions`, the **S.N.I.D.E. tile** — blurb and the marker status line — in **light** and **dark**, at 1280 and 375. This is the surface the nightly measured.
- `/factions/snide` — hero and all four panels stand on the same wall since #2343.
- `/tasks` — the S.N.I.D.E. task card (`SnideTaskCard`), same ground, same two inks.
- A S.N.I.D.E. **praxis card** on `/praxis` (wall dress) and on a task-detail page (the black slab dress — should be *unchanged*; it resolves `-card-*`, not `-note-*`).
- The edit-praxis composer, if you can reach one: its sheet shares the grain/scan/wash tokens, so its texture eased too even though its own ink tiers did not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
