### PR TITLE
The multiplier's orphaned catalog word goes, and its absence guard stops asserting a string it can no longer spell (#2821)

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -151,7 +151,10 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *    design's "ratio", so that a faction word could not fork one number's name
  *    between two surfaces. #2634 settled the question by removing the label
  *    entirely: a chip on the base line names itself, on all nine stamps, and
- *    the notation stays `×0.80` through the shared `formatMult`.
+ *    the notation stays `×0.80` through the shared `formatMult`. #2821 then
+ *    deleted the key, this being the last skin that had ever cast it; the
+ *    stamp's own test guards the absence off the base cell's SHAPE rather than
+ *    off a catalog word, which a deleted key would have made vacuous.
  *  • the design draws no metatask row (its sample has none). One is drawn here,
  *    in the box pattern's own place, because the stamp must stay legible in all
  *    five states.

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/canonicalStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/canonicalStamp.test.tsx
@@ -335,11 +335,15 @@ describe('the ledger speaks in one register (#2634 ruling 4)', () => {
     // bare labels; they are deleted. `card.stamp.subtotal` already existed and
     // is reused.
     //
-    // `mult` SURVIVES WITH NO READER, deliberately. #2634's chip is bare on all
-    // nine — the shape UA, S.N.I.D.E. and WOW already drew — so the Ephemerists
-    // cell, which was the last skin to label its ratio, gave the word up. That
-    // leaves a key nothing prints, which is a COPY decision the issue did not
-    // make; it is flagged on the PR rather than taken here.
+    // THE MULTIPLIER'S WORD IS GONE TOO, since #2821. #2634's chip is bare on
+    // all nine — the shape UA, S.N.I.D.E. and WOW already drew — so the
+    // Ephemerists cell, which was the last skin to label its ratio, gave the
+    // word up, and #2634 left the key standing because deleting copy is a
+    // decision it had not been asked to make. The owner made it on #2821: a key
+    // nothing renders is a key that rots. The Ephemerists stamp's own test now
+    // guards the chip's wordlessness off the base cell's SHAPE, because an
+    // absence asserted through `i18n.t` goes vacuous the moment the key it
+    // spells stops existing.
     //
     // Asserted as the whole key SET rather than as two absences, and read off
     // the catalog rather than through `i18n.exists`. Both halves matter: an
@@ -351,7 +355,6 @@ describe('the ledger speaks in one register (#2634 ruling 4)', () => {
     expect(Object.keys(praxisCatalog.card.stamp).sort()).toEqual(
       [
         'base',
-        'mult',
         'meta',
         'habit',
         'votes',

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
@@ -295,13 +295,18 @@ describe('every line of the working reads figure-then-word (#2285)', () => {
     expect(cells.figure.text, 'the base figure still opens its own cell').toBe('18')
     expect(html, 'the ratio, in the number column').toContain('×1.50')
     // AND NO WORD FOR IT — read off the cell's SHAPE since #2821, not off the
-    // catalog. This line was `not.toContain(i18n.t('praxis:card.stamp.mult'))`;
-    // #2821 deleted that orphaned key, and a missing key makes `i18n.t` return
-    // the key PATH, so the assertion would have degraded to "the markup does not
-    // contain the string `card.stamp.mult`" — true of every markup ever rendered.
-    // The whole base figure cell, tags stripped, is the figure and the ratio and
-    // nothing else, so ANY word put back in the chip fails this — not just the
-    // one word the deleted key happened to spell.
+    // catalog. This line used to ask `i18n.t` for the multiplier's own catalog
+    // entry under `card.stamp` and assert the result absent. #2821 deleted that
+    // orphaned entry, and a missing key makes `i18n.t` hand back the key PATH,
+    // so the assertion would have degraded to "the markup does not contain that
+    // dotted path" — true of every markup ever rendered. The whole base figure
+    // cell, tags stripped, is the figure and the ratio and nothing else, so ANY
+    // word put back in the chip fails this — not just the one word the deleted
+    // key happened to spell.
+    //
+    // (The path is not spelled in full anywhere here on purpose: the #1911 scan
+    // in `locales/__tests__/factionCopyCollapse.test.ts` reads source RAW and
+    // would take a quoted `ns:a.b.c` out of a COMMENT as a live lookup.)
     expect(cells.figure.all, 'the base cell is its figure and the ratio, no word').toBe('18×1.50')
     // The subtotal's brass rule is the one thing that spans both columns now.
     expect(html).toContain('grid-column:1 / -1')

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
@@ -105,9 +105,10 @@ describe('the stamp reads working-then-total (#2145)', () => {
   it('puts every working row ABOVE the rose', () => {
     const html = render()
     const rose = html.indexOf(NORTH)
-    // `card.stamp.mult` left this list with #2634: the ratio is a bare chip on
-    // the base line now and carries no word, exactly as it never did on the
-    // three stamps that already drew one. The subtotal takes its place.
+    // The multiplier left this list with #2634: the ratio is a bare chip on the
+    // base line now and carries no word, exactly as it never did on the three
+    // stamps that already drew one. The subtotal takes its place. Its catalog
+    // key went with it in #2821, once nothing read it.
     const rows = [
       i18n.t('praxis:card.stamp.base'),
       i18n.t('praxis:card.stamp.subtotal'),
@@ -226,7 +227,15 @@ describe('every line of the working reads figure-then-word (#2285)', () => {
     const inner = html.slice(figureAt).replace(/^<span style="[^"]*"[^>]*>/, '')
     // The cell's own text, up to whatever it wraps — the chip, or nothing.
     const figureText = inner.slice(0, inner.search(/</))
-    return { figure: { style: figureStyle, text: figureText }, label: { style, text: label } }
+    // THE WHOLE CELL, tags stripped — the figure AND whatever it wraps. The cell
+    // runs from its own opening tag to the label cell's, so any word added
+    // inside it (a chip label above all) lands in this string. #2821's guard
+    // reads it; nothing else does.
+    const figureAll = html.slice(figureAt, cellAt).replace(/<[^>]*>/g, '')
+    return {
+      figure: { style: figureStyle, text: figureText, all: figureAll },
+      label: { style, text: label },
+    }
   }
 
   /** Base, the multiplier's two terms aside, and the three lines added to it. */
@@ -285,7 +294,15 @@ describe('every line of the working reads figure-then-word (#2285)', () => {
     const cells = row(html, 'base')
     expect(cells.figure.text, 'the base figure still opens its own cell').toBe('18')
     expect(html, 'the ratio, in the number column').toContain('×1.50')
-    expect(html, 'and no word for it').not.toContain(i18n.t('praxis:card.stamp.mult'))
+    // AND NO WORD FOR IT — read off the cell's SHAPE since #2821, not off the
+    // catalog. This line was `not.toContain(i18n.t('praxis:card.stamp.mult'))`;
+    // #2821 deleted that orphaned key, and a missing key makes `i18n.t` return
+    // the key PATH, so the assertion would have degraded to "the markup does not
+    // contain the string `card.stamp.mult`" — true of every markup ever rendered.
+    // The whole base figure cell, tags stripped, is the figure and the ratio and
+    // nothing else, so ANY word put back in the chip fails this — not just the
+    // one word the deleted key happened to spell.
+    expect(cells.figure.all, 'the base cell is its figure and the ratio, no word').toBe('18×1.50')
     // The subtotal's brass rule is the one thing that spans both columns now.
     expect(html).toContain('grid-column:1 / -1')
   })

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -44,7 +44,6 @@
     "votedBy": "voted by {{name}}",
     "stamp": {
       "base": "base",
-      "mult": "mult",
       "meta": "meta",
       "habit": "habit",
       "votes": "votes",


### PR DESCRIPTION
The multiplier's catalog word is deleted, and the guard that watched for it stops
watching a word it can no longer spell.

Closes #2821

## The seam

**The rendered markup of `EphemeristsScoreStamp` (`renderToStaticMarkup`)** — the
seam that file already tests at, and the only place the chip's wordlessness is
observable. Not the catalog: reading the absence out of the catalog is exactly what
went wrong.

## Two things, because one of them alone is wrong

**1. The guard, re-aimed (first commit).** `ephemeristsScoreStamp.test.tsx:288` read

```js
expect(html, 'and no word for it').not.toContain(i18n.t('praxis:card.stamp.mult'))
```

Delete the key and `i18n.t` hands back the key PATH, so the assertion degrades to
"the markup does not contain the string `card.stamp.mult`" — true of every markup
ever rendered. It now reads the base row's **whole figure cell with its tags
stripped**, which must be exactly the figure and the ratio:

```js
expect(cells.figure.all, 'the base cell is its figure and the ratio, no word').toBe('18×1.50')
```

That is strictly stronger than the line it replaces: it fails on **any** word put
back in the chip, not only on the one word the deleted key happened to spell. The
`row()` helper gains one field — the cell runs from its own opening tag to the label
cell's, so anything added inside it lands in that string.

**2. The key, deleted (second commit).** `praxis.json` loses `card.stamp.mult`.
`base` / `subtotal` / `votes` / `habit` and the rest of `card.stamp.*` are untouched
— only `mult` was orphaned.

## I broke it on purpose and watched it go red

Twice, once before the key was deleted and once after, by making the chip render a
word again (`mult {formatMult(mult)}` in `EphemeristsScoreStamp.tsx`):

```
AssertionError: the base cell is its figure and the ratio, no word:
  expected '18mult ×1.50' to be '18×1.50'
```

Reverted both times; the component is byte-identical to `main` apart from one
docblock paragraph. The old assertion, post-deletion, would have passed against that
same broken render — which is the whole point of the issue.

## A fourth site the grep did not find

The issue names three references, all found by `git grep 'card\.stamp\.mult'`. There
is a **fourth**, invisible to that grep because it spells the key **bare inside an
array**: `canonicalStamp.test.tsx` asserts the exact key SET of `card.stamp`, and its
comment recorded `mult` as "SURVIVES WITH NO READER, deliberately … flagged on the PR
rather than taken here" — i.e. it was written pointing at this very issue. It loses
the entry and keeps the exact-set shape, so a key quietly *added* still fails it.

Prose also had to be careful: `factionCopyCollapse.test.ts` (#1911) scans source
**raw** and takes a quoted `ns:a.b.c` out of a **comment** as a live lookup, so
writing the deleted path in full in the new comment failed CI until it was rephrased.
There is a note in the test saying so. Nothing was added to `DELIBERATE_MISSES`.

## Verification

- `npm run lint` — clean
- `npm run typecheck` + `npm run typecheck:design-sync` — clean
- `npm test` — **475 files, 9839 passed, 1 skipped**
- `npm run build` — clean
- `npm run budget` — JS `WARN 137.3 KB`, CSS `ok 21.9 KB`. Pre-existing on `main`
  and non-blocking: this diff **deletes** 15 bytes of catalog JSON and adds no code,
  so it cannot have grown the payload.
- Rebased onto `origin/main` @ `bbedc127`; suite re-run green after the rebase.
- No backend, route, or schema change, so `api-schema` has nothing to regenerate.

**Visual QA is outstanding — I have no browser and no dev stack.** The expectation is
that this renders **identically** on all nine stamps: the chip has been bare since
#2634 and the deleted key had no runtime reader, so no pixel should move. That
expectation is unverified.

## What to eyeball

- An Ephemerists praxis card with a multiplier: the base line still reads `18 ×1.50`
  — figure, then the ruled chamfered chip, then the word `base` in the word column,
  and **no word between the chip and the ratio**.
- The chip's chamfer and its `--text-lg` ratio are unchanged, and the brass rule
  under it still spans both columns with exactly one line above it.
- The other eight stamps' multiplier chips, which never carried the word: unchanged.
- Nothing anywhere renders a bare `mult` or the literal string `card.stamp.mult`
  where copy used to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
