### PR TITLE
142 types stop advertising a name nothing asks for (#2694)

### DIFF
--- a/frontend/src/api/activityFeed.ts
+++ b/frontend/src/api/activityFeed.ts
@@ -150,10 +150,10 @@ function movesThePendingCount(itemKey: string): boolean {
 
 /** Result of archiving/restoring one item. `archived` is the state AFTER the
  *  call (both endpoints are idempotent); `changed` says whether a row moved. */
-export type FeedItemArchiveResult = components['schemas']['FeedItemArchiveResponse']
+type FeedItemArchiveResult = components['schemas']['FeedItemArchiveResponse']
 
 /** Result of a bulk archive/restore — how many items moved. */
-export type FeedBulkArchiveResult = components['schemas']['FeedBulkArchiveResponse']
+type FeedBulkArchiveResult = components['schemas']['FeedBulkArchiveResponse']
 
 export async function getActivityFeed(params?: {
   filter?: string

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -24,7 +24,7 @@ export type AccountDetail = components['schemas']['AccountDetail']
 export type CharacterStatus = components['schemas']['CharacterStatus']
 
 /** Full admin character row. */
-export type AdminCharacterSummary = components['schemas']['CharacterSummary']
+type AdminCharacterSummary = components['schemas']['CharacterSummary']
 
 /** One flag row on a queue item (#237, ADR-0037). `reason` is a vocabulary key;
  *  legacy free text and `other` notes surface via `reason_detail`, which is

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -19,7 +19,7 @@ export type FactionConfigOut = components['schemas']['FactionConfigOut']
  * a `StrEnum` so the schema carries the union — after which the cast goes and
  * `LevelUnlock` / `LevelProfile` / `GameConfigOut` can alias with it.
  */
-export type LevelUnlockKind = 'ability' | 'sense'
+type LevelUnlockKind = 'ability' | 'sense'
 
 // ADR-0031: the backend emits copy KEYS; the progression.json catalog owns the
 // words. Resolve with t('progression:unlocks.<key>.name' | '.desc') and

--- a/frontend/src/api/relationships.ts
+++ b/frontend/src/api/relationships.ts
@@ -34,7 +34,7 @@ export interface RelationshipListItem {
   display_status: 'Mutual Friends' | 'Rivals' | 'Tsundere' | 'One-sided Friend' | 'One-sided Foe' | 'Secret Admirer' | 'Targeted' | 'Unknown'
 }
 
-export interface RelationshipFilters {
+interface RelationshipFilters {
   status?: string
   type?: string
 }

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -45,7 +45,7 @@ export type TaskCreate = components['schemas']['TaskCreate']
  */
 export type TaskSort = 'newest' | 'oldest' | 'level'
 
-export interface TaskFilters {
+interface TaskFilters {
   status?: string
   /**
    * Repeated `?faction=` — a UNION, not an intersection (#1364). One slug

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -112,7 +112,7 @@ const HAIRLINE_FAINT = 'color-mix(in srgb, var(--faction-default-card-line) 55%,
 // mechanic. The `mechanic` flag that picked it out of three went with them —
 // nothing to pick from. `perks.record` is rendered by name below, no map.
 
-export interface AlbescentInvitationProps {
+interface AlbescentInvitationProps {
   /** The account's roster (every life but the banned ones). */
   lives: CharacterOut[]
   /**

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -77,7 +77,7 @@ interface Perk {
  */
 const MECHANIC_INDEX = 1
 
-export interface InvitationLetterPopupProps {
+interface InvitationLetterPopupProps {
   factionSlug: string
   onClose: () => void
 }

--- a/frontend/src/components/InvitationWatcher.tsx
+++ b/frontend/src/components/InvitationWatcher.tsx
@@ -8,7 +8,7 @@ export function seenInvitesKey(characterId: number): string {
   return `${SEEN_INVITES_KEY_PREFIX}${characterId}`
 }
 
-export interface InviteDiff {
+interface InviteDiff {
   /** Slugs earned since the last observation, in stable (sorted) order. */
   toAnnounce: string[]
   /** The set to persist as last-seen (a superset of `stored`, never shrinking). */

--- a/frontend/src/components/LevelUpPopup.tsx
+++ b/frontend/src/components/LevelUpPopup.tsx
@@ -371,7 +371,7 @@ function MobileLevelUpCard({
   )
 }
 
-export interface LevelUpPopupProps {
+interface LevelUpPopupProps {
   level: number
   /** ADR-0031: a progression.json rank key, resolved to prose here. */
   rankKey: string

--- a/frontend/src/components/LevelUpWatcher.tsx
+++ b/frontend/src/components/LevelUpWatcher.tsx
@@ -9,7 +9,7 @@ export function lastSeenLevelKey(characterId: number): string {
   return `${LAST_SEEN_LEVEL_KEY_PREFIX}${characterId}`
 }
 
-export interface LevelDiff {
+interface LevelDiff {
   levelsToAnnounce: number[]
   nextStored: number
 }

--- a/frontend/src/components/TheArray.tsx
+++ b/frontend/src/components/TheArray.tsx
@@ -53,7 +53,7 @@ import { isFactionHiddenFromChoosers } from '../utils/factions'
  */
 
 /** One faction's row in the readout — the six modifiers, plus the flag. */
-export interface ArrayFactionRow {
+interface ArrayFactionRow {
   slug: string
   own_task_modifier: number
   other_task_modifier: number
@@ -65,7 +65,7 @@ export interface ArrayFactionRow {
 }
 
 /** The era rules stated as prose everywhere else, stated as numbers here. */
-export interface ArrayRules {
+interface ArrayRules {
   level_thresholds: number[]
   duel_level_required: number
   max_task_signups: number
@@ -73,7 +73,7 @@ export interface ArrayRules {
   pending_task_admin_review_hours: number
 }
 
-export interface ArrayReadout {
+interface ArrayReadout {
   rules: ArrayRules
   factions: ArrayFactionRow[]
   level_profiles: LevelProfile[]

--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -116,7 +116,7 @@ export function userMediaHook(character: CharacterOut): string | undefined {
  * faction avatar variants so the img/initial + sizing logic lives in one place;
  * only the border/surface/text colors differ per faction.
  */
-export interface CircleStyle {
+interface CircleStyle {
   borderColor: string
   bg: string
   textColor: string

--- a/frontend/src/components/badges/badgeArt.tsx
+++ b/frontend/src/components/badges/badgeArt.tsx
@@ -22,7 +22,7 @@ import { hasOwnKey } from '../../utils/hasOwnKey'
 // where no faction archetype has asked for the sheet.
 import '../../factionFaces'
 
-export interface BadgeArtProps {
+interface BadgeArtProps {
   /** px box (square). */
   size?: number
 }

--- a/frontend/src/components/cardMasthead/CardMasthead.tsx
+++ b/frontend/src/components/cardMasthead/CardMasthead.tsx
@@ -87,7 +87,7 @@ import { factionName } from "../../utils/factions";
  */
 const MARK = 20;
 
-export interface CardMastheadProps {
+interface CardMastheadProps {
   /** Whose band this is. Real components know their own faction (#2027). */
   slug: string;
   /**

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -14,7 +14,7 @@ import type { CharacterOut } from '../../api/auth'
 import type { CommentMention, CommentOut } from '../../api/comments'
 import { MentionDropdown, useMentionAutocomplete } from './useMentionAutocomplete'
 
-export interface CommentRowProps {
+interface CommentRowProps {
   mode: 'row'
   comment: CommentOut
   /** Lift an author edit back into the thread's list (re-renders with is_edited). */
@@ -23,7 +23,7 @@ export interface CommentRowProps {
   onWithdrawn?: (id: number) => void
 }
 
-export interface CommentComposerProps {
+interface CommentComposerProps {
   mode: 'composer'
   character: CharacterOut
   value: string

--- a/frontend/src/components/comments/useMentionAutocomplete.tsx
+++ b/frontend/src/components/comments/useMentionAutocomplete.tsx
@@ -21,7 +21,7 @@ const WHITESPACE = /\s/
 const DEBOUNCE_MS = 200
 const RESULT_LIMIT = 8
 
-export interface ActiveMention {
+interface ActiveMention {
   /** Text between '@' and the token end (empty for a bare '@'). */
   query: string
   /** Index of the '@'. */

--- a/frontend/src/components/duel/DuelSealSheet.tsx
+++ b/frontend/src/components/duel/DuelSealSheet.tsx
@@ -49,7 +49,7 @@ import { useFormFactor } from '../../hooks/useFormFactor'
  */
 export const SEAL_SCRIM = 'radial-gradient(circle, rgba(0,0,0,0.55), rgba(0,0,0,0.75))'
 
-export interface DuelSealSheetProps {
+interface DuelSealSheetProps {
   /** The dialog's accessible name — every skin passes `copy.heading`. */
   label: string
   /** The desktop scrim behind the card. Defaults to {@link SEAL_SCRIM}. */

--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -149,7 +149,7 @@ export function duelSides(
 /* Stakes arithmetic                                                          */
 /* -------------------------------------------------------------------------- */
 
-export interface DuelStakes {
+interface DuelStakes {
   /** Base points if this side wins the head-to-head. */
   win: number
   /** Base points if it loses. `0` for Snide — by construction, not by branch. */
@@ -410,7 +410,7 @@ export function RaceRoster({
 export type DuelSealMode = 'submit' | 'forfeit'
 
 /** Everything that varies between the modes, resolved once for every skin. */
-export interface DuelSealCopy {
+interface DuelSealCopy {
   /** Dialog title, also its `aria-label`. */
   heading: string
   /** The main body line. */

--- a/frontend/src/components/factionMarks/CovenCauldron.tsx
+++ b/frontend/src/components/factionMarks/CovenCauldron.tsx
@@ -33,7 +33,7 @@ import { CARD, DEEP, DISPLAY, READING, SOFT } from "./covenSlip";
 /** The drawing's own coordinate space. The design draws it at 158 CSS px. */
 const VIEW = 132;
 
-export interface CovenCauldronProps {
+interface CovenCauldronProps {
   /** The figure held in the pot, already formatted for display (`29.5`). */
   total: string;
   /** The caption struck under it — `points` on the stamp, shorter elsewhere. */

--- a/frontend/src/components/factionMarks/DefaultPointsRing.tsx
+++ b/frontend/src/components/factionMarks/DefaultPointsRing.tsx
@@ -54,7 +54,7 @@ import { factionRoleVar } from "../../utils/factionRoles";
 /** Lora, via the shared display token — the face the `na` task-card design names. */
 const LORA = "var(--font-display)";
 
-export interface DefaultPointsRingProps {
+interface DefaultPointsRingProps {
   /** The figure inside the ring, already formatted by the caller. */
   value: string | number;
   /** The unit lettered under it. */

--- a/frontend/src/components/factionMarks/Enso.tsx
+++ b/frontend/src/components/factionMarks/Enso.tsx
@@ -48,7 +48,7 @@ import type { FactionMarkProps } from "./Lotus";
 /** Where the asset lives under `public/`. */
 const ENSO_ASSET = "url(/factionMarks/enso.webp)";
 
-export interface EnsoProps extends Omit<FactionMarkProps, "lineColor"> {
+interface EnsoProps extends Omit<FactionMarkProps, "lineColor"> {
   /**
    * Box height, when the mark must fill a non-square slot. Defaults to
    * {@link FactionMarkProps.size}, so the ordinary call stays square. The mask

--- a/frontend/src/components/factionMarks/EphemeristsGloss.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsGloss.tsx
@@ -85,7 +85,7 @@ import { CAPS } from "./ephemeristsPlate";
 
 /** The registered scripts, in the order the design names them. */
 export const SCRIPTS = ["cuneiform", "arabic", "japanese", "latin"] as const;
-export type Script = (typeof SCRIPTS)[number];
+type Script = (typeof SCRIPTS)[number];
 
 /** Every word the catalog glosses. Derived, so a typo cannot compile. */
 export type GlossWord = keyof typeof catalog;

--- a/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
@@ -118,7 +118,7 @@ const DECLINATION = "+44° 03′";
  * a register under keys of its own.
  */
 
-export type MastheadScale = "page" | "card";
+type MastheadScale = "page" | "card";
 
 interface MastheadSize {
   /** The sigil's box. It was a HEIGHT while the mark owned a 486:560 ratio

--- a/frontend/src/components/factionMarks/EphemeristsNotationBand.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsNotationBand.tsx
@@ -140,7 +140,7 @@ export function markCount(width: number): number {
   return Math.min(CEILING, Math.max(FLOOR, Math.round(width / PITCH)));
 }
 
-export interface NotationMark {
+interface NotationMark {
   /** The two marks this slot turns between; `frames[0]` is the resting one. */
   frames: string[];
   /** Raw px — ornament geometry. See {@link MARK_SIZES}. */

--- a/frontend/src/components/factionMarks/SingularityReadout.tsx
+++ b/frontend/src/components/factionMarks/SingularityReadout.tsx
@@ -39,7 +39,7 @@ import { factionRoleVars } from "../../utils/factionRoles";
 
 const MONO = "var(--sg-readout-face)"; /* Share Tech Mono */
 
-export interface SingularityReadoutProps {
+interface SingularityReadoutProps {
   /**
    * The figure. Pre-formatted by the caller — the task card prints an integer
    * point value and the stamp prints `formatPoints(total)`, and neither

--- a/frontend/src/components/factionMarks/TaskCrown.tsx
+++ b/frontend/src/components/factionMarks/TaskCrown.tsx
@@ -26,7 +26,7 @@ import i18n from "../../i18n";
  * for this one mark, and #1219 stands everywhere else. The disc and the glyph
  * still flip; only the ring stopped.
  */
-export interface TaskCrownProps {
+interface TaskCrownProps {
   /** Overall medallion diameter, px. */
   size?: number;
   /** Ring inset from the edge, px (the coloured rainbow band width). */

--- a/frontend/src/components/factionMarks/UaMandala.tsx
+++ b/frontend/src/components/factionMarks/UaMandala.tsx
@@ -33,7 +33,7 @@ import type { CSSProperties, ReactElement } from "react";
  */
 
 /** How loudly the pattern speaks on a surface. `absent` draws nothing. */
-export type UaMandalaStrength = "full" | "texture" | "absent";
+type UaMandalaStrength = "full" | "texture" | "absent";
 
 /** Default opacity per strength. `texture` sits mid-range of the kit's 6-22%. */
 const STRENGTH_OPACITY: Record<UaMandalaStrength, number> = {
@@ -42,7 +42,7 @@ const STRENGTH_OPACITY: Record<UaMandalaStrength, number> = {
   absent: 0,
 };
 
-export interface UaMandalaProps {
+interface UaMandalaProps {
   /** Rendered box, in px. The figure is square and fills it. */
   size?: number;
   /** Which of the three strengths this surface is entitled to. */

--- a/frontend/src/components/factionMarks/everymenCogs.tsx
+++ b/frontend/src/components/factionMarks/everymenCogs.tsx
@@ -84,7 +84,7 @@ function buildCogPath(): string {
  */
 export const EVERYMEN_COG_PATH = buildCogPath();
 
-export interface EverymenCogProps {
+interface EverymenCogProps {
   /** Drawn width and height in px. Ornament geometry (§4a). */
   size: number;
   /** The teeth and rim. A token, never a hex. */

--- a/frontend/src/components/factionMarks/wowOrnament.tsx
+++ b/frontend/src/components/factionMarks/wowOrnament.tsx
@@ -425,7 +425,7 @@ const FLAKE_INKS = ["var(--faction-wow-hatch)", "var(--faction-wow-court-glow)"]
 /** Ornament strength for the bunches, on the `UaMandala` "texture" rung (§6). */
 const BALLOON_WATERMARK = 0.15;
 
-export interface WowFlake {
+interface WowFlake {
   /** Percent across and down the plate, so the throw reflows with the banner. */
   left: number;
   top: number;

--- a/frontend/src/components/feed/FeedBankFullModal.tsx
+++ b/frontend/src/components/feed/FeedBankFullModal.tsx
@@ -40,7 +40,7 @@ import { useEffect, useId, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
 /** One in-progress praxis the viewer may drop to free a bank slot. */
-export interface BankFullDropOption {
+interface BankFullDropOption {
   /** The praxis id — the React key, never rendered. */
   id: number
   /** The fully worded button, built by the caller from its own catalog keys. */

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -28,7 +28,7 @@ interface Props {
  * pair. Pure, exported, and tested directly: the harness is
  * `renderToStaticMarkup`, so the branch is provable but the click is not.
  */
-export type AcceptMode = "one-click" | "confirm-first" | "suppressed";
+type AcceptMode = "one-click" | "confirm-first" | "suppressed";
 
 /**
  * Which `Accept` a holder of this letter gets.

--- a/frontend/src/components/feed/feedRowSkin.ts
+++ b/frontend/src/components/feed/feedRowSkin.ts
@@ -131,7 +131,7 @@ export function resolveFeedRowInk(
 }
 
 /** The figure the row would otherwise print in its own caption voice. */
-export interface FeedRowPoints {
+interface FeedRowPoints {
   /** Pre-formatted points string, e.g. "40 pts" / "+12 pts", or null. */
   points: string | null
   level: number | null

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -43,7 +43,7 @@ export const FACTION_ROW_TYPES = new Set([
  * here — a state drawn on a sheet with no API behind it is not built (epic
  * #1192 amendment, owner ruling 2026-07-29).
  */
-export type FeedRowCall = { endpoint: 'leavePraxis'; praxisId: number }
+type FeedRowCall = { endpoint: 'leavePraxis'; praxisId: number }
 
 /**
  * A CTA in the row's action slot (epic #1192 amendment §3). The slot is a

--- a/frontend/src/components/imageEdit/imageEditHelpers.ts
+++ b/frontend/src/components/imageEdit/imageEditHelpers.ts
@@ -181,7 +181,7 @@ export function blobToFile(blob: Blob, originalName: string): File {
  */
 export type ApplyFailureReason = 'not-ready' | 'render-failed'
 
-export interface ApplyImageEditOptions {
+interface ApplyImageEditOptions {
   /** The picked source image. */
   file: File
   /** Object URL backing the cropper, null before the effect has minted it. */

--- a/frontend/src/components/layout/PendingBadge.tsx
+++ b/frontend/src/components/layout/PendingBadge.tsx
@@ -32,7 +32,7 @@ const BADGE_STYLE: CSSProperties = {
   background: 'var(--badge-collab)',
 }
 
-export interface PendingBadgeProps {
+interface PendingBadgeProps {
   readonly count: number
   /** Positioning only — the mobile bell pins its badge over the icon. */
   readonly className?: string

--- a/frontend/src/components/layout/ShellContent.tsx
+++ b/frontend/src/components/layout/ShellContent.tsx
@@ -42,7 +42,7 @@ import SidebarColumn from './SidebarColumn'
  * the whole rail appears BELOW the page. `col-start-*` is inert with no grid
  * active, so the signed-out and mobile branches are untouched.
  */
-export interface ShellContentProps {
+interface ShellContentProps {
   /** Straight from `useFormFactor()`; the region only re-dresses itself. */
   readonly isMobile: boolean
   /** Held by `Layout`, not here — `ShellContent` is called as a plain function

--- a/frontend/src/components/layout/SidebarColumn.tsx
+++ b/frontend/src/components/layout/SidebarColumn.tsx
@@ -41,7 +41,7 @@ import SidebarHandle from './SidebarHandle'
  * FieldDesk — so since #1456 the response carries the count itself rather than
  * up to 100 serialized feed items for three callers to run `.length` over.
  */
-export interface SidebarColumnProps {
+interface SidebarColumnProps {
   readonly collapsed: boolean
   readonly onToggle: () => void
 }

--- a/frontend/src/components/metataskSeal/MetataskSeal.tsx
+++ b/frontend/src/components/metataskSeal/MetataskSeal.tsx
@@ -4,7 +4,7 @@ import type { TaskOut } from '../../api/tasks'
 import { surfaceMap } from '../../factions'
 import { resolveVariant } from '../../utils/factionDispatch'
 
-export interface MetataskSealProps {
+interface MetataskSealProps {
   /**
    * The praxis's applied metatasks (`PraxisOut.applied_metatasks`). One seal is
    * rendered per entry, stacked in order.

--- a/frontend/src/components/nav/Breadcrumb.tsx
+++ b/frontend/src/components/nav/Breadcrumb.tsx
@@ -81,7 +81,7 @@ export function shrinkIndex(crumbs: readonly Crumb[]): number {
   return widest;
 }
 
-export interface BreadcrumbProps {
+interface BreadcrumbProps {
   /** The task all three of these surfaces hang off. */
   taskId: number;
   taskTitle: string;

--- a/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
+++ b/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
@@ -44,7 +44,7 @@ export interface ScoredPraxis {
   score: number;
 }
 
-export interface ScoreBreakdown {
+interface ScoreBreakdown {
   /**
    * The task's base points, or null when the base row is hidden because it
    * would only restate the total (#1131).

--- a/frontend/src/components/praxisCard/usePraxisCard.ts
+++ b/frontend/src/components/praxisCard/usePraxisCard.ts
@@ -19,7 +19,7 @@ import { useAdminMode } from "../../auth/AdminModeContext";
 import { extractError } from "../../utils/errors";
 import type { AdminProps } from "./shared";
 
-export interface PraxisCardModeration {
+interface PraxisCardModeration {
   localPraxis: PraxisCardOut;
   adminProps: AdminProps;
 }

--- a/frontend/src/components/selectCard/DefaultSelectCard.tsx
+++ b/frontend/src/components/selectCard/DefaultSelectCard.tsx
@@ -80,7 +80,7 @@ const MONO = "var(--font-body)";
 /** Bebas Neue — the unaffiliated display face, as on the Default praxis card. */
 const DISPLAY = "var(--na-select-card-face, var(--faction-default-card-font))";
 
-export interface DefaultSelectCardProps
+interface DefaultSelectCardProps
   extends Omit<FactionSelectCardProps, "faction"> {
   /**
    * Whose words and whose mark. Defaults to the unaffiliated sheet, which is

--- a/frontend/src/components/taskCard/TaskCard.tsx
+++ b/frontend/src/components/taskCard/TaskCard.tsx
@@ -48,7 +48,7 @@ export interface CardProps {
  * `inProgressCount` is a plain read off the task. Defaulting once here beats
  * spelling both out at every call site — and keeps the skin contract total.
  */
-export type TaskCardProps =
+type TaskCardProps =
   Omit<CardProps, 'multiplier' | 'inProgressCount'>
   & Partial<Pick<CardProps, 'multiplier' | 'inProgressCount'>>
 

--- a/frontend/src/components/ui/FilterBar/filterState.ts
+++ b/frontend/src/components/ui/FilterBar/filterState.ts
@@ -11,7 +11,7 @@
 import type { ReactNode } from 'react'
 
 /** One choice on a rail. `value` is what the page stores and puts in the URL. */
-export interface FilterSegment {
+interface FilterSegment {
   value: string
   label: string
 }
@@ -75,7 +75,7 @@ export interface FilterFacet {
 }
 
 /** A removable statement of one applied filter. */
-export interface AppliedChip {
+interface AppliedChip {
   key: string
   label: string
   /** Set only when the chip's facet draws one — see `FilterFacet`. */
@@ -125,7 +125,7 @@ export interface SegmentBox {
 }
 
 /** Inline geometry for the sliding thumb. */
-export interface ThumbGeometry {
+interface ThumbGeometry {
   left: string
   top: string
   width: string

--- a/frontend/src/components/ui/FilterBar/index.tsx
+++ b/frontend/src/components/ui/FilterBar/index.tsx
@@ -13,7 +13,7 @@ export { default as OptionPicker } from './OptionPicker'
 const REMOVE_GLYPH = '×'
 const CARET_GLYPH = '▾'
 
-export interface FilterBarProps {
+interface FilterBarProps {
   /** 2–6 segments each, one value per rail, one `ORDER BY` per rail. */
   rails: FilterRail[]
   /**

--- a/frontend/src/components/vote/pendingCasts.ts
+++ b/frontend/src/components/vote/pendingCasts.ts
@@ -51,9 +51,9 @@ import { recordCastTally } from './castTallies'
 const DEBOUNCE_MS = 2_000
 
 /** Who the viewer is, for the row we draw before the server draws it. */
-export type VoterIdentity = Omit<VoterDetail, 'value'>
+type VoterIdentity = Omit<VoterDetail, 'value'>
 
-export interface PendingCast {
+interface PendingCast {
   /**
    * The star that stands for this viewer: optimistic until the flush lands,
    * then the server's own `viewer_vote`. Null when there is nothing to show —

--- a/frontend/src/components/vote/useVotedPraxis.ts
+++ b/frontend/src/components/vote/useVotedPraxis.ts
@@ -14,7 +14,7 @@ import { useCastTally } from './castTallies'
  * decision instead of two that can drift. `voter_count` is optional because a
  * duel side carries none.
  */
-export type VoteScoredPraxis = ScoredPraxis & { voter_count?: number }
+type VoteScoredPraxis = ScoredPraxis & { voter_count?: number }
 
 /**
  * Overwrite a payload's vote numbers with the tally the server returned (#1382).

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -1,12 +1,12 @@
 import i18n from '../../i18n'
 import { hasOwnKey } from '../../utils/hasOwnKey'
 
-export interface ReframeTier {
+interface ReframeTier {
   value: number
   label: string
 }
 
-export interface VoteReframe {
+interface VoteReframe {
   /** Omit for arabic; 'roman' for Ephemerists-style roman numeral display. */
   numeral?: 'roman'
   tiers: ReframeTier[]

--- a/frontend/src/factions/index.ts
+++ b/frontend/src/factions/index.ts
@@ -67,7 +67,7 @@ export const FACTION_MANIFESTS: readonly FactionManifest[] = [
 ]
 
 /** A slug-keyed map of one surface, in the shape `resolveVariant` consumes. */
-export type SurfaceMap<K extends FactionSurface> = Record<
+type SurfaceMap<K extends FactionSurface> = Record<
   string,
   ReturnType<NonNullable<FactionManifest[K]>>
 >

--- a/frontend/src/factions/lazyArchetype.tsx
+++ b/frontend/src/factions/lazyArchetype.tsx
@@ -52,7 +52,7 @@ import { useEffect, useState, type ComponentProps, type ComponentType } from 're
 type AnyArchetype = ComponentType<any>
 
 /** A deferred archetype that can be forced to resolve ahead of render. */
-export type LazyArchetype<C extends AnyArchetype> = C & {
+type LazyArchetype<C extends AnyArchetype> = C & {
   preload: () => Promise<void>
   /** The component this resolved to, or undefined before `preload()` has run. */
   resolved: () => C | undefined

--- a/frontend/src/hooks/cachedResource.ts
+++ b/frontend/src/hooks/cachedResource.ts
@@ -79,7 +79,7 @@ export const SESSION_TTL_MS = Number.POSITIVE_INFINITY
  */
 export const AMBIENT_TTL_MS = 5 * 60 * 1000
 
-export interface CacheEntry<T> {
+interface CacheEntry<T> {
   readonly value: T
   /** `Date.now()` at the moment the fetch RESOLVED, not when it was issued. */
   readonly fetchedAt: number
@@ -94,7 +94,7 @@ export function isFresh(entry: CacheEntry<unknown> | null, now: number, ttlMs: n
   return entry !== null && now - entry.fetchedAt < ttlMs
 }
 
-export interface ResourceCache<T> {
+interface ResourceCache<T> {
   /** The held value, fresh or stale; `null` before the first response. */
   peek: () => T | null
   /**

--- a/frontend/src/hooks/useMotion.tsx
+++ b/frontend/src/hooks/useMotion.tsx
@@ -132,7 +132,7 @@ export function usePrefersReducedMotion(): boolean {
   return useSyncExternalStore(subscribeReducedMotion, readReducedMotion, readReducedMotion)
 }
 
-export interface MotionState {
+interface MotionState {
   /** What the reader chose. Not necessarily what is in effect — see `motion`. */
   readonly chosen: Motion
   /** What is actually in effect, after the OS has had its say. */

--- a/frontend/src/hooks/usePagedResource.ts
+++ b/frontend/src/hooks/usePagedResource.ts
@@ -100,7 +100,7 @@ export function loadPage<T>(
   return cached.cache.read(pageCacheKey(cached.viewer, deps), () => fetchPage(limit))
 }
 
-export interface PagedResource<T> {
+interface PagedResource<T> {
   /** The current page's rows (null before the first settle). */
   data: T[] | null
   loading: boolean

--- a/frontend/src/hooks/useResource.ts
+++ b/frontend/src/hooks/useResource.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useState, type DependencyList } from 'react'
 
-export interface UseResourceResult<T> {
+interface UseResourceResult<T> {
   data: T | null
   loading: boolean
   error: Error | null
   refetch: () => void
 }
 
-export interface ResourceHandlers<T> {
+interface ResourceHandlers<T> {
   onStart: () => void
   onData: (data: T) => void
   onError: (error: Error) => void

--- a/frontend/src/hooks/useRespondToRequest.ts
+++ b/frontend/src/hooks/useRespondToRequest.ts
@@ -14,7 +14,7 @@ import { extractError } from '../utils/errors'
  * `undefined` ids).
  */
 
-export type RequestResponseStatus = 'pending' | 'accepted' | 'declined'
+type RequestResponseStatus = 'pending' | 'accepted' | 'declined'
 
 /**
  * Collapse the per-type raw status into the three states the UI cares about.
@@ -70,7 +70,7 @@ export async function respondToRequest(
   }
 }
 
-export interface RespondResult {
+interface RespondResult {
   ok: boolean
   /** Praxis to navigate to after a successful accept (null on decline/failure). */
   praxisId: number | null

--- a/frontend/src/hooks/useSearchQueryParam.ts
+++ b/frontend/src/hooks/useSearchQueryParam.ts
@@ -82,7 +82,7 @@ export function writeSearchQuery(setSearchParams: SearchParamsSetter, next: stri
   )
 }
 
-export type SearchQueryBinding = [query: string, setQuery: (next: string) => void]
+type SearchQueryBinding = [query: string, setQuery: (next: string) => void]
 
 export function useSearchQueryParam(): SearchQueryBinding {
   const [searchParams, setSearchParams] = useSearchParams()

--- a/frontend/src/hooks/useSidebarCollapsed.ts
+++ b/frontend/src/hooks/useSidebarCollapsed.ts
@@ -23,7 +23,7 @@ export function resolveInitialCollapsed(stored: string | null): boolean {
   return stored === COLLAPSED
 }
 
-export interface SidebarCollapsedState {
+interface SidebarCollapsedState {
   readonly collapsed: boolean
   readonly toggle: () => void
 }

--- a/frontend/src/hooks/useSidebarPanelLayout.ts
+++ b/frontend/src/hooks/useSidebarPanelLayout.ts
@@ -54,7 +54,7 @@ export const SIDEBAR_PANEL_COLLAPSIBLE: Readonly<Record<SidebarPanelId, boolean>
   'recent-activity': true,
 }
 
-export interface SidebarPanelLayout {
+interface SidebarPanelLayout {
   readonly order: readonly SidebarPanelId[]
   readonly collapsed: readonly SidebarPanelId[]
 }
@@ -175,7 +175,7 @@ export function movePanelBy(
   return movePanelTo(order, movedId, order[to])
 }
 
-export interface SidebarPanelLayoutState {
+interface SidebarPanelLayoutState {
   readonly order: readonly SidebarPanelId[]
   readonly isCollapsed: (id: SidebarPanelId) => boolean
   readonly toggleCollapsed: (id: SidebarPanelId) => void

--- a/frontend/src/hooks/useSidebarPanels.tsx
+++ b/frontend/src/hooks/useSidebarPanels.tsx
@@ -18,7 +18,7 @@ const EMPTY_PANELS: SidebarPanels = {
   active_praxes: [],
 }
 
-export interface SidebarState extends SidebarPanels {
+interface SidebarState extends SidebarPanels {
   /** True until the first response lands. Drives the FieldDesk's task skeleton. */
   loading: boolean
   /** Re-read all three panels. One call, so one request — the panels move together. */

--- a/frontend/src/hooks/useTaskSignup.ts
+++ b/frontend/src/hooks/useTaskSignup.ts
@@ -24,7 +24,7 @@ import { extractError } from '../utils/errors'
  * `{ id, msg, ok }` on `/tasks` alone and no caller ever set `ok: true` nor
  * read `id`, so it reconciles down to the string the other two already used.
  */
-export interface TaskSignup {
+interface TaskSignup {
   /** Why the last sign-up failed, or `null`. Cleared at the start of each try. */
   signupMsg: string | null
   handleSignup: (id: number) => Promise<void>

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -56,7 +56,7 @@ export function persistTheme(theme: Theme): void {
   localStorage.setItem(THEME_STORAGE_KEY, theme)
 }
 
-export interface ThemeState {
+interface ThemeState {
   theme: Theme
   toggle: () => void
 }

--- a/frontend/src/locales/__tests__/findDuplicateJsonKeys.ts
+++ b/frontend/src/locales/__tests__/findDuplicateJsonKeys.ts
@@ -14,7 +14,7 @@
 // finds duplicate object keys. Array indices are not reflected in the reported
 // path — a duplicate inside `[{...}, {...}]` reports the enclosing key path.
 
-export interface DuplicateKey {
+interface DuplicateKey {
   /** Dotted path to the object that holds the duplicate, plus the key itself. */
   path: string
   key: string

--- a/frontend/src/pages/admin/ModerationTab.tsx
+++ b/frontend/src/pages/admin/ModerationTab.tsx
@@ -41,7 +41,7 @@ export type QueueItem =
   | { kind: 'comment'; comment: FlaggedCommentOut }
 
 /** Client-side content-type filter over the merged queue (#576). */
-export type QueueFilter = 'all' | 'praxis' | 'comment'
+type QueueFilter = 'all' | 'praxis' | 'comment'
 
 /** Narrow the merged queue to one content type; 'all' passes through (#576). */
 export function filterQueueByType(queue: QueueItem[], filter: QueueFilter): QueueItem[] {

--- a/frontend/src/pages/characterPaths/PortraitPicker.tsx
+++ b/frontend/src/pages/characterPaths/PortraitPicker.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from 'react-i18next'
  * owns its archetype) and only gained the accessible name the ring was missing.
  */
 
-export interface PortraitPickerProps {
+interface PortraitPickerProps {
   /** The picker hook's input handler — validates size, then opens the cropper. */
   onChange: (event: ChangeEvent<HTMLInputElement>) => void
   /**

--- a/frontend/src/pages/characterPaths/editCharacterSlots.tsx
+++ b/frontend/src/pages/characterPaths/editCharacterSlots.tsx
@@ -85,7 +85,7 @@ export function FactionRow({ slug }: { slug: string | null | undefined }) {
   )
 }
 
-export interface DeleteCharacterProps {
+interface DeleteCharacterProps {
   /** The EDITED character's faction, which is what paints the alarm ink. */
   slug: string | null | undefined
   deleting: boolean

--- a/frontend/src/pages/characterPaths/useAvatarPicker.ts
+++ b/frontend/src/pages/characterPaths/useAvatarPicker.ts
@@ -29,7 +29,7 @@ const TOO_LARGE_MESSAGE = 'Portrait must be under 10 MB.'
  * releases the current one. Extracted (and exported) so the preview lifecycle is
  * unit-testable without a DOM.
  */
-export interface ObjectUrlSlot {
+interface ObjectUrlSlot {
   set: (source: Blob) => string
   revoke: () => void
   current: () => string | null
@@ -53,7 +53,7 @@ export function createObjectUrlSlot(): ObjectUrlSlot {
   }
 }
 
-export interface AvatarPicker {
+interface AvatarPicker {
   /** The cropped file awaiting upload (null until a crop is confirmed). */
   avatarFile: File | null
   /** The raw file currently open in the crop modal (null when closed). */

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -256,7 +256,7 @@ function progressionFigures(progression: ProfileBodyProps['progression']) {
  * rule, and the same shape `DefaultTaskDetail`'s `worthSlot` and
  * `DefaultPraxisDetail`'s `ornament` already take.
  */
-export interface DefaultProfileBodyProps extends ProfileBodyProps {
+interface DefaultProfileBodyProps extends ProfileBodyProps {
   identityOrnament?: ReactNode
 }
 

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -43,7 +43,7 @@ import type { ProfileBodyProps } from '../FactionProfileBody'
 
 /** The costume knobs a faction fills in. Everything is a CSS var reference or
  *  faction-appropriate copy — no literal hex, no per-theme branching. */
-export interface ProfileKit {
+interface ProfileKit {
   /** faction_slug this kit skins (drives the shared CredentialCard skin). */
   slug: string
   /** Fixed theme for always-dark/always-light factions; scoped to the

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -574,7 +574,7 @@ export function InviteSearch({
   );
 }
 
-export interface FilePickerSkin {
+interface FilePickerSkin {
   buttonStyle: CSSProperties;
   /**
    * Optional since #2089, and unset by all eight composers: the words depend on
@@ -641,7 +641,7 @@ export function FilePicker({
   );
 }
 
-export interface DropButtonSkin {
+interface DropButtonSkin {
   style?: CSSProperties;
   label?: string;
   className?: string;
@@ -704,7 +704,7 @@ export function DropButton({
 /* Nothing here asks first — saving a draft destroys nothing, so a confirm      */
 /* would be ceremony. (The composer has `askConfirm` for the ones that do.)     */
 /* -------------------------------------------------------------------------- */
-export interface SaveDraftButtonSkin {
+interface SaveDraftButtonSkin {
   style?: CSSProperties;
   label?: string;
   /** Replaces the shared classes rather than adding to them (#1181). */
@@ -759,7 +759,7 @@ export function SaveDraftButton({
 /* previews); this control only owns the value/onChange binding so no         */
 /* archetype re-implements it.                                                */
 /* -------------------------------------------------------------------------- */
-export interface TitleFieldSkin {
+interface TitleFieldSkin {
   inputStyle: CSSProperties;
   placeholder?: string;
   /**
@@ -907,7 +907,7 @@ export function TitleField({
 /* bespoke chrome (line-number gutters, etc.) can still consume the shared     */
 /* binding.                                                                    */
 /* -------------------------------------------------------------------------- */
-export interface BodyTextareaSkin {
+interface BodyTextareaSkin {
   /**
    * The body's box. Dresses the editor's host (#1742) exactly as it dressed the
    * `<textarea>` before it — ground, rule, radius, padding, min-height, ink,
@@ -1434,7 +1434,7 @@ export function BodyTextarea({
 /* -------------------------------------------------------------------------- */
 export type ComposerTab = "write" | "preview";
 
-export interface WriteUpTabsSkin {
+interface WriteUpTabsSkin {
   containerStyle?: CSSProperties;
   buttonStyle?: (active: boolean) => CSSProperties;
 }
@@ -1487,7 +1487,7 @@ export function WriteUpTabs({
 /* MarkdownPreview block component. The archetype supplies the bespoke wrapper, */
 /* eyebrow label, and markdown typography via the skin.                        */
 /* -------------------------------------------------------------------------- */
-export interface BodyPreviewSkin {
+interface BodyPreviewSkin {
   wrapperStyle?: CSSProperties;
   label?: ReactNode;
   markdownClassName?: string;
@@ -1544,14 +1544,14 @@ export function BodyPreview({
 /* metadata and renders each option's bespoke button via `renderOption` —      */
 /* arrangement stays the faction's identity (ADR-0016).                        */
 /* -------------------------------------------------------------------------- */
-export interface ModeOptionRenderArgs {
+interface ModeOptionRenderArgs {
   active: boolean;
   disabled: boolean;
   onSelect: () => void;
   index: number;
 }
 
-export interface ModePickerSkin<O extends { key: PraxisType }> {
+interface ModePickerSkin<O extends { key: PraxisType }> {
   containerStyle?: CSSProperties;
   options: O[];
   renderOption: (option: O, args: ModeOptionRenderArgs) => ReactNode;

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -163,7 +163,7 @@ export function composerStageWord(state: EditPraxisState): string {
  * bypasses the guard, which is what #1003 retired.
  * ========================================================================== */
 
-export interface ComposerSizes {
+interface ComposerSizes {
   /** Column width. Desktop pins the design's 720; mobile fills the phone. */
   maxWidth: number | string;
   /** Sheet padding, from the --space-* scale. */
@@ -289,7 +289,7 @@ export function composerDropGround(field: string): string {
   return `color-mix(in srgb, ${field} 42%, transparent)`;
 }
 
-export interface ComposerBand {
+interface ComposerBand {
   /**
    * The band's fill. The skin's CTA while there is something to file, and its
    * CAST paint once the viewer has — the confirmation signal the design says the
@@ -858,7 +858,7 @@ export function RingMark({
  */
 const COPY_MEASURE = 260;
 
-export interface TaskSlipProps {
+interface TaskSlipProps {
   praxis: PraxisOut;
   task: TaskOut | null;
   /**

--- a/frontend/src/pages/editPraxis/blocks/HoldoutPublishNotice.tsx
+++ b/frontend/src/pages/editPraxis/blocks/HoldoutPublishNotice.tsx
@@ -42,7 +42,7 @@ import { collabCopy } from "../../../components/collab/collabCopy";
 import { factionCssVar } from "../../../utils/factions";
 import { collabPublishWindow } from "../waiting/waitingClock";
 
-export interface HoldoutPublishNoticeProps {
+interface HoldoutPublishNoticeProps {
   members: readonly PraxisMemberOut[];
   currentCharacterId: number | null | undefined;
   factionSlug: string | null | undefined;

--- a/frontend/src/pages/editPraxis/blocks/markdownToolbar.ts
+++ b/frontend/src/pages/editPraxis/blocks/markdownToolbar.ts
@@ -214,7 +214,7 @@ export function applyMarkdown(
 }
 
 /** A single-range document edit, in the shape CodeMirror's `dispatch` takes. */
-export interface TextReplacement {
+interface TextReplacement {
   from: number;
   to: number;
   insert: string;

--- a/frontend/src/pages/editPraxis/mediaBatchUpload.ts
+++ b/frontend/src/pages/editPraxis/mediaBatchUpload.ts
@@ -45,7 +45,7 @@ export const MEDIA_BATCH_MAX_FILES = 20
  */
 export const MEDIA_BATCH_MAX_BYTES = 100 * 1024 * 1024
 
-export interface BatchUploadOutcome {
+interface BatchUploadOutcome {
   /** Successfully stored media, in selection order — ready to append to the gallery. */
   uploaded: MediaItemOut[]
   /** One message per failed file, in selection order. */

--- a/frontend/src/pages/editPraxis/roomPresence.ts
+++ b/frontend/src/pages/editPraxis/roomPresence.ts
@@ -69,7 +69,7 @@ const SELECTION_TINT = "22%";
 const IDENTITY_WEIGHT = "60%";
 
 /** What this client publishes about itself. JSON — it crosses a socket. */
-export interface PresenceUser {
+interface PresenceUser {
   characterId: number;
   name: string;
   factionSlug: string;
@@ -96,7 +96,7 @@ export interface AwarenessLike {
 }
 
 /** The identity fields presence publishes. A `CharacterOut` satisfies it. */
-export interface PresenceCharacter {
+interface PresenceCharacter {
   id: number;
   display_name: string;
   faction_slug: string;

--- a/frontend/src/pages/editPraxis/useComposerConfirm.ts
+++ b/frontend/src/pages/editPraxis/useComposerConfirm.ts
@@ -14,7 +14,7 @@
 import { useCallback, useRef, useState } from "react";
 import type { ConfirmRequest } from "../../components/confirm/composerConfirms";
 
-export interface ComposerConfirm {
+interface ComposerConfirm {
   pendingConfirm: ConfirmRequest | null;
   /** Ask, and await the answer. Resolves false on dismiss. */
   askConfirm: (request: ConfirmRequest) => Promise<boolean>;

--- a/frontend/src/pages/editPraxis/useComposerDraft.ts
+++ b/frontend/src/pages/editPraxis/useComposerDraft.ts
@@ -21,7 +21,7 @@
  */
 import { useCallback, useState } from "react";
 
-export interface ComposerDraft {
+interface ComposerDraft {
   title: string;
   setTitle: (value: string) => void;
   body: string;

--- a/frontend/src/pages/editPraxis/useComposerDuel.ts
+++ b/frontend/src/pages/editPraxis/useComposerDuel.ts
@@ -23,7 +23,7 @@ import type { ConfirmRequest } from "../../components/confirm/composerConfirms";
 import { extractError } from "../../utils/errors";
 import i18n from "../../i18n";
 
-export interface ComposerDuel {
+interface ComposerDuel {
   duel: DuelDetailOut | null;
   setDuel: (duel: DuelDetailOut | null) => void;
   /** The challenge pane is open: the search box is picking an opponent. */

--- a/frontend/src/pages/editPraxis/useComposerMedia.ts
+++ b/frontend/src/pages/editPraxis/useComposerMedia.ts
@@ -48,7 +48,7 @@ export function imageEditFailureMessage(
   });
 }
 
-export interface ComposerMedia {
+interface ComposerMedia {
   media: MediaItemOut[];
   /** Seed the tray from a freshly loaded praxis, or from a mode switch. */
   setMedia: (items: MediaItemOut[]) => void;

--- a/frontend/src/pages/editPraxis/useComposerRoster.ts
+++ b/frontend/src/pages/editPraxis/useComposerRoster.ts
@@ -54,7 +54,7 @@ export interface CrewNudgeResult {
   skipped: number;
 }
 
-export interface ComposerRoster {
+interface ComposerRoster {
   inviteQuery: string;
   setInviteQuery: (value: string) => void;
   inviteResults: CharacterOut[];

--- a/frontend/src/pages/editPraxis/waiting/waitingClock.ts
+++ b/frontend/src/pages/editPraxis/waiting/waitingClock.ts
@@ -20,7 +20,7 @@
  * than a confident wrong number.
  */
 
-export interface CollabPublishWindow {
+interface CollabPublishWindow {
   /** How much of the window is gone, clamped to 0–1. Drives the ring sweep. */
   fraction: number;
   /** Whole days left. */

--- a/frontend/src/pages/factionDetail/sectionDisclosure.tsx
+++ b/frontend/src/pages/factionDetail/sectionDisclosure.tsx
@@ -46,7 +46,7 @@ import { useAuth } from "../../auth/AuthContext";
 /** The two long galleries, in page order. */
 export const FACTION_SECTION_IDS = ["tasks", "praxis"] as const;
 
-export type FactionSectionId = (typeof FACTION_SECTION_IDS)[number];
+type FactionSectionId = (typeof FACTION_SECTION_IDS)[number];
 
 /** Base key; the account id is appended, exactly as the rail's is. */
 export const FACTION_SECTION_STORAGE_KEY = "wz-faction-sections";
@@ -112,7 +112,7 @@ export function toggleCollapsedSection(
 }
 
 /** One section's disclosure: what the heading needs and what the body needs. */
-export interface FactionSection {
+interface FactionSection {
   readonly open: boolean;
   readonly bodyId: string;
   readonly toggle: () => void;

--- a/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
@@ -10,7 +10,7 @@ const STATUS_INVITED = 'invited'
 const STATUS_NOT_INVITED = 'not_invited'
 const STATUS_CAN_RETURN = 'can_return'
 
-export interface FactionsDirectoryViewProps {
+interface FactionsDirectoryViewProps {
   /** Slug-only faction list from GET /factions — Albescent absent until revealed. */
   factions: FactionOut[]
   /** Per-faction viewer status from GET /factions/status — drives card state. */

--- a/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
+++ b/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
@@ -85,7 +85,7 @@ export interface FieldDeskHomeState {
  * answer, and neither used to say which it was. `PendingRowPill.activityLabel`
  * holds the copy and the argument.
  */
-export type PendingRowKind = 'requests' | 'notifications' | 'clear'
+type PendingRowKind = 'requests' | 'notifications' | 'clear'
 
 export interface PendingRowState {
   kind: PendingRowKind
@@ -104,7 +104,7 @@ export interface PendingRowState {
 }
 
 /** The news side of `/me/sidebar`, which reports it twice over. */
-export interface NewsWaiting {
+interface NewsWaiting {
   /**
    * `global_activity_count` — how many items there are. `undefined` only under
    * deploy skew, when the API predates the field (#1587).

--- a/frontend/src/pages/players/PlayersFilterBar.tsx
+++ b/frontend/src/pages/players/PlayersFilterBar.tsx
@@ -8,7 +8,7 @@ import {
   type PlayersRail,
 } from './playersData'
 
-export interface PlayersFilterBarProps {
+interface PlayersFilterBarProps {
   filters: PlayersFilters
   onChange: (next: PlayersFilters) => void
   /**

--- a/frontend/src/pages/players/ScoreToggle.tsx
+++ b/frontend/src/pages/players/ScoreToggle.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { ScoreMode } from './playersData'
 
-export interface ScoreToggleProps {
+interface ScoreToggleProps {
   mode: ScoreMode
   onChange: (mode: ScoreMode) => void
   /** `--text-*` token — the phone sets these pills a rung smaller. */

--- a/frontend/src/pages/players/SectionHeading.tsx
+++ b/frontend/src/pages/players/SectionHeading.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 /** Decorative disclosure caret. An expression, so it is not user-facing copy. */
 const CARET_GLYPH = '▾'
 
-export interface SectionHeadingProps {
+interface SectionHeadingProps {
   title: string
   /** The "{{count}} players" chip the roster heading carries. */
   meta?: ReactNode

--- a/frontend/src/pages/players/playersData.ts
+++ b/frontend/src/pages/players/playersData.ts
@@ -278,7 +278,7 @@ export function selectRoster(
  * the page renders fully without them and the footer simply does not draw when
  * one is missing or its request failed.
  */
-export interface LatestPraxis {
+interface LatestPraxis {
   taskTitle: string
   submittedAt: string | null
 }
@@ -304,12 +304,12 @@ export interface PlayersViewProps {
 }
 
 /** The gap the pin jumps: the global ranks that are loaded past but not drawn. */
-export interface RosterGap {
+interface RosterGap {
   from: number
   to: number
 }
 
-export interface RosterView {
+interface RosterView {
   /** The loaded page, in rank order. */
   rows: RankedPlayer[]
   /** Set only when the viewer's own row is pinned below the page. */

--- a/frontend/src/pages/praxisDetail/DuelCard.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCard.tsx
@@ -112,7 +112,7 @@ const AVATAR_SIZE = 30
  * the guard only reads inks and grounds. Nothing else about this comment is
  * advisory any more.
  */
-export interface DuelCardInk {
+interface DuelCardInk {
   /** The duellist's name. Default `--faction-default-card-text`. */
   name?: string
   /** A side's total, and the em-dash standing in for an absent one. Default `--faction-default-card-text`. */
@@ -282,7 +282,7 @@ function sidesForPraxis(
     : { mine: duel.challenger, rival: duel.opponent }
 }
 
-export interface DuelCardProps {
+interface DuelCardProps {
   state: PraxisDetailState
   /** The archetype's panel chrome, so a faction skin dresses the card as its own. */
   style?: CSSProperties

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -181,7 +181,7 @@ export function orderedMembers(praxis: PraxisOut): PraxisMemberOut[] {
 }
 
 /** One face in the byline's stack of discs/plates/octagons. */
-export interface BylineFace {
+interface BylineFace {
   id: number
   name: string
   /**
@@ -585,7 +585,7 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
  *    member's `has_submitted` clears, not just the viewer's.
  *  - `solo` — the original copy, unchanged.
  */
-export type UnsubmitCase = 'solo' | 'collabGroup' | 'collabOwnPart' | 'duelLive'
+type UnsubmitCase = 'solo' | 'collabGroup' | 'collabOwnPart' | 'duelLive'
 
 export function unsubmitCase(
   praxis: PraxisOut,

--- a/frontend/src/pages/proposeTask/useProposeTask.ts
+++ b/frontend/src/pages/proposeTask/useProposeTask.ts
@@ -35,7 +35,7 @@ import { UNAFFILIATED_FACTION_SLUG } from "../../utils/factions";
 export { UNAFFILIATED_FACTION_SLUG };
 
 /** Raw form fields the submission planner reads. */
-export interface ProposalFields {
+interface ProposalFields {
   isMetatask: boolean;
   title: string;
   description: string;
@@ -49,7 +49,7 @@ export interface ProposalFields {
 }
 
 /** Which endpoint {@link handleSubmit} will hit, plus its ready-built body. */
-export type ProposalPlan =
+type ProposalPlan =
   | { kind: "metatask"; body: MetataskProposal }
   | { kind: "standard"; body: TaskCreate };
 

--- a/frontend/src/pages/settings/SettingsCard.tsx
+++ b/frontend/src/pages/settings/SettingsCard.tsx
@@ -15,7 +15,7 @@ import { useFormFactor } from '../../hooks/useFormFactor'
  * same key that names the nav item — one string, so the rail cannot point at an
  * anchor that does not exist.
  */
-export interface SettingsCardProps {
+interface SettingsCardProps {
   readonly sectionId: string
   readonly title: string
   readonly lead?: string

--- a/frontend/src/pages/settings/SettingsRow.tsx
+++ b/frontend/src/pages/settings/SettingsRow.tsx
@@ -14,7 +14,7 @@ import type { CSSProperties, ReactNode } from 'react'
  * Hierarchy therefore comes from ink rather than size — primary over secondary
  * — which is the same split the canvas uses on top of the size step.
  */
-export interface SettingsRowProps {
+interface SettingsRowProps {
   readonly title: string
   readonly help: string
   /**

--- a/frontend/src/pages/settings/SettingsSwitch.tsx
+++ b/frontend/src/pages/settings/SettingsSwitch.tsx
@@ -32,7 +32,7 @@ import type { CSSProperties } from 'react'
  * `disabled` button leaves the tab order, so the one reader most likely to need
  * the explanation is the one who can never reach it.
  */
-export interface SettingsSwitchProps {
+interface SettingsSwitchProps {
   readonly checked: boolean
   /** The accessible name. Carries the REASON when the switch is not movable. */
   readonly label: string

--- a/frontend/src/pages/taskDetail/levelJump.ts
+++ b/frontend/src/pages/taskDetail/levelJump.ts
@@ -16,7 +16,7 @@
  * When it returns false (allowance spent, or the task is plainly out of reach)
  * the sign-up CTA does not render at all, so the task reads as locked.
  */
-export interface LevelJumpSignupParams {
+interface LevelJumpSignupParams {
   /** Whether the backend says this viewer may sign up (trusted, not recomputed). */
   canSignUp: boolean;
   /** Levels above own level the viewer's faction grants (0 = no such ability). */

--- a/frontend/src/pages/taskDetail/signupCta.ts
+++ b/frontend/src/pages/taskDetail/signupCta.ts
@@ -107,9 +107,9 @@ const DENIAL_KEYS = {
   is_metatask: "detail.signup.denied.isMetatask",
 } as const;
 
-export type SignupDenialKey = (typeof DENIAL_KEYS)[keyof typeof DENIAL_KEYS];
+type SignupDenialKey = (typeof DENIAL_KEYS)[keyof typeof DENIAL_KEYS];
 
-export type SignupCtaKey =
+type SignupCtaKey =
   | typeof SIGNUP_CTA_KEY
   | typeof CTA_AGAIN_KEY
   | typeof SIGNUP_IN_PROGRESS_KEY

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -39,7 +39,7 @@ const DEFAULT_MAX_TASK_SLOTS = 20;
  * that none of the nine archetypes has to know a confirm exists. They keep
  * calling `handleDrop`; this is what the dispatcher draws when they do.
  */
-export interface DropConfirmState {
+interface DropConfirmState {
   /** Fully worded, built by `composerConfirms` — see `dropConfirm` below. */
   request: ConfirmRequest;
   onConfirm: () => void;

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -103,7 +103,7 @@ export const TASK_FILTER_PARAMS = {
  * may SEE `retired` / `pending` is a separate, server-owned question — see
  * `statusFilters`, which is what the control offers.
  */
-export type TaskStatusFilter = 'All' | 'active' | 'retired' | 'pending'
+type TaskStatusFilter = 'All' | 'active' | 'retired' | 'pending'
 
 /** Browse mode default: ordinary tasks, metatasks excluded backend-side. */
 export const TASK_TYPE_DEFAULT: TaskType = 'standard'
@@ -166,7 +166,7 @@ const TASK_STATUSES: readonly TaskStatusFilter[] = [
 const FILTER_NAV_OPTIONS = { replace: true } as const
 
 /** Every filter axis the browse owns, as read out of the address bar. */
-export interface TaskFilterAxes {
+interface TaskFilterAxes {
   taskType: TaskType
   sort: TaskSort
   status: TaskStatusFilter

--- a/frontend/src/pages/updates/requestsQueueCursor.ts
+++ b/frontend/src/pages/updates/requestsQueueCursor.ts
@@ -136,7 +136,7 @@ export function isQueueDone(items: readonly ActivityFeedItem[]): boolean {
   return items.length === 0
 }
 
-export interface QueueTray {
+interface QueueTray {
   /** The chips to draw, in feed order, never including the card on screen. */
   chips: ActivityFeedItem[]
   /** How many waiting obligations the cap is hiding — the `+N more` number. */

--- a/frontend/src/utils/commentTime.ts
+++ b/frontend/src/utils/commentTime.ts
@@ -18,7 +18,7 @@ import { hasOwnKey } from './hasOwnKey'
  * and that is deliberate: see DIALECTS below for why #783 requires it.
  */
 
-export interface TimeDelta {
+interface TimeDelta {
   minutes: number
   hours: number
   days: number

--- a/frontend/src/utils/contrastBaseline.ts
+++ b/frontend/src/utils/contrastBaseline.ts
@@ -41,7 +41,7 @@ import {
 } from './contrast';
 import type { Finding } from './contrastScan';
 
-export type BaselineEntry = {
+type BaselineEntry = {
   /** Measured ratio when this entry landed. Every entry here was MEASURED. */
   ratio: number;
   /** The issue that owns the fix. 651 = found by the sweep, awaiting a child. */
@@ -305,7 +305,7 @@ export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
  * The darkest and lightest opaque colour a fill can put under text. `lo`/`hi`
  * are ordered by WCAG relative luminance, not by stop order.
  */
-export type FillBand = { lo: Rgba; hi: Rgba };
+type FillBand = { lo: Rgba; hi: Rgba };
 
 /** A finding whose ground is known — either resolved by the scanner or banded here. */
 type Resolved = Finding & { background: string };
@@ -481,7 +481,7 @@ export function measureOverFill(finding: Finding): Resolved | null {
 }
 
 /** What the sweep does with one test's worth of findings. */
-export type Triage = {
+type Triage = {
   /** Measured below AA and not grandfathered — these FAIL the run. */
   failures: Finding[];
   /** Grandfathered pairs that now clear AA — the list only shrinks, so these FAIL too. */

--- a/frontend/src/utils/contrastSweep.ts
+++ b/frontend/src/utils/contrastSweep.ts
@@ -77,7 +77,7 @@ export type SweepTheme = (typeof SWEEP_THEMES)[number];
 export type SweepViewport = keyof typeof SWEEP_VIEWPORTS;
 
 /** One cell of the 9 × 2 × 2 matrix. */
-export type SweepRun = {
+type SweepRun = {
   faction: SweepFaction;
   theme: SweepTheme;
   viewport: SweepViewport;
@@ -234,7 +234,7 @@ function nodesIn(surfaces: Map<string, Finding[]>): number {
 }
 
 /** Everything one run of the sweep concluded. The spec asserts on it and prints it. */
-export type SweepVerdict = {
+type SweepVerdict = {
   /** Distinct AA failures, already deduped and human-described. Must be empty. */
   failures: string[];
   failureMessage: string;

--- a/frontend/src/utils/factionRoles.ts
+++ b/frontend/src/utils/factionRoles.ts
@@ -98,7 +98,7 @@ export type FactionRole = (typeof FACTION_ROLES)[number];
  * no expressions: a `color-mix` or a gradient is a surface's business, because
  * it is composed from a role rather than being one.
  */
-export type FactionRoleMap = Record<FactionRole, string | null>;
+type FactionRoleMap = Record<FactionRole, string | null>;
 
 /**
  * The grounds a surface can ask a faction to answer for.

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -45,7 +45,7 @@ const tString = i18n.t as unknown as (
 export const UNAFFILIATED_FACTION_SLUG = "na";
 
 /** What getAllFactions() hands back. Slug only — colour comes from the cascade. */
-export interface FactionConfig {
+interface FactionConfig {
   slug: string;
 }
 

--- a/frontend/src/utils/taunts.ts
+++ b/frontend/src/utils/taunts.ts
@@ -20,7 +20,7 @@ const tString = i18n.t as unknown as (
   o: { from_name: string; to_name: string },
 ) => string
 
-export interface TauntRef {
+interface TauntRef {
   id: number
   faction_slug: string
   trigger_type: string


### PR DESCRIPTION
Closes #2694

## The seam

The seam is the **module boundary** — the set of names a module publishes with
`export`. A type that nothing imports is not a type problem, it is a boundary
that claims more surface than it has. Nothing about the type's *shape* changes
here; only whether its name is part of the module's contract.

The failing check at that seam is a reference scan over the whole TypeScript
corpus — `frontend/src`, `frontend/e2e`, `frontend/.ds-kit`,
`.design-sync/previews`, plus the frontend root config files. It finds every
`export interface X` / `export type X = …` declared under `src/` whose name
appears in **no other file**, with comments stripped first so prose that merely
names a type does not keep it exported. It went red at **142** before this
change and reports **0** after.

## Not 169 — 142

The issue's number is from 2026-08-25 and several batches have merged since.
Re-running the scan on today's `origin/main` (ae837a4e) finds:

- 344 exported type/interface declarations under `src/` (excluding
  `src/api/generated/`)
- **142** of them imported by nothing
- 36 of the 142 are `*Props` interfaces — matching the issue's "about 34"

All sixteen names the issue sampled (`FeedBulkArchiveResult`,
`FeedItemArchiveResult`, `LevelUnlockKind`, `RelationshipFilters`,
`DuelSealCopy`, `DuelStakes`, `CacheEntry`, `ResourceCache`,
`ResourceHandlers`, `UseResourceResult`, `ThemeState`, `LatestPraxis`,
`RosterGap`, `RosterView`, `FactionRoleMap`, `TauntRef`) are in the 142, so the
premise holds — the population is just smaller than it was three days ago.

`export const enum` / `export enum` / `export abstract class`: zero in `src/`.
The issue's "zero dead runtime values" still holds.

## What the diff is

142 removals of the word `export `, across 104 files. 142 insertions, 142
deletions, no line added or removed anywhere. Nothing was reorganised, moved,
collapsed or tidied.

**No declaration was deleted.** The issue's first DO-NOT is the whole risk, and
the compiler settled it rather than judgement: `tsconfig.json` has
`noUnusedLocals: true`, so a type that had lost its last referent would have
failed with TS6196 the moment the `export` came off. `tsc --noEmit` reports
nothing. Every one of the 142 is still used inside its own module — mostly as
the declared shape of an exported function's return value, or as a component's
props — which is exactly the case the issue warned against inlining.

### Barrel re-exports

Checked. `src` has exactly two `export * from` lines, both in
`components/ui/FilterBar/index.tsx`, and three of the 142 sit in the module they
re-export (`FilterSegment`, `AppliedChip`, `ThumbGeometry`). All three are
internal shapes of other exported types in the same file; no consumer names them
through the barrel, and `tsc` agrees. `export { X } from` re-export lines
contain the name and so were never scanned as dead in the first place.

`src/api/generated/schema.d.ts` and `.ds-kit/` were excluded from the
declaration sweep, per the issue — but both are still part of the *search*
corpus, so an export either of them consumes counts as alive.

## Verification

All five CI steps in the `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `tsc --noEmit` | clean |
| `tsc -p tsconfig.e2e.json --noEmit` | clean |
| `tsc -p tsconfig.design-sync.json --noEmit` | clean |
| `npm test` | 475 files, 9839 passed, 1 skipped |
| `npm run build` | clean |
| `npm run budget` | unchanged (see below) |
| reference scan | **0** |

The three `tsc` invocations are the real backstop, not the scan: every directory
the scan searches is covered by one of the three projects, so dropping an
`export` something actually imports could not have stayed green.

### Bytes

Types erase at compile time, so this should move zero bytes — and it does,
verified rather than assumed. Building the tree at `HEAD~1` and at `HEAD`
produces byte-identical output: `index-Bu0MfxEl.js` and `index-ClTPlUyG.css`
have the same content hashes and the same Vite-computed names on both sides.
The budget line is unchanged from `main` and is not a finding of this PR.

## What I could not verify

**No visual QA.** I have no browser and no dev stack. This diff should render
absolutely nothing differently — it removes a compile-time keyword and the
emitted bundles are byte-identical to the pre-change build — but that is an
expectation from the build artifacts, not an observation of the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
