### PR TITLE
Give the switch ring a compliant hairline edge (#2845)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8853,6 +8853,40 @@
      thumb-off`). Two senses of `-off` under one prefix is the confusion #2623
      was filed to remove, so the owner ruled `--switch-*` instead. */
   --switch-thumb-off: color-mix(in srgb, var(--color-text-primary) 8%, transparent);
+
+  /* The ring's compliant edge (#2845). `--faction-default-stop-3` / `-4`
+     (yellow / green) measure 2.37:1 / 2.66:1 against `--switch-well` in
+     light — the rainbow ring is the only perceivable state signal on a
+     two-state switch (the thumb itself is 1.22:1 / 1.30:1 light/dark against
+     the same well), so 1.4.11's 3:1 graphical-object floor applies to it.
+
+     The stops cannot move to fix this: `--faction-default-rainbow` IS the
+     faction hue wheel, drawn on mastheads, bands, the points ring, the CTA
+     rules, and #2845 rules the wheel does not move for a switch.
+
+     NO WELL DENSITY CLEARS BOTH STOPS EITHER, so darkening `--switch-well`
+     (the other switch-local lever, and the one #2845 says to measure first)
+     was tried and measured out: stop-3 (yellow, relative luminance 0.307)
+     caps at 2.94:1 against a PURE WHITE well, and clearing stop-4 (green,
+     luminance 0.269) on the dark side needs the well mixed to ~80%
+     `--color-text-primary` — at that density the well is not a well in light
+     mode for anyone, and `--switch-well` is read by the filter rail, the
+     cookie toggles and the notification rail besides this switch (see the
+     note above), so the cost would land on every one of them to fix two
+     stops on one control.
+
+     So the ring gets a second, ALWAYS-DRAWN edge instead: a solid hairline
+     just inside the rainbow border (`SettingsSwitch.tsx`'s `track`). Once
+     that edge exists the rainbow sits on top of a compliant boundary and is
+     emphasis in 1.4.11's own terms, so the seven stops are not individually
+     re-measured for it — `frontend/src/utils/__tests__/factionContrast.test.ts`
+     asserts this token's own edge instead, at the site, so a future repoint
+     cannot drift back unseen. Aliased straight to `--color-text-tertiary`
+     rather than minted as a new value: that ink already clears both
+     `--switch-well` composites at 6.89:1 (light) / 7.34:1 (dark) — see
+     "filter well, tertiary ink" in the contrast test — so nothing new is
+     being measured here, only named for this site. */
+  --switch-ring-hairline: var(--color-text-tertiary);
 }
 
 :root {

--- a/frontend/src/pages/settings/SettingsSwitch.tsx
+++ b/frontend/src/pages/settings/SettingsSwitch.tsx
@@ -19,6 +19,16 @@ import type { CSSProperties } from 'react'
  * repo keeps collapsing. See the note beside `--switch-thumb-off` in
  * `index.css` about the family's name.
  *
+ * THE RING NEEDS A SECOND, COMPLIANT EDGE (#2845). The rainbow is the only
+ * perceivable state signal on this control — the thumb alone is 1.22:1 /
+ * 1.30:1 against the well — and two of its seven stops read under 1.4.11's
+ * 3:1 there in light. The stops are the faction hue wheel and may not move
+ * for a switch, and no `--switch-well` density clears both without going
+ * effectively black (see `--switch-ring-hairline` in `index.css`), so
+ * `TRACK_RING_HAIRLINE` draws a solid, always-opaque line just inside the
+ * rainbow border on the ON state, which alone carries the 3:1 the ring itself
+ * cannot at every stop. The rainbow is emphasis once that edge exists.
+ *
  * DISABLED IS A REAL STATE HERE, AND IT IS DELIBERATE. The house rule is to
  * hide a control a reader cannot use rather than render it dead — this is the
  * ruled exception (#2154). When the OS asks for reduced motion the Animations
@@ -48,6 +58,20 @@ const TRACK_WELL = 'linear-gradient(var(--switch-well), var(--switch-well)) padd
 const TRACK_EDGE_ON = 'var(--faction-default-rainbow) border-box'
 const TRACK_EDGE_OFF =
   'linear-gradient(var(--color-border-strong), var(--color-border-strong)) border-box'
+
+/**
+ * The rainbow edge's compliant boundary (#2845). Two of the ring's seven
+ * stops (yellow, green) read under 1.4.11's 3:1 against `--switch-well` in
+ * light, and the stops may not move to fix a switch — see
+ * `--switch-ring-hairline` in `index.css` for the measurement that ruled out
+ * darkening the well instead. This hairline is a second, always-opaque edge
+ * drawn just inside the rainbow border; it alone clears the floor (6.89:1
+ * light / 7.34:1 dark, asserted in `factionContrast.test.ts`), so once it is
+ * there the rainbow is emphasis on a boundary that is already perceivable,
+ * and the stops themselves stay unmeasured. ON only: the OFF edge is already
+ * a flat, non-hue line and was never the pairing this issue found.
+ */
+const TRACK_RING_HAIRLINE = 'inset 0 0 0 1px var(--switch-ring-hairline)'
 
 const track: CSSProperties = {
   position: 'relative',
@@ -94,6 +118,7 @@ export default function SettingsSwitch({
         ...track,
         cursor: disabled ? 'not-allowed' : 'pointer',
         background: `${TRACK_WELL}, ${checked ? TRACK_EDGE_ON : TRACK_EDGE_OFF}`,
+        boxShadow: checked ? TRACK_RING_HAIRLINE : undefined,
       }}
     >
       <span

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2304,6 +2304,51 @@ const CALLING_CHIP_PAIRS: Pair[] = [
 ];
 
 /**
+ * THE SWITCH RING'S COMPLIANT EDGE (#2845), a block of its own — do not fold
+ * into CALLING_CHIP_PAIRS above; that block is #2852's and this is a
+ * different site.
+ *
+ * `--faction-default-stop-3` / `-4` (yellow / green) measure 2.37:1 / 2.66:1
+ * against `--switch-well` in light. The two-state switch's rainbow ring is
+ * the only perceivable state signal — the thumb itself is 1.22:1 / 1.30:1
+ * light/dark against the same well — so 1.4.11's 3:1 graphical-object floor
+ * applies to the ring, and two of its seven stops miss it.
+ *
+ * THE STOPS DO NOT MOVE. `--faction-default-rainbow` is the faction hue
+ * wheel — mastheads, bands, the points ring, the CTA rules — and #2845 rules
+ * it does not move for a switch.
+ *
+ * OPTION 1 (darken `--switch-well`, switch-local, measure first) WAS
+ * MEASURED AND RULED OUT, not skipped: stop-3 (yellow, relative luminance
+ * 0.307) caps at 2.94:1 against a PURE WHITE well — lightening cannot clear
+ * it either — and clearing stop-4 (green, luminance 0.269) on the dark side
+ * needs the well mixed to ~80% `--color-text-primary`, which is not a "well"
+ * for anyone in light mode and would carry into the filter rail, the cookie
+ * toggles and the notification rail besides this switch (`--switch-well`'s
+ * other readers, per its own note in index.css).
+ *
+ * SO THIS IS OPTION 2: `SettingsSwitch.tsx`'s `track` now draws a second,
+ * always-opaque hairline (`--switch-ring-hairline`, aliased to
+ * `--color-text-tertiary`) just inside the rainbow border on the ON state.
+ * That edge alone clears the floor, which is what this row asserts; once it
+ * is there the rainbow sits on top of a boundary that is already
+ * perceivable, so it is decorative in 1.4.11's own terms and its seven
+ * stops are deliberately NOT re-measured row-by-row here — asserting them
+ * would require moving the wheel to pass, which is the one thing #2845
+ * forbids.
+ */
+const SWITCH_RING_PAIRS: Pair[] = [
+  {
+    what: "switch ring hairline, on the switch well",
+    surface: "--color-bg-page",
+    veil: { token: "--color-text-primary", alpha: 0.06 },
+    text: "--switch-ring-hairline",
+    floor: AA_LARGE,
+    nonText: "the switch ring's compliant edge is a drawn line, not lettering — 1.4.11's 3:1 (#2845)",
+  },
+];
+
+/**
  * A `SKY_PAIRS` block stood here (#1792): seven rows measuring each faction's
  * `-on-night` ink against `--sky-bg`, the Constellation's own night canvas.
  *
@@ -2485,6 +2530,7 @@ const PAIRS: Pair[] = [
   ...ARCHETYPE_PAIRS,
   ...RAIL_PAIRS,
   ...CALLING_CHIP_PAIRS,
+  ...SWITCH_RING_PAIRS,
 ];
 
 /**

--- a/frontend/src/utils/__tests__/frozenThemeAliases.test.ts
+++ b/frontend/src/utils/__tests__/frozenThemeAliases.test.ts
@@ -165,6 +165,10 @@ const KNOWN_ROOT_ONLY_ALIASES = [
   "--label-ink",
   "--link-ink",
   "--link-ink-hover",
+  // The switch ring's compliant edge (#2845) — aliased straight to
+  // `--color-text-tertiary`, which the dark block rebinds, so it flips on its
+  // own. Same composed-neutral shape as the rest of the `--switch-*` family.
+  "--switch-ring-hairline",
   "--switch-thumb",
   "--switch-thumb-edge",
   // The two-state switch's OFF thumb (#2154), minted beside its ON twin above


### PR DESCRIPTION
## What

Two of the switch ring's seven stops (`--faction-default-stop-3` yellow, `-4` green) read 2.37:1 / 2.66:1 against `--switch-well` in light mode. The rainbow ring is the only perceivable on/off signal on a two-state switch (the thumb alone is 1.22:1 / 1.30:1 light/dark against the same well), so 1.4.11's 3:1 graphical-object floor applies to the ring — and two of its seven stops missed it.

**Option taken: option 2 (hairline/inner edge), not option 1.**

Option 1 (darken `--switch-well`, switch-local, "measure this first") was measured and ruled out rather than skipped:

- Stop-3 (yellow, relative luminance 0.307) caps at **2.94:1 against a pure-white well** — lightening the well cannot clear it either, it's already near its ceiling at the current 6% mix.
- Clearing stop-4 (green, luminance 0.269) on the dark side needs the well mixed to **~80% `--color-text-primary`** — a well that is, at that density, not a "well" for anyone in light mode.
- `--switch-well` isn't actually switch-private: it's read by the filter rail's segmented-rail interior, the cookie toggles, and (per its own doc comment) the notification rail to come. Darkening it to fix two rainbow stops would blacken every one of those surfaces in light mode.

So the fix is option 2: `SettingsSwitch.tsx`'s ON track now draws a second, always-opaque hairline (`--switch-ring-hairline`, aliased to `--color-text-tertiary`) just inside the rainbow border. That edge alone clears 6.89:1 (light) / 7.34:1 (dark) against the same well — already true of `--color-text-tertiary`, asserted elsewhere in the file, so nothing new is being measured in *value*, only named at this *site*. Once that edge exists, the rainbow sits on top of an already-perceivable boundary and is decorative in 1.4.11's own terms; the seven stops are deliberately not re-measured row-by-row, since doing so would mean moving the hue wheel, which #2845 forbids.

## Where

- `frontend/src/index.css` — new `--switch-ring-hairline` token (aliased to `--color-text-tertiary`), with the measurement that ruled out option 1 written at the site.
- `frontend/src/pages/settings/SettingsSwitch.tsx` — ON-state track now carries `boxShadow: inset 0 0 0 1px var(--switch-ring-hairline)`. OFF state is untouched (its edge was never the reported pairing).
- `frontend/src/utils/__tests__/factionContrast.test.ts` — new `SWITCH_RING_PAIRS` block (own delimited section, added after `CALLING_CHIP_PAIRS` without touching it, per the note that PR #2859 just landed that const) asserting the hairline by name against the switch-well composite, `floor: AA_LARGE`, `nonText` stated.
- `frontend/src/utils/__tests__/frozenThemeAliases.test.ts` — added `--switch-ring-hairline` to `KNOWN_ROOT_ONLY_ALIASES` (composed-neutral family, same shape as the rest of `--switch-*`).

`--faction-default-stop-*` are unchanged — grep confirms no edit to those lines.

## Verified

- `npx tsc --noEmit`, `npx tsc -p tsconfig.e2e.json --noEmit`, `npx tsc -p tsconfig.design-sync.json --noEmit` — all clean.
- `npm run lint` — clean.
- `npm test` — 476 files, 9863 passed / 1 skipped, including the new contrast row and the updated alias inventory.
- `npm run build` — succeeds (one pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` warning on `FactionSigil.tsx`, unrelated to this change).
- `npm run budget` — exits 0 (JS is in its pre-existing WARN band, unrelated to this diff; CSS is `ok` at 21.9 KB against a 22.2 KB warn line).

## Visual QA is outstanding

I have no browser or dev server in this environment — this was verified via `tsc`/lint/vitest/build only. The seam tested is `SWITCH_RING_PAIRS` in `factionContrast.test.ts`, which measures `--switch-ring-hairline` against the real composited `--switch-well` ground (`--color-bg-page` + 6% `--color-text-primary` veil) in both cascades — the same math the issue used to report 2.37:1 / 2.66:1 for the two failing stops.

### What to eyeball

- Settings → Appearance section, both switches, **light mode**, checked (ON): the rainbow ring should now show a thin darker line just inside it, all the way around, including through the yellow/green arc.
- Same switches, **dark mode**, checked (ON): confirm the added hairline doesn't look heavy or double up oddly against the already-passing dark ring.
- Settings → Cookies section rows (same `SettingsSwitch` component), light and dark, checked (ON).
- Any switch in the **OFF** state, light and dark — should be pixel-identical to before this change (no hairline added there).
- `.filter-rail` (FilterBar's segmented rail) shares the exact same `--switch-well` + `--faction-default-rainbow` pattern and is very likely carrying the identical 2.37:1 / 2.66:1 defect — it is **out of scope** for this PR (the issue names the switch and the cookie rows only) but worth a follow-up issue if a human confirms it visually.

Closes #2845
