### PR TITLE
Exempt /settings from the character-less redirect

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import InvitationWatcher from './InvitationWatcher'
 import TheArray from './TheArray'
 import NavBar from './NavBar'
 import { flushPendingCasts } from './vote/pendingCasts'
+import { needsCharacterRedirect } from './layout/characterOnboardingGate'
 import MobileHeader from './layout/MobileHeader'
 import MobileTabBar from './layout/MobileTabBar'
 import ShellContent from './layout/ShellContent'
@@ -51,7 +52,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   }, [pathname])
 
   useEffect(() => {
-    if (!loading && user && !user.character && pathname !== '/characters/create') {
+    if (needsCharacterRedirect(loading, Boolean(user), Boolean(user?.character), pathname)) {
       navigate('/characters/create')
     }
   }, [user, loading, pathname, navigate])

--- a/frontend/src/components/layout/__tests__/characterOnboardingGate.test.ts
+++ b/frontend/src/components/layout/__tests__/characterOnboardingGate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+
+import { needsCharacterRedirect } from '../characterOnboardingGate'
+
+/**
+ * #2849: a signed-in, character-less account had no route that didn't bounce
+ * to `/characters/create` — including `/settings`, which is where the app's
+ * only sign-out control lives. Pins both halves of the fix: `/settings` (and
+ * `/characters/create`) must stay reachable, and every other route must keep
+ * bouncing. A test overlooking either half is exactly how the trap shipped —
+ * two correct-looking changes (the redirect, and moving sign-out into
+ * Settings) meeting with nothing between them.
+ */
+describe('needsCharacterRedirect', () => {
+  it('does not bounce a character-less account away from /settings', () => {
+    expect(needsCharacterRedirect(false, true, false, '/settings')).toBe(false)
+  })
+
+  it('does not bounce a character-less account away from /characters/create', () => {
+    expect(needsCharacterRedirect(false, true, false, '/characters/create')).toBe(false)
+  })
+
+  it('still bounces a character-less account away from every other route', () => {
+    for (const pathname of ['/', '/tasks', '/praxis', '/leaderboard', '/factions', '/updates']) {
+      expect(needsCharacterRedirect(false, true, false, pathname)).toBe(true)
+    }
+  })
+
+  it('never bounces a character-less account while still loading', () => {
+    expect(needsCharacterRedirect(true, true, false, '/tasks')).toBe(false)
+  })
+
+  it('never bounces a signed-out visitor', () => {
+    expect(needsCharacterRedirect(false, false, false, '/tasks')).toBe(false)
+  })
+
+  it('never bounces an account that already has a character', () => {
+    expect(needsCharacterRedirect(false, true, true, '/tasks')).toBe(false)
+    expect(needsCharacterRedirect(false, true, true, '/settings')).toBe(false)
+  })
+})

--- a/frontend/src/components/layout/characterOnboardingGate.ts
+++ b/frontend/src/components/layout/characterOnboardingGate.ts
@@ -1,0 +1,40 @@
+/**
+ * The character-less redirect's path exemptions, kept apart from `Layout`.
+ *
+ * `Layout`'s effect bounces a signed-in, character-less account to
+ * `/characters/create` on every render — a pure predicate is what lets the
+ * DOM-less test harness reach that rule, the same move `api/sessionRedirect.ts`
+ * makes for the 401 → landing bounce.
+ */
+
+/**
+ * Paths a character-less account may still reach.
+ *
+ * `/characters/create` is the onboarding page the redirect exists to send
+ * people to. `/settings` joined it in #2849: it is where the app's only
+ * sign-out control lives (#2155 moved it off the NavBar), and it is also the
+ * only route that reaches Appearance, Cookies and local storage, and the
+ * delete-account danger zone. Before this, a character-less account — every
+ * new signup between the OAuth callback and creating a character, plus anyone
+ * who cancels out of creation or signed in with the wrong provider account —
+ * had no route in the app that did not bounce, and the session cookie is
+ * httpOnly, so clearing site data was the only escape.
+ *
+ * A SET, matched whole, not a prefix — the same shape `SESSION_PROBES` in
+ * `api/sessionRedirect.ts` uses, and for the same reason: exact intent, no
+ * silent widening from a future route that happens to start with the string.
+ */
+export const CHARACTER_REDIRECT_EXEMPT_PATHS: ReadonlySet<string> = new Set([
+  '/characters/create',
+  '/settings',
+])
+
+/** Whether `Layout`'s onboarding redirect should fire for this render. */
+export function needsCharacterRedirect(
+  loading: boolean,
+  hasUser: boolean,
+  hasCharacter: boolean,
+  pathname: string,
+): boolean {
+  return !loading && hasUser && !hasCharacter && !CHARACTER_REDIRECT_EXEMPT_PATHS.has(pathname)
+}


### PR DESCRIPTION
## Summary

A signed-in account with **no character** was bounced away from every route in the app, including `/settings` — the one place the sign-out control lives since #2155 moved it off the NavBar. That left a character-less account (every new signup between OAuth callback and character creation, or anyone who cancels out) with no way to sign out or reach Appearance / Cookies and local storage / the delete-account danger zone. The session cookie is `httpOnly`, so clearing site data was the only escape.

This is the owner-ruled fix from the issue: exempt `/settings` from `Layout`'s character-less redirect, beside the existing `/characters/create` exemption. Nothing else about the redirect changes.

- `frontend/src/components/layout/characterOnboardingGate.ts` — the redirect's path-exemption set and gate predicate, pulled out of `Layout.tsx` into a pure, DOM-less-testable function (same shape as `api/sessionRedirect.ts`'s `shouldReturnToLanding`, for the same reason: this test harness has no DOM, so `Layout`'s `useEffect` + `navigate()` call can't be exercised directly under `renderToStaticMarkup`).
- `frontend/src/components/Layout.tsx` — now calls `needsCharacterRedirect(...)` instead of inlining the exemption check.
- `frontend/src/components/layout/__tests__/characterOnboardingGate.test.ts` — new test, pinning **both halves**: `/settings` and `/characters/create` stay reachable without a character, and `/`, `/tasks`, `/praxis`, `/leaderboard`, `/factions`, `/updates` still redirect. Also covers the loading/no-user/has-character cases so the predicate can't regress into an unconditional redirect or an unconditional pass-through.

## Not in scope (per the issue's ruling)

- No sign-out was restored to `NavBar` / `MobileHeader` — #2155's removal stands.
- The redirect's existence and onboarding intent are untouched — only its exemption list changed.

## Verified

- `AccountSection.tsx` already branches correctly with `character = null` (existing code, unchanged) — this PR just makes the route reachable.
- `AppearanceSection` and `CookiesSection` don't reference `character` as user data at all, so they render fine character-less.
- After `signOut()`, `user` becomes `null`, and `/settings`'s `ProtectedRoute` sends a null-user viewer to `/?login=required` — "somewhere sensible," already existing behavior.
- `tsc --noEmit`: 0 errors.
- `npm run lint`: clean.
- `npm run typecheck:design-sync`: clean (this change touches no shared contract, so expected).
- Full `vitest run`: 476 test files / 9845 passed, 1 pre-existing skip.
- `npm run build`: succeeds (one pre-existing, unrelated `INEFFECTIVE_DYNAMIC_IMPORT` warning about `FactionSigil.tsx`, present on `main` too).
- `npm run budget`: WARN (not a failing gate) — confirmed by diffing against `main` with the same build that this WARN pre-exists and is not caused by this change.

## What to eyeball

**Visual QA is outstanding — I have no browser tooling in this environment, so this was verified via `tsc`/lint/tests/build only.** Please check, ideally with a character-less test account:

- [ ] `/settings` renders (not a redirect bounce) for a signed-in account with no character.
- [ ] All three Settings sections (Account, Appearance, Cookies and local storage) render without a crash or a blank/placeholder-looking pane — particularly Account's "no character" copy and its "create" (not "manage") character link.
- [ ] The sign-out button in Account works and lands somewhere sane (expected: `/?login=required`, since `/settings` is a `ProtectedRoute`).
- [ ] Every *other* route (`/tasks`, `/praxis`, `/leaderboard`, `/factions`, `/updates`, `/`) still bounces a character-less account to `/characters/create`, unchanged.

Closes #2849