### PR TITLE
Fix media-delete 500 on an unresolvable path; move it into services.praxis

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -5,7 +5,6 @@ Replaces the old submissions, collaborations, and praxes routers.
 """
 
 import logging
-import os
 from typing import List, Optional
 
 from fastapi import (
@@ -85,6 +84,7 @@ from services.praxis import (
     cancel_invite,
     change_praxis_type,
     create_praxis,
+    delete_media_item,
     delete_praxis,
     flag_praxis,
     get_praxis,
@@ -106,7 +106,7 @@ from services.praxis_out import (
     build_praxis_cards,
     build_praxis_out,
 )
-from services.media import process_and_save_media, resolve_stored_media_path
+from services.media import process_and_save_media
 from services.nudge import nudge_the_crew, send_nudge
 from services.vote import cast_vote_on_praxis
 
@@ -457,33 +457,7 @@ async def delete_media_route(
     if media_item is None or media_item.praxis_id != praxis_id:
         raise_coded(404, ErrorCode.media_item_not_found, "Media item not found.")
 
-    # Through the shared predicate, not a bare join. `resolve_stored_media_path`
-    # is documented as the one "is this a file we own?" gate every
-    # column-value-to-filesystem operation passes; this route bypassed it and
-    # joined MEDIA_ROOT to `file_path` directly. `file_path` is server-generated
-    # today so there is no live traversal — but `os.path.join` with an absolute
-    # or `..`-bearing value escapes MEDIA_ROOT entirely, so the day any other
-    # writer touches that column (an import, an admin editor, a migration) this
-    # silently becomes an arbitrary-unlink primitive. Same two lines as
-    # `delete_stored_avatar`.
-    abs_path = resolve_stored_media_path(media_item.file_path)
-    try:
-        if abs_path is not None:
-            os.remove(abs_path)
-    except OSError:
-        pass
-    # Each upload owns its directory (#1336), so removing the file leaves that
-    # directory empty. rmdir refuses a non-empty one, which is exactly the guard
-    # we want for pre-#1336 rows that still share a per-praxis directory.
-    try:
-        os.rmdir(os.path.dirname(abs_path))
-    except OSError:
-        pass
-
-    await session.delete(media_item)
-    await session.flush()
-    # Removing media edits the shared document — cancels a pending publish (ADR-0012).
-    await on_member_edit(praxis, session)
+    await delete_media_item(praxis, media_item, session, era=CURRENT_ERA)
     return Response(status_code=204)
 
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -3,6 +3,7 @@
 Handles all three praxis types: solo, collab, and duel.
 """
 
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -51,6 +52,7 @@ from services.character_stats import (
 from services.faction_service import faction_permits
 from services.media import (
     process_and_save_media,
+    resolve_stored_media_path,
     restore_media_to_mount,
     withdraw_media_from_mount,
 )
@@ -1269,6 +1271,51 @@ async def add_media_batch(
     if saved_count:
         await collab_consensus.on_member_edit(praxis, session, era)
     return results
+
+
+async def delete_media_item(
+    praxis: Praxis,
+    media_item: MediaItem,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> None:
+    """Remove one media item from a live praxis: DB row authoritative, disk best-effort.
+
+    Caller contract: the praxis has been fetched, ``_require_member`` has
+    passed, and ``media_item`` has been confirmed to belong to ``praxis`` —
+    same batch-wide-verdicts-first contract as :func:`add_media_batch`.
+
+    Through the shared predicate, not a bare join. ``resolve_stored_media_path``
+    is the one "is this a file we own?" gate every column-value-to-filesystem
+    operation passes (see its docstring): ``file_path`` is server-generated
+    today so there is no live traversal, but joining ``MEDIA_ROOT`` to it
+    directly would let a stored value with an absolute or ``..``-bearing path
+    escape ``MEDIA_ROOT`` entirely, the day any other writer touches that
+    column. Same two lines as ``delete_stored_avatar``.
+
+    ``resolve_stored_media_path`` returning ``None`` -- an unresolvable path,
+    same as a row this process does not own -- means there is nothing on disk
+    to touch, and removing the row is still a no-op success, never a 500.
+    """
+    abs_path = resolve_stored_media_path(media_item.file_path)
+    if abs_path is not None:
+        try:
+            os.remove(abs_path)
+        except OSError:
+            pass
+        # Each upload owns its directory (#1336), so removing the file leaves
+        # that directory empty. rmdir refuses a non-empty one, which is
+        # exactly the guard we want for pre-#1336 rows that still share a
+        # per-praxis directory.
+        try:
+            os.rmdir(os.path.dirname(abs_path))
+        except OSError:
+            pass
+
+    await session.delete(media_item)
+    await session.flush()
+    # Removing media edits the shared document — cancels a pending publish (ADR-0012).
+    await collab_consensus.on_member_edit(praxis, session, era)
 
 
 async def can_view_praxis(

--- a/backend/tests/integration/test_praxis_media_batch.py
+++ b/backend/tests/integration/test_praxis_media_batch.py
@@ -18,6 +18,7 @@ from PIL import Image
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.character import Character
+from models.praxis import MediaItem
 from models.task import Task
 from services import collab_consensus
 from services import media as media_service
@@ -422,3 +423,45 @@ async def test_deleting_one_same_named_file_leaves_the_other_readable(
     with open(survivor, "rb") as handle:
         assert handle.read() == second_bytes
     assert not os.path.exists(os.path.join(str(media_root), first_item["file_path"]))
+
+
+@pytest.mark.asyncio
+async def test_deleting_media_with_unresolvable_path_is_a_noop_not_a_500(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    media_root,
+):
+    """#2876: `resolve_stored_media_path` returning None must stay a no-op.
+
+    Before the fix, the second cleanup step called
+    ``os.rmdir(os.path.dirname(abs_path))`` unconditionally — with
+    ``abs_path is None`` that is ``os.path.dirname(None)``, a ``TypeError``
+    the surrounding ``except OSError`` does not catch, turning a delete of a
+    media item this process doesn't own into a 500 instead of the intended
+    no-op.
+    """
+    praxis_id = await _in_progress_solo(client, active_task, auth_headers)
+
+    upload = await client.post(
+        f"/praxes/{praxis_id}/media/batch",
+        files=[_image_part("proof.jpg")],
+        headers=auth_headers,
+    )
+    assert upload.status_code == 201, upload.text
+    item = upload.json()[0]["media_item"]
+
+    # Force the stored column into something `resolve_stored_media_path`
+    # refuses to resolve (a `..` escape) -- the same shape as a row an import
+    # or admin editor wrote, which the gate's own docstring calls out as the
+    # reason this predicate exists.
+    media_item = await db_session.get(MediaItem, item["id"])
+    media_item.file_path = "../outside.jpg"
+    await db_session.commit()
+
+    deletion = await client.delete(
+        f"/praxes/{praxis_id}/media/{item['id']}", headers=auth_headers
+    )
+    assert deletion.status_code == 204, deletion.text


### PR DESCRIPTION
## Summary

- `resolve_stored_media_path(...) is None` only guarded `os.remove`. The
  following `os.rmdir(os.path.dirname(abs_path))` ran unconditionally, so
  `os.path.dirname(None)` raised `TypeError`, which `except OSError` does not
  catch — a media item whose stored path no longer resolves turned a delete
  into a 500 instead of the intended no-op.
- Media delete was the one media operation still inline in the route handler
  (`routers/praxes.py`), doing its own DB write and filesystem mutation.
  Moved it into `services/praxis.py` as `delete_media_item`, right beside its
  sibling `add_media_batch` — the route handler is now a thin adapter:
  fetch praxis, check membership, fetch+verify the media item, call the
  service, return 204.
- `resolve_stored_media_path` is untouched and still the only "is this a file
  we own?" gate the operation passes through.
- No behavior change on the happy path — same two filesystem calls, same
  `on_member_edit` cancellation of a pending publish (ADR-0012), same 204.

Closes #2876

## Seam tested

HTTP route (`DELETE /praxes/{praxis_id}/media/{media_id}`) through the
service call, in `backend/tests/integration/test_praxis_media_batch.py`:

- Added `test_deleting_media_with_unresolvable_path_is_a_noop_not_a_500`,
  which forces a media item's `file_path` to a `..`-escaping value (the same
  shape as a row an import or admin editor could write) and asserts 204. This
  test reproduces the reported `TypeError` against the pre-fix code (verified
  red, now green).
- Existing sibling `test_deleting_one_same_named_file_leaves_the_other_readable`
  (happy path) still passes unchanged, confirming no behavior regression.

Ran locally against a dedicated test DB (`wz2876_test`):
`pytest tests/integration/test_praxis_media_batch.py -v` → 13 passed.
Full suite: `pytest --cov=. --cov-fail-under=92` → 1722 passed, 94.42%
coverage.
`ruff check` on the touched files: same finding count before/after (46), and
`tests/unit/test_ruff_clean.py` (the allowlist ratchet) passes.
`scripts/regen_api_client.py` run and confirmed no diff to `openapi.json` /
`schema.d.ts` (no route signature or schema changed).

## Out of scope (left alone on purpose)

- `routers/praxes.py:225`'s optional-admin expression — #2894.
- The Shape-B prologue this handler carries and `flag_praxis`'s duplicated
  eligibility checks — #2875 owns that collapse; not touched here.
- Everything else in `praxis.py` — #2872/#2873/#2874.

## What to eyeball

Visual QA is outstanding — this is a pure backend change with no UI surface,
and I have no browser/dev-stack access in this environment. Worth a human
glance at:

- [ ] The composer's "remove attachment" control on a praxis whose media row
  has a stale/foreign `file_path` (hard to hit organically today since
  `file_path` is server-generated — this matters once #2875's admin editor or
  an import lands) now shows the attachment disappearing cleanly instead of
  an error toast.
- [ ] Normal media delete (remove one of several attachments from a live
  praxis) still behaves identically — same 204, same UI refresh.