### PR TITLE
Derive select-tile box + register invariants over all nine kits (#2816)

### DIFF
--- a/frontend/src/components/selectCard/__tests__/covenWearsTheSlipRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/covenWearsTheSlipRegister.test.ts
@@ -49,9 +49,7 @@ const read = (relative: string): string =>
 const code = (relative: string): string => stripComments(read(relative));
 
 const TILE = "../CovenSelectCard.tsx";
-const TASK_CARD = "../../taskCard/CovenTaskCard.tsx";
 const SLIP = "../../factionMarks/covenSlip.tsx";
-const BANDS = "../../cardMasthead/factionBands.tsx";
 
 /** Every top-level binding in a module, mapped to its own declaration text. */
 function declarations(source: string): Map<string, string> {
@@ -115,39 +113,14 @@ function tokensPainting(relative: string): Set<string> {
   return new Set([...props].filter(isFactionPaint));
 }
 
-function registerTokens(): Set<string> {
-  const bandDecls = declarations(code(BANDS));
-  expect(
-    [...bandDecls.keys()],
-    "no `CovenBand` in cardMasthead/factionBands.tsx",
-  ).toContain("CovenBand");
-  // ONLY Coven's band. `factionBands` holds all seven, and the reach is by
-  // reference from `CovenBand` outward, so WOW's plum and the Ephemerists'
-  // brass never enter this faction's register.
-  const props = tokensPainting(TASK_CARD);
-  for (const prop of propsBehind(bandDecls, ["CovenBand"])) {
-    if (isFactionPaint(prop)) props.add(prop);
-  }
-  return props;
-}
-
+/**
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no token family its own task card does not" (#2321) — now
+ * live in `everySelectTileWearsItsCardsRegister.test.ts`, derived over all
+ * nine kits including the `Default`-backed tile this suite could not reach
+ * (#2816). This file keeps everything bespoke to Coven.
+ */
 describe("the Coven tile wears the spell slip's register (#2325)", () => {
-  it("names no token family its own task card does not", () => {
-    const register = registerTokens();
-    const strays = [...tokensPainting(TILE)].filter((prop) => !register.has(prop));
-
-    expect(
-      strays,
-      `Each name is a token the DIRECTORY TILE paints with — directly, or through
-a \`covenSlip\` constant — and the TASK CARD never names. That is the shape
-#2321 calls a forked family, and Coven's instance was
-\`--faction-coven-ward-card\` arriving through \`SLIP_PANEL\`: the faction
-DETAIL page's paper, boxed up and laid on the slip. Fix it by finding the
-\`--faction-coven-slip-*\` role that answers the same question, or by saying
-in the PR that the task card has no answer — not by widening this test.`,
-    ).toEqual([]);
-  });
-
   it("takes the ward family off the tile for good", () => {
     // The specific fork, named. The sweep above would also pass if `CARD` were
     // ever added to the task card; this says the tile does not want it either
@@ -176,15 +149,5 @@ in the PR that the task card has no answer — not by widening this test.`,
       source,
       "Caveat ships at 400 only (`fonts.faction.css`), so a 700 here is a synthesised faux bold",
     ).not.toMatch(/fontWeight: 700[\s\S]{0,120}HAND|HAND[\s\S]{0,120}fontWeight: 700/);
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 });

--- a/frontend/src/components/selectCard/__tests__/ephemeristsWearsThePlateRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/ephemeristsWearsThePlateRegister.test.ts
@@ -82,6 +82,13 @@ function tokensNamedByTile(): Map<string, string> {
   return used;
 }
 
+/**
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no token family its own task card does not use" (#2321)
+ * — now live in `everySelectTileWearsItsCardsRegister.test.ts`, derived over
+ * all nine kits including the `Default`-backed tile this suite could not
+ * reach (#2816). This file keeps everything bespoke to the Ephemerists.
+ */
 describe("the Ephemerists tile wears the plate's register (#2323)", () => {
   it("grounds on a sheet that FLIPS, not on the theme-invariant band", () => {
     // The root style object is the first one in the file, and its `background`
@@ -124,14 +131,6 @@ dark-only. Find the PLATE role that answers the same question (\`INK\`,
     ).toEqual([]);
   });
 
-  it("names no token family its own task card does not use", () => {
-    // #2322's sweep, kept so the eight siblings encode one rule — and applied to
-    // the RESOLVED names, since this tile spells none of them literally.
-    const register = [code("../../taskCard/EphemeristsTaskCard.tsx"), code(PLATE_MODULE)].join("\n");
-    const strays = [...tokensNamedByTile().values()].filter((prop) => !register.includes(prop));
-    expect(strays).toEqual([]);
-  });
-
   it("leaves no `--eph-*` codex consumer in the tile", () => {
     // The retired illuminated codex. Its family is still DECLARED and has no
     // dark override tuned for the plate, so a stray reader is a silent
@@ -152,15 +151,5 @@ dark-only. Find the PLATE role that answers the same question (\`INK\`,
         new RegExp(`\\b${property}:`),
       );
     }
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 });

--- a/frontend/src/components/selectCard/__tests__/everySelectTileWearsItsCardsRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/everySelectTileWearsItsCardsRegister.test.ts
@@ -1,0 +1,401 @@
+/**
+ * THE SEAM: two of the select-tile invariants are faction-INVARIANT, and
+ * before #2816 both were written out by hand in the seven bespoke
+ * `*WearsThe*Register.test.ts` files next door — never derived, and never
+ * asserted for the `Default`-backed tile (`na`, and by construction
+ * `albescent`, which is `DefaultSelectCard` plus a geometry-only wrapper).
+ *
+ *  1. `keeps the fluid 360x300 box the directory grid is built on (#732)` —
+ *     four identical `toContain`/`not.toMatch` calls, copied seven times.
+ *  2. `names no token family its own task card does not (#2321)` — the
+ *     register rule. The SHAPE of that check is the same seven times over
+ *     (does the tile paint with a name its task card's rendered register never
+ *     does?), but the RESOLUTION is genuinely bespoke per kit — Coven and the
+ *     Ephemerists spell zero literal `--` tokens in their own file, reaching
+ *     their palette through a JS module instead, while WOW spells every name
+ *     inline. That is `frontend/CLAUDE.md`'s no-unify rule at work: this file
+ *     does not flatten those seven recipes into one algorithm — it relocates
+ *     each recipe's `strays()` answer here, unmodified, and loops the shared
+ *     assertion over it. The seven sibling files keep everything ELSE they
+ *     assert (the ward family, the wordmark, the plate register, the CTA
+ *     face…); only the two titled invariants above move.
+ *
+ * Both loops derive their membership from `surfaceMap('factionSelectCard')`
+ * — never a typed list (#2815) — so a tenth kit that registers a tile and
+ * forgets to wire it into `TILE_PATHS` / `REGISTER` below fails loudly
+ * (`TILE_PATHS[slug]` / `REGISTER[slug]` reads `undefined`) instead of
+ * silently passing.
+ *
+ * ── ALBESCENT IS EXCLUDED, NAMED, NOT SILENTLY DROPPED ──────────────────────
+ *
+ * `AlbescentSelectCard.tsx` is a geometry-only wrapper (#2632): it repeats the
+ * `width: 100% / maxWidth: 360` half of invariant 1 as its own flex-item
+ * contract, but mounts `minHeight: 300` and every register token by rendering
+ * `DefaultSelectCard` — it names no `--faction-` token of its own at all. So
+ * a per-file source scan of the wrapper alone would either miss `minHeight`
+ * (a false red) or, for the register, vacuously pass on an empty tile
+ * (asserting nothing). Covering `na` covers Albescent's tile BY CONSTRUCTION,
+ * and `albescentRedactsAndUnlocksTogether` already covers the one thing that
+ * IS the wrapper's own — the redaction gate — so a ninth copy here would
+ * duplicate one and fake the other.
+ *
+ * No DOM: `renderToStaticMarkup` is the harness's ceiling and nothing here
+ * even needs it — reading the sources is enough, exactly as the seven files
+ * this one replaces already established.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+import { stripComments } from "../../../utils/__tests__/cssVars";
+import { surfaceMap } from "../../../factions";
+import { ALBESCENT_FACTION_SLUG } from "../../../utils/factions";
+import { FACTION_ROLES, factionRoleVar } from "../../../utils/factionRoles";
+
+const read = (relative: string): string =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+/** Comments are the decision record and cite retired names on purpose. */
+const code = (relative: string): string => stripComments(read(relative));
+
+/**
+ * The nine registered kits, minus Albescent (see the file header). `na` stays
+ * in — it is the whole point of #2816 — and is the row that used to be
+ * absent from both invariants.
+ */
+const SLUGS = Object.keys(surfaceMap("factionSelectCard")).filter(
+  (slug) => slug !== ALBESCENT_FACTION_SLUG,
+);
+
+const BANDS = "../../cardMasthead/factionBands.tsx";
+const CTA_MODULE = "../../taskCard/cardCta.ts";
+
+/* -------------------------------------------------------------------------- */
+/* Shared low-level readers — textually identical across the seven originals */
+/* -------------------------------------------------------------------------- */
+
+/** Every top-level binding in a module, mapped to its own declaration text. */
+function declarations(source: string): Map<string, string> {
+  const heads = [...source.matchAll(/^(?:export (?:default )?)?(?:const|function) ([A-Za-z_$][\w$]*)/gm)];
+  return new Map(
+    heads.map((head, i) => [
+      head[1],
+      source.slice(head.index!, i + 1 < heads.length ? heads[i + 1].index! : source.length),
+    ]),
+  );
+}
+
+/** The custom properties a binding paints with, following the module's own aliases. */
+function propsBehind(
+  decls: Map<string, string>,
+  names: readonly string[],
+  seen = new Set<string>(),
+): Set<string> {
+  const found = new Set<string>();
+  for (const name of names) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const declaration = decls.get(name);
+    if (!declaration) continue;
+    for (const [, prop] of declaration.matchAll(/(--[a-z0-9-]+)/g)) found.add(prop);
+    const onward = [...decls.keys()].filter(
+      (other) => other !== name && new RegExp(`\\b${other}\\b`).test(declaration),
+    );
+    for (const prop of propsBehind(decls, onward, seen)) found.add(prop);
+  }
+  return found;
+}
+
+/** Every custom property literally spelled in a source, deduplicated. */
+function literalProps(source: string): Set<string> {
+  return new Set([...source.matchAll(/(--[a-z0-9-]+)/g)].map((match) => match[0]));
+}
+
+/** One faction's band, sliced out of the module that holds all nine. */
+function bandSlice(bandsSource: string, fnName: string): string {
+  const at = bandsSource.indexOf(`function ${fnName}()`);
+  expect(at, `no \`${fnName}\` in cardMasthead/factionBands.tsx`).toBeGreaterThan(-1);
+  return bandsSource.slice(at, bandsSource.indexOf("\n}", at));
+}
+
+/** One faction's CTA constant, sliced out of the module that holds all nine. */
+function ctaSlice(name: string): string {
+  const module = code(CTA_MODULE);
+  const at = module.indexOf(`export const ${name}`);
+  expect(at, `no \`${name}\` in taskCard/cardCta.ts`).toBeGreaterThan(-1);
+  return module.slice(at, module.indexOf("\n};", at));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Invariant 1 — the fluid 360x300 box (#732)                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Tile source per slug. Derived from the ACTUAL registered path, not a
+ * capitalisation guess: every one of these is the same file the seven
+ * bespoke suites (and `factionSelectCardDispatch.test.tsx`) already name.
+ */
+const TILE_PATHS: Record<string, string> = {
+  coven: "../CovenSelectCard.tsx",
+  ephemerists: "../EphemeristsSelectCard.tsx",
+  everymen: "../EverymenSelectCard.tsx",
+  singularity: "../SingularitySelectCard.tsx",
+  snide: "../SnideSelectCard.tsx",
+  ua: "../UaSelectCard.tsx",
+  wow: "../WowSelectCard.tsx",
+  na: "../DefaultSelectCard.tsx",
+};
+
+describe("every select tile keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
+  it("covers every kit but Albescent's wrapper (see file header)", () => {
+    expect(SLUGS.sort()).toEqual(
+      ["coven", "ephemerists", "everymen", "na", "singularity", "snide", "ua", "wow"].sort(),
+    );
+  });
+
+  it.each(SLUGS)("%s", (slug) => {
+    const path = TILE_PATHS[slug];
+    expect(path, `${slug} has no row in TILE_PATHS — wire its tile in`).toBeDefined();
+    const source = code(path);
+    // Not a colour question, and the one geometry the epic promised not to
+    // move: the 375px single-column mobile directory depends on all three.
+    expect(source).toContain('width: "100%"');
+    expect(source).toContain("maxWidth: 360");
+    expect(source).toContain("minHeight: 300");
+    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Invariant 2 — names no token family its own task card does not (#2321)     */
+/* -------------------------------------------------------------------------- */
+
+/** Faction paint. House tokens — spacing, the type ramp, radii — are everyone's. */
+const isFactionPaint = (prop: string): boolean =>
+  prop.startsWith("--faction-") || prop.startsWith("--font-faction-");
+
+// ---- coven (#2325) ---------------------------------------------------------
+
+const COVEN_TILE = TILE_PATHS.coven;
+const COVEN_TASK_CARD = "../../taskCard/CovenTaskCard.tsx";
+const COVEN_SLIP = "../../factionMarks/covenSlip.tsx";
+
+function covenSlipImports(source: string): string[] {
+  const clause = source.match(/import \{([^}]*)\} from "[^"]*covenSlip"/);
+  return clause ? clause[1].split(",").map((name) => name.trim()).filter(Boolean) : [];
+}
+
+function covenPaint(relative: string): Set<string> {
+  const source = code(relative);
+  const props = propsBehind(declarations(code(COVEN_SLIP)), covenSlipImports(source));
+  for (const prop of literalProps(source)) props.add(prop);
+  return new Set([...props].filter(isFactionPaint));
+}
+
+function covenStrays(): string[] {
+  const bandDecls = declarations(code(BANDS));
+  const register = covenPaint(COVEN_TASK_CARD);
+  for (const prop of propsBehind(bandDecls, ["CovenBand"])) if (isFactionPaint(prop)) register.add(prop);
+  return [...covenPaint(COVEN_TILE)].filter((prop) => !register.has(prop));
+}
+
+// ---- ephemerists (#2323) ---------------------------------------------------
+
+const EPH_TILE = TILE_PATHS.ephemerists;
+const EPH_TASK_CARD = "../../taskCard/EphemeristsTaskCard.tsx";
+const EPH_PLATE = "../../factionMarks/ephemeristsPlate.tsx";
+
+/** `ephemeristsPlate.tsx`'s palette, as `{ EXPORT_NAME: '--custom-property' }`. */
+function ephemeristsPalette(): Map<string, string> {
+  const source = code(EPH_PLATE);
+  const map = new Map<string, string>();
+  for (const [, name, prop] of source.matchAll(/export const (\w+) = "var\((--[\w-]+)\)";/g)) {
+    map.set(name, prop);
+  }
+  return map;
+}
+
+/** Every `eph.X` the tile names, resolved to the custom property behind it. */
+function ephemeristsTokensNamedByTile(): string[] {
+  const source = code(EPH_TILE);
+  const palette = ephemeristsPalette();
+  const used: string[] = [];
+  for (const [, name] of source.matchAll(/\beph\.(\w+)\b/g)) {
+    const prop = palette.get(name);
+    if (prop !== undefined) used.push(prop);
+  }
+  return used;
+}
+
+function ephemeristsStrays(): string[] {
+  const register = [code(EPH_TASK_CARD), code(EPH_PLATE)].join("\n");
+  return ephemeristsTokensNamedByTile().filter((prop) => !register.includes(prop));
+}
+
+// ---- everymen (#2327) -------------------------------------------------------
+
+const EM_TILE = TILE_PATHS.everymen;
+const EM_TASK_CARD = "../../taskCard/EverymenTaskCard.tsx";
+
+/** Everymen's kit is spelled under bare `--everymen-*` as well as `--faction-everymen-*`. */
+const isEverymenPaint = (prop: string): boolean =>
+  prop.startsWith("--faction-") || prop.startsWith("--font-") || prop.startsWith("--everymen-");
+
+const everymenPropsIn = (source: string): Set<string> =>
+  new Set([...literalProps(source)].filter(isEverymenPaint));
+
+function everymenStrays(): string[] {
+  const bandDecls = declarations(code(BANDS));
+  const register = everymenPropsIn(code(EM_TASK_CARD));
+  for (const prop of propsBehind(bandDecls, ["EverymenBand"])) if (isEverymenPaint(prop)) register.add(prop);
+  const ctaDecls = declarations(code(CTA_MODULE));
+  for (const prop of propsBehind(ctaDecls, ["EVERYMEN_CARD_CTA"])) if (isEverymenPaint(prop)) register.add(prop);
+  return [...everymenPropsIn(code(EM_TILE))].filter((prop) => !register.has(prop));
+}
+
+// ---- singularity (#2326) ---------------------------------------------------
+
+const SG_TILE = TILE_PATHS.singularity;
+
+function singularityRegisterSource(): string {
+  const bands = code(BANDS);
+  return [
+    code("../../taskCard/SingularityTaskCard.tsx"),
+    code("../../factionMarks/SingularityReadout.tsx"),
+    code("../../factionMarks/SingularityProcessLight.tsx"),
+    bandSlice(bands, "SingularityBand"),
+    ctaSlice("SINGULARITY_CARD_CTA"),
+  ].join("\n");
+}
+
+function singularityStrays(): string[] {
+  const register = singularityRegisterSource();
+  return [...literalProps(code(SG_TILE))]
+    .filter((prop) => prop.startsWith("--faction-") || prop.startsWith("--font-"))
+    .filter((prop) => !register.includes(prop));
+}
+
+// ---- snide (#2322) ----------------------------------------------------------
+
+const SN_TILE = TILE_PATHS.snide;
+
+function snideRegisterSource(): string {
+  const bands = code(BANDS);
+  return [
+    code("../../taskCard/SnideTaskCard.tsx"),
+    code("../../factionMarks/snideAtoms.tsx"),
+    bandSlice(bands, "SnideBand"),
+    ctaSlice("SNIDE_CARD_CTA"),
+  ].join("\n");
+}
+
+function snideStrays(): string[] {
+  const register = snideRegisterSource();
+  return [...literalProps(code(SN_TILE))]
+    .filter(
+      (prop) => prop.startsWith("--faction-") || prop.startsWith("--font-") || prop.startsWith("--snide-"),
+    )
+    .filter((prop) => !register.includes(prop));
+}
+
+// ---- ua (#2324) ---------------------------------------------------------------
+
+const UA_TILE = TILE_PATHS.ua;
+/** The one proven synonym: `-parchment` reads the praxis-card-only exception's stock. */
+const UA_GROUND_SYNONYM_PUBLIC_NAME = "--faction-ua-parchment";
+
+function uaRegisterSource(): string {
+  const bands = code(BANDS);
+  return [
+    code("../../taskCard/UaTaskCard.tsx"),
+    code("../../factionMarks/uaAtoms.tsx"),
+    bandSlice(bands, "UaBand"),
+  ].join("\n");
+}
+
+function uaStrays(): string[] {
+  const register = uaRegisterSource();
+  return [...literalProps(code(UA_TILE))]
+    .filter((prop) => prop.startsWith("--faction-") || prop.startsWith("--font-"))
+    .filter((prop) => prop !== UA_GROUND_SYNONYM_PUBLIC_NAME)
+    .filter((prop) => !register.includes(prop));
+}
+
+// ---- wow (#2328) --------------------------------------------------------------
+
+const WOW_TILE = TILE_PATHS.wow;
+const WOW_TASK_CARD = "../../taskCard/WowTaskCard.tsx";
+
+/** `factionRoleVars('wow', …)` hands a file paint by INTERPOLATION (#2674). */
+const WOW_ROLE_MAP_PROPS = FACTION_ROLES.map((role) =>
+  factionRoleVar("wow", role).replace(/^var\(|\)$/g, ""),
+);
+
+function wowTokensPainting(relative: string): Set<string> {
+  const source = code(relative);
+  const props = new Set(literalProps(source));
+  if (/factionRoleVars\(\s*["']wow["']/.test(source)) {
+    for (const prop of WOW_ROLE_MAP_PROPS) props.add(prop);
+  }
+  return new Set([...props].filter(isFactionPaint));
+}
+
+function wowStrays(): string[] {
+  const bandDecls = declarations(code(BANDS));
+  const register = wowTokensPainting(WOW_TASK_CARD);
+  for (const prop of propsBehind(bandDecls, ["WowBand"])) if (isFactionPaint(prop)) register.add(prop);
+  return [...wowTokensPainting(WOW_TILE)].filter((prop) => !register.has(prop));
+}
+
+// ---- na / Default (#2816, new) -------------------------------------------------
+
+const NA_TILE = TILE_PATHS.na;
+const NA_TASK_CARD = "../../taskCard/DefaultTaskCard.tsx";
+/**
+ * `DefaultSelectCard`'s own docblock: "VISUAL LANGUAGE — the Default PRAXIS
+ * card (#820, #842)". Unlike the eight kits above, na's tile is documented as
+ * patterning off the PRAXIS card, not the task card — and `DefaultTaskCard`'s
+ * own head names the divergence on purpose: it picks Lora "deliberately NOT
+ * `--faction-default-card-font`, which is Bebas Neue: the face #839 chose for
+ * the unaffiliated PRAXIS card." So na's register is the union of both cards
+ * — the one documented split in the kit, not a narrowing to dodge a finding.
+ */
+const NA_PRAXIS_CARD = "../../praxisCard/desktop/DefaultPraxisCard.tsx";
+
+function naStrays(): string[] {
+  const register = new Set([
+    ...[...literalProps(code(NA_TASK_CARD))].filter(isFactionPaint),
+    ...[...literalProps(code(NA_PRAXIS_CARD))].filter(isFactionPaint),
+  ]);
+  return [...literalProps(code(NA_TILE))].filter(isFactionPaint).filter((prop) => !register.has(prop));
+}
+
+// ---- the loop -----------------------------------------------------------------
+
+const REGISTER: Record<string, () => string[]> = {
+  coven: covenStrays,
+  ephemerists: ephemeristsStrays,
+  everymen: everymenStrays,
+  singularity: singularityStrays,
+  snide: snideStrays,
+  ua: uaStrays,
+  wow: wowStrays,
+  na: naStrays,
+};
+
+describe("every select tile names no token family its own task card does not (#2321)", () => {
+  it.each(SLUGS)("%s", (slug) => {
+    const compute = REGISTER[slug];
+    expect(compute, `${slug} has no row in REGISTER — wire its recipe in`).toBeTypeOf("function");
+
+    const strays = compute();
+    expect(
+      strays,
+      `Each name is a token the ${slug} DIRECTORY TILE paints with and the
+TASK CARD (na: the task card AND the praxis card — see the comment above)
+never names — the shape #2321 calls a forked family. Fix it by finding the
+role on the card that answers the same question, or by saying in the PR that
+the task card has no answer — not by widening this test.`,
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/components/selectCard/__tests__/everymenWearsTheBillRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/everymenWearsTheBillRegister.test.ts
@@ -59,107 +59,17 @@ const read = (relative: string): string =>
 const code = (relative: string): string => stripComments(read(relative));
 
 const TILE = "../EverymenSelectCard.tsx";
-const TASK_CARD = "../../taskCard/EverymenTaskCard.tsx";
-const BANDS = "../../cardMasthead/factionBands.tsx";
-/**
- * The card's sign-up paint, which stopped being spelt in the card in #2642: one
- * constant per faction, spread by the card AND by the task detail, so the two
- * can no longer drift. It is the same reach the band already needed — the card
- * AS RENDERED, not the one file — and `cardCta.ts` holds all nine, so only
- * `EVERYMEN_CARD_CTA`'s own binding counts.
- */
-const CARD_CTA = "../../taskCard/cardCta.ts";
-
-/** Every top-level binding in a module, mapped to its own declaration text. */
-function declarations(source: string): Map<string, string> {
-  const heads = [...source.matchAll(/^(?:export (?:default )?)?(?:const|function) ([A-Za-z_$][\w$]*)/gm)];
-  return new Map(
-    heads.map((head, i) => [
-      head[1],
-      source.slice(head.index!, i + 1 < heads.length ? heads[i + 1].index! : source.length),
-    ]),
-  );
-}
-
-/**
- * The custom properties a binding paints with, following the module's own
- * aliases. One level of grep misses `EverymenBand`'s face: the band spells
- * `POSTER`, and `POSTER` is a sibling binding holding
- * `--faction-everymen-card-font`.
- */
-function propsBehind(
-  decls: Map<string, string>,
-  names: readonly string[],
-  seen = new Set<string>(),
-): Set<string> {
-  const found = new Set<string>();
-  for (const name of names) {
-    if (seen.has(name)) continue;
-    seen.add(name);
-    const declaration = decls.get(name);
-    if (!declaration) continue;
-    for (const [, prop] of declaration.matchAll(/(--[a-z0-9-]+)/g)) found.add(prop);
-    const onward = [...decls.keys()].filter(
-      (other) => other !== name && new RegExp(`\\b${other}\\b`).test(declaration),
-    );
-    for (const prop of propsBehind(decls, onward, seen)) found.add(prop);
-  }
-  return found;
-}
-
-/**
- * Faction paint and faces. Everymen's kit is spelt under the BARE
- * `--everymen-*` prefix as well as `--faction-everymen-*`, which is why this
- * predicate is wider than S.N.I.D.E.'s or Singularity's — a filter that only
- * knew `--faction-` would have reported the field register clean.
- *
- * House tokens — `--space-*`, the `--text-*` ramp, `--color-*` — are every
- * tile's and are not a faction family.
- */
-const isFactionPaint = (prop: string): boolean =>
-  prop.startsWith("--faction-") || prop.startsWith("--font-") || prop.startsWith("--everymen-");
-
-const propsIn = (source: string): Set<string> =>
-  new Set([...source.matchAll(/--[a-z0-9-]+/g)].map((match) => match[0]).filter(isFactionPaint));
-
-function registerTokens(): Set<string> {
-  const bandDecls = declarations(code(BANDS));
-  expect(
-    [...bandDecls.keys()],
-    "no `EverymenBand` in cardMasthead/factionBands.tsx",
-  ).toContain("EverymenBand");
-  const props = propsIn(code(TASK_CARD));
-  for (const prop of propsBehind(bandDecls, ["EverymenBand"])) {
-    if (isFactionPaint(prop)) props.add(prop);
-  }
-  const ctaDecls = declarations(code(CARD_CTA));
-  expect([...ctaDecls.keys()], "no `EVERYMEN_CARD_CTA` in taskCard/cardCta.ts").toContain(
-    "EVERYMEN_CARD_CTA",
-  );
-  for (const prop of propsBehind(ctaDecls, ["EVERYMEN_CARD_CTA"])) {
-    if (isFactionPaint(prop)) props.add(prop);
-  }
-  return props;
-}
 
 const themes = readThemes(read("../../../index.css"));
 
+/**
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no token its own task card does not" (#2321) — now live
+ * in `everySelectTileWearsItsCardsRegister.test.ts`, derived over all nine
+ * kits including the `Default`-backed tile this suite could not reach
+ * (#2816). This file keeps everything bespoke to Everymen.
+ */
 describe("the Everymen tile wears the bill's register (#2327)", () => {
-  it("names no token its own task card does not", () => {
-    const register = registerTokens();
-    const strays = [...propsIn(code(TILE))].filter((prop) => !register.has(prop));
-
-    expect(
-      strays,
-      `Each name is a token the DIRECTORY TILE paints with and the TASK CARD
-never names — the shape #2321 calls a forked family. Both halves are real
-tokens, so no lint, census or contrast sweep can see it, and in LIGHT the two
-grounds are even the same hex. Fix it by finding the role on the bill that
-answers the same question, or by saying in the PR that the task card has no
-answer — not by widening this test.`,
-    ).toEqual([]);
-  });
-
   it("leaves the poster FIELD register off the tile for good", () => {
     // The specific fork, named, so a failure says WHICH one came back. The
     // sweep above would also go quiet if the task card ever gained one of
@@ -229,15 +139,5 @@ answer — not by widening this test.`,
     expect(source, "the identity mark is the canonical `EverymenSigil`").toContain("EverymenSigil");
     expect(source, "the furniture cog is the one drawing from #2121").toContain("EverymenCog");
     expect(source, "a surface that spells the cog's path is drawing it twice").not.toContain("EVERYMEN_COG_PATH");
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 });

--- a/frontend/src/components/selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts
@@ -35,68 +35,13 @@ const code = (relative: string): string => stripComments(read(relative));
 const TILE = "../SingularitySelectCard.tsx";
 
 /**
- * THE REGISTER IS THE TASK CARD AS RENDERED, not the one file — the same call
- * #2322 had to make. `SingularityTaskCard` mounts its window chrome from
- * `cardMasthead/factionBands` and its points well and process light from
- * `factionMarks/`, and several of the register's inks are spelt only in those:
- * the chrome ground and the hairline rule in the band, and `-term-blue` in
- * {@link SingularityReadout}, which is where #2042 moved it when the well
- * became a shared mark. The card's own file still names it — in a COMMENT,
- * saying it left. Slicing the card alone reports those as inventions.
- *
- * `factionBands` holds all nine factions' bands, so only `SingularityBand`'s own
- * body counts: S.N.I.D.E.'s acid is not Singularity's register.
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no token family its own task card does not" (#2321) — now
+ * live in `everySelectTileWearsItsCardsRegister.test.ts`, derived over all
+ * nine kits including the `Default`-backed tile this suite could not reach
+ * (#2816). This file keeps everything bespoke to Singularity.
  */
-function registerSource(): string {
-  const bands = code("../../cardMasthead/factionBands.tsx");
-  const at = bands.indexOf("function SingularityBand()");
-  expect(at, "no `SingularityBand` in cardMasthead/factionBands.tsx").toBeGreaterThan(-1);
-  return [
-    code("../../taskCard/SingularityTaskCard.tsx"),
-    code("../../factionMarks/SingularityReadout.tsx"),
-    code("../../factionMarks/SingularityProcessLight.tsx"),
-    bands.slice(at, bands.indexOf("\n}", at)),
-    // The lit key, which stopped being spelt in the card in #2642: one CTA
-    // constant per faction, spread by the card AND by the task detail so the
-    // two can no longer drift. Same reach as the band above — the card AS
-    // RENDERED — and `cardCta.ts` holds all nine, so only this one's body
-    // counts.
-    ctaSource("SINGULARITY_CARD_CTA"),
-  ].join("\n");
-}
-
-/** One faction's CTA constant, sliced out of the module that holds all eight. */
-function ctaSource(name: string): string {
-  const module = code("../../taskCard/cardCta.ts");
-  const at = module.indexOf(`export const ${name}`);
-  expect(at, `no \`${name}\` in taskCard/cardCta.ts`).toBeGreaterThan(-1);
-  return module.slice(at, module.indexOf("\n};", at));
-}
-
-/** Every custom property named in a source, in document order, deduplicated. */
-const propsIn = (source: string): string[] => [
-  ...new Set([...source.matchAll(/--[a-z0-9-]+/g)].map((match) => match[0])),
-];
-
 describe("the Singularity tile wears the terminal's register (#2326)", () => {
-  it("names no token family its own task card does not", () => {
-    const register = registerSource();
-    const strays = propsIn(code(TILE))
-      // House tokens — spacing, the type ramp, radii — are not a faction family
-      // and are shared by every tile in the directory.
-      .filter((prop) => prop.startsWith("--faction-") || prop.startsWith("--font-"))
-      .filter((prop) => !register.includes(prop));
-
-    expect(
-      strays,
-      `Each name is a token the DIRECTORY TILE paints with and the TASK CARD
-never names — the shape #2321 calls a forked family. Both halves are real
-tokens, so no lint, census or contrast sweep can see it; only this can.
-Fix it by finding the \`--faction-singularity-term-*\` role that answers the
-same question, not by widening this test.`,
-    ).toEqual([]);
-  });
-
   it("leaves no theme-INVARIANT Singularity family on the tile", () => {
     // The named half of the assertion above, spelt out so a failure says WHICH
     // fork returned. These five are the exact names the tile carried before
@@ -125,15 +70,5 @@ same question, not by widening this test.`,
     const source = resolveRoleReads(code(TILE));
     expect(source, "--font-faction-terminal is the raw family").not.toContain("--font-faction-terminal");
     expect(source).toContain("--faction-singularity-card-font");
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 });

--- a/frontend/src/components/selectCard/__tests__/snideWearsTheClippingRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/snideWearsTheClippingRegister.test.ts
@@ -33,64 +33,13 @@ const code = (relative: string): string => stripComments(read(relative));
 const TILE = "../SnideSelectCard.tsx";
 
 /**
- * THE REGISTER IS THE TASK CARD AS RENDERED, not the one file. `SnideTaskCard`
- * mounts its masthead from `cardMasthead/factionBands` and its wall and its
- * points mark from `factionMarks/snideAtoms`, so two of the register's inks —
- * the bar's ordinal and the walked pink — are spelt in those modules and never
- * in the card. Slicing the card alone would report them as inventions.
- *
- * `factionBands` holds all nine factions' bands, so only `SnideBand`'s own body
- * counts; UA's brass is not S.N.I.D.E.'s register.
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no token family its own task card does not" (#2321) — now
+ * live in `everySelectTileWearsItsCardsRegister.test.ts`, derived over all
+ * nine kits including the `Default`-backed tile this suite could not reach
+ * (#2816). This file keeps everything bespoke to S.N.I.D.E.
  */
-function registerSource(): string {
-  const bands = code("../../cardMasthead/factionBands.tsx");
-  const at = bands.indexOf("function SnideBand()");
-  expect(at, "no `SnideBand` in cardMasthead/factionBands.tsx").toBeGreaterThan(-1);
-  return [
-    code("../../taskCard/SnideTaskCard.tsx"),
-    code("../../factionMarks/snideAtoms.tsx"),
-    bands.slice(at, bands.indexOf("\n}", at)),
-    // The sprayed stencil, which stopped being spelt in the card in #2642: one
-    // CTA constant per faction, spread by the card AND by the task detail so
-    // the two can no longer drift. Same reach as the band above — the card AS
-    // RENDERED — and `cardCta.ts` holds all nine, so only this one's body
-    // counts.
-    ctaSource("SNIDE_CARD_CTA"),
-  ].join("\n");
-}
-
-/** One faction's CTA constant, sliced out of the module that holds all eight. */
-function ctaSource(name: string): string {
-  const module = code("../../taskCard/cardCta.ts");
-  const at = module.indexOf(`export const ${name}`);
-  expect(at, `no \`${name}\` in taskCard/cardCta.ts`).toBeGreaterThan(-1);
-  return module.slice(at, module.indexOf("\n};", at));
-}
-
-/** Every custom property named in a source, in document order, deduplicated. */
-const propsIn = (source: string): string[] => [
-  ...new Set([...source.matchAll(/--[a-z0-9-]+/g)].map((match) => match[0])),
-];
-
 describe("the S.N.I.D.E. tile wears the clipping's register (#2322)", () => {
-  it("names no token family its own task card does not", () => {
-    const register = registerSource();
-    const strays = propsIn(code(TILE))
-      // House tokens — spacing, the type ramp, radii — are not a faction family
-      // and are shared by every tile in the directory.
-      .filter((prop) => prop.startsWith("--faction-") || prop.startsWith("--font-") || prop.startsWith("--snide-"))
-      .filter((prop) => !register.includes(prop));
-
-    expect(
-      strays,
-      `Each name is a token the DIRECTORY TILE paints with and the TASK CARD
-never names — the shape #2321 calls a forked family. Both halves are real
-tokens, so no lint, census or contrast sweep can see it; only this can.
-Fix it by finding the \`--faction-snide-note-*\` role that answers the same
-question, not by widening this test.`,
-    ).toEqual([]);
-  });
-
   it("spells the faces as the faction's own font tokens, not the global names", () => {
     const source = code(TILE);
     for (const [global, faction] of [
@@ -118,15 +67,5 @@ question, not by widening this test.`,
         new RegExp(`^\\s*${name}\\s*:`, "m"),
       );
     }
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 });

--- a/frontend/src/components/selectCard/__tests__/uaWearsTheLeafRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/uaWearsTheLeafRegister.test.ts
@@ -34,27 +34,6 @@ const code = (relative: string): string => stripComments(read(relative));
 
 const TILE = "../UaSelectCard.tsx";
 
-/**
- * THE REGISTER IS THE TASK CARD AS RENDERED, not the one file. `UaTaskCard`
- * mounts its two faces and its ensō from `factionMarks/uaAtoms` and its
- * masthead from `cardMasthead/factionBands`, so `--faction-ua-card-font` and
- * `--faction-ua-body-font` are spelt in the atoms and never in the card.
- * Slicing the card alone would report them as inventions.
- *
- * `factionBands` holds all nine factions' bands, so only `UaBand`'s own body
- * counts; S.N.I.D.E.'s acid is not UA's register.
- */
-function registerSource(): string {
-  const bands = code("../../cardMasthead/factionBands.tsx");
-  const at = bands.indexOf("function UaBand()");
-  expect(at, "no `UaBand` in cardMasthead/factionBands.tsx").toBeGreaterThan(-1);
-  return [
-    code("../../taskCard/UaTaskCard.tsx"),
-    code("../../factionMarks/uaAtoms.tsx"),
-    bands.slice(at, bands.indexOf("\n}", at)),
-  ].join("\n");
-}
-
 /** One faction's CTA constant, sliced out of the module that holds all eight. */
 function ctaSource(name: string): string {
   const module = code("../../taskCard/cardCta.ts");
@@ -62,11 +41,6 @@ function ctaSource(name: string): string {
   expect(at, `no \`${name}\` in taskCard/cardCta.ts`).toBeGreaterThan(-1);
   return module.slice(at, module.indexOf("\n};", at));
 }
-
-/** Every custom property named in a source, in document order, deduplicated. */
-const propsIn = (source: string): string[] => [
-  ...new Set([...source.matchAll(/--[a-z0-9-]+/g)].map((match) => match[0])),
-];
 
 /**
  * The one SYNONYM, and it is proven below rather than waived.
@@ -87,26 +61,14 @@ function declaration(css: string, name: string): string {
   return css.slice(at + name.length + 3, css.indexOf(";", at)).replace(/\s+/g, " ").trim();
 }
 
+/**
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no token its own task card does not" (#2321) — now live
+ * in `everySelectTileWearsItsCardsRegister.test.ts`, derived over all nine
+ * kits including the `Default`-backed tile this suite could not reach
+ * (#2816). This file keeps everything bespoke to UA.
+ */
 describe("the UA tile wears the vellum leaf's register (#2324)", () => {
-  it("names no token its own task card does not", () => {
-    const register = registerSource();
-    const strays = propsIn(code(TILE))
-      // House tokens — spacing, the type ramp, radii, the shared cast — are not
-      // a faction register and are worn by every tile in the directory.
-      .filter((prop) => prop.startsWith("--faction-") || prop.startsWith("--font-"))
-      .filter((prop) => prop !== GROUND_SYNONYM[0])
-      .filter((prop) => !register.includes(prop));
-
-    expect(
-      strays,
-      `Each name is a token the DIRECTORY TILE paints with and the TASK CARD
-never names — the drift #2321 is about. Both halves are real tokens, so no
-lint, census or contrast sweep can see it; only this can. Fix it by finding
-the role on \`UaTaskCard.tsx\` that answers the same question, not by
-widening this test.`,
-    ).toEqual([]);
-  });
-
   it("grounds on the leaf's own paper stock, under the name every UA surface may read", () => {
     const css = read("../../../index.css");
     const [publicName, cardName] = GROUND_SYNONYM;
@@ -146,16 +108,6 @@ widening this test.`,
     expect(code(TILE), "the bare fill / on-fill pair is the retired CTA").not.toMatch(
       /var\(--faction-ua\)|--faction-ua-on-fill/,
     );
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 
   it("draws the wordmark, not the faction name (#2332)", () => {

--- a/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/wowWearsTheDecreeRegister.test.ts
@@ -83,45 +83,7 @@ function ctaSource(name: string): string {
 }
 
 const TILE = "../WowSelectCard.tsx";
-const TASK_CARD = "../../taskCard/WowTaskCard.tsx";
-const BANDS = "../../cardMasthead/factionBands.tsx";
 const CSS = "../../../index.css";
-
-/** Every top-level binding in a module, mapped to its own declaration text. */
-function declarations(source: string): Map<string, string> {
-  const heads = [...source.matchAll(/^(?:export (?:default )?)?(?:const|function) ([A-Za-z_$][\w$]*)/gm)];
-  return new Map(
-    heads.map((head, i) => [
-      head[1],
-      source.slice(head.index!, i + 1 < heads.length ? heads[i + 1].index! : source.length),
-    ]),
-  );
-}
-
-/**
- * The custom properties a binding paints with, following the module's own
- * aliases. `WowBand` spells none itself — its plum, its gilt and its face all
- * arrive through `GILT_MID` and `MED`, module-level bindings that sit beside it.
- */
-function propsBehind(
-  decls: Map<string, string>,
-  names: readonly string[],
-  seen = new Set<string>(),
-): Set<string> {
-  const found = new Set<string>();
-  for (const name of names) {
-    if (seen.has(name)) continue;
-    seen.add(name);
-    const declaration = decls.get(name);
-    if (!declaration) continue;
-    for (const [, prop] of declaration.matchAll(/(--[a-z0-9-]+)/g)) found.add(prop);
-    const onward = [...decls.keys()].filter(
-      (other) => other !== name && new RegExp(`\\b${other}\\b`).test(declaration),
-    );
-    for (const prop of propsBehind(decls, onward, seen)) found.add(prop);
-  }
-  return found;
-}
 
 /**
  * Rider 2's one genuine case: `utils/factionRoles` DOES hand a file paint, and
@@ -150,16 +112,6 @@ function tokensPainting(relative: string): Set<string> {
     for (const prop of ROLE_MAP_PROPS) props.add(prop);
   }
   return new Set([...props].filter(isFactionPaint));
-}
-
-function registerTokens(): Set<string> {
-  const bandDecls = declarations(code(BANDS));
-  expect([...bandDecls.keys()], "no `WowBand` in cardMasthead/factionBands.tsx").toContain("WowBand");
-  const props = tokensPainting(TASK_CARD);
-  for (const prop of propsBehind(bandDecls, ["WowBand"])) {
-    if (isFactionPaint(prop)) props.add(prop);
-  }
-  return props;
 }
 
 /** One import statement: the module it reads, and the names taken from it. */
@@ -209,22 +161,14 @@ const ALLOWED_IMPORTS: readonly (string | { from: string; bindings: readonly str
   "./FactionSelectCard",
 ];
 
+/**
+ * The two invariants this file used to assert here — the fluid 360x300 box
+ * (#732) and "names no TOKEN its own task card does not" (#2321) — now live
+ * in `everySelectTileWearsItsCardsRegister.test.ts`, derived over all nine
+ * kits including the `Default`-backed tile this suite could not reach
+ * (#2816). This file keeps everything bespoke to WOW.
+ */
 describe("the WOW tile wears the quest decree's register (#2328)", () => {
-  it("names no TOKEN its own task card does not", () => {
-    const register = registerTokens();
-    const strays = [...tokensPainting(TILE)].filter((prop) => !register.has(prop));
-
-    expect(
-      strays,
-      `Each name is a token the DIRECTORY TILE paints with and the TASK CARD
-never names. Asked per FAMILY this tile passed while wearing the avatar's gilt
-button and the faction page's tag plate, which is why #2321's five finished
-children sharpened the question to the token. Fix it by finding the decree's
-own answer to the same role, or by saying in the PR that the task card has no
-answer — not by widening this test.`,
-    ).toEqual([]);
-  });
-
   it("takes the page kit's and the avatar's plates off the tile for good", () => {
     // The specific strays, named. The sweep above would also pass if one of
     // these were ever added to the task card; this says the tile does not want
@@ -316,15 +260,5 @@ with the same proof the listed ones carry — never because the path is on the l
       code(TILE),
       "the raw 16 was a `no-raw-style-values` exemption arguing a label token would flatten the placard; the decree's CTA IS `--text-content`, so the exemption went with it",
     ).not.toContain("local/no-raw-style-values -- ornament: the CTA");
-  });
-
-  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
-    // Not a colour question, and the one geometry the epic promised not to move:
-    // the 375px single-column mobile directory depends on all three.
-    const source = code(TILE);
-    expect(source).toContain('width: "100%"');
-    expect(source).toContain("maxWidth: 360");
-    expect(source).toContain("minHeight: 300");
-    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `frontend/src/components/selectCard/__tests__/everySelectTileWearsItsCardsRegister.test.ts`, a loop over `surfaceMap('factionSelectCard')` (never a typed list — #2815) that carries the two faction-invariant assertions the seven `*WearsThe*Register.test.ts` files used to hand-copy:
  - `keeps the fluid 360x300 box the directory grid is built on (#732)`
  - `names no token family its own task card does not (#2321)`
- Extends both invariants to the `Default`-backed `na` tile, which was previously untested, and — by construction, since `AlbescentSelectCard` is a geometry-only wrapper around `DefaultSelectCard` — to Albescent's tile too. Albescent is filtered out of the loop with a named, commented reason rather than silently dropped; `albescentRedactsAndUnlocksTogether` already covers the one thing that genuinely is the wrapper's own (the redaction gate).
- Removes the now-duplicated `it(...)` blocks (and any helper that only they used) from all seven bespoke files — `covenWearsTheSlipRegister`, `ephemeristsWearsThePlateRegister`, `everymenWearsTheBillRegister`, `singularityWearsTheTerminalRegister`, `snideWearsTheClippingRegister`, `uaWearsTheLeafRegister`, `wowWearsTheDecreeRegister`. Every other bespoke assertion in those files (ward family, ground synonym, CTA chip pairing, import allowlist, wordmark, etc.) is untouched — nine files stay nine files, per `frontend/CLAUDE.md`'s no-unify rule.

**On the register invariant's resolution:** each kit's original recipe for "does the tile paint with a name its task card's rendered register never does?" is genuinely bespoke — Coven and the Ephemerists resolve their palette through a JS module (zero literal `--` tokens in their own file), WOW spells every name inline and additionally pins its import list, Everymen/UA/Singularity/S.N.I.D.E. each reach a slightly different set of files (bands, marks, CTA constants). Rather than flattening these into one weaker algorithm, the loop relocates each kit's `strays()` recipe unmodified into a `REGISTER` map keyed by the same derived slug list, and loops the shared assertion over it. A tenth kit that registers a tile without adding a row to `TILE_PATHS` / `REGISTER` fails loudly (undefined lookup) rather than passing silently.

**On `na`'s register:** `DefaultSelectCard`'s own docblock says its visual language follows the Default **praxis** card, not the task card — and `DefaultTaskCard`'s own header names the divergence on purpose (it deliberately does *not* use `--faction-default-card-font`, the Bebas Neue face #839 chose for the praxis card, picking Lora for the v2 task-card design instead). So `na`'s register is defined as the union of `DefaultTaskCard.tsx` and `DefaultPraxisCard.tsx` — the one documented split in the kit, spelled out in a comment, not a narrowing to dodge a finding. With that union, `na` passes cleanly; without it, `--faction-default-card-font` would be a real (but not a bug) stray, exactly the kind of finding the issue anticipated.

## Verification (seam: `code(relative)` source-text scans, no DOM)

- `npx tsc --noEmit` — 0 errors, repo-wide.
- `npm run typecheck:design-sync` — 0 errors.
- `npm run lint` — clean.
- `npm test` (vitest) — 477 files, 9864 passed / 1 pre-existing skip, repo-wide. The touched `selectCard` directory: 10 files, 58 tests (55 original − 14 relocated + 17 in the new derived file: 8 box + 1 canary + 8 register).
- `npm run build` — succeeds (the one warning is a pre-existing, unrelated `INEFFECTIVE_DYNAMIC_IMPORT` note on `FactionSigil`).
- `npm run budget` — pre-existing WARN (not FAIL), unaffected by this change since these are test-only files never bundled.

No backend or route changes, so `api-schema` regeneration does not apply.

Closes #2816

## What to eyeball

Visual QA is outstanding — I have no browser/dev-stack access in this environment, only tests/tsc/eslint/build. Nothing in this PR changes shipped component code (only test files), so there should be zero visual delta, but worth a human's confirmation that:

- [ ] The `/factions` directory grid still renders na's (unaffiliated) and Albescent's tiles at the same 360×300-max fluid box as the other seven, at both desktop and the 375px mobile single-column breakpoint.
- [ ] No visible regression on any of the nine select tiles (this PR does not touch `DefaultSelectCard.tsx`, `AlbescentSelectCard.tsx`, or any of the seven faction tiles — test-only diff).
