### PR TITLE
Fill the two real UA/WOW praxis-detail invariant gaps (#2801)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -219,6 +219,21 @@ describe("UA praxis detail — the layout contract (#1129)", () => {
     expect(render(state(), "mobile").html, "and only when crowned").not.toContain(crown);
   });
 
+  it("carries its ground on the column, never the viewport", () => {
+    // WORLD_ZERO_STYLE §5 / #1028: the site background must still show around
+    // the page. The toothed vellum is painted on the leaf itself, not a
+    // `position: fixed` mount.
+    const { html } = render(state());
+    expect(html, "the leaf is the column").toContain("ua-praxis-leaf");
+    expect(html, "no full-viewport ground").not.toContain("position:fixed");
+  });
+
+  it("mounts the comments region with the layout's heading, not the thread's", () => {
+    const { text } = render(state());
+    expect(text, "the layout's section head").toContain("Discussion");
+    expect(text, "and not a second heading for the same list").not.toContain("0 comments");
+  });
+
   it("moves the score above the proof on mobile, and draws it exactly once", () => {
     const wide = render(state());
     expect(wide.text.match(/Score/g)?.length, "one score block on desktop").toBe(1);

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -197,6 +197,21 @@ describe("WOW praxis detail — the layout contract (#1129)", () => {
     expect(render(state(), "mobile").html, "and only when crowned").not.toContain(crown);
   });
 
+  it("carries its ground on the column, never the viewport", () => {
+    // WORLD_ZERO_STYLE §5 / #1028: the site background must still show around
+    // the page. The parchment field is painted on the column itself, not a
+    // `position: fixed` mount.
+    const { html } = render(state());
+    expect(html, "the field is the column").toContain("wow-detail-field");
+    expect(html, "no full-viewport ground").not.toContain("position:fixed");
+  });
+
+  it("mounts the comments region with the layout's heading, not the thread's", () => {
+    const { text } = render(state());
+    expect(text, "the layout's section head").toContain("Discussion");
+    expect(text, "and not a second heading for the same list").not.toContain("0 comments");
+  });
+
   it("moves the score above the proof on mobile, and draws it exactly once", () => {
     const wide = render(state());
     expect(wide.text.match(/Score/g)?.length, "one score block on desktop").toBe(1);


### PR DESCRIPTION
## Summary

#2801's final scope comment (17:51, superseding the body and the withdrawn
17:25 ruling) lists nine faction-invariant behaviours it says are hand-copied
across four-to-six kit suites each, and asks for them to be closed via a
looped contract, with a note to re-measure before building.

**I re-measured, and I disagree with six of the nine counts.** The scope
comment's own method note (from sibling epic #2814, same session) names the
exact trap that produced this: *"the same test is called 'shows the crown at
BOTH form factors' in two suites and '…on a crowned praxis' in three… a
census that matches on the literal title under-reports."* Grepping `it(`
titles for each of the nine behaviours across all nine kit suites, then
reading the test **body** (not just the title) for every title-miss, finds:

| invariant | scope's count | my re-measurement |
|---|---|---|
| draws no navigation, at either width | 6 | **9/9** — closed by `kitInvariants.test.tsx` (#2822, already merged) |
| hides comment region on invisible praxis | 5 | **9/9** — closed by #2822 |
| lists who voted / each voter's own rung | 4 | **9/9** — closed by #2822 |
| shows the crown at both form factors | 4 | **9/9** by hand, three different wordings ("BOTH form factors", "…on a crowned praxis", "…against the design's own note", "…never gated") |
| shows owner controls to a member, not a visitor | 5 | **9/9** — UA and WOW assert it inside a combined `"renders as visitor, owner and steward"` test instead of a dedicated one; Albescent inherits it via its byte-for-byte Default-delegation proof |
| reads the shared neutral words in every content slot | 4 | **8/9**, and the ninth (Unaffiliated/`na`) IS the shared-neutral-words page — asserting "the neutral page speaks the neutral words" is definitionally true, not a hole |
| leaves the report card outside the costume | 5 | **9/9** — Ephemerists asserts it folded into a `"keeps moderation and system chrome…"` test; Albescent inherits via delegation |
| **carries its ground on the column, never the viewport** | 5 | **7/9** — genuinely missing from UA and WOW |
| **mounts the comments region with the layout's heading** | 5 | **7/9** — genuinely missing from UA and WOW |

Seven of the nine listed behaviours are not holes at all once you read past
the title. **The two that are real holes are both missing, only, from UA and
WOW** — which the issue's own body separately named as the two sparsest
suites in the directory (the "near-twin" pair the first pass proposed
merging).

## What this PR does

Adds one test each to `uaPraxisDetail.test.tsx` and `wowPraxisDetail.test.tsx`:

- `carries its ground on the column, never the viewport` — asserts the
  faction's own ground-sheet class (`ua-praxis-leaf` / `wow-detail-field`) is
  present and that the markup never carries a `position:fixed` full-viewport
  mount. Verified against each archetype's source: both set
  `position: "relative"` on that wrapper.
- `mounts the comments region with the layout's heading, not the thread's` —
  asserts the shared "Discussion" heading is present and that no second,
  thread-owned heading (`"0 comments"`) leaks in — matching the assertion the
  other seven kits already make under this or an equivalent title.

**Why per-kit tests, not a loop:** each faction paints its own ground with a
different marker class (`em-dispatch`, `eph-plate-sheet`, `snd-detail-sheet`,
`na-backdrop`, …) — there's no single string a loop could assert positively
across all nine without a slug→class lookup table, which is the "typed list"
anti-pattern #2815 exists to remove. The other seven kits already carry this
assertion in their own suite; UA and WOW now match that existing pattern
rather than getting a tenth, differently-shaped mechanism.

**No hand-written per-kit copy is deleted or unified.** Nine suites stay nine
files (`frontend/CLAUDE.md`'s no-unify rule), and phase 2 (collapsing the
loop-covered invariants) stays HELD pending owner QA of phase 1, per #2801
and #2814.

## Per-kit inheritance note (required by #2801's acceptance criteria)

Albescent adds no invariant of its own for: `hides comment region`,
`lists voter rung`, `leaves report card outside costume`,
`mounts comments heading`, `shows owner controls`. It inherits all five
through its byte-for-byte "renders `DefaultPraxisDetail` byte for byte once
undressed" proof (`albescentPraxisDetail.test.tsx`), which is checked over
every state axis including owner/visitor/steward, at both form factors — per
#2801's guidance not to "fill" Albescent by copying assertions into it.
Albescent does assert `crown at both form factors`,
`carries ground on the column`, and `reads the shared neutral words` directly,
in addition to inheriting them.

UA and WOW: everything except the two behaviours added here is asserted
directly (not inherited) — neither delegates to Default.

## What to eyeball

Nothing rendered changed — this PR is test-only, no production code touched.
There is no visual surface to review; **visual QA is not applicable here**,
and I did not run the dev stack (no browser tools available in this session).

## Checks

- `npx vitest run` from `frontend/`: **476 files / 9865 passing, 1 skipped**
  (includes the two new tests, confirmed they fail without the production
  markup they assert and pass with it — verified against the real
  `UaPraxisDetail.tsx` / `WowPraxisDetail.tsx` source).
- `npx tsc --noEmit`: clean.
- `npx eslint` on both touched files: clean.

Refs #2801, #2814 (epic), #2822 (loop layer this measurement builds on).

Closes #2801
