### PR TITLE
Move six task-detail invariants into detailContract's per-kit loop (#2812)

### DIFF
--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -274,30 +274,7 @@ describe("task-detail worth readout", () => {
   }
 });
 
-describe("na / Default task detail — the reference anatomy", () => {
-  it("hides the multiplier badge at the identity factor", () => {
-    const { text } = render(<DefaultTaskDetail state={baseState()} />);
-    expect(text).not.toContain("×");
-  });
-
-  it("shows the raw multiplier badge once an era ships a real factor", () => {
-    const { text } = render(
-      <DefaultTaskDetail
-        state={baseState({ factionMultiplier: 1.25, modifiedPoints: 23 })}
-      />,
-    );
-    expect(text).toContain("×1.25");
-    // Base and total are both legible; the badge is not a substitute for either.
-    expect(text).toContain("18");
-    expect(text).toContain("23");
-  });
-
-  it("renders the in-progress population as a header count", () => {
-    const { text } = render(<DefaultTaskDetail state={baseState()} />);
-    expect(text).toContain("people working on this");
-    expect(text).toContain("6");
-  });
-
+describe("na / Default task detail — the state contract", () => {
   /**
    * #1262 — the roster is unrenderable, not merely unrendered.
    *
@@ -313,32 +290,84 @@ describe("na / Default task detail — the reference anatomy", () => {
     // @ts-expect-error `signups` is not part of TaskDetailState.
     baseState({ signups: [] });
   });
+});
 
-  it("renders the author byline from the task's denormalised fields", () => {
-    const { html, text } = render(<DefaultTaskDetail state={baseState()} />);
-    expect(text).toContain("Wren Abalone");
-    expect(text).toContain("author · lvl 4");
-    expect(html).toContain('href="/characters/31"');
-  });
+/**
+ * The six invariants that used to run against `DefaultTaskDetail` alone,
+ * under the "na / Default task detail — the reference anatomy" heading
+ * (#2812). Each was already hand-copied into up to eight of the nine per-kit
+ * suites; this loop is the one copy that reaches all nine. The per-kit
+ * copies stay for now — deleting them is held for a follow-up once the owner
+ * has QA'd this loop green.
+ */
+describe("task-detail header population", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders the in-progress population as a header count`, () => {
+      const { text } = render(<Archetype state={baseState()} />);
+      expect(text).toContain("people working on this");
+      expect(text).toContain("6");
+    });
+  }
+});
 
-  it("draws the brief in full — no clamp, no truncation", () => {
-    const long = "x".repeat(2000);
-    const { text } = render(
-      <DefaultTaskDetail
-        state={baseState({ task: { ...TASK, description: long } })} />,
-    );
-    expect(text).toContain(long);
-  });
+describe("task-detail multiplier badge", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    // `/×\d/`, not a bare `×`: the Ephemerists plate draws decorative rune
+    // strips that put a bare `×` in the markup as ornament, unrelated to the
+    // multiplier badge. See `ephemeristsDetail.test.tsx`'s own version of
+    // this check.
+    it(`${slug} hides the multiplier badge at the identity factor`, () => {
+      const { text } = render(<Archetype state={baseState()} />);
+      expect(text).not.toMatch(/×\d/);
+    });
 
-  it("speaks the shared neutral copy, not the retired na voice", () => {
-    const { text } = render(<DefaultTaskDetail state={baseState()} />);
-    expect(text).toContain("Task Description");
-    expect(text).toContain("Discussion");
-    // ADR-0057: the old na-voiced headings are gone from this surface.
-    expect(text).not.toContain("The brief");
-    expect(text).not.toContain("What people filed");
-    expect(text).not.toContain("counts for everyone");
-  });
+    it(`${slug} shows the raw multiplier badge once an era ships a real factor`, () => {
+      const { text } = render(
+        <Archetype state={baseState({ factionMultiplier: 1.25, modifiedPoints: 23 })} />,
+      );
+      expect(text).toContain("×1.25");
+      // Base and total are both legible; the badge is not a substitute for either.
+      expect(text).toContain("18");
+      expect(text).toContain("23");
+    });
+  }
+});
+
+describe("task-detail author byline", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders the author byline from the task's denormalised fields`, () => {
+      const { html, text } = render(<Archetype state={baseState()} />);
+      expect(text).toContain("Wren Abalone");
+      expect(text).toContain("author · lvl 4");
+      expect(html).toContain('href="/characters/31"');
+    });
+  }
+});
+
+describe("task-detail brief", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} draws the brief in full — no clamp, no truncation`, () => {
+      const long = "x".repeat(2000);
+      const { text } = render(
+        <Archetype state={baseState({ task: { ...TASK, description: long } })} />,
+      );
+      expect(text).toContain(long);
+    });
+  }
+});
+
+describe("task-detail shared neutral copy", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} speaks the shared neutral copy, not the retired na voice`, () => {
+      const { text } = render(<Archetype state={baseState()} />);
+      expect(text).toContain("Task Description");
+      expect(text).toContain("Discussion");
+      // ADR-0057: the old na-voiced headings are gone from this surface.
+      expect(text).not.toContain("The brief");
+      expect(text).not.toContain("What people filed");
+      expect(text).not.toContain("counts for everyone");
+    });
+  }
 });
 
 /**


### PR DESCRIPTION
Closes #2812

## Seam tested at

`renderToStaticMarkup` against each registered `taskDetail` archetype in
`pages/taskDetail/__tests__/detailContract.test.tsx`'s existing `archetypes`
map (`surfaceMap("taskDetail")` plus `__default__` for na) — the same seam
the file's other ten loop rows already use. No DOM, no effects, no browser.

## What this does

Six assertions sat under a literal `"na / Default task detail — the
reference anatomy"` describe block, running only against `DefaultTaskDetail`:

- `hides the multiplier badge at the identity factor`
- `shows the raw multiplier badge once an era ships a real factor`
- `renders the in-progress population as a header count`
- `renders the author byline from the task's denormalised fields`
- `draws the brief in full — no clamp, no truncation`
- `speaks the shared neutral copy, not the retired na voice`

Each was independently hand-copied (often with drifted wording — e.g.
`hides the modifier row…`, `bylines the author…`, `prints the brief
whole…`) into most of the eight per-kit suites. All six are now loop rows
over the file's `archetypes` map, so each runs once, against all nine kits.

**I re-measured both layers myself rather than trusting the issue's table**
(re-verifying is what the issue itself asks for, given it was already wrong
once). Per invariant:

| invariant | loop layer (before this PR) | per-kit layer |
|---|---|---|
| hides multiplier badge at identity | **neither** — the existing loop only checks the base-row drops, never asserts `×` is absent | 9/9 (albescent + ephemerists + snide + ua combine it with the "shows" case) |
| shows raw multiplier badge on a real factor | **both**, functionally — the pre-existing (untouched) loop row `${slug} keeps base, chip and total once a factor is real` already asserts the exact raw string (`×1.25`) for every kit, which is the same non-reconstruction guarantee ADR-0055 asks for | 9/9 |
| in-progress population as header count | partial — the existing reading-order loop anchors on the *label* text ("people working on this") but never asserts the *number* is correct | 9/9 |
| author byline | neither | 7/9 (albescent, wow had no direct assertion — see below) |
| brief in full, no clamp | neither | 7/9 (albescent, wow had no direct assertion) |
| shared neutral copy, not retired na voice | neither (each kit's own suite checks against *its own* retired voice, not na's) | 9/9 |

One disagreement with the issue body worth flagging: the "shows raw
multiplier badge" row is arguably already covered by the pre-existing
`${slug} keeps base, chip and total once a factor is real` loop row (same
numbers, same non-reconstruction guarantee). I left that existing loop row
untouched per "leave the ten alone," and added the new row anyway rather
than unilaterally judging it redundant and skipping it — the issue names it
explicitly as one of the six to move, and the two rows read as answering
slightly different questions (row policy vs. raw-badge provenance) even
though their assertions overlap. Flagging it here rather than silently
building to my own call.

Albescent and WOW had no direct per-kit assertion for the byline or the
unclamped brief (they only asserted them indirectly — Albescent via its
word-set-equality-with-Default test, WOW not at all). Running the new loop
rows against every kit **did not turn up any kit defects** — all 9 archetypes
pass all six invariants. Nothing to file.

## What this does NOT do

Per the issue's Phase 1/Phase 2 split, this PR only adds the loop. The
per-kit hand-copies in the eight kit suites are untouched — no assertion is
lost, and all nine suites still exist, unchanged. Deleting the now-redundant
per-kit copies is Phase 2, held until this loop has been seen green and
QA'd.

`archetypeSlots.test.tsx`'s seven-item loop and `detailContract.test.tsx`'s
existing ten-item loop are untouched.

## Verification

- `tsc --noEmit`: clean
- `eslint` on the touched file: clean
- `vitest run` on `pages/taskDetail`: 489/489 pass (18 files)
- `vitest run` full suite: 9915 passed, 1 skipped, 0 failed
- `vite build`: succeeds (one pre-existing, unrelated `INEFFECTIVE_DYNAMIC_IMPORT` warning on `FactionSigil`, not touched by this change)

This is a test-only change — no routes, schemas, or CSS touched, so
`api-schema` and the byte budget are unaffected.

## What to eyeball

- Nothing visual — this PR only reshapes test files. **Visual QA is
  outstanding** on the underlying task-detail surfaces themselves, as it
  would be for any test-only change; nothing here changes runtime behavior.
- Owner should confirm the "shows raw multiplier badge" overlap call above
  reads the right way — happy to drop the new row and rely solely on the
  pre-existing `keeps base, chip and total` loop if that's preferred.
