### PR TITLE
Name the edit-character phone column's three orphan labels (#2834)

### DIFF
--- a/frontend/src/pages/characterPaths/__tests__/editCharacterDispatch.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/editCharacterDispatch.test.tsx
@@ -302,3 +302,38 @@ describe('the focus ring survives every skin, at both widths (#2825)', () => {
     )
   }
 })
+
+describe('the phone column names every control it draws a <label> for (#2834)', () => {
+  /* `createCharacterFields.test.tsx`'s "a label that names no control is not
+     drawn as a <label>" guard sweeps the createCharacter registry only — the
+     `na` create archetype used to draw orphan <label>s, got fixed, and the
+     guard was scoped to the surface it was fixed on. The edit registry carried
+     the same shape (`MobileColumn`'s three phone-column fields: a <label>
+     sibling of its <input>, no `htmlFor`, no `id`) and was never swept, so it
+     shipped unnoticed until #2834. This extends the sweep here rather than
+     standing up a third file, using the same `renderFor` this file already
+     drives the registry through.
+
+     MOBILE ONLY, on purpose. `DesktopPlate` associates by WRAPPING its
+     <input> in the <label> (valid implicit association, no `for` needed) —
+     a shape a bare "every <label> needs `for`" regex cannot tell from an
+     orphan one, so the check below only counts a label an orphan when it
+     neither carries `for` nor wraps the field it names. */
+  function orphanLabels(html: string): string[] {
+    const found: string[] = []
+    for (const [whole, attrs, inner] of html.matchAll(/<label\b([^>]*)>([\s\S]*?)<\/label>/g)) {
+      const hasFor = /\bfor="[^"]*"/.test(attrs)
+      const wrapsControl = /<(?:input|textarea)\b/.test(inner)
+      if (!hasFor && !wrapsControl) found.push(whole.trim())
+    }
+    return found
+  }
+
+  it.each([...REGISTERED, UNAFFILIATED_FACTION_SLUG])(
+    'slug "%s" draws no orphan <label> on mobile',
+    (slug) => {
+      const html = renderFor(slug, 'mobile')
+      expect(orphanLabels(html), 'a <label> with nothing to point at').toEqual([])
+    },
+  )
+})

--- a/frontend/src/pages/characterPaths/archetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/DefaultEditCharacter.tsx
@@ -52,7 +52,7 @@
  * `__tests__/createCharacterContrast.test.ts` is the measurement, and
  * `eslint.config.js` names both files in the one paired exemption.
  */
-import { useRef, type CSSProperties } from 'react'
+import { useId, useRef, type CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { mediaUrl } from '../../../utils/media'
@@ -397,6 +397,11 @@ function MobileColumn({ state }: { state: EditCharacterState }) {
   const { t } = useTranslation(['forms', 'common'])
   const navigate = useNavigate()
   const fileRef = useRef<HTMLInputElement>(null)
+  // One id per field, so each label names its own control (#2834) — the same
+  // shape `DefaultCreateCharacter` already uses; these three drew a sibling
+  // <label> with no `htmlFor` and no `id`, so neither the desktop plate's
+  // implicit (wrapping) association nor an explicit one existed.
+  const fieldId = useId()
   const {
     id,
     character,
@@ -479,8 +484,9 @@ function MobileColumn({ state }: { state: EditCharacterState }) {
 
       {/* Name */}
       <div>
-        <label style={label}>{t('editCharacter.displayNameLabel')}</label>
+        <label htmlFor={`${fieldId}-name`} style={label}>{t('editCharacter.displayNameLabel')}</label>
         <input
+          id={`${fieldId}-name`}
           data-composer-field
           value={displayName}
           onChange={(e) => setDisplayName(e.target.value)}
@@ -496,8 +502,9 @@ function MobileColumn({ state }: { state: EditCharacterState }) {
           takes the desktop label so both surfaces call the same field the same
           thing. */}
       <div>
-        <label style={label}>{t('editCharacter.storyLabel')}</label>
+        <label htmlFor={`${fieldId}-story`} style={label}>{t('editCharacter.storyLabel')}</label>
         <input
+          id={`${fieldId}-story`}
           data-composer-field
           value={bio}
           onChange={(e) => setBio(e.target.value)}
@@ -510,8 +517,9 @@ function MobileColumn({ state }: { state: EditCharacterState }) {
 
       {/* Tagline — the slogan line (#1628), capped far below the bio above it. */}
       <div>
-        <label style={label}>{t('editCharacter.taglineLabel')}</label>
+        <label htmlFor={`${fieldId}-tagline`} style={label}>{t('editCharacter.taglineLabel')}</label>
         <input
+          id={`${fieldId}-tagline`}
           data-composer-field
           value={tagline}
           onChange={(e) => setTagline(e.target.value)}


### PR DESCRIPTION
Closes #2834

## What

`DefaultEditCharacter.tsx`'s `MobileColumn` drew three `<label>` elements
(display name, story, tagline) as siblings of their `<input>`, with no
`htmlFor` and no `id`. Neither the explicit nor the implicit label
association existed, so a screen reader announced an unlabelled textbox
and clicking the visible label text did not focus the field.

Fix: each field gets an `id` (`useId()`, the same convention
`DefaultCreateCharacter` already uses) and its `<label>` points at it
with `htmlFor`. `DesktopPlate` is untouched — it already associates by
**wrapping** its `<input>` in the `<label>`, which is valid implicit
association and needs no `htmlFor`.

`editCharacterDispatch.test.tsx` (the file that already sweeps the edit
registry at both widths) gets a new guard, "a `<label>` that names no
control is not drawn as a `<label>`", mirroring the one
`createCharacterFields.test.tsx` already runs on the create registry —
extended here rather than duplicated. It's scoped to **mobile only**:
the check tells an orphan `<label>` from a wrapping one (no `for` *and*
no nested `<input>`/`<textarea>`), and the only orphan instances on this
page are on the phone column.

## Sequencing note (from `/planner-bot` triage on #2834)

The issue's own comment thread flags a conflict with #2793's owner
ruling, which later **deletes** all three of these labels
(`editCharacter.displayNameLabel`, `.storyLabel`, `.taglineLabel`) in
favour of placeholder-only fields with `aria-label`. The same thread's
fallback guidance, if this has to ship before #2793: do the `htmlFor`/`id`
association now and say so, rather than block on ordering. That's what
this PR does — #2793 will supersede the label markup this PR touches
(not the widened guard, which survives and gets stronger post-#2793).

## Also noticed, deliberately NOT touched

`DesktopPlate`'s "Change portrait" heading (`editCharacter.avatarLabel`,
around line 227) is also a `<label>` that points at nothing — it heads a
`PortraitPicker` whose real control is a `<button>`, not an `<input>` the
label could wrap. `DefaultCreateCharacter` hit the identical shape and
fixed it by using a `<span>` instead of a `<label>` (see its "portrait
key" comment). This PR does not touch it: the issue and its triage
explicitly scope this fix to the three phone-column fields and rule the
desktop half untouched. Filing this as a candidate for its own issue
rather than folding it in here.

## Verified

- `tsc --noEmit`: clean
- `tsc -p tsconfig.design-sync.json --noEmit`: clean
- `eslint` on both touched files: clean
- `vitest run` (full suite): 475 files / 9841 passed, 1 pre-existing skip
- `npm run build`: succeeds (the `INEFFECTIVE_DYNAMIC_IMPORT` warning is
  pre-existing/unrelated — `FactionSigil`)
- `npm run budget`: WARN (not fail), and pre-existing — `DefaultEditCharacter`
  is a lazy-loaded route chunk, not part of the initial bundle this budget
  measures

## What to eyeball

Visual QA is outstanding — this worktree has no dev stack/browser. The
seam tested is markup only (`renderToStaticMarkup`, no DOM, per
`SPEC-testing.md`), so please eyeball:

- Edit Character on a phone-width viewport: tapping "Display name" /
  "Your story" / "Tagline" label text should focus the matching input.
- A screen reader (VoiceOver/NVDA) landing on each of those three phone
  inputs should announce the field's name, not a bare "edit text".
- Desktop Edit Character should look and behave byte-identically to
  before — no markup changed there.
