### PR TITLE
Add section banners to index.css (#2890) — comments only, byte-identical build

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,19 @@
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION MARKERS (#2890) — navigation only: no rule moved, no selector
+   changed, not one byte of built output differs. Each banner below marks a
+   boundary between concerns that already existed in this file:
+
+     PRELUDE             · this block — font-face import + Tailwind directives
+     BASE TOKENS (light) · :root / :root,[data-theme] token blocks
+     BASE TOKENS (dark)  · the one large [data-theme="dark"] override block
+     FACTION CHROME      · per-faction component classes + token blocks,
+                           in two runs (interrupted once by LAYOUT)
+     COMPONENT CLASSES   · @layer base, @layer components, shared utilities
+     LAYOUT              · filter bar / requests queue, settings inventory
+
+   Prefactor for #2891, which will split the file along these seams.
+   ══════════════════════════════════════════════════════════════════════════ */
+
 /* The SHELL's three self-hosted faces (#1977, #2079). Generated — see
    scripts/fetch-fonts.mjs. First, because @import must precede every rule, and
    because these are the @font-face blocks --font-display / --font-body /
@@ -11,6 +27,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — BASE TOKENS (light / theme-invariant) (#2890).
+   :root and :root,[data-theme] custom-property blocks: color, spacing,
+   type, motion, shadow, radius, and the shared faction palette (rainbow
+   spine, on-fill/on-accent inks, tints, borders, card paint, fonts). Runs
+   to the [data-theme="dark"] override block below.
+   ══════════════════════════════════════════════════════════════════════════ */
 
 /* ══════════════════════════════════════════
    COLOR SYSTEM — Single source of truth
@@ -3234,6 +3258,12 @@
   --badge-admin-text: #f7f4ee;
 }
 
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — BASE TOKENS: DARK OVERRIDES (#2890).
+   The one large [data-theme="dark"] block mirroring the light tokens above,
+   property by property, for every value that flips.
+   ══════════════════════════════════════════════════════════════════════════ */
+
 /* ══════════════════════════════════════════
    DARK MODE OVERRIDES
    Applied via [data-theme="dark"] on <html>
@@ -4058,6 +4088,15 @@
   --faction-everymen-vote-glow-5: drop-shadow(0 0 9px rgba(255, 175, 60, 0.95));
 }
 
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — FACTION CHROME, first run (#2890).
+   The file's first per-faction component classes (Everymen stamp/dispatch,
+   S.N.I.D.E. detail sheet, na backdrop) interleaved with more base-token
+   :root/[data-theme] blocks (motion durations, type scale, Task Crown, the
+   cross-faction notice/alarm/credit ink family) and the shared faction-page
+   grid class. Ends where the Tailwind layers begin.
+   ══════════════════════════════════════════════════════════════════════════ */
+
 /* ══ Everymen rubber-stamp print (#841) ══
    The tally stamp and the points roundel are INKED onto the sheet, so in light
    they multiply into the paper's rule lines. On the dark broadsheet multiply
@@ -4671,6 +4710,11 @@
   }
 }
 
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — COMPONENT CLASSES: Tailwind `@layer base` (#2890).
+   Global element resets (body, headings, placeholder ink).
+   ══════════════════════════════════════════════════════════════════════════ */
+
 @layer base {
   body {
     @apply bg-paper font-body text-ink;
@@ -4739,6 +4783,11 @@
     opacity: 1;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — COMPONENT CLASSES: Tailwind `@layer components` (#2890).
+   Shared card patterns read by every faction archetype.
+   ══════════════════════════════════════════════════════════════════════════ */
 
 @layer components {
   /* ── Shared card patterns ── */
@@ -5579,6 +5628,15 @@
      the token blocks above and below). `frontend/src/__tests__/snideWearsNoTape.test.ts`
      is what keeps it retired. */
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — FACTION CHROME, second run (#2890).
+   Backdrops, keyframe animation and per-faction card/detail/profile chrome,
+   ordered by commit history rather than grouped by faction — Ephemerists,
+   Singularity, Coven, WOW, Everymen, S.N.I.D.E. and Albescent all recur
+   more than once below. Interrupted once by the LAYOUT run marked further
+   down, then resumes.
+   ══════════════════════════════════════════════════════════════════════════ */
 
 /* ══════════════════════════════════════════════════════════════
    EPHEMERISTS BACKDROP — the page under the faction page and a
@@ -8926,6 +8984,12 @@
   }
 }
 
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — LAYOUT: task feed filter bar + requests queue (#2890).
+   Not faction-specific — shared filtering/queue chrome interrupting the
+   FACTION CHROME run above and below.
+   ══════════════════════════════════════════════════════════════════════════ */
+
 .filter-bar {
   border: 1px solid var(--color-border);
   border-radius: var(--space-md);
@@ -9647,6 +9711,11 @@
   }
 }
 
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — FACTION CHROME, second run resumes (#2890).
+   Per-faction profile-page identity chrome (Albescent, Coven, Ephemerists).
+   ══════════════════════════════════════════════════════════════════════════ */
+
 /* ── #1630: identity-header flair, one treatment per faction ────────────────
    Two of the seven are perpetual motions, so both live here behind the shared
    `prefers-reduced-motion: no-preference` guard rather than in an inline
@@ -9902,6 +9971,12 @@
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   SECTION — COMPONENT CLASSES: shared cross-faction utilities (#2890).
+   Disabled-control contrast (+ Singularity variant) and the metatask
+   picker's selection tick.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ══════════════════════════════════════════════════════════════════════════
    THE DISABLED PRIMARY ACTION (#2486)
 
    Ten controls in this tree start out disabled and one of them is the first
@@ -10050,6 +10125,10 @@
   color: var(--faction-default-card-bg);
   box-shadow: 0 0 0 2px var(--faction-default-card-bg);
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION — LAYOUT: settings page inventory panel (#2890).
+   ══════════════════════════════════════════════════════════════════════════ */
 
 /* ── SETTINGS · THE STORAGE INVENTORY'S SHAPE IS THE PANE'S CALL (#2824) ─────
    The eleven-row cookie/localStorage inventory was a three-column grid on every


### PR DESCRIPTION
## Summary

`frontend/src/index.css` is 10,088 lines (10,122 as of `origin/main` — PR #2898
landed `--switch-ring-hairline` an hour before this branch was cut) with zero
section markers. This PR adds 11 comment banners marking the boundaries that
already existed implicitly:

- **PRELUDE** — font-face import + Tailwind directives (this banner also
  carries the section map)
- **BASE TOKENS (light / theme-invariant)** — the `:root` / `:root,[data-theme]`
  blocks (color, spacing, type, motion, shadow, faction palette)
- **BASE TOKENS: DARK OVERRIDES** — the one large `[data-theme="dark"]` block
- **FACTION CHROME, first run** — Everymen/S.N.I.D.E./na component classes
  interleaved with more base-token blocks (motion durations, type scale, Task
  Crown, the cross-faction notice/alarm/credit family)
- **COMPONENT CLASSES: `@layer base`** and **`@layer components`**
- **FACTION CHROME, second run** — backdrops, keyframe animation, per-faction
  card/detail/profile chrome, in commit order rather than grouped by faction
- **LAYOUT: filter bar + requests queue** — the one non-faction interruption
  in the middle of that run
- **FACTION CHROME, second run resumes** — Albescent/Coven/Ephemerists profile
  chrome
- **COMPONENT CLASSES: shared cross-faction utilities** — disabled-control
  contrast + the metatask picker tick
- **LAYOUT: settings inventory panel**

This is the prefactor for #2891 (the actual split), part of epic #2862.

**No rule moved, no selector changed, not one byte of built output differs.**

## Not this ticket

- Restructuring faction paint (#2649), finding bytes (#2843), splitting the
  file (#2891) — none of those are touched here.

## Findings recorded but NOT fixed (per instructions — write down, don't fix)

- The banner boundaries are honest about the file's real shape, not a tidy
  one: "FACTION CHROME" runs twice, interrupted once by "LAYOUT" (the filter
  bar/requests queue block sits in the middle of otherwise faction-specific
  chrome), and within each FACTION CHROME run individual factions (Ephemerists,
  Singularity, Coven, WOW, Everymen, S.N.I.D.E., Albescent) recur multiple
  times rather than being grouped together — this reflects genuine commit
  history, not a mistake to fix here. Whoever picks up #2891 should decide
  whether the split gathers each faction's scattered fragments into one file
  or keeps today's interleaved order.
- Several `:root` blocks late in the file (~line 7716, 7744) are now almost
  entirely retired-token tombstone comments with very little live code left —
  candidates for #2843 (byte-finding), not touched here.

## How the "no rule moved" claim was verified

1. **Byte-identical build.** Built `vite build` with the banners in place,
   captured `dist/assets/index-*.css` and `dist/assets/factionFaces-*.css`
   (SHA-256: `e892679d...751efce` and `170e5e95...62df8f9`). Then
   `git stash` on just `index.css`, rebuilt from the un-bannered file, and
   compared: `diff` reported no differences and the SHA-256 hashes were
   **identical** for both CSS assets — even the content-hashed output
   filenames (`index-BqI1e9_O.css`) matched byte for byte.
2. **Diff shape.** `git diff --stat` shows `1 file changed, 79 insertions(+)`
   with **zero deletions**; every added line is either a comment or a blank
   line (confirmed by grepping the diff for non-comment `+` lines — there are
   none).
3. **Line endings / encoding.** Confirmed LF-only (no `\r`), UTF-8, no BOM,
   both before and after — the insertion script (deleted after use, not
   committed) wrote raw UTF-8 bytes joined on `\n`, never touching an existing
   line.

## CI (per `.github/workflows/test.yml`, `frontend` job)

- `eslint src .ds-kit e2e` — clean
- `tsc --noEmit` — clean
- `tsc -p tsconfig.e2e.json --noEmit` — clean
- `tsc -p tsconfig.design-sync.json --noEmit` — clean
- `vitest run` — 477 test files, 9924 passed / 1 skipped
- `vite build` — succeeds
- `node scripts/bundle-budget.mjs` — CSS line reports `ok` (21.9 KB, unchanged
  from before this PR, confirmed by the byte-identical build above); the JS
  line shows the pre-existing WARN, which is #2843's territory and untouched
  by this change.

(`test` and `api-schema` jobs don't apply — no backend/route/schema changes.)

## What to eyeball

Nothing should render any differently — literally: the built CSS is
byte-for-byte identical before and after this change, verified by SHA-256
above. **Visual QA is outstanding**, but for this PR specifically that's
because there is nothing visual to QA — a diff worth eyeballing here is
`git diff` itself (does each banner land at a sensible boundary, does the
prose read true), not the rendered app.

Closes #2890
