### PR TITLE
Seal-stamp the demo-seed's per-faction praxis site (#2846)

### DIFF
--- a/backend/scripts/seed_demo_praxes.py
+++ b/backend/scripts/seed_demo_praxes.py
@@ -4,8 +4,10 @@ by real demo Characters, so the per-faction praxis cards render with genuine
 scores for local testing.
 
 Idempotent: re-running creates only what's missing (keyed on demo usernames and
-a per-faction title marker). Dev DB only — these are throwaway test rows; remove
-with `scripts/seed_demo_praxes.py --remove`.
+a per-faction title marker), and repairs any of its own rows a prior run left
+corrupt (#2846 — status=submitted with no submitted_at, which the app hides
+from every feed and profile). Dev DB only — these are throwaway test rows;
+remove with `scripts/seed_demo_praxes.py --remove`.
 
     backend/.venv/Scripts/python scripts/seed_demo_praxes.py
     backend/.venv/Scripts/python scripts/seed_demo_praxes.py --remove
@@ -637,8 +639,88 @@ async def get_or_create_players(
     return chars
 
 
+async def _repair_corrupt_submitted(session) -> int:
+    """Repair pre-existing rows this script created that violate the sealed
+    invariant (#2846): ``status == submitted`` with a NULL ``submitted_at``.
+
+    Only the per-faction loop below ever produced these — every other creation
+    site in this file has always passed ``submitted_at`` — but a script that
+    just learned to stop making them is still pointed at a database that may
+    already hold the six it made before. ``if already: continue`` above keys
+    on title, so a plain re-run would skip past them forever and keep printing
+    ``=  … already present``. Scoped to ``TITLE_MARKER``-prefixed titles: rows
+    this script owns, never anything a player created.
+
+    Uses each praxis's own ``created_at`` as the seal time — the row was never
+    sealed through ``collab_consensus._apply_seal``, so there is no real seal
+    moment to recover; ``created_at`` is the closest fact on hand and is fixture
+    data either way. Repairs the matching submitted ``PraxisMember`` rows too,
+    so a repaired row is shaped the same as one this script creates fresh.
+    """
+    rows = (
+        await session.execute(
+            select(Praxis).where(
+                Praxis.title.like(f"{TITLE_MARKER}%"),
+                Praxis.status == PraxisStatus.submitted,
+                Praxis.submitted_at.is_(None),
+            )
+        )
+    ).scalars().all()
+    for praxis in rows:
+        praxis.submitted_at = praxis.created_at
+        members = (
+            await session.execute(
+                select(PraxisMember).where(
+                    PraxisMember.praxis_id == praxis.id,
+                    PraxisMember.has_submitted.is_(True),
+                    PraxisMember.submitted_at.is_(None),
+                )
+            )
+        ).scalars().all()
+        for member in members:
+            member.submitted_at = praxis.created_at
+    if rows:
+        await session.flush()
+        print(
+            f"  ! repaired {len(rows)} pre-existing corrupt row(s) "
+            "(status=submitted, submitted_at=NULL — #2846) — re-stamped from created_at"
+        )
+    return len(rows)
+
+
+async def _assert_no_corrupt_submitted(session) -> None:
+    """Fail loudly rather than report success over a row the app will hide.
+
+    ``services.praxis.list_praxes`` documents and enforces the invariant this
+    checks: ``status == submitted`` implies ``submitted_at IS NOT NULL``. This
+    is the check that stops the defect from returning silently the next time a
+    creation site is added to this file — it does not trust any one call site
+    to have gotten it right, it verifies the database after. Scoped to
+    ``TITLE_MARKER``, which is every row this script owns.
+    """
+    bad = (
+        await session.execute(
+            select(func.count())
+            .select_from(Praxis)
+            .where(
+                Praxis.title.like(f"{TITLE_MARKER}%"),
+                Praxis.status == PraxisStatus.submitted,
+                Praxis.submitted_at.is_(None),
+            )
+        )
+    ).scalar()
+    if bad:
+        raise RuntimeError(
+            f"seed_demo_praxes: {bad} row(s) with status=submitted and "
+            "submitted_at=NULL survived seeding — services/praxis.py hides "
+            "these from every feed and profile. Fix the creation site that "
+            "made them; see #2846."
+        )
+
+
 async def seed(session, era: EraConfig = CURRENT_ERA) -> None:
     players = await get_or_create_players(session, era)
+    repaired = await _repair_corrupt_submitted(session)
     created = 0
     for faction, (author_username, title, body, ptype, stars) in DEMOS.items():
         task = (
@@ -662,6 +744,7 @@ async def seed(session, era: EraConfig = CURRENT_ERA) -> None:
             print(f"  = {faction}: demo praxis already present — skipped")
             continue
 
+        now = datetime.now(timezone.utc)
         praxis = Praxis(
             task_id=task.id,
             type=ptype,
@@ -670,11 +753,17 @@ async def seed(session, era: EraConfig = CURRENT_ERA) -> None:
             body_text=body,
             created_by_id=author.id,
             moderation_status=ModerationStatus.visible,
+            submitted_at=now,
         )
         session.add(praxis)
         await session.flush()
 
-        session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id, has_submitted=True))
+        session.add(PraxisMember(
+            praxis_id=praxis.id,
+            character_id=author.id,
+            has_submitted=True,
+            submitted_at=now,
+        ))
         voters = [c for c in players.values() if c.id != author.id][: len(stars)]
         for voter, star in zip(voters, stars):
             session.add(Vote(
@@ -688,7 +777,11 @@ async def seed(session, era: EraConfig = CURRENT_ERA) -> None:
 
     await seed_score_fixtures(session, players, era)
     await session.commit()
-    print(f"\nDone. {created} demo praxis(es) created.")
+    await _assert_no_corrupt_submitted(session)
+    summary = f"\nDone. {created} demo praxis(es) created"
+    if repaired:
+        summary += f", {repaired} corrupt row(s) repaired"
+    print(summary + ".")
     print_login_recipe(era)
 
 

--- a/backend/tests/integration/test_seed_demo_praxes.py
+++ b/backend/tests/integration/test_seed_demo_praxes.py
@@ -1,0 +1,207 @@
+"""The per-faction demo praxis site seals its rows correctly (#2846).
+
+`seed_demo_praxes.seed`'s per-faction loop used to create `status=submitted`
+rows with a NULL `submitted_at` — the one creation site in this file that
+didn't match its three siblings. `services.praxis.list_praxes` documents and
+enforces the invariant `status == submitted -> submitted_at IS NOT NULL`
+(established by `collab_consensus._apply_seal`) and drops any row that
+violates it, so those six rows were silently invisible in the `/praxis` feed
+and on the author's profile even though the script printed them as created.
+
+The seam under test is `services.praxis.list_praxes` — the real production
+read path both surfaces share — fed by `scripts.seed_demo_praxes.seed`, not a
+private inspection of ORM attributes. That is what actually caught the
+original defect: a row can carry a correct-looking `status` and still never
+render.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisStatus
+from models.task import Task, TaskStatus, TaskType
+from scripts.seed_demo_praxes import (
+    DEMOS,
+    TITLE_MARKER,
+    _assert_no_corrupt_submitted,
+    _repair_corrupt_submitted,
+    fixture_faction_slugs,
+    seed,
+)
+from services.praxis import list_praxes
+
+
+async def _board(
+    db_session: AsyncSession, author: Character, era: EraConfig = CURRENT_ERA
+) -> None:
+    """Every era faction plus one task per faction `seed()` needs.
+
+    Covers both the per-faction `DEMOS` slugs and the score-fixture slugs
+    (`fixture_faction_slugs`, which `seed()` also drives) — for Era 1 the
+    latter is already a subset of the former, but the union keeps this board
+    correct if that ever stops being true.
+    """
+    for slug in era.factions:
+        existing = (
+            await db_session.execute(select(Faction).where(Faction.slug == slug))
+        ).scalar_one_or_none()
+        if existing is None:
+            db_session.add(Faction(slug=slug, status=FactionStatus.visible))
+    await db_session.flush()
+    for slug in set(DEMOS) | set(fixture_faction_slugs(era)):
+        db_session.add(Task(
+            title=f"Board task ({slug})",
+            description="fixture",
+            point_value=100,
+            level_required=0,
+            status=TaskStatus.active,
+            task_type=TaskType.standard,
+            created_by=author.id,
+            primary_faction_slug=slug,
+        ))
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_seeded_demo_praxes_are_visible_via_list_praxes(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """Every DEMOS faction's row is returned by the real submitted-feed query.
+
+    This is the seam the original bug hid behind: the row existed with
+    status=submitted, but `list_praxes` — the query the `/praxis` feed and the
+    profile grid both call — filtered it out for a NULL `submitted_at`.
+    """
+    await _board(db_session, character)
+    await seed(db_session, CURRENT_ERA)
+
+    results = await list_praxes(db_session, status=PraxisStatus.submitted)
+    titles = {p.title for p in results}
+    for _author, title, *_ in DEMOS.values():
+        assert TITLE_MARKER + title in titles
+
+
+@pytest.mark.asyncio
+async def test_seeded_demo_praxis_and_member_carry_submitted_at(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """A freshly seeded row is shaped like one `_apply_seal` would produce."""
+    await _board(db_session, character)
+    await seed(db_session, CURRENT_ERA)
+
+    author_username, title, *_ = DEMOS["ua"]
+    praxis = (
+        await db_session.execute(
+            select(Praxis).where(Praxis.title == TITLE_MARKER + title)
+        )
+    ).scalar_one()
+    assert praxis.submitted_at is not None
+
+    member = (
+        await db_session.execute(
+            select(PraxisMember).where(PraxisMember.praxis_id == praxis.id)
+        )
+    ).scalar_one()
+    assert member.has_submitted is True
+    assert member.submitted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reseeding_repairs_a_preexisting_corrupt_row(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """A dev DB already holding the pre-#2846 corrupt shape gets repaired, not skipped.
+
+    The `if already: continue` title check would otherwise skip a row exactly
+    like this forever, leaving a re-run silent about a database that is still
+    broken.
+    """
+    await _board(db_session, character)
+    # Seed once normally so players/tasks/other fixtures exist, then hand-roll
+    # a corrupt row in the exact pre-fix shape for one faction and delete the
+    # correct sibling so the repair path is what puts it back.
+    await seed(db_session, CURRENT_ERA)
+
+    author_username, title, *_ = DEMOS["everymen"]
+    marked_title = TITLE_MARKER + title
+    praxis = (
+        await db_session.execute(select(Praxis).where(Praxis.title == marked_title))
+    ).scalar_one()
+    praxis.status = PraxisStatus.submitted
+    praxis.submitted_at = None
+    member = (
+        await db_session.execute(
+            select(PraxisMember).where(PraxisMember.praxis_id == praxis.id)
+        )
+    ).scalar_one()
+    member.submitted_at = None
+    await db_session.commit()
+
+    # Confirm the corrupt fixture is actually invisible before the repair —
+    # otherwise this test would pass for a reason unrelated to the repair.
+    invisible = await list_praxes(db_session, status=PraxisStatus.submitted)
+    assert marked_title not in {p.title for p in invisible}
+
+    await seed(db_session, CURRENT_ERA)
+
+    await db_session.refresh(praxis)
+    await db_session.refresh(member)
+    assert praxis.submitted_at is not None
+    assert member.submitted_at is not None
+
+    visible = await list_praxes(db_session, status=PraxisStatus.submitted)
+    assert marked_title in {p.title for p in visible}
+
+
+@pytest.mark.asyncio
+async def test_assert_no_corrupt_submitted_raises_on_a_violation(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """The self-check fails loudly rather than letting seed() report success.
+
+    Exercises the guard directly against a hand-rolled violation, independent
+    of whether any current creation site can still produce one — this is the
+    check that is supposed to catch a *future* site that forgets.
+    """
+    await _board(db_session, character)
+    task = (
+        await db_session.execute(
+            select(Task).where(Task.primary_faction_slug == "ua")
+        )
+    ).scalars().first()
+    db_session.add(Praxis(
+        task_id=task.id,
+        type=DEMOS["ua"][3],
+        status=PraxisStatus.submitted,
+        title=TITLE_MARKER + "a future site that forgot submitted_at",
+        body_text="",
+        created_by_id=character.id,
+        moderation_status=ModerationStatus.visible,
+        # submitted_at deliberately left NULL — the violation under test.
+    ))
+    await db_session.flush()
+
+    # `_repair_corrupt_submitted` would also fix this row — it's the same
+    # corrupt shape — so the guard is exercised directly, un-repaired, to
+    # prove it is a real backstop and not merely unreachable dead code.
+    with pytest.raises(RuntimeError, match="submitted_at"):
+        await _assert_no_corrupt_submitted(db_session)
+
+    # And the repair pass really does clear the violation it was asked to
+    # detect, confirming the two halves (repair, verify) agree on the shape.
+    repaired = await _repair_corrupt_submitted(db_session)
+    assert repaired == 1
+    await _assert_no_corrupt_submitted(db_session)  # no longer raises

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 641
+RUFF_FINDING_TOTAL = 640
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -148,7 +148,7 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "scripts/era_reset.py::E501": 8,
     "scripts/reset_e2e_db.py::E501": 3,
     "scripts/reset_render_db.py::E501": 5,
-    "scripts/seed_demo_praxes.py::E501": 11,
+    "scripts/seed_demo_praxes.py::E501": 10,
     "scripts/seed_demo_praxes.py::I001": 1,
     "scripts/sweep_orphan_media.py::E501": 11,
     "seed.py::E501": 3,


### PR DESCRIPTION
## Summary

`backend/scripts/seed_demo_praxes.py`'s per-faction demo loop (`seed()`) was
the one creation site in the file that set `status=submitted` without
`submitted_at`. `services/praxis.py`'s read-side filter enforces the
invariant `status == submitted ⟹ submitted_at IS NOT NULL` (established by
`collab_consensus._apply_seal`, the production sealer) and silently drops any
row that violates it — so the script printed six `+ {faction}: ...` success
lines for rows that could never appear in the `/praxis` feed or on the
author's profile.

`services/praxis.py`, `collab_consensus.py`, and the read-side filter are
untouched — they are correct, and the bug was entirely in the seed script.

## Changes

- The per-faction site now passes `submitted_at` on `Praxis` (matching the
  script's other three creation sites) and on the corresponding
  `PraxisMember` too, so a seeded row is shaped exactly like one
  `_apply_seal` would produce.
- **Repair pass** (`_repair_corrupt_submitted`): on every run, before
  creating anything, repairs any of the script's own rows (title prefixed
  with `TITLE_MARKER`) that already carry `status=submitted` with
  `submitted_at IS NULL` — the exact shape the six pre-existing corrupt rows
  have. The old `if already: continue` title check meant a plain re-run
  would skip past them forever; this fixes a dev DB that already holds them
  instead of requiring a manual step.
- **Self-check** (`_assert_no_corrupt_submitted`): after commit, asserts no
  row this script owns still violates the invariant and raises loudly
  instead of printing a `Done.` summary. This is the backstop against a
  fifth creation site being added later without `submitted_at`.

## What I tested at

**`services.praxis.list_praxes`** — the real query the `/praxis` feed and
the profile grid both call — fed by `scripts.seed_demo_praxes.seed()`. This
is the seam where the original defect actually hid: the row existed with a
correct-looking `status`, but the production read path filtered it out. A
test that only inspected `Praxis.submitted_at` on the ORM object would have
been a weaker proxy for the same claim; this goes through the same code path
the feed and the profile actually run.

New file: `backend/tests/integration/test_seed_demo_praxes.py` (4 tests):
- fresh-seed rows are returned by `list_praxes(status=submitted)`
- a fresh row's `Praxis.submitted_at` and its `PraxisMember.submitted_at`
  are both non-null
- a hand-rolled pre-existing corrupt row (the pre-fix shape) is invisible
  via `list_praxes` before a re-seed, then repaired and visible after
- `_assert_no_corrupt_submitted` raises on a hand-rolled violation and stops
  raising once `_repair_corrupt_submitted` has run

Confirmed these tests go red against the pre-fix script (temporarily
reverted to `origin/main`'s copy locally, not committed) before restoring
the fix, per the "write the failing test first" convention.

## Verification

- `pytest backend/tests/integration/test_seed_demo_praxes.py backend/tests/integration/test_seed_score_fixtures.py -q` → **13 passed**
- `pytest backend/tests/unit/test_ruff_clean.py -q` → **8 passed** (the file's `E501` count dropped 11→10; `ruff_allowlist.py` updated to match, `RUFF_FINDING_TOTAL` 641→640)
- Full suite: `pytest --cov=. --cov-report=term-missing --cov-fail-under=92` → **1721 passed**, coverage **94.38%** (gate 92%)
- No route/schema/model changes → no Alembic migration, no `openapi.json`/generated-types regen needed
- `ruff check backend/scripts/seed_demo_praxes.py backend/tests/integration/test_seed_demo_praxes.py`

## What to eyeball

I have no browser or dev-stack access from this environment — **visual QA is
outstanding.** On a running stack:

1. Drop the dev DB (or start from an empty one), run
   `backend/.venv/Scripts/python scripts/seed_demo_praxes.py` from `/backend`
   against a board that has at least one task per faction, and confirm the
   console prints `Done. 6 demo praxis(es) created.` with no `repaired` line
   and no traceback.
2. Load `/praxis` (default `this_era` scope) and confirm all six
   `[demo] ...` cards render: **ua** ("Mapped the unmarked stair"),
   **everymen** ("Hit the bench. Then hit it again"), **wow** ("Threw a
   stranger a parade"), **snide** ("Flyposted the quiet block"),
   **ephemerists** ("Traced a myth to its road"), **singularity** ("Logged
   the signal at 0300").
3. Open each demo author's profile (`demo_quill`, `demo_sol`,
   `demo_marigold`, `demo_riot`, `demo_vesper`, `demo_unit`) and confirm the
   praxis card shows there too, instead of "No praxis submitted yet."
4. To exercise the **repair path**: on a dev DB that still has the six
   pre-fix corrupt rows from before this PR, re-run the script and confirm
   the console prints `! repaired 6 pre-existing corrupt row(s) ...` and
   `Done. 0 demo praxis(es) created, 6 corrupt row(s) repaired.`, then that
   the same six cards now render on `/praxis` and on each profile.
5. Confirm `scripts/seed_demo_praxes.py --remove` still cleans everything up
   (unaffected by this change, but worth a pass since it deletes by
   membership/authorship, not by shape).

## Note on scope

While tracing this I noticed `coven` — a real, joinable Era 1 faction — never
gets a demo praxis from this script at all (`DEMOS` doesn't include it, and
the score-fixture slugs always land on `ua`/`snide`/`wow`). That's a
pre-existing gap, not something this issue's repro or "already decided"
scope named, so I left it alone; flagging it here in case it's worth its own
issue.

Closes #2846
