### PR TITLE
Design-sync round 6: three new components mapped, and the Albescent edit form stops clipping

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -992,3 +992,118 @@ stale), #2686 re-cut S.N.I.D.E. chrome contrast 1.03:1 -> 7.71:1, #2528 touched
 `DefaultSettings` line this round had flagged). Merged, regenerated kit.css +
 ds-types + both barrels, re-ran the whole chain. **Re-check `origin/main` immediately
 before `finalize_plan`, every single time** — this is now five for five.
+
+## [2026-08-28] Sixth round — 305 -> 308, and the auth that never arrived
+
+Ran from a worktree at `origin/main` 3fb2cf6f (115+ commits past the 08-25 round's
+d3f98246). Build clean, `package-validate.mjs` **exit 0**, zero new warn lines.
+
+### THE BLOCKER: `DesignSync` cannot authorize from a Claude Code desktop session
+Every `DesignSync` call — `get_project`, `get_file` — returned the same error:
+
+> DesignSync needs design-system authorization, but /design-login requires an
+> interactive terminal and is not available in this environment.
+
+Tried four times across the run, including after the owner ran `/design-login` in a
+separate interactive terminal. **The credential does not propagate into an
+already-running session.** So this round: no `_ds_sync.json` anchor fetch, no diff, no
+upload. Everything else was completed locally.
+
+**Next round: authorize BEFORE starting.** Run `/design-login` first, then start the
+session. Do not begin the build expecting to fetch the anchor part-way through — the
+anchor decides the verification scope, and without it the render check is unscoped.
+
+### The whole-tree scan, sixth round running — 37 unmapped, 3 genuinely new
+`.design-sync/.cache/newdirs.mjs` (regenerate it; gitignored) found 37. **34 were
+documented deliberate exclusions** — the route-level `src/pages/*.tsx`, `src/auth`,
+`pages/admin` set (NOTES line ~488), `TheArray`, and one false positive
+(`BackdropContext.tsx`, which IS mapped, under the component name `BackdropProvider` —
+the scan keys by basename, so a file mapped under a different name reads as unmapped).
+
+The 3 real ones:
+- `LevelTrackMeta` (`src/components/`, #2767) — the shared baseline row under the level
+  track. ONE ROW, NINE MOUNTS; it is TREE not skin, and the kit's voice arrives entirely
+  through the `style` prop.
+- `AlbescentEditCharacter` (#2788) and `AlbescentProposeTask` (#2802) — the two surfaces
+  that grew a second faction skin this cycle.
+
+### Do NOT mirror the Default sibling's viewport for `*EditCharacter`
+Mirroring `DefaultEditCharacter`'s `390x760` onto `AlbescentEditCharacter` **clipped the
+card**: the save bar overlapped the faction explainer and the delete control fell off the
+bottom edge entirely. #2788's whole point is "the fold, and the two slots a create dress
+has no room for" — the Albescent edit form is genuinely taller. It now sits at
+**`390x1280`** and renders whole.
+
+This is NOT the thing the 08-25 note warns against normalising. That warning is about the
+`*CreateCharacter` pair (Albescent + Default at `390x760` because they render the shorter
+na form, against the other seven at `390x1280`). Different component, opposite direction,
+decided on evidence from the sheet.
+
+Related trap: `preview-rebuild.mjs` **refuses** after an `cfg.overrides` change —
+`[CONFIG_STALE]`, "run package-build.mjs first". A `package-capture.mjs` fired straight
+afterwards will happily capture the STALE html and hand you a sheet of the old viewport.
+Full build first, then recapture.
+
+### `AlbescentProposeTask` ships the floor card on purpose
+Its own family sibling `DefaultProposeTask` has no authored preview either, and
+`previews/_state.tsx` has no `proposeTaskState` builder — authoring it means building a
+whole `ProposeTaskState` fixture from scratch. Floor tier, consistent with the family.
+The standing offer for any future round.
+
+### Playwright drift: the repo pin moved, the cache did not
+`frontend/package.json` now asks for `@playwright/test@^1.62.1`, which pins **chromium
+1234**. The box still caches **chromium-1228**. The 08-17 recipe is unchanged and still
+correct: `cd .ds-sync && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm i playwright@1.61.1`.
+Expect this line to keep drifting as the repo bumps; always check
+`playwright-core/browsers.json` (read it as a FILE — the exports map blocks `require`)
+against the `ms-playwright` cache dir name rather than trusting either pin.
+
+### The conventions header had ONE stale claim
+All 37 components it names, all 7 Tailwind utilities and 67/74 tokens verified against
+the fresh build. The 7 that did not are `--faction-albescent-*`, which the header never
+claims — it says Albescent has no palette of its own, and that is still true.
+
+What HAD rotted: it listed `DefaultEditCharacter` among "the singletons". #2788 and #2802
+made `editcharacter` and `proposetask` dispatched families of two. Left alone, a design
+agent would never reach for `AlbescentEditCharacter`. Fixed with the owner's approval.
+
+**Checked and deliberately NOT added**: the per-faction class layer in the shipped CSS
+(`.alb-*` 28, `.eph-*` 21, `.wow-*` 20, `.ua-*` 9, `.coven-*` 4, `.snide-*` 2, `.na-*` 1).
+These are **component-internal** — `.alb-desk` is applied inside `AlbescentFieldDesk`,
+`.ua-gilt` inside `UaPraxisCard`/`UaScoreStamp`. The header is right to omit them and
+right to say "compose the faction's own component and let it carry its identity". Do not
+"fix" this next round by enumerating them; it would teach the agent to hand-apply classes
+that belong to a component.
+
+### Known render warns — unchanged standing set, nothing new
+`[TOKENS_MISSING]` 35 (33 `--tw-*` + `--rail-face` + one more, all runtime-set),
+`[FONT_MISSING]` the same 4 system families (Marker Felt, Trajan Pro, Impact,
+Trebuchet MS), `[RENDER_THIN]` on `EphemeristsSigil` (pure SVG mark, no text node).
+All three were already recorded. Sampled render check 39/39 clean, 10 floor cards.
+All 308 `.d.ts` parse cleanly; `window.WZ` carries 309 exports (308 + `DSProvider`).
+
+### Re-sync risks (2026-08-28)
+- **Nothing was uploaded this round.** The project still holds the 08-25 build, so its
+  `_ds_sync.json` anchor describes **305** components, not 308. The next authorized round
+  will see `LevelTrackMeta`, `AlbescentEditCharacter`, `AlbescentProposeTask` as `added`
+  and a large `changed` partition (new bundle across 115+ commits) — budget for a wide
+  render check, not a scoped one.
+- **Grades for the two newly authored components live in the gitignored `.cache/`.**
+  They are campaign-local and what makes them durable is the upload, which did not
+  happen. A fresh clone re-grades both. They are cheap (3 cells) — just do not be
+  surprised.
+- The full 308-preview render check was **never run this round** (sampled 39). A round
+  that uploads must run it unsampled, via the driver.
+- `.design-sync/overrides/source-kit.mjs` is still exactly 2 deltas from the bundled
+  `lib/source-kit.mjs` (header + relative imports, and the widened `GENERIC_DIR`).
+  Upstream has not moved under it. Verified again this round.
+- `LevelTrackMeta` lands in the `general` group, the only component there. If a future
+  round wants it grouped by surface, that is a `docsMap` stub, not a code change.
+- **NOTES contradicts itself on `frontend/.ds-kit/index.tsx`** — the "How the build is
+  wired" section calls it committed, the "Two barrels now" section calls it generated and
+  gitignored. Git is the truth: `index.tsx` is **tracked** (it shows up in `git status`
+  after `gen-barrel.mjs`), `frontend/index.d.ts` and `frontend/ds-types/` are **not**.
+  So a barrel regen is part of the commit; the types tree is not.
+- The `newdirs.mjs` basename-keying false positive (`BackdropContext` -> mapped as
+  `BackdropProvider`) will recur every round. Two more files are mapped under a name
+  that differs from their basename? Not as of this round — but the scan cannot tell you.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -17,6 +17,7 @@
     "AlbescentComment": "src/components/comments/voices/AlbescentComment.tsx",
     "AlbescentCreateCharacter": "src/pages/characterPaths/archetypes/AlbescentCreateCharacter.tsx",
     "AlbescentDuelSealConfirm": "src/components/duel/AlbescentDuelSealConfirm.tsx",
+    "AlbescentEditCharacter": "src/pages/characterPaths/archetypes/AlbescentEditCharacter.tsx",
     "AlbescentEditPraxis": "src/pages/editPraxis/archetypes/AlbescentEditPraxis.tsx",
     "AlbescentFactionBody": "src/pages/factionDetail/archetypes/AlbescentFactionBody.tsx",
     "AlbescentFactionHero": "src/components/factionHero/AlbescentFactionHero.tsx",
@@ -26,6 +27,7 @@
     "AlbescentPraxisCard": "src/components/praxisCard/desktop/AlbescentPraxisCard.tsx",
     "AlbescentPraxisDetail": "src/pages/praxisDetail/archetypes/AlbescentPraxisDetail.tsx",
     "AlbescentProfileBody": "src/pages/characterProfile/archetypes/AlbescentProfileBody.tsx",
+    "AlbescentProposeTask": "src/pages/proposeTask/archetypes/AlbescentProposeTask.tsx",
     "AlbescentScoreStamp": "src/components/praxisCard/scoreStamp/AlbescentScoreStamp.tsx",
     "AlbescentSeal": "src/components/metataskSeal/skins/AlbescentSeal.tsx",
     "AlbescentSelectCard": "src/components/selectCard/AlbescentSelectCard.tsx",
@@ -174,6 +176,7 @@
     "JoinControl": "src/components/JoinControl.tsx",
     "Layout": "src/components/Layout.tsx",
     "LevelGem": "src/components/ui/LevelGem.tsx",
+    "LevelTrackMeta": "src/components/LevelTrackMeta.tsx",
     "LevelUpPopup": "src/components/LevelUpPopup.tsx",
     "LevelUpWatcher": "src/components/LevelUpWatcher.tsx",
     "Lotus": "src/components/factionMarks/Lotus.tsx",
@@ -332,6 +335,10 @@
       "cardMode": "single",
       "viewport": "700x680"
     },
+    "AlbescentEditCharacter": {
+      "cardMode": "single",
+      "viewport": "390x1280"
+    },
     "AlbescentEditPraxis": {
       "cardMode": "single",
       "viewport": "1200x900"
@@ -356,6 +363,10 @@
       "viewport": "1200x900"
     },
     "AlbescentProfileBody": {
+      "cardMode": "single",
+      "viewport": "1200x900"
+    },
+    "AlbescentProposeTask": {
       "cardMode": "single",
       "viewport": "1200x900"
     },
@@ -828,6 +839,6 @@
   },
   "readmeHeader": ".design-sync/conventions.md",
   "libOverrides": {
-    "source-kit.mjs": "GENERIC_DIR += pages,archetypes,mobileArchetypes,desktop,mobile,skins,blocks,waiting → page skins and card families group by surface"
+    "source-kit.mjs": "GENERIC_DIR += pages,archetypes,mobileArchetypes,desktop,mobile,skins,blocks,waiting \u00e2\u2020\u2019 page skins and card families group by surface"
   }
 }

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -80,8 +80,14 @@ internally and stacks single-column on a phone):
 the phone skins. Character profile went the same way in #1319 (`*ProfileBody`).
 
 **Mobile-only screens**: `DefaultFieldDesk` / `WowFieldDesk` / `UaFieldDesk` / `SnideFieldDesk` …
-(`fielddesk`), plus the singletons `DefaultTasks`, `DefaultEditCharacter`,
-`DefaultFactionsDirectory`.
+(`fielddesk`), plus the singletons `DefaultTasks` and `DefaultFactionsDirectory`.
+
+**`editcharacter` and `proposetask` are faction-dispatched families of two, not
+singletons**: `DefaultEditCharacter` / `AlbescentEditCharacter` (#2788), and
+`DefaultProposeTask` / `AlbescentProposeTask` (#2802). `Default*` is the `na` dress;
+reach for the Albescent skin to pin that faction. Each pair takes the same
+`EditCharacterState` / `ProposeTaskState` and reads `useFormFactor()` itself.
+
 Players is the one surface still split by form factor: `MobilePlayers` and
 `DesktopPlayers`, each taking the same `playersProps` shape.
 

--- a/.design-sync/previews/AlbescentEditCharacter.tsx
+++ b/.design-sync/previews/AlbescentEditCharacter.tsx
@@ -1,0 +1,7 @@
+// AlbescentEditCharacter mobile — Edit Character wears the faction it edits (#2788).
+import { AlbescentEditCharacter } from 'worldzero-frontend'
+import { editCharacterState } from './_state'
+
+export function Edit() {
+  return <AlbescentEditCharacter state={editCharacterState('albescent')} />
+}

--- a/.design-sync/previews/LevelTrackMeta.tsx
+++ b/.design-sync/previews/LevelTrackMeta.tsx
@@ -1,0 +1,58 @@
+// LevelTrackMeta — the baseline row under the level track (#2767).
+// ONE ROW, NINE MOUNTS: it is TREE, not skin, and the kit's voice arrives
+// entirely through `style`. The two cells are the component's own documented
+// branches — the mid-curve one-liner every character below the top renders,
+// and the top-of-curve pair that has no gap at which it fits, so it wraps.
+import type { CSSProperties } from 'react'
+import { LevelTrackMeta } from 'worldzero-frontend'
+import type { LevelTrack } from '../../frontend/src/utils/levelTrack'
+
+/** Ported verbatim from DefaultFieldDesk's own `trackMetaStyle`. */
+const caption: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-base)',
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'var(--color-text-secondary)',
+}
+
+/** The rail the row actually mounts in is ~272px wide — the width is the point. */
+const RAIL = 272
+
+const midCurve: LevelTrack = {
+  nextLevel: 9,
+  pointsToNext: 114,
+  currentThreshold: 2_600,
+  nextThreshold: 3_200,
+  pointsIntoLevel: 486,
+  levelSpan: 600,
+  fillPercent: 81,
+}
+
+const topOfCurve: LevelTrack = {
+  nextLevel: null,
+  pointsToNext: 0,
+  currentThreshold: 3_200,
+  nextThreshold: 0,
+  pointsIntoLevel: 0,
+  levelSpan: 0,
+  fillPercent: 100,
+}
+
+/** Both captions fit: one line, all-time flush right on its auto margin. */
+export function MidCurve() {
+  return (
+    <div style={{ width: RAIL }}>
+      <LevelTrackMeta track={midCurve} allTimeScore={3_886} style={caption} />
+    </div>
+  )
+}
+
+/** The sentence branch — the pair cannot fit, so all-time drops to its own line. */
+export function TopOfCurve() {
+  return (
+    <div style={{ width: RAIL }}>
+      <LevelTrackMeta track={topOfCurve} allTimeScore={3_886} style={caption} />
+    </div>
+  )
+}

--- a/frontend/.ds-kit/index.tsx
+++ b/frontend/.ds-kit/index.tsx
@@ -9,6 +9,7 @@ export { default as AlbescentBackdrop } from "../src/components/backdrop/Albesce
 export { default as AlbescentComment } from "../src/components/comments/voices/AlbescentComment";
 export { default as AlbescentCreateCharacter } from "../src/pages/characterPaths/archetypes/AlbescentCreateCharacter";
 export { default as AlbescentDuelSealConfirm } from "../src/components/duel/AlbescentDuelSealConfirm";
+export { default as AlbescentEditCharacter } from "../src/pages/characterPaths/archetypes/AlbescentEditCharacter";
 export { default as AlbescentEditPraxis } from "../src/pages/editPraxis/archetypes/AlbescentEditPraxis";
 export { default as AlbescentFactionBody } from "../src/pages/factionDetail/archetypes/AlbescentFactionBody";
 export { default as AlbescentFactionHero } from "../src/components/factionHero/AlbescentFactionHero";
@@ -18,6 +19,7 @@ export { default as AlbescentInvitation } from "../src/components/AlbescentInvit
 export { default as AlbescentPraxisCard } from "../src/components/praxisCard/desktop/AlbescentPraxisCard";
 export { default as AlbescentPraxisDetail } from "../src/pages/praxisDetail/archetypes/AlbescentPraxisDetail";
 export { default as AlbescentProfileBody } from "../src/pages/characterProfile/archetypes/AlbescentProfileBody";
+export { default as AlbescentProposeTask } from "../src/pages/proposeTask/archetypes/AlbescentProposeTask";
 export { default as AlbescentScoreStamp } from "../src/components/praxisCard/scoreStamp/AlbescentScoreStamp";
 export { default as AlbescentSeal } from "../src/components/metataskSeal/skins/AlbescentSeal";
 export { default as AlbescentSelectCard } from "../src/components/selectCard/AlbescentSelectCard";
@@ -166,6 +168,7 @@ export { default as InvitationWatcher } from "../src/components/InvitationWatche
 export { JoinControl } from "../src/components/JoinControl";
 export { default as Layout } from "../src/components/Layout";
 export { default as LevelGem } from "../src/components/ui/LevelGem";
+export { default as LevelTrackMeta } from "../src/components/LevelTrackMeta";
 export { default as LevelUpPopup } from "../src/components/LevelUpPopup";
 export { default as LevelUpWatcher } from "../src/components/LevelUpWatcher";
 export { default as Lotus } from "../src/components/factionMarks/Lotus";


### PR DESCRIPTION
Sixth design-sync round, run against `origin/main` 3fb2cf6f. Sync inputs only — no product code.

## What changed

**Three new components mapped (305 → 308).** The whole-tree scan found 37 unmapped; 34 are the documented deliberate exclusions (route-level `src/pages/*.tsx`, `src/auth`, `pages/admin`, `TheArray`) plus one false positive from keying by basename (`BackdropContext.tsx` is mapped, under the name `BackdropProvider`). The three real ones:

- `LevelTrackMeta` (#2767)
- `AlbescentEditCharacter` (#2788)
- `AlbescentProposeTask` (#2802)

**`AlbescentEditCharacter` needed its own viewport.** Mirroring `DefaultEditCharacter`'s `390x760` clipped the card — the save bar covered the faction explainer and the delete control fell off the bottom edge. #2788 adds "the fold, and the two slots a create dress has no room for", so the form is genuinely taller. It sits at `390x1280` now.

This is deliberately *not* the thing NOTES warns against normalising. That warning covers the `*CreateCharacter` pair sitting at `390x760` against the other seven at `390x1280`; this is a different component moving the opposite direction, decided from the render sheet.

**Previews authored and graded good** for `LevelTrackMeta` (both documented branches — the mid-curve one-liner and the top-of-curve wrap) and `AlbescentEditCharacter`. `AlbescentProposeTask` keeps the floor card: its sibling `DefaultProposeTask` has none either, and `_state.tsx` has no `proposeTaskState` builder yet.

**`conventions.md` had one stale claim.** It listed `DefaultEditCharacter` among "the singletons", which #2788 and #2802 made false — a design agent reading it would never reach for the Albescent skins. Corrected. All 37 components, 7 Tailwind utilities and 67/74 tokens it names verify against the fresh build; the 7 that don't are `--faction-albescent-*`, which the header never claims.

The per-faction class layer (`.alb-*` 28, `.eph-*` 21, `.wow-*` 20, …) was checked and **deliberately left out** — those are component-internal (`.alb-desk` is applied inside `AlbescentFieldDesk`), so naming them would teach the agent to hand-apply classes a component owns.

## Verification

- `package-build.mjs` clean — 308 components, README carries the corrected header
- `package-validate.mjs` **exit 0** — 3 warnings, all already in NOTES' known list, **zero new**
- Render check sampled 39/308, 39/39 clean; all 308 `.d.ts` parse; `window.WZ` has 309 exports
- `npm run typecheck:design-sync` passes (this is the CI gate covering `previews/`)

## Not done

**Nothing was uploaded.** `DesignSync` could not authorize from this session type — the credential doesn't reach an already-running session. The project still holds the 08-25 build and its anchor still describes 305 components, so the next authorized round will see 3 `added` plus a wide `changed` partition.

The full 308-preview render check was **not** run (sampled 39) — a round that uploads must run it unsampled via the driver. NOTES records this, the blocker, and the playwright pin drift (repo now wants `1.62.1`/chromium-1234; the box still caches 1228, so `playwright@1.61.1` remains the one to install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
