### PR TITLE
Move the selected calling chip's sigil to the host's onFill ink (#2852)

### DIFF
--- a/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
@@ -527,8 +527,12 @@ export default function CovenCreateCharacter({ state }: { state: CreateCharacter
                       }}
                     >
                       {/* The faction's own mark, from the dispatcher every other
-                          chooser draws (#2223). */}
-                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                          chooser draws (#2223). Selected, the ground becomes
+                          CTA_BAND — this kit's own fill, not the offered
+                          slug's — so the mark has to move to this kit's
+                          `onFill` ink the same way the label beside it
+                          already does (#2852). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? CTA_INK : undefined} />
                       <span
                         style={{
                           fontFamily: factionCssVar(slug, 'card-font'),

--- a/frontend/src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx
@@ -473,8 +473,11 @@ export default function EphemeristsCreateCharacter({ state }: { state: CreateCha
                     }}
                   >
                     {/* The faction's own mark, from the dispatcher every other
-                        chooser draws (#2223). */}
-                    <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                        chooser draws (#2223). Selected, the ground becomes
+                        CTA — this kit's own fill, not the offered slug's — so
+                        the mark has to move to this kit's `onFill` ink the
+                        same way the label beside it already does (#2852). */}
+                    <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? CTA_INK : undefined} />
                     <span style={{ fontFamily: factionCssVar(slug, 'card-font'), fontSize: 'var(--text-content)', color: selected ? CTA_INK : INK }}>
                       {factionName(slug)}
                     </span>

--- a/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
@@ -511,8 +511,12 @@ export default function EverymenCreateCharacter({ state }: { state: CreateCharac
                       }}
                     >
                       {/* The faction's own mark, from the dispatcher every other
-                          chooser draws (#2223). */}
-                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                          chooser draws (#2223). Selected, the ground becomes
+                          BAR — this kit's own fill, not the offered slug's —
+                          so the mark has to move to this kit's `onFill` ink
+                          the same way the label beside it already does
+                          (#2852). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? BAR_INK : undefined} />
                       <span
                         style={{
                           fontFamily: factionCssVar(slug, 'card-font'),

--- a/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
@@ -532,8 +532,12 @@ export default function SingularityCreateCharacter({ state }: { state: CreateCha
                       }}
                     >
                       {/* The faction's own mark, from the dispatcher every other
-                          chooser draws (#2223). */}
-                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                          chooser draws (#2223). Selected, the ground becomes
+                          CTA_BG — this kit's own fill, not the offered slug's
+                          — so the mark has to move to this kit's `onFill` ink
+                          the same way the label beside it already does
+                          (#2852). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? CTA_INK : undefined} />
                       <span
                         style={{
                           // The PICKED faction's own face, by role (#2675).

--- a/frontend/src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx
@@ -427,8 +427,12 @@ export default function SnideCreateCharacter({ state }: { state: CreateCharacter
                       }}
                     >
                       {/* The faction's own mark, from the dispatcher every other
-                          chooser draws (#2223). */}
-                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                          chooser draws (#2223). Selected, the ground becomes
+                          ACID — this kit's own fill, not the offered slug's —
+                          so the mark has to move to this kit's `onFill` ink
+                          the same way the label beside it already does
+                          (#2852). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? PRESS_INK : undefined} />
                       <span
                         style={{
                           fontFamily: factionCssVar(slug, 'card-font'),

--- a/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
@@ -445,8 +445,12 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
                       }}
                     >
                       {/* The faction's own mark, from the dispatcher every other
-                          chooser draws (#2223). */}
-                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                          chooser draws (#2223). Selected, the ground becomes
+                          FILL — this kit's own fill, not the offered slug's —
+                          so the mark has to move to this kit's `onFill` ink
+                          the same way the label beside it already does
+                          (#2852). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? ON_FILL : undefined} />
                       <span
                         style={{
                           fontFamily: factionCssVar(slug, 'card-font'),

--- a/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
@@ -478,8 +478,12 @@ export default function WowCreateCharacter({ state }: { state: CreateCharacterSt
                       }}
                     >
                       {/* The faction's own mark, from the dispatcher every other
-                          chooser draws (#2223). */}
-                      <FactionSigil slug={slug} size={PICKER_SIGIL} />
+                          chooser draws (#2223). Selected, the ground becomes
+                          PLUM_FILL — this kit's own fill, not the offered
+                          slug's — so the mark has to move to this kit's
+                          `onFill` ink the same way the label beside it already
+                          does (#2852). */}
+                      <FactionSigil slug={slug} size={PICKER_SIGIL} color={selected ? ON_PLUM : undefined} />
                       <span
                         style={{
                           fontFamily: factionCssVar(slug, 'card-font'),

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2225,6 +2225,85 @@ const ARCHETYPE_PAIRS: Pair[] = [
 ];
 
 /**
+ * #2852 — the "answer a calling" chip on `/characters/create`, SELECTED.
+ *
+ * Six of the seven archetypes that draw this chip (na's picker ground never
+ * changes on selection, so it is not in this list; Albescent offers no
+ * calling at all) repaint the chip's ground to the HOST kit's own fill when
+ * it is selected. `FactionSigil` now receives that same host's `onFill` ink
+ * on the selected branch — the label beside it already did — so this is the
+ * SITE that pairing has to hold at, not a restatement of a ratio measured
+ * elsewhere. Every token below is one already declared and already gated by
+ * name for its own site (WOW's decree CTA, S.N.I.D.E.'s motto sticker, the
+ * Ephemerists' plate CTA band, Everymen's bill CTA bar, Coven's slip CTA
+ * band, Singularity's terminal CTA) — this is the SAME pair read again at the
+ * picker, per #2661's own "the ratio is not the fact at risk, the SITE is."
+ *
+ * UA IS NOT HERE. Its picker's ground and ink are `factionRoleVars('ua',
+ * 'leaf-create-character')`'s `fill`/`onFill` — the bare vocabulary pairing,
+ * unwalked by any ground override — which resolves to the exact tokens
+ * `ROLE_PAIRS` already measures as `ua/sheet onFill on fill`. Naming it again
+ * here would be the same two token names a second time, not a second site.
+ *
+ * 1.4.11's 3:1 floor, not 1.4.3's 4.5 — the sigil is a drawn mark, not
+ * lettering, the same call every other graphical-object row in this file
+ * makes.
+ */
+const CALLING_CHIP_PAIRS: Pair[] = [
+  {
+    what: "wow calling chip, selected sigil",
+    surface: "--faction-wow-plum-surface",
+    text: "--faction-wow-on-plum",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+  {
+    what: "snide calling chip, selected sigil",
+    surface: "--faction-snide-acid",
+    text: "--faction-snide-ink",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+  {
+    what: "ephemerists calling chip, selected sigil",
+    surface: "--faction-ephemerists-plate-cta-bg",
+    text: "--faction-ephemerists-plate-cta-ink",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+  {
+    what: "everymen calling chip, selected sigil",
+    surface: "--faction-everymen-bill-cta-bg",
+    text: "--faction-everymen-bill-cta-ink",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+  // Coven's ground is the slip CTA's two-stop gradient, so both stops carry
+  // the row — same shape as "coven slip CTA band top/foot" above.
+  {
+    what: "coven calling chip, selected sigil (band top)",
+    surface: "--faction-coven-slip-cta-from",
+    text: "--faction-coven-slip-cta-ink",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+  {
+    what: "coven calling chip, selected sigil (band foot)",
+    surface: "--faction-coven-slip-cta-to",
+    text: "--faction-coven-slip-cta-ink",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+  {
+    what: "singularity calling chip, selected sigil",
+    surface: "--faction-singularity-term-cta-bg",
+    text: "--faction-singularity-term-cta-ink",
+    floor: AA_LARGE,
+    nonText: "the calling chip's sigil is a drawn mark — 1.4.11's 3:1",
+  },
+];
+
+/**
  * A `SKY_PAIRS` block stood here (#1792): seven rows measuring each faction's
  * `-on-night` ink against `--sky-bg`, the Constellation's own night canvas.
  *
@@ -2405,6 +2484,7 @@ const PAIRS: Pair[] = [
   ...SNIDE_WALL_PAIRS,
   ...ARCHETYPE_PAIRS,
   ...RAIL_PAIRS,
+  ...CALLING_CHIP_PAIRS,
 ];
 
 /**


### PR DESCRIPTION
Closes #2852

## The defect

On `/characters/create`, the "answer a calling" chip repaints its ground to the HOST archetype's own fill when selected. The label beside the sigil already resolves to that host's `onFill` ink; the sigil kept its default (the OFFERED faction's own hue), which coincided with the ground for WoW, S.N.I.D.E. and the Ephemerists — 1.00:1, invisible.

## The fix

`FactionSigil`'s `color` prop is now forwarded on the selected branch, using the same `onFill`-role constant each archetype's label already reads:

| archetype | ground (already existed) | ink forwarded (already existed, now also reaches the mark) |
|---|---|---|
| Wow | `PLUM_FILL` (`--faction-wow-plum-surface`) | `ON_PLUM` (`--faction-wow-on-plum`) |
| Snide | `ACID` (`--faction-snide-acid`) | `PRESS_INK` (`--faction-snide-ink`) |
| Ephemerists | `CTA` (`--faction-ephemerists-plate-cta-bg`) | `CTA_INK` (`--faction-ephemerists-plate-cta-ink`) |
| Everymen | `BAR` (`--faction-everymen-bill-cta-bg`) | `BAR_INK` (`--faction-everymen-bill-cta-ink`) |
| Coven | `CTA_BAND` gradient | `CTA_INK` (`--faction-coven-slip-cta-ink`) |
| Ua | `FILL` (role `fill`) | `ON_FILL` (role `onFill`) |
| Singularity | `CTA_BG` (`--faction-singularity-term-cta-bg`) | `CTA_INK` (`--faction-singularity-term-cta-ink`) |

No new colour anywhere — every token was already declared and already legible for the label at the same site.

Default's picker ground never changes on selection (only a boxShadow ring), so it is untouched — there is no ground/ink pairing to fix. Albescent offers no calling at all, consistent with its secrecy rules, and is untouched.

## The two factions the original measurement missed, checked rather than assumed

- **UA** draws its mark as a CSS mask (`Enso.tsx`, `background-color`, not an SVG `fill`) — confirmed by reading the component. Its picker ground/ink are `factionRoleVars('ua', 'leaf-create-character')`'s bare `fill`/`onFill` role pair, so it had the same defect (ink not forwarded) and is fixed the same way.
- **Singularity**'s glyph is a stroked SVG (`SingularitySigil`, `stroke={color}`) — confirmed by reading the component. Its `SingularitySigilAdapter` already forwards `color` correctly; the defect was purely the call site never passing one on selection. Fixed the same way as the rest.

## Contrast guard

Added `CALLING_CHIP_PAIRS` to `frontend/src/utils/__tests__/factionContrast.test.ts` — one small array, spread into `PAIRS` with a single new line, kept away from the existing array literals to minimize collision with #2845's own additions to the same file. Asserts each pairing above by name at 1.4.11's 3:1 floor (`AA_LARGE`, with `nonText` stated, since the sigil is a drawn mark, not lettering). Coven gets two rows for the gradient's two stops, matching the existing `coven slip CTA band top/foot` precedent.

UA is deliberately **not** a new row: its pairing is the bare `onFill`-on-`fill` role pair, already named by the existing `ROLE_PAIRS` loop as `ua/sheet onFill on fill` / `ua/chrome onFill on fill`. A new row would restate the same two token names, not gate a new site.

Nothing was added to `BASELINE` — this is a fix, not new debt.

## Verification

- `tsc --noEmit` — clean
- `npx eslint .` — clean
- `npx vitest run` — 475 files, 9853 passed / 1 skipped (full suite)
- `npm run typecheck:design-sync` — clean
- `npm run build` — clean (the `INEFFECTIVE_DYNAMIC_IMPORT` note for `FactionSigil.tsx` is pre-existing and unrelated — that dispatcher is both statically and dynamically imported by design)
- `npm run budget` — pre-existing JS WARN (137.2 KB vs 130.9 KB warn line), unrelated to this change: none of the files this PR touches are in the initial-load chunk list, and the same warning reproduces on an unmodified build

**Visual QA is outstanding — I have no browser and no dev stack.**

## What to eyeball

On `/characters/create`, with a test account holding invitations, for each of these seven kits: select the calling chip and confirm the sigil is legible on the filled ground (not invisible or muddy), then deselect and confirm the unselected state is pixel-identical to before (it should be — that branch is untouched):

- **Warriors of Whimsy** — plum fill, cream sigil (was invisible)
- **S.N.I.D.E.** — acid green fill, near-black sigil (was invisible)
- **The Ephemerists** — near-black plate CTA fill, brass sigil in light / near-black-on-brass in dark (was invisible)
- **Everymen** — the bill's CTA bar fill, cream sigil (was already fine — confirm still fine, now by role rather than by accident)
- **Cozy Coven** — the pink/violet CTA gradient, white (light) or near-black (dark) sigil (was already fine — confirm still fine)
- **UA** — the ensō mask on the leaf's own fill (was NOT independently verified before this fix — this is the one to look at hardest)
- **Singularity** — the terminal's CTA green fill, the stroked caret (was NOT independently verified before this fix — look hardest here too)

Also worth a glance: a calling chip offering a faction whose sigil is a *different* kit's mark than the host page (e.g. WoW's picker offering a Singularity or UA calling) — the fix is host-based, so the ink should always be the HOST's `onFill`, regardless of which faction's mark is being drawn.
