### PR TITLE
Close the homeTrackBand hole and convert the nine dual-census loops (#2815)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/ephemeristsCta.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsCta.test.tsx
@@ -27,8 +27,7 @@
  * nowhere else a CTA suite would look: #2144's chart net at 0.10 held the mount
  * until #2195 ruled one ornament per faction, and the gravity field took it.
  */
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
@@ -39,9 +38,9 @@ vi.mock("../../../hooks/useFormFactor", () => ({ useFormFactor: () => "desktop" 
 
 import EphemeristsTaskCard from "../../taskCard/EphemeristsTaskCard";
 import { aTask } from "../../../test/fixtures";
+import { sourceFiles, toRelative } from "../../../test/sourceScan";
 import { ruleBodies, stripComments } from "../../../utils/__tests__/cssVars";
 
-const SRC = fileURLToPath(new URL("../../..", import.meta.url));
 const CSS = stripComments(
   readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8"),
 );
@@ -185,16 +184,7 @@ describe("the CTA block is ONE column, rule and runes alike (#2724)", () => {
 });
 
 describe("every bordered plate CTA wears it, and the list is the assertion", () => {
-  const files: [string, string][] = [];
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === "__tests__") continue;
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (/\.tsx?$/.test(entry.name)) files.push([full, readFileSync(full, "utf8")]);
-    }
-  };
-  walk(SRC);
+  const files: [string, string][] = sourceFiles().map((path) => [path, readFileSync(path, "utf8")]);
 
   const WEARS = /className[=:]\s*[{`"']?[^"'`]*eph-cta/;
 
@@ -222,7 +212,7 @@ describe("every bordered plate CTA wears it, and the list is the assertion", () 
     // kit names this class in prose, and a census a comment can join is a
     // census nobody keeps.
       .filter(([, source]) => WEARS.test(source))
-      .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
+      .map(([path]) => toRelative(path));
     expect(mounts.sort()).toEqual([
       "components/selectCard/EphemeristsSelectCard.tsx",
       "components/taskCard/EphemeristsTaskCard.tsx",
@@ -243,7 +233,7 @@ describe("every bordered plate CTA wears it, and the list is the assertion", () 
       /border: (`2px solid \$\{BRASS\}`|"2px solid var\(--faction-ephemerists-plate-brass\)")/;
     const restating = files
       .filter(([, source]) => RESTATEMENT.test(source))
-      .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
+      .map(([path]) => toRelative(path));
     expect(restating).toEqual([]);
   });
 });

--- a/frontend/src/components/metataskSeal/__tests__/sealMasthead.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealMasthead.test.tsx
@@ -26,7 +26,8 @@
  * decoration: the band is a `<Link>`, so mounting it drags a router requirement
  * into every host that renders a seal.
  */
-import { readFileSync, readdirSync } from 'node:fs'
+import { basename } from 'node:path'
+import { readFileSync } from 'node:fs'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
@@ -35,22 +36,14 @@ import type { ReactElement } from 'react'
 import MetataskSeal from '../MetataskSeal'
 import { PraxisBody } from '../../praxisCard/desktop/shared'
 import praxisCopy from '../../../locales/en/praxis.json'
+import { FACTION_MANIFESTS } from '../../../factions'
 import { factionName } from '../../../utils/factions'
+import { sourceFiles } from '../../../test/sourceScan'
 import type { PraxisCardOut } from '../../../api/praxis'
 import type { TaskOut } from '../../../api/tasks'
 
 /** Every faction that can issue a metatask — all nine mount a band (#2648). */
-const SLUGS = [
-  'albescent',
-  'coven',
-  'ephemerists',
-  'everymen',
-  'na',
-  'singularity',
-  'snide',
-  'ua',
-  'wow',
-] as const
+const SLUGS = FACTION_MANIFESTS.map((manifest) => manifest.slug).sort()
 
 function metatask(slug: string): TaskOut {
   return {
@@ -160,7 +153,7 @@ describe('the band names the ISSUING faction, not the host card (#2648)', () => 
 })
 
 describe('no seal skin draws a faction label of its own (#2648)', () => {
-  const skins = readdirSync(SKINS).filter((file) => file.endsWith('.tsx'))
+  const skins = sourceFiles({ dir: SKINS, match: /\.tsx$/ }).map((path) => basename(path))
 
   it('finds all nine skins', () => {
     expect(skins).toHaveLength(9)
@@ -222,7 +215,7 @@ describe('every seal captions itself with the word the band cannot say', () => {
     })
   }
 
-  const skins = readdirSync(SKINS).filter((file) => file.endsWith('.tsx'))
+  const skins = sourceFiles({ dir: SKINS, match: /\.tsx$/ }).map((path) => basename(path))
 
   for (const file of skins) {
     it(`${file} draws the caption in its own hand`, () => {

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -11,8 +11,7 @@
  * SSR-only harness (renderToStaticMarkup, no DOM, effects never run), so these
  * are assertions about markup given props — never interaction.
  */
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
@@ -26,6 +25,7 @@ import EphemeristsPraxisCard from '../desktop/EphemeristsPraxisCard'
 import { GLYPHS } from '../../factionMarks/ephemeristsPlate'
 import MetataskSeal from '../../metataskSeal/MetataskSeal'
 import { factionName } from '../../../utils/factions'
+import { sourceFiles, stripComments } from '../../../test/sourceScan'
 
 /** The retired illuminated-codex family. None of it may reach a plate surface. */
 const CODEX = /--eph-[a-z]/
@@ -323,34 +323,17 @@ describe('one card, both form factors (ADR-0067)', () => {
  * ornament; grepping the tree costs nothing and catches the case rendering
  * cannot see, which is a NEW hand-copy appearing later.
  */
-const SKINS = fileURLToPath(new URL('../../..', import.meta.url))
 const KIT = fileURLToPath(new URL('../../factionMarks/ephemeristsPlate.tsx', import.meta.url))
 
 /**
  * Every shipped `.ts`/`.tsx` under `src/`, with comments stripped and tests
- * skipped. Both exclusions matter: the files that RETIRED a mark name it in
- * prose so the next reader knows it was deleted rather than mislaid, and this
- * very file names them in the assertions below.
+ * skipped (the shared walk — `sourceFiles()` skips `__tests__` by default).
+ * Both exclusions matter: the files that RETIRED a mark name it in prose so
+ * the next reader knows it was deleted rather than mislaid, and this very
+ * file names them in the assertions below.
  */
 function sources(): { path: string; source: string }[] {
-  const found: { path: string; source: string }[] = []
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === '__tests__') continue
-      const full = join(dir, entry.name)
-      if (entry.isDirectory()) walk(full)
-      else if (/\.tsx?$/.test(entry.name)) {
-        found.push({
-          path: full,
-          source: readFileSync(full, 'utf8')
-            .replace(/\/\*[\s\S]*?\*\//g, '')
-            .replace(/^\s*\/\/.*$/gm, ''),
-        })
-      }
-    }
-  }
-  walk(SKINS)
-  return found
+  return sourceFiles().map((path) => ({ path, source: stripComments(readFileSync(path, 'utf8')) }))
 }
 
 describe('one ornament vocabulary, and it is the notation band (#2210)', () => {

--- a/frontend/src/components/taskCard/__tests__/ephemeristsCompassRose.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/ephemeristsCompassRose.test.tsx
@@ -19,14 +19,14 @@
  * This file is deliberately its own, not an append to `taskCardsV3.test.tsx`:
  * six sibling faction passes are in flight against that shared table.
  */
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
 import i18n from '../../../i18n'
+import { sourceFiles } from '../../../test/sourceScan'
 
 const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
 
@@ -161,21 +161,9 @@ describe('the rose is drawn in exactly one file', () => {
   const KIT = fileURLToPath(
     new URL('../../factionMarks/ephemeristsPlate.tsx', import.meta.url),
   )
-  const SRC = fileURLToPath(new URL('../../..', import.meta.url))
 
   it('declares the needle path only in the kit', () => {
-    const found: string[] = []
-    const walk = (dir: string) => {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (entry.name === '__tests__') continue
-        const full = join(dir, entry.name)
-        if (entry.isDirectory()) walk(full)
-        else if (/\.tsx?$/.test(entry.name) && readFileSync(full, 'utf8').includes(NORTH)) {
-          found.push(full)
-        }
-      }
-    }
-    walk(SRC)
+    const found = sourceFiles().filter((path) => readFileSync(path, 'utf8').includes(NORTH))
     expect(found).toEqual([KIT])
   })
 })

--- a/frontend/src/components/taskCard/__tests__/everymenOneBurst.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/everymenOneBurst.test.tsx
@@ -27,7 +27,7 @@
  * look of the collapsed drawing on nine surfaces is visual QA and is stated as
  * outstanding on the PR.
  */
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ReactElement } from 'react'
@@ -43,6 +43,7 @@ import EverymenPraxisCard from '../../praxisCard/desktop/EverymenPraxisCard'
 import type { ArchetypeProps } from '../../praxisCard/desktop/shared'
 import { BackdropContext } from '../../backdrop/BackdropContext'
 import { aTask, aPraxisCard } from '../../../test/fixtures'
+import { sourceFiles, toRelative } from '../../../test/sourceScan'
 import { ruleBodies, stripComments } from '../../../utils/__tests__/cssVars'
 
 const SRC = fileURLToPath(new URL('../../../', import.meta.url))
@@ -53,16 +54,8 @@ const CONIC =
   'repeating-conic-gradient(from 0deg at 50% 50%, var(--em-burst-ray, var(--faction-everymen-bill-ray)) 0 5.2deg, transparent 5.2deg 10.4deg)'
 const MASK = 'radial-gradient(130% 100% at 50% 16%, #000 40%, transparent 96%)'
 
-function walk(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
-    entry.isDirectory() ? walk(join(dir, entry.name)) : [join(dir, entry.name)],
-  )
-}
-
 /** Every Everymen component in the tree — the surfaces that could re-draw it. */
-const EVERYMEN_SOURCES = walk(SRC).filter(
-  (path) => /Everymen/.test(path) && /\.tsx?$/.test(path) && !path.includes('__tests__'),
-)
+const EVERYMEN_SOURCES = sourceFiles().filter((path) => /Everymen/.test(path))
 
 const adminProps = {
   showAdminControls: false,
@@ -144,7 +137,7 @@ describe('Everymen draws ONE burst (#2195)', () => {
       const code = readFileSync(path, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
       expect(
         code,
-        `${path.slice(SRC.length)} draws its own conic — mount \`em-burst\` instead`,
+        `${toRelative(path)} draws its own conic — mount \`em-burst\` instead`,
       ).not.toContain('repeating-conic-gradient')
     }
   })

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -19,26 +19,21 @@
  * markup — a mis-wire surfaces there, not as a bare identity check here.
  */
 import { describe, it, expect } from 'vitest'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { join, relative, sep } from 'node:path'
-import { surfaceMap, SURFACE_KEYS } from '..'
+import { readFileSync } from 'node:fs'
+import { FACTION_MANIFESTS, surfaceMap, SURFACE_KEYS } from '..'
 import type { FactionSurface } from '..'
+import { sourceFiles, toRelative } from '../../test/sourceScan'
 
-/** Every non-test source module under `src`, as [path relative to src, text]. */
-function walkSource(root: string): Array<[string, string]> {
-  const files = (dir: string): string[] =>
-    readdirSync(dir).flatMap((entry) => {
-      const full = join(dir, entry)
-      return statSync(full).isDirectory() ? files(full) : [full]
-    })
-  return files(root)
-    .filter(
-      (path) =>
-        /\.tsx?$/.test(path) &&
-        !/\.test\.tsx?$/.test(path) &&
-        !path.includes(`${sep}__tests__${sep}`),
-    )
-    .map((path) => [relative(root, path), readFileSync(path, 'utf8')])
+/**
+ * Every non-test source module under `src`, as [path relative to src, text].
+ * The walk itself is the shared one (`sourceFiles` already skips `__tests__`
+ * dirs); the one thing that was ever different here is the extra filter for a
+ * stray `*.test.tsx` sitting outside a `__tests__` dir.
+ */
+function walkSource(): Array<[string, string]> {
+  return sourceFiles()
+    .filter((path) => !/\.test\.tsx?$/.test(path))
+    .map((path) => [toRelative(path), readFileSync(path, 'utf8')])
 }
 
 // The table asserts each surface's registry CONTENTS: a bespoke slug has an
@@ -56,9 +51,9 @@ function walkSource(root: string): Array<[string, string]> {
 // to the surface Default" would be asking na's row not to exist. What the row
 // meant is asserted where it is now true — `defaultManifest.test.tsx` pins each
 // of the twenty to the component this dispatcher used to name by hand.
-const ALL_SLUGS = [
-  'coven', 'snide', 'ephemerists', 'singularity', 'everymen', 'ua', 'wow', 'albescent',
-]
+const ALL_SLUGS = FACTION_MANIFESTS.map((manifest) => manifest.slug).filter(
+  (slug) => slug !== 'na',
+)
 
 // The six with a full bespoke treatment. (They HAD a bespoke desktop skin and a
 // separate bespoke phone one on several surfaces; ADR-0056/0058/0061/0065/0067
@@ -316,7 +311,7 @@ describe('WOW is bespoke on every core surface, never the Default', () => {
  * — by the time `pickVariant` has an object, the injected key is
  * indistinguishable from a registered one.
  */
-const CALL_SITES = walkSource(join(process.cwd(), 'src'))
+const CALL_SITES = walkSource()
 const READS_SURFACE_MAP = CALL_SITES.filter(([, text]) => text.includes('surfaceMap('))
 
 describe('every dispatcher reads surfaceMap() whole (#2529)', () => {

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, join, relative, sep } from 'node:path'
+import { basename, dirname, join, relative } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import i18n from '../../i18n'
 import common from '../en/common.json'
@@ -12,6 +12,7 @@ import taunts from '../en/taunts.json'
 import votes from '../en/votes.json'
 import { findDuplicateJsonKeys } from './findDuplicateJsonKeys'
 import { factionName } from '../../utils/factions'
+import { sourceFiles, toRelative } from '../../test/sourceScan'
 
 // Factions with a vote voice (per-faction tier labels). Kept as an explicit
 // list, mirroring the seed catalog this test was ported from. Albescent is not
@@ -296,13 +297,12 @@ function catalogLeaves(): Array<[string, string]> {
     }
     return []
   }
-  return readdirSync(dir)
-    .filter((entry) => entry.endsWith('.json'))
-    .flatMap((entry) =>
-      walk(JSON.parse(readFileSync(join(dir, entry), 'utf8')), []).map(
-        ([key, value]) => [`${entry}:${key}`, value] as [string, string],
-      ),
+  return sourceFiles({ dir, match: /\.json$/ }).flatMap((path) => {
+    const entry = basename(path)
+    return walk(JSON.parse(readFileSync(path, 'utf8')), []).map(
+      ([key, value]) => [`${entry}:${key}`, value] as [string, string],
     )
+  })
 }
 
 /**
@@ -642,10 +642,7 @@ describe('no duplicate keys in any locale catalog', () => {
   // cannot catch it — we scan the raw file text instead. Guard for #670.
   const localesDir = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-  // recursive + no withFileTypes → path strings; the cast drops the string|Buffer union.
-  const jsonFiles = (readdirSync(localesDir, { recursive: true }) as string[])
-    .filter((entry) => entry.endsWith('.json'))
-    .map((entry) => join(localesDir, entry))
+  const jsonFiles = sourceFiles({ dir: localesDir, match: /\.json$/ })
 
   it('finds catalog files to scan', () => {
     // Fails loudly if the glob ever silently matches nothing (moved dir, etc.).
@@ -1226,10 +1223,9 @@ const INTERPOLATED_KEYS = new Set(
 
 /** Every `.ts`/`.tsx` under `src` that ships, src-relative and slash-separated. */
 function shippedSources(): string[] {
-  return readdirSync(SRC_ROOT, { recursive: true, encoding: 'utf8' })
-    .map((name) => name.split(sep).join('/'))
-    .filter((name) => /\.tsx?$/.test(name))
-    .filter((name) => !name.includes('__tests__/') && !name.startsWith('locales/'))
+  return sourceFiles()
+    .map((path) => toRelative(path))
+    .filter((name) => !name.startsWith('locales/'))
 }
 
 /**

--- a/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
+++ b/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
@@ -20,11 +20,12 @@
  * Both read the catalog and the source tree rather than any rendered markup —
  * the harness has no DOM, and the words are what changed.
  * ========================================================================== */
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, extname, join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import i18n from '../../i18n'
+import { sourceFiles as walkSource, toRelative } from '../../test/sourceScan'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const EN = join(HERE, '..', 'en')
@@ -42,13 +43,12 @@ function catalogLeaves(): Array<[string, string]> {
     }
     return []
   }
-  return readdirSync(EN)
-    .filter((entry) => entry.endsWith('.json'))
-    .flatMap((entry) =>
-      walk(JSON.parse(readFileSync(join(EN, entry), 'utf8')), []).map(
-        ([key, value]) => [`${entry.replace(/\.json$/, '')}:${key}`, value] as [string, string],
-      ),
+  return walkSource({ dir: EN, match: /\.json$/ }).flatMap((path) => {
+    const entry = path.slice(EN.length + 1)
+    return walk(JSON.parse(readFileSync(path, 'utf8')), []).map(
+      ([key, value]) => [`${entry.replace(/\.json$/, '')}:${key}`, value] as [string, string],
     )
+  })
 }
 
 /**
@@ -248,15 +248,14 @@ describe('the 40 per-faction key families are one shared string each (#1911)', (
 /**
  * Every `.ts`/`.tsx` under `src/`, minus the generated API client and the
  * ambient declarations — `i18next.d.ts` documents the call shape with a literal
- * example key, which is prose, not a lookup.
+ * example key, which is prose, not a lookup. `__tests__` stays IN, unlike the
+ * shared walk's default: this sweep wants every `t()` call in the tree,
+ * fixtures included, not just what ships.
  */
 function sourceFiles(dir: string): string[] {
-  return readdirSync(dir).flatMap((entry) => {
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) return entry === 'generated' ? [] : sourceFiles(full)
-    if (entry.endsWith('.d.ts')) return []
-    return ['.ts', '.tsx'].includes(extname(entry)) ? [full] : []
-  })
+  return walkSource({ dir, includeTests: true })
+    .filter((path) => !toRelative(path).split('/').includes('generated'))
+    .filter((path) => !path.endsWith('.d.ts'))
 }
 
 /**

--- a/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/joinControlOrder.test.tsx
@@ -41,15 +41,17 @@
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { join, sep } from 'node:path'
+import { join } from 'node:path'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
 import { FACTION_MANIFESTS } from '../../../factions'
 import type { FactionDetailState, Membership } from '../useFactionDetail'
 import type { CharacterOut } from '../../../api/auth'
 import { JoinConfirm, type JoinControlSkin } from '../../../components/JoinControl'
+import { sourceFiles as walkSource, toRelative } from '../../../test/sourceScan'
 
 const mocks = vi.hoisted(() => ({
   formFactor: 'desktop' as 'mobile' | 'desktop',
@@ -225,7 +227,7 @@ describe('the join pair keeps #646 order on every faction', () => {
 })
 
 describe('no faction body writes the trio itself', () => {
-  const bodies = readdirSync(ARCHETYPES).filter((name) => name.endsWith('.tsx'))
+  const bodies = walkSource({ dir: ARCHETYPES, match: /\.tsx$/ }).map((path) => basename(path))
 
   it('finds the archetypes it means to scan', () => {
     expect(bodies.length).toBeGreaterThanOrEqual(9)
@@ -253,9 +255,7 @@ const SRC = fileURLToPath(new URL('../../..', import.meta.url))
 
 /** Every `.ts`/`.tsx` under `src`, src-relative and slash-separated. */
 function sourceFiles(): string[] {
-  return readdirSync(SRC, { recursive: true, encoding: 'utf8' })
-    .map((name) => name.split(sep).join('/'))
-    .filter((name) => /\.tsx?$/.test(name))
+  return walkSource({ dir: SRC, includeTests: true }).map((path) => toRelative(path))
 }
 
 function read(name: string): string {

--- a/frontend/src/pages/fieldDesk/__tests__/homeTrackBand.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/homeTrackBand.test.tsx
@@ -44,6 +44,7 @@ vi.mock('../../../api/me', () => ({
 
 // Imported after the mocks are registered.
 import FieldDesk from '../../FieldDesk'
+import { surfaceMap } from '../../../factions'
 
 function currentUser(faction_slug: string): CurrentUser {
   const character: CharacterOut = {
@@ -98,10 +99,16 @@ function render(faction_slug: string): string {
 }
 
 // Every mobile home skin paints the same track; a per-faction skin that grew
-// its own arithmetic is the defect one level up, so all eight are checked.
-const SKINS = ['na', 'coven', 'snide', 'wow', 'ua', 'everymen', 'singularity', 'ephemerists']
+// its own arithmetic is the defect one level up, so every registered skin —
+// all nine, including Albescent's DefaultFieldDesk wrapper (#2815) — is
+// checked. Derived from the manifest so a tenth kit is covered by existing.
+const SKINS = Object.keys(surfaceMap('mobileFieldDesk'))
 
 describe('the home level track', () => {
+  it('covers every skin the app can dispatch mobileFieldDesk to', () => {
+    expect(SKINS).toHaveLength(9)
+  })
+
   it.each(SKINS)('fills against the current band on the %s home', (slug) => {
     const html = render(slug)
     expect(html).toContain('width:9.375%')

--- a/frontend/src/test/__tests__/loopListsAreDerived.test.ts
+++ b/frontend/src/test/__tests__/loopListsAreDerived.test.ts
@@ -3,15 +3,17 @@
  *
  * A parameterised test looks exhaustive. Whether it is depends entirely on the
  * list it loops, and a hand-typed list is a population someone has to remember
- * to update. `pages/fieldDesk/__tests__/homeTrackBand.test.tsx` types eight
- * slugs under a comment reading "so all eight are checked" — there are nine, and
- * `AlbescentFieldDesk` is registered on `mobileFieldDesk`. The claim outlived the
- * list, which is worse than no claim at all.
+ * to update. `pages/fieldDesk/__tests__/homeTrackBand.test.tsx` USED TO type
+ * eight slugs under a comment reading "so all eight are checked" — there were
+ * nine, and `AlbescentFieldDesk` is registered on `mobileFieldDesk`. The claim
+ * outlived the list, which is worse than no claim at all; #2815 converted it,
+ * so it is gone from GRANDFATHERED below and the tripwire now watches a
+ * different survivor.
  *
  * WHAT THIS GUARD DOES NOT SAY. Not every slug array is wrong. A fixture, a
  * contrast pair table, an expected-order assertion — those name slugs because
  * the slugs ARE the subject. Sixty-one test files hold a slug array; only the
- * twenty-five below drive a `.each`, and only those are making a completeness
+ * ones below drive a `.each`, and only those are making a completeness
  * claim. This guard is narrow on purpose.
  *
  * TYPING IS SOMETIMES RIGHT, AND THE EXCEPTION MATTERS.
@@ -22,10 +24,10 @@
  * own subject proves nothing. So the rule is not "always derive" — it is
  * "derive, or be on this list having said why".
  *
- * THIS IS A RATCHET. The twenty-five entries below are grandfathered: they exist
- * today and #2815 converts them. The guard's job is that the twenty-sixth cannot
- * appear quietly. Removing an entry as it is converted is the intended direction;
- * adding one needs a reason in the review, not just a green suite.
+ * THIS IS A RATCHET. The entries below are grandfathered: they exist today and
+ * #2815 is converting them, a few per PR. The guard's job is that a new one
+ * cannot appear quietly. Removing an entry as it is converted is the intended
+ * direction; adding one needs a reason in the review, not just a green suite.
  */
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -66,7 +68,6 @@ const GRANDFATHERED: ReadonlySet<string> = new Set([
   'pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx|SLUGS',
   'pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx|SLUGS',
   'pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx|SLUGS',
-  'pages/fieldDesk/__tests__/homeTrackBand.test.tsx|SKINS',
   'pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx|WALL_ALARM',
   'pages/tasks/__tests__/equalHeightRow.test.tsx|SKINS',
 ])
@@ -101,8 +102,11 @@ describe('a list driving per-kit iteration is derived from the manifest', () => 
   // so a scanner that silently stopped matching would report a perfect board.
   it('still finds the typed lists it is meant to be watching', () => {
     expect(TYPED.length, 'the scan matched nothing — the regexes have drifted').toBeGreaterThan(15)
-    expect(TYPED, 'the known worst case must still be visible to the scan').toContain(
-      'pages/fieldDesk/__tests__/homeTrackBand.test.tsx|SKINS',
+    // homeTrackBand (the issue's worked example) converted in #2815 and its
+    // GRANDFATHERED entry came off with it. Any still-typed survivor works as
+    // the tripwire; equalHeightRow is one #2815 left for a later pass.
+    expect(TYPED, 'the scan must still see a known typed list').toContain(
+      'pages/tasks/__tests__/equalHeightRow.test.tsx|SKINS',
     )
   })
 


### PR DESCRIPTION
## Summary

- `pages/fieldDesk/__tests__/homeTrackBand.test.tsx` typed eight mobile-home skins under a comment claiming "all eight are checked" — there are nine, and `AlbescentFieldDesk` (`factions/albescent.ts` `mobileFieldDesk` row, which wraps `DefaultFieldDesk` whole) was the missing one. `SKINS` now derives from `Object.keys(surfaceMap('mobileFieldDesk'))`, with a `toHaveLength(9)` tripwire, so a tenth kit is covered by existing rather than by someone remembering to edit this file.
- The nine files #2862 flagged as holding **both** a typed slug list **and** a private recursive filesystem walk get both fixes in one edit, per the issue's instruction that this issue owns them for both censuses:
  - `components/factionMarks/__tests__/ephemeristsCta.test.tsx`
  - `components/metataskSeal/__tests__/sealMasthead.test.tsx`
  - `components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx`
  - `components/taskCard/__tests__/ephemeristsCompassRose.test.tsx`
  - `components/taskCard/__tests__/everymenOneBurst.test.tsx`
  - `factions/__tests__/surfaceDispatch.test.ts`
  - `locales/__tests__/catalog.test.ts`
  - `locales/__tests__/factionCopyCollapse.test.ts`
  - `pages/factionDetail/__tests__/joinControlOrder.test.tsx`

  Each private `readdirSync`/recursive-walk implementation now imports `sourceFiles()`/`toRelative()` from `src/test/sourceScan.ts`. Where a file also had a typed slug list that **drove iteration** (`sealMasthead`'s `SLUGS`, `surfaceDispatch`'s `ALL_SLUGS`), it now derives from `FACTION_MANIFESTS`. `joinControlOrder.test.tsx`'s `SLUGS` was already derived — only its two private walks needed the swap.

- `src/test/__tests__/loopListsAreDerived.test.ts` (the ratchet): `homeTrackBand`'s `GRANDFATHERED` entry is deleted, and the tripwire now watches `equalHeightRow` (a still-typed survivor) instead, since the old tripwire target no longer appears in the scan once converted.

## What was deliberately left typed, and why

- `factions/__tests__/surfaceDispatch.test.ts`'s `BESPOKE` per-surface arrays, `REFERENCE_FACTIONS`, and the `no duplicate keys` / `#1863` / `#1948` / `#1909` / `#1910` allowlists in the two `locales` files — these are the **subject** of their assertions (which slugs are bespoke, which strings are voiced, which keys are deliberately retired), not a population being iterated for completeness. Deriving them from their own subject would be the tautology `defaultManifest.test.tsx` already warns against.
- `sealMasthead.test.tsx`'s shallow `readdirSync` over its own `skins/` directory (enumerating skin files, not a recursive tree walk) is now routed through `sourceFiles({ dir, match })` too, for consistency, but this was a directory listing intrinsic to the test's own job rather than a duplicate of the shared walk.

## Remaining scope (not in this PR)

Per the issue, this is a partial PR. 24 typed lists in `GRANDFATHERED` remain unconverted: `feedRow`, `invitationPerks`, `collabCopy`, `commentFootRule`, `mentionPopoverClip`, `factionWordmarkWrap`, `feedRowInk`, `bylineDivider`, `praxisMasthead`, `pointsMarkUnification`, `factionSigil`, `factionTaskCardsV2`, `mastheadFactionLink`, `mobileCardFillsColumn`, `taskCardsV3`, `placeholderInk`, `singularityCreateCharacterRegister`, `factionProfileBody`, `profileAbout`, `collabSignals`, `composerDispatch`, `taskSlipLink`, `detailWallAlarmInk`, `equalHeightRow`. A follow-up PR converts these.

## Verification

- `tsc --noEmit`, `tsc -p tsconfig.design-sync.json --noEmit`, `tsc -p tsconfig.e2e.json --noEmit`: clean.
- `eslint src .ds-kit e2e`: clean.
- `vitest run`: 477 files / 9926 tests passed, 1 pre-existing skip.
- `vite build`: succeeds (pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` warning on `FactionSigil`, unrelated to this change).
- Seam tested at: each converted test file's own suite (rendered-markup/source-scan assertions), plus the shared `loopListsAreDerived` ratchet.

## What to eyeball

- No visual/runtime surface changed — this PR only touches test files (slug-list derivation and filesystem-walk plumbing). **Visual QA is not applicable**; nothing here should change any rendered output.
- Worth a second pair of eyes on the `homeTrackBand` conversion specifically: confirm `AlbescentFieldDesk`'s wrapper-over-`DefaultFieldDesk` behavior really does paint the same `width:9.375%` track math as the other eight skins (the test asserts this, and it passed, but it's the one conversion that changes *which* faction now gets exercised, not just how the list is built).
- `GRANDFATHERED`'s new tripwire target (`equalHeightRow`) — confirm it stays typed/present until a follow-up PR converts it, or the tripwire test will need repointing again.

Part of #2815