### PR TITLE
Give the locked-on cookie switch a lock glyph, not a dim (#2844)

### DIFF
--- a/frontend/src/pages/settings/SettingsSwitch.tsx
+++ b/frontend/src/pages/settings/SettingsSwitch.tsx
@@ -41,6 +41,23 @@ import type { CSSProperties } from 'react'
  * `aria-disabled` rather than the `disabled` attribute, on purpose: a
  * `disabled` button leaves the tab order, so the one reader most likely to need
  * the explanation is the one who can never reach it.
+ *
+ * THE LOCK GLYPH IS "LOCKED ON" ONLY, NOT "LOCKED" IN GENERAL (#2844). A
+ * locked-off switch (`Analytics`, `Marketing`) already reads as a distinct
+ * state without any glyph: its edge is the flat `--color-border-strong` line
+ * from `TRACK_EDGE_OFF`, not the rainbow, and its thumb sits left. The only
+ * pairing that was pixel-identical to a live, changeable switch was
+ * locked-**on** (`Essential`) against `Dark mode` — same rainbow edge, same
+ * thumb position, only `cursor` differed, and cursor needs a hover that a
+ * touch reader never gets. So the glyph is gated on `checked && disabled`
+ * specifically, not on `disabled` alone; giving it to the off switches too
+ * would draw a distinction nothing needs. The design canvas's `opacity: .45`
+ * dim on the locked track is deliberately NOT ported — see the measurement
+ * in #2844: at .45 every one of the rainbow ring's seven stops falls under
+ * 1.4.11's 3:1, and the ring is the only perceivable state signal this
+ * control has (see #2845 above). The glyph is drawn in `--switch-thumb-edge`,
+ * the token already load-bearing for the thumb's own ring, so it introduces
+ * no new token and no new `factionContrast.test.ts` pairing.
  */
 interface SettingsSwitchProps {
   readonly checked: boolean
@@ -91,9 +108,33 @@ const knob: CSSProperties = {
   width: 20,
   height: 20,
   borderRadius: 999,
-  display: 'block',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   boxShadow: 'inset 0 0 0 1px var(--switch-thumb-edge)',
   transition: 'left 180ms ease',
+}
+
+/**
+ * The locked-on glyph (#2844). Decorative only — the outer knob `<span>` is
+ * already `aria-hidden`, and the accessible name (set by the caller) already
+ * says the switch is locked. Sized to sit inside the 20px thumb with room to
+ * spare, and drawn in `--switch-thumb-edge` — the same token the thumb's own
+ * ring already uses, so this mints nothing new.
+ */
+function LockGlyph() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 12 12" width="10" height="10">
+      <path
+        d="M3.5 5V3.6a2.5 2.5 0 0 1 5 0V5"
+        fill="none"
+        stroke="var(--switch-thumb-edge)"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      <rect x="2.5" y="5" width="7" height="5.5" rx="1.1" fill="var(--switch-thumb-edge)" />
+    </svg>
+  )
 }
 
 export default function SettingsSwitch({
@@ -128,7 +169,9 @@ export default function SettingsSwitch({
           left: checked ? 22 : 3,
           background: checked ? 'var(--switch-thumb)' : 'var(--switch-thumb-off)',
         }}
-      />
+      >
+        {checked && disabled && <LockGlyph />}
+      </span>
     </button>
   )
 }

--- a/frontend/src/pages/settings/SettingsSwitch.tsx
+++ b/frontend/src/pages/settings/SettingsSwitch.tsx
@@ -55,9 +55,23 @@ import type { CSSProperties } from 'react'
  * dim on the locked track is deliberately NOT ported — see the measurement
  * in #2844: at .45 every one of the rainbow ring's seven stops falls under
  * 1.4.11's 3:1, and the ring is the only perceivable state signal this
- * control has (see #2845 above). The glyph is drawn in `--switch-thumb-edge`,
- * the token already load-bearing for the thumb's own ring, so it introduces
- * no new token and no new `factionContrast.test.ts` pairing.
+ * control has (see #2845 above).
+ *
+ * THE GLYPH'S OWN INK IS `--color-text-tertiary`, NOT `--switch-thumb-edge`
+ * (review finding on #2844's first pass). `--switch-thumb-edge` is 18% of
+ * `--color-text-primary` — a wash on the OUTER side of the thumb, against the
+ * well, where it reads. Drawn INSIDE the thumb instead, its only neighbour is
+ * the thumb's own fill (`--switch-thumb`, a 10% wash of the same primary), and
+ * 18%-ink-on-10%-ink composites to 1.44:1 light / 1.65:1 dark — reproduced with
+ * this file's own `compositeOver`/`contrastRatio` helpers over the same
+ * page -> `--switch-well` (6%) -> `--switch-thumb` (10%) stack `SWITCH_RING_PAIRS`
+ * documents. That is not perceivable, so it would have shipped the acceptance
+ * criterion's exact failure mode again with different pixels. `--color-text-tertiary`
+ * on that same composited thumb measures 5.66:1 light / 6.04:1 dark — comfortably
+ * over 1.4.11's 3:1 in both — and it is not a new token: it is the same one
+ * `--switch-ring-hairline` already aliases for the ring (#2845). Asserted as its
+ * own row in `factionContrast.test.ts`, "switch lock glyph, on the locked-on
+ * thumb".
  */
 interface SettingsSwitchProps {
   readonly checked: boolean
@@ -119,8 +133,13 @@ const knob: CSSProperties = {
  * The locked-on glyph (#2844). Decorative only — the outer knob `<span>` is
  * already `aria-hidden`, and the accessible name (set by the caller) already
  * says the switch is locked. Sized to sit inside the 20px thumb with room to
- * spare, and drawn in `--switch-thumb-edge` — the same token the thumb's own
- * ring already uses, so this mints nothing new.
+ * spare.
+ *
+ * `--color-text-tertiary`, NOT `--switch-thumb-edge` — see the long note
+ * above `knob` for the measurement. The ring's own edge token washes out to
+ * 1.44:1 / 1.65:1 once it is drawn against the thumb's fill instead of the
+ * well; tertiary clears 5.66:1 / 6.04:1 on that same composited thumb and is
+ * an existing token, not a new one.
  */
 function LockGlyph() {
   return (
@@ -128,11 +147,11 @@ function LockGlyph() {
       <path
         d="M3.5 5V3.6a2.5 2.5 0 0 1 5 0V5"
         fill="none"
-        stroke="var(--switch-thumb-edge)"
+        stroke="var(--color-text-tertiary)"
         strokeWidth="1.2"
         strokeLinecap="round"
       />
-      <rect x="2.5" y="5" width="7" height="5.5" rx="1.1" fill="var(--switch-thumb-edge)" />
+      <rect x="2.5" y="5" width="7" height="5.5" rx="1.1" fill="var(--color-text-tertiary)" />
     </svg>
   )
 }

--- a/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
@@ -66,6 +66,8 @@ const list = () => renderToStaticMarkup(<StorageInventory id="sec-cookies-invent
 const text = (markup: string) => markup.replace(/<[^>]*>/g, '')
 const control = (markup: string, testId: string) =>
   new RegExp(`<button[^>]*data-testid="${testId}"[^>]*>`).exec(markup)?.[0] ?? ''
+const controlWithChildren = (markup: string, testId: string) =>
+  new RegExp(`<button[^>]*data-testid="${testId}"[^>]*>[\\s\\S]*?</button>`).exec(markup)?.[0] ?? ''
 
 const names = STORED_ENTRIES.map((entry) => entry.name)
 
@@ -225,6 +227,39 @@ describe('all three switches render, all three inert, all three say why', () => 
       expect(button).toMatch(/aria-describedby="sec-cookies-[a-z]+-note"/)
     },
   )
+})
+
+/**
+ * #2844 — the locked-ON switch (`Essential`) now carries a lock glyph, so it
+ * no longer renders byte-identically to a live, changeable switch. The
+ * locked-OFF switches (`Analytics`, `Marketing`) do NOT get the glyph — see
+ * the rationale on `SettingsSwitch`: the flat, non-rainbow edge already reads
+ * as "off" there, so only "locked on" was ever ambiguous.
+ */
+describe('the locked-on switch carries a lock glyph; the locked-off ones do not', () => {
+  it('draws a glyph on the locked-and-checked Essential switch', () => {
+    const button = controlWithChildren(html(), 'settings-cookies-essential')
+    expect(button).toContain('<svg')
+  })
+
+  it.each(['settings-cookies-analytics', 'settings-cookies-marketing'])(
+    'draws no glyph on the locked-and-unchecked %s switch',
+    (testId) => {
+      const button = controlWithChildren(html(), testId)
+      expect(button).not.toContain('<svg')
+    },
+  )
+
+  it('never adds opacity to the track — the dim was rejected on measurement, not lost', () => {
+    for (const testId of [
+      'settings-cookies-essential',
+      'settings-cookies-analytics',
+      'settings-cookies-marketing',
+    ]) {
+      const button = controlWithChildren(html(), testId)
+      expect(button).not.toContain('opacity')
+    }
+  })
 })
 
 /**

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2349,6 +2349,46 @@ const SWITCH_RING_PAIRS: Pair[] = [
 ];
 
 /**
+ * THE LOCKED-ON SWITCH'S LOCK GLYPH (#2844), a block of its own — do not fold
+ * into SWITCH_RING_PAIRS above (#2845's) or CALLING_CHIP_PAIRS (#2852's);
+ * this is a third site on the same control.
+ *
+ * `Essential` (on, locked) was pixel-identical to a live `Dark mode` switch
+ * except for `cursor: not-allowed`, which needs a hover a touch reader never
+ * gets. The design canvas's `opacity: .45` fix cannot ship (measured in
+ * #2844: every rainbow stop falls under 3:1 at that dim), so the fix is a
+ * lock glyph drawn inside the thumb instead, gated on `checked && disabled`.
+ *
+ * THE FIRST PASS AT THIS GLYPH REUSED `--switch-thumb-edge`, the token the
+ * thumb's own ring already carries, on the reasoning that it "mints nothing
+ * new". That reasoning does not transfer: the ring reads because its OUTER
+ * side borders `--switch-well`, a different neighbour than the thumb's fill.
+ * A glyph drawn INSIDE the thumb only ever contrasts against the thumb, and
+ * 18%-ink-on-10%-ink composites to 1.44:1 (light) / 1.65:1 (dark) — under
+ * 1.4.11's 3:1, the same failure #2844 was filed to fix, with different
+ * pixels.
+ *
+ * SO THE GLYPH USES `--color-text-tertiary` INSTEAD — the same token
+ * `--switch-ring-hairline` already aliases (#2845), not a new one. On the
+ * composited stack `page -> --switch-well (6%) -> --switch-thumb (10%)`, the
+ * SAME stack `SWITCH_RING_PAIRS` above documents one layer short of, it
+ * measures 5.66:1 light / 6.04:1 dark.
+ */
+const SWITCH_LOCK_GLYPH_PAIRS: Pair[] = [
+  {
+    what: "switch lock glyph, on the locked-on thumb",
+    surface: "--color-bg-page",
+    veil: [
+      { token: "--color-text-primary", alpha: 0.06 }, // --switch-well
+      { token: "--color-text-primary", alpha: 0.1 }, // --switch-thumb
+    ],
+    text: "--color-text-tertiary",
+    floor: AA_LARGE,
+    nonText: "the lock glyph is a drawn mark inside the thumb, not lettering — 1.4.11's 3:1 (#2844)",
+  },
+];
+
+/**
  * A `SKY_PAIRS` block stood here (#1792): seven rows measuring each faction's
  * `-on-night` ink against `--sky-bg`, the Constellation's own night canvas.
  *
@@ -2531,6 +2571,7 @@ const PAIRS: Pair[] = [
   ...RAIL_PAIRS,
   ...CALLING_CHIP_PAIRS,
   ...SWITCH_RING_PAIRS,
+  ...SWITCH_LOCK_GLYPH_PAIRS,
 ];
 
 /**


### PR DESCRIPTION
Closes #2844

## The defect
The `Essential` cookie switch (on, locked) rendered byte-identically to the live, interactive `Dark mode` switch — same rainbow ring, same thumb position, same thumb alpha. The only shipped difference was `cursor: not-allowed`, which needs a hover and never appears on a touch device. `Analytics`/`Marketing` (off, locked) already read differently via a flat grey ring, but that difference says *off*, not *locked*.

This is not a functional defect — the control is inert and its accessible name is already correct. This PR is pixels only.

## The fix
- `SettingsSwitch.tsx`: a small inline-SVG lock glyph renders inside the thumb, gated on `checked && disabled` — i.e. specifically the locked-**on** case. Drawn in `--color-text-tertiary`.
- The design canvas's `opacity: .45` dim is deliberately **not** ported — per the owner ruling on #2844, it was measured and drops every rainbow stop under 1.4.11's 3:1. No `opacity` is added anywhere on the control.
- The `--switch-ring-hairline` edge from #2845/#2898 is untouched — the glyph sits inside the thumb, not on the ring, and doesn't disturb that boundary.

## Review round 2 — the glyph's ink, and the two measured ratios
The first pass drew the glyph in `--switch-thumb-edge` (the token the thumb's outer ring already uses) on the reasoning that it "mints nothing new". A blocking review caught that this doesn't transfer: that token reads *on the ring* because its neighbour there is `--switch-well`; drawn *inside* the thumb, its only neighbour is the thumb's own fill (`--switch-thumb`, a 10% wash of the same ink), and 18%-on-10% composites to:

| theme | `--switch-thumb-edge` on the thumb (rejected) | `--color-text-tertiary` on the thumb (shipped) |
|---|---|---|
| light | **1.44:1** | **5.66:1** |
| dark | **1.65:1** | **6.04:1** |

Both measured on the same composited stack `page -> --switch-well (6%) -> --switch-thumb (10%) -> ink`, using this repo's own `compositeOver`/`contrastRatio` helpers (`src/utils/contrast.ts`) — the same math `factionContrast.test.ts` runs. The rejected figures reproduce the reviewer's numbers exactly, which is why the ink changed rather than the reasoning about `--switch-thumb-edge`'s validity elsewhere.

`--color-text-tertiary` is not a new token — it's the same one `--switch-ring-hairline` already aliases for the ring (#2845) — and it clears 1.4.11's 3:1 comfortably in both themes on the thumb. Asserted as its own block in `factionContrast.test.ts`, `SWITCH_LOCK_GLYPH_PAIRS`, kept separate from `SWITCH_RING_PAIRS` (#2845's) and `CALLING_CHIP_PAIRS` (#2852's), and nothing was added to `BASELINE`.

## The consistency question (required by the issue)
**Answered: the glyph means "locked ON" specifically, not "locked" in general — Analytics/Marketing do NOT get it.** The rationale is written as a comment on `SettingsSwitch.tsx`: the locked-off switches already have a distinct, non-rainbow flat edge and a left-sitting thumb, so nothing there was ever ambiguous. The only pairing that was pixel-identical to a live switch was locked-on vs. live-on, so the glyph is scoped to exactly that case (`checked && disabled`).

## Test seam
`frontend/src/pages/settings/__tests__/cookiesSection.test.tsx` (the existing render seam for this section, `renderToStaticMarkup`), extended with a `describe` block:
- the locked-and-checked `Essential` switch's markup contains an `<svg`
- the locked-and-unchecked `Analytics`/`Marketing` switches' markup does not
- none of the three switches' markup contains `opacity`, guarding against the rejected dim ever coming back

Plus `SWITCH_LOCK_GLYPH_PAIRS` in `factionContrast.test.ts` — the token-value contrast gate — asserting the 5.66:1 / 6.04:1 pairing above so a future ink change on this site is caught mechanically rather than by a second eyeball review.

## Verification
- `tsc --noEmit`: 0 errors
- `tsc -p tsconfig.design-sync.json --noEmit`: 0 errors
- `eslint` on touched files: clean
- `vitest run` (full suite): 477 files / 9930 passed, 1 skipped (pre-existing skip)
- `vite build`: succeeds; the one `INEFFECTIVE_DYNAMIC_IMPORT` warning is pre-existing and unrelated (`FactionSigil.tsx`)
- `npm run budget`: WARN at 137.3 KB JS — identical to the `origin/main` baseline measured on the same worktree, so this PR does not grow the initial-load payload (the Settings page is its own lazy chunk)

## What to eyeball
Visual QA is outstanding — I have no browser/dev-stack access in this environment. A human should compare, in both light and dark theme, on Settings → Cookies and local storage:
- **Essential** (on, locked) — should now show a small lock glyph centered in the thumb, ring still full-strength rainbow, no dimming anywhere on the track. The glyph should read clearly against the thumb without needing to hover or squint — that's the 5.66:1 / 6.04:1 above.
- **Analytics** and **Marketing** (off, locked) — should look exactly as before this change: flat grey ring, thumb left, **no** lock glyph.
- **Dark mode** (Settings → Appearance, on, live/interactive) — should look exactly as before: full rainbow ring, no glyph, since it is not `disabled`.

The seam I tested at is `renderToStaticMarkup` of `CookiesSection` (no real DOM/browser in this harness) for the glyph's presence/absence, plus the token-value contrast gate for the glyph ink's ratio — not a rendered/computed-style measurement, since there is no browser here.