### PR TITLE
Extract the era-gate leaf: nine level unlocks become named predicates

### DIFF
--- a/backend/services/character_capabilities.py
+++ b/backend/services/character_capabilities.py
@@ -22,8 +22,15 @@ Design choices:
 from dataclasses import dataclass
 
 from game_config import CURRENT_ERA, EraConfig
+from services.era_gates import (
+    may_apply_metatask,
+    may_comment,
+    may_propose_metatask,
+    may_propose_task,
+    may_see_pending_tasks,
+    may_see_retired_tasks,
+)
 from services.level_jump import available_level_reach, faction_level_jump_reach
-from services.meta_task import faction_bypasses_metatask_level
 
 
 @dataclass(frozen=True)
@@ -72,13 +79,6 @@ def compute_capabilities(
     level_jump_used_at_level: int | None = None,
 ) -> CharacterCapabilities:
     granted_reach = faction_level_jump_reach(faction_slug, era)
-    # Stated once, before the three returns, because it is the same answer in
-    # all of them: the faction bypass alone is enough, so an Albescent member
-    # below the level still gets True (#1973).
-    can_apply_metatask = character_level is not None and (
-        faction_bypasses_metatask_level(faction_slug, era)
-        or character_level >= era.metatask_apply_level
-    )
     # Level 0 is the tutorial state, and it has precisely one thing to do: a
     # character reaches level 1 *by* signing up for the game-wide level-0
     # onboarding task and posting a praxis for it (era_1.py, level profiles).
@@ -97,53 +97,36 @@ def compute_capabilities(
             > 0
         )
 
-    if is_admin:
-        return CharacterCapabilities(
-            can_propose_task=True,
-            can_propose_metatask=True,
-            can_see_retired_tasks=True,
-            can_see_pending_tasks=True,
-            can_comment=True,
-            can_apply_metatask=can_apply_metatask,
-            level_jump_reach=granted_reach,
-            level_jump_available=jump_available,
-            task_browse_defaults_to_eligible=browse_defaults_to_eligible,
-        )
-
-    if character_level is None:
-        return CharacterCapabilities(
-            can_propose_task=False,
-            can_propose_metatask=False,
-            can_see_retired_tasks=False,
-            can_see_pending_tasks=False,
-            can_comment=False,
-            can_apply_metatask=False,
-            level_jump_reach=granted_reach,
-            level_jump_available=False,
-            task_browse_defaults_to_eligible=browse_defaults_to_eligible,
-        )
-
+    # Every threshold comparison below is stated exactly once, in
+    # ``services.era_gates`` — this function only wires character state onto
+    # the named predicate for each unlock (#2867). ``is_admin`` and
+    # ``character_level is None`` are each predicate's own concern (see that
+    # module's docstrings for which gates admin bypasses and which it does
+    # not — ``may_apply_metatask`` deliberately does not).
     return CharacterCapabilities(
-        can_propose_task=character_level >= era.level_to_propose_task,
-        can_propose_metatask=character_level >= era.level_to_propose_metatask,
-        # Both thresholds are enforced by ``services.task.list_tasks``, which is
-        # what makes these two flags honest. They were not: retired was gated
-        # here and by nothing there (anonymous callers could read the archive),
-        # and pending was gated here by level but there by ``is_admin`` alone
-        # (#1672), so a level-3 player was offered a filter tab that always
-        # answered nothing.
-        #
-        # The faction clause mirrors the same clause in ``list_tasks`` — a
-        # faction the era lets work retired tasks can reach them from level 0,
-        # so the tab must be offered from level 0 too, or the flag is lying
-        # again in the other direction.
-        can_see_retired_tasks=(
-            character_level >= era.level_to_see_retired_tasks
-            or faction_slug in era.allow_praxis_on_retired_task_factions
+        can_propose_task=may_propose_task(
+            character_level, faction_slug, is_admin, era
         ),
-        can_see_pending_tasks=character_level >= era.level_to_see_pending_tasks,
-        can_comment=character_level >= era.comment_level_required,
-        can_apply_metatask=can_apply_metatask,
+        can_propose_metatask=may_propose_metatask(
+            character_level, faction_slug, is_admin, era
+        ),
+        # Enforced by ``services.task.list_tasks``, which is what makes these
+        # two flags honest. They were not: retired was gated here and by
+        # nothing there (anonymous callers could read the archive), and
+        # pending was gated here by level but there by ``is_admin`` alone
+        # (#1672), so a level-3 player was offered a filter tab that always
+        # answered nothing. The two enforcement sites still restate these
+        # clauses today — #2868 repoints them onto the same predicates.
+        can_see_retired_tasks=may_see_retired_tasks(
+            character_level, faction_slug, is_admin, era
+        ),
+        can_see_pending_tasks=may_see_pending_tasks(
+            character_level, faction_slug, is_admin, era
+        ),
+        can_comment=may_comment(character_level, faction_slug, is_admin, era),
+        can_apply_metatask=may_apply_metatask(
+            character_level, faction_slug, is_admin, era
+        ),
         level_jump_reach=granted_reach,
         level_jump_available=jump_available,
         task_browse_defaults_to_eligible=browse_defaults_to_eligible,

--- a/backend/services/era_gates.py
+++ b/backend/services/era_gates.py
@@ -1,0 +1,203 @@
+"""The nine level-gate predicates, named and stated exactly once (#2867).
+
+Every level gate in the game was written twice — once in
+``services.character_capabilities`` to *advertise* the action, once in
+whichever service enforces it — joined only by a comment ("mirrors the same
+clause in ``list_tasks``"). #1672 is what that drift costs: anonymous callers
+could read the retired-task archive, and a level-3 player was offered a
+pending-tasks filter tab that always answered nothing, because the two sides
+disagreed and nothing caught it.
+
+This module is the one statement of each gate. Every predicate here is a pure
+function of ``(level, faction_slug, is_admin, era)`` — no DB, no session, no
+character/stats row — so both the *advertise* side (``/auth/me`` capability
+flags) and, in #2868, the *enforce* side can read the same answer.
+
+**This module must stay a leaf.** ``character_capabilities`` is imported by
+``services.current_user``, the auth dependency that runs on every request.
+Importing, say, ``services.task`` (which already imports ``services.praxis``,
+the heaviest module in the backend) to reuse its existing
+``viewer_sees_pending_tasks`` would drag that whole graph into the auth path
+for every request, admin or anonymous. So this module imports ``game_config``
+and nothing else — not even the sibling helpers in ``services.level_jump`` or
+``services.meta_task``, which are themselves leaves but still one hop further
+than this needs. Where a predicate here needs a faction perk (metatask
+apply's bypass, retired-tasks' archive perk), it reads ``era.factions``
+directly rather than importing the service that also reads it.
+
+Nine era fields, nine predicates — but only six get repointed here:
+
+- ``level_to_propose_task``, ``level_to_propose_metatask``,
+  ``level_to_see_retired_tasks``, ``level_to_see_pending_tasks``,
+  ``comment_level_required``, ``metatask_apply_level`` — all six are
+  advertised inline in ``character_capabilities.compute_capabilities`` today,
+  so this PR repoints that one file onto the predicates below.
+- ``collaboration_level_required`` and ``duel_level_required`` — both sites
+  for each live in ``praxis.py`` / ``duel.py``, files this ticket does not
+  touch (enforcement moves in #2868). Their predicates are included here,
+  unwired, as a pure level floor matching today's enforcement
+  (``services.praxis.available_creation_modes``,
+  ``services.duel.accept_duel``/``create_duel_challenge``) — no admin or
+  faction bypass exists at either site today.
+- ``albescent_level_required`` is deliberately **not** given a predicate here.
+  Its two sites read the SAME era field in OPPOSITE directions for two
+  different questions: ``services.character.character_earns_albescent``
+  (character.py:209) is a floor ("has this life, plus a DB-backed
+  covers-every-faction check, earned the door") and
+  ``services.faction_service`` (faction_service.py:248) is a ceiling ("this
+  life's climb must still be ahead of it — the only maximum-level gate in the
+  game"). The floor question is not answerable without a session (it unions
+  two tables against the character's history), so it does not fit the pure
+  ``(level, faction_slug, is_admin, era)`` shape this module promises. Forcing
+  a partial predicate here would invite #2868 to reuse it as the whole rule
+  when it is at most half of one. Left to #2868 to reconcile with a session
+  in hand.
+"""
+from game_config import CURRENT_ERA, EraConfig
+
+
+def may_propose_task(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.level_to_propose_task`` — admin bypasses, no character never meets it."""
+    if is_admin:
+        return True
+    if level is None:
+        return False
+    return level >= era.level_to_propose_task
+
+
+def may_propose_metatask(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.level_to_propose_metatask`` — admin bypasses, no character never meets it."""
+    if is_admin:
+        return True
+    if level is None:
+        return False
+    return level >= era.level_to_propose_metatask
+
+
+def may_see_retired_tasks(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.level_to_see_retired_tasks`` OR the archive-access faction perk.
+
+    The faction clause (#1672) is not an exception to the level gate, it is the
+    only way the perk means anything: a faction the era lets work retired tasks
+    cannot be forbidden from finding them. Reads ``era.allow_praxis_on_retired_task_factions``
+    directly, matching ``services.task.list_tasks``'s ``viewer_sees_retired``
+    clause exactly (``skip_level_check or level >= threshold or faction in
+    the set``, with ``is_admin`` this module's name for ``skip_level_check``
+    and ``level is None`` this module's shape for "no viewer").
+    """
+    if is_admin:
+        return True
+    if level is not None and level >= era.level_to_see_retired_tasks:
+        return True
+    return faction_slug in era.allow_praxis_on_retired_task_factions
+
+
+def may_see_pending_tasks(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.level_to_see_pending_tasks`` — admins watch the moderation queue too.
+
+    Matches today's enforcement (``services.task.viewer_sees_pending_tasks``)
+    exactly: ``is_admin or level >= threshold``. #2863 (not yet landed) may
+    revisit whether the advertised side should agree with a faction bypass;
+    until it does, this predicate states the rule as both sides implement it
+    today.
+    """
+    if is_admin:
+        return True
+    if level is None:
+        return False
+    return level >= era.level_to_see_pending_tasks
+
+
+def may_comment(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.comment_level_required`` — admin bypasses, no character never meets it."""
+    if is_admin:
+        return True
+    if level is None:
+        return False
+    return level >= era.comment_level_required
+
+
+def may_apply_metatask(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.metatask_apply_level`` OR the faction bypass — NOT short-circuited by admin.
+
+    Unlike every predicate above, ``is_admin`` does not bypass this one:
+    ``services.praxis_metatask.apply_metatask`` has no admin escape hatch, so
+    True here would offer an admin a control the API answers 403 to (#1973).
+    The faction clause reads ``era.factions[...].can_apply_metatask_at_any_level``
+    directly — the same field ``services.meta_task.faction_bypasses_metatask_level``
+    reads — rather than importing that helper, which would pull in
+    ``services.meta_task``'s SQLAlchemy/model imports for no reason a pure
+    predicate needs.
+    """
+    if level is None:
+        return False
+    faction = era.factions.get(faction_slug) if faction_slug is not None else None
+    if faction is not None and faction.can_apply_metatask_at_any_level:
+        return True
+    return level >= era.metatask_apply_level
+
+
+def may_create_collab_praxis(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.collaboration_level_required`` — a flat floor, no admin/faction bypass today.
+
+    Matches ``services.praxis.available_creation_modes``'s
+    ``character_level >= era.collaboration_level_required`` clause. Not yet
+    read by any caller — both the advertise and enforce sites live in
+    ``praxis.py``, which is out of scope for this ticket (#2868).
+    """
+    if level is None:
+        return False
+    return level >= era.collaboration_level_required
+
+
+def may_create_duel(
+    level: int | None,
+    faction_slug: str | None,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """``era.duel_level_required`` — a flat floor, no admin/faction bypass today.
+
+    Matches the identical checks in ``services.duel`` at both the challenge
+    (create) and accept sites: ``stats.level < era.duel_level_required`` ->
+    403. Not yet read by any caller — both sites live in ``duel.py``, which is
+    out of scope for this ticket (#2868).
+    """
+    if level is None:
+        return False
+    return level >= era.duel_level_required

--- a/backend/services/era_gates.py
+++ b/backend/services/era_gates.py
@@ -37,8 +37,8 @@ Nine era fields, nine predicates — but only six get repointed here:
   touch (enforcement moves in #2868). Their predicates are included here,
   unwired, as a pure level floor matching today's enforcement
   (``services.praxis.available_creation_modes``,
-  ``services.duel.accept_duel``/``create_duel_challenge``) — no admin or
-  faction bypass exists at either site today.
+  ``services.duel.issue_duel_challenge``/``respond_to_duel_challenge``) — no
+  admin or faction bypass exists at either site today.
 - ``albescent_level_required`` is deliberately **not** given a predicate here.
   Its two sites read the SAME era field in OPPOSITE directions for two
   different questions: ``services.character.character_earns_albescent``

--- a/backend/services/era_gates.py
+++ b/backend/services/era_gates.py
@@ -76,7 +76,7 @@ def may_propose_metatask(
     is_admin: bool,
     era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """``era.level_to_propose_metatask`` — admin bypasses, no character never meets it."""
+    """``era.level_to_propose_metatask`` — admin bypasses, no character meets it."""
     if is_admin:
         return True
     if level is None:
@@ -94,11 +94,12 @@ def may_see_retired_tasks(
 
     The faction clause (#1672) is not an exception to the level gate, it is the
     only way the perk means anything: a faction the era lets work retired tasks
-    cannot be forbidden from finding them. Reads ``era.allow_praxis_on_retired_task_factions``
-    directly, matching ``services.task.list_tasks``'s ``viewer_sees_retired``
-    clause exactly (``skip_level_check or level >= threshold or faction in
-    the set``, with ``is_admin`` this module's name for ``skip_level_check``
-    and ``level is None`` this module's shape for "no viewer").
+    cannot be forbidden from finding them. Reads
+    ``era.allow_praxis_on_retired_task_factions`` directly, matching
+    ``services.task.list_tasks``'s ``viewer_sees_retired`` clause exactly
+    (``skip_level_check or level >= threshold or faction in the set``, with
+    ``is_admin`` this module's name for ``skip_level_check`` and ``level is
+    None`` this module's shape for "no viewer").
     """
     if is_admin:
         return True
@@ -148,7 +149,7 @@ def may_apply_metatask(
     is_admin: bool,
     era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """``era.metatask_apply_level`` OR the faction bypass — NOT short-circuited by admin.
+    """``era.metatask_apply_level`` OR the faction bypass — admin does not bypass.
 
     Unlike every predicate above, ``is_admin`` does not bypass this one:
     ``services.praxis_metatask.apply_metatask`` has no admin escape hatch, so
@@ -173,7 +174,7 @@ def may_create_collab_praxis(
     is_admin: bool,
     era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """``era.collaboration_level_required`` — a flat floor, no admin/faction bypass today.
+    """``era.collaboration_level_required`` — a flat floor, no bypass today.
 
     Matches ``services.praxis.available_creation_modes``'s
     ``character_level >= era.collaboration_level_required`` clause. Not yet

--- a/backend/tests/unit/test_era_gates.py
+++ b/backend/tests/unit/test_era_gates.py
@@ -1,0 +1,159 @@
+"""Unit tests for services.era_gates — the nine level-gate predicates (#2867).
+
+Pure functions, no DB, no fixtures. Era passed explicitly (``ERA_1``), never
+``CURRENT_ERA``, per the per-era rules pattern (#2709, ``CONTEXT.md``). No
+faction is named for a rule that holds in every era — only the two fields
+that carry a real faction clause (retired-task archive access, metatask
+apply bypass) name one.
+"""
+from dataclasses import replace
+
+import pytest
+
+from game_config import ERA_1
+from services.era_gates import (
+    may_apply_metatask,
+    may_comment,
+    may_create_collab_praxis,
+    may_create_duel,
+    may_propose_metatask,
+    may_propose_task,
+    may_see_pending_tasks,
+    may_see_retired_tasks,
+)
+
+# Era 1 thresholds exercised below: propose_task=3, propose_metatask=5,
+# see_retired=2, see_pending=3, comment=2, metatask_apply=5, collab=1, duel=2.
+
+
+# --- admin-bypassed floors: propose_task / propose_metatask / see_pending / comment
+
+@pytest.mark.parametrize(
+    "predicate,threshold_field",
+    [
+        (may_propose_task, "level_to_propose_task"),
+        (may_propose_metatask, "level_to_propose_metatask"),
+        (may_see_pending_tasks, "level_to_see_pending_tasks"),
+        (may_comment, "comment_level_required"),
+    ],
+)
+def test_floor_gates_meet_and_miss_the_threshold(predicate, threshold_field) -> None:
+    threshold = getattr(ERA_1, threshold_field)
+    assert predicate(threshold - 1, None, False, ERA_1) is False
+    assert predicate(threshold, None, False, ERA_1) is True
+    assert predicate(threshold + 1, None, False, ERA_1) is True
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [may_propose_task, may_propose_metatask, may_see_pending_tasks, may_comment],
+)
+def test_floor_gates_no_character_is_false(predicate) -> None:
+    assert predicate(None, None, False, ERA_1) is False
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [may_propose_task, may_propose_metatask, may_see_pending_tasks, may_comment],
+)
+def test_floor_gates_admin_bypasses_even_with_no_character(predicate) -> None:
+    assert predicate(0, None, True, ERA_1) is True
+    assert predicate(None, None, True, ERA_1) is True
+
+
+# --- retired tasks: threshold OR the archive-access faction perk -----------
+
+def test_retired_tasks_meets_and_misses_the_threshold() -> None:
+    threshold = ERA_1.level_to_see_retired_tasks
+    assert may_see_retired_tasks(threshold - 1, None, False, ERA_1) is False
+    assert may_see_retired_tasks(threshold, None, False, ERA_1) is True
+
+
+def test_retired_tasks_faction_perk_reaches_from_level_zero() -> None:
+    """Ephemerists (#1672) can reach the archive from level 0 — the whole
+    point of the perk is that it is not gated by the level floor at all."""
+    assert may_see_retired_tasks(0, "ephemerists", False, ERA_1) is True
+
+
+def test_retired_tasks_non_perk_faction_still_needs_the_level() -> None:
+    assert may_see_retired_tasks(0, "wow", False, ERA_1) is False
+
+
+def test_retired_tasks_no_character_is_false_even_with_admin_off() -> None:
+    assert may_see_retired_tasks(None, None, False, ERA_1) is False
+
+
+def test_retired_tasks_admin_bypasses() -> None:
+    assert may_see_retired_tasks(0, None, True, ERA_1) is True
+
+
+# --- metatask apply: threshold OR the faction bypass, is_admin does NOT gate
+
+def test_apply_metatask_meets_and_misses_the_threshold() -> None:
+    threshold = ERA_1.metatask_apply_level
+    assert may_apply_metatask(threshold - 1, None, False, ERA_1) is False
+    assert may_apply_metatask(threshold, None, False, ERA_1) is True
+
+
+def test_apply_metatask_albescent_bypasses_below_the_level() -> None:
+    assert may_apply_metatask(0, "albescent", False, ERA_1) is True
+
+
+def test_apply_metatask_non_bypassing_faction_below_the_level_cannot() -> None:
+    assert may_apply_metatask(0, "wow", False, ERA_1) is False
+
+
+def test_apply_metatask_no_character_is_false() -> None:
+    assert may_apply_metatask(None, "albescent", False, ERA_1) is False
+    assert may_apply_metatask(None, "albescent", True, ERA_1) is False
+
+
+def test_apply_metatask_admin_does_not_bypass_the_level() -> None:
+    """#1973: is_admin must NOT short-circuit this one, unlike the others —
+    apply_metatask has no admin escape hatch server-side."""
+    assert may_apply_metatask(0, None, True, ERA_1) is False
+
+
+def test_apply_metatask_unknown_faction_slug_gets_no_bypass() -> None:
+    """A slug the era does not define (e.g. carried over from a prior era)
+    grants no ability rather than erroring."""
+    assert may_apply_metatask(0, "not-a-real-faction", False, ERA_1) is False
+
+
+# --- collaboration / duel: flat floors, unwired but included for #2868 -----
+
+def test_collab_meets_and_misses_the_threshold() -> None:
+    threshold = ERA_1.collaboration_level_required
+    assert may_create_collab_praxis(threshold - 1, None, False, ERA_1) is False
+    assert may_create_collab_praxis(threshold, None, False, ERA_1) is True
+
+
+def test_collab_no_character_is_false() -> None:
+    assert may_create_collab_praxis(None, None, False, ERA_1) is False
+
+
+def test_duel_meets_and_misses_the_threshold() -> None:
+    threshold = ERA_1.duel_level_required
+    assert may_create_duel(threshold - 1, None, False, ERA_1) is False
+    assert may_create_duel(threshold, None, False, ERA_1) is True
+
+
+def test_duel_no_character_is_false() -> None:
+    assert may_create_duel(None, None, False, ERA_1) is False
+
+
+# --- reads era.*, never a hardcoded threshold -------------------------------
+
+def test_reads_thresholds_off_the_era_argument() -> None:
+    """A custom EraConfig, not ERA_1's live values, decides the answer."""
+    strict_era = replace(
+        ERA_1,
+        level_to_propose_task=10,
+        collaboration_level_required=10,
+        duel_level_required=10,
+    )
+    assert may_propose_task(9, None, False, strict_era) is False
+    assert may_create_collab_praxis(9, None, False, strict_era) is False
+    assert may_create_duel(9, None, False, strict_era) is False
+    # Untouched fields keep ERA_1's values.
+    assert may_comment(2, None, False, strict_era) is True


### PR DESCRIPTION
Closes #2867

## What this does

Adds `backend/services/era_gates.py` — one named, pure predicate per level
unlock, each `(level: int | None, faction_slug: str | None, is_admin: bool,
era: EraConfig = CURRENT_ERA) -> bool`. The module imports only `game_config`
(verified: `ast`-walked the file, single `ImportFrom(module='game_config')`),
so it stays a genuine leaf under the auth-path import chain
(`current_user.py` -> `character_capabilities.py` -> `era_gates.py`), and
importing `services.current_user` with a stub `.env` confirms no cycle.

`character_capabilities.compute_capabilities` now delegates every threshold
comparison to that module instead of composing the clauses inline — it does
no `level >= era.*` comparison of its own anymore.

## The nine rows — which got repointed here, which didn't

| era field | repointed here? | why |
|---|---|---|
| `level_to_propose_task` | yes | advertise site is `character_capabilities.py` itself |
| `level_to_propose_metatask` | yes | same |
| `level_to_see_retired_tasks` | yes | same — the two-clause OR (threshold **or** the archive-access faction perk) now exists exactly once, in `may_see_retired_tasks` |
| `level_to_see_pending_tasks` | yes | same; matches today's enforcement shape (`is_admin or level >= threshold`) per the issue's explicit note, since #2863 hasn't landed |
| `comment_level_required` | yes | same. (`services.comment.can_comment` already calls `compute_capabilities` rather than restating the clause, so it inherits this for free with no edit to `comment.py`) |
| `metatask_apply_level` | yes | same — `may_apply_metatask` reads `era.factions[...].can_apply_metatask_at_any_level` directly rather than importing `services.meta_task`, to keep the leaf import-only-`game_config`; `character_capabilities.py` no longer imports `services.meta_task` at all |
| `collaboration_level_required` | **no** | both sites are in `praxis.py` (advertise: `praxis.py:1612`, enforce: `praxis.py:1126`), explicitly out of scope — other agents (#2876, #2870/#2871) are in that file right now. Predicate `may_create_collab_praxis` is defined and matches `services.praxis.available_creation_modes`'s existing clause, unwired, for #2868 |
| `duel_level_required` | **no** | both sites are in `duel.py`, excluded by scope. Predicate `may_create_duel` is defined and matches both level checks in `services.duel` (`issue_duel_challenge` and `respond_to_duel_challenge`), unwired, for #2868 |
| `albescent_level_required` | **no predicate at all** | its two sites read the *same* era field in *opposite* directions for two different questions — `services.character.character_earns_albescent` (character.py:209) is a floor requiring a DB-backed covers-every-faction check (unions two tables against the character's history — not answerable from `(level, faction_slug, is_admin, era)` alone), and `services.faction_service` (faction_service.py:248) is a ceiling ("the only maximum-level gate in the game", New-Game+ only). A partial pure predicate here would invite #2868 to reuse it as the whole rule when it's at most half of one, so I left it out rather than guess. Flagging this for #2868/#2869 explicitly. |

6 of 9 repointed; 2 of 9 (collaboration, duel) have predicates ready but
unwired because their files are out of scope; 1 of 9 (albescent) has no
predicate because it doesn't fit the pure-function contract this leaf
promises — see the module docstring in `era_gates.py` for the full reasoning.

## Seam tested at

Unit, at the predicate boundary: `backend/tests/unit/test_era_gates.py`
exercises all eight predicates against `ERA_1` (passed explicitly, per the
per-era rules pattern in #2709/CONTEXT.md — never `CURRENT_ERA` read inside
the module). `tests/unit/test_character_capabilities.py` is the existing
table-driven regression suite for `compute_capabilities` and is untouched —
it still passes unmodified, which is the "no behaviour change" proof the
issue asks for.

## What I ran

- `pytest tests/unit/test_era_gates.py tests/unit/test_character_capabilities.py -q` -> 57 passed
- `pytest --cov=. --cov-fail-under=92` (dedicated DB `wz2867_test`, migrated with `alembic upgrade head`) -> **1749 passed**, coverage 94.40%
- `ruff check services/era_gates.py services/character_capabilities.py tests/unit/test_era_gates.py` -> clean
- Import-cycle check: `import services.current_user` with a stub `.env` -> succeeds, no cycle

No route or schema changes, so no `openapi.json` / generated-TS regen needed.

## What to eyeball

- `backend/services/era_gates.py` — the module docstring's account of why
  three of the nine rows aren't wired here, and whether the albescent
  decision (no predicate, not even a partial one) is the right call rather
  than something #2868 should decide instead
- `backend/services/character_capabilities.py` — confirms it now does zero
  threshold comparisons of its own
- The `may_see_retired_tasks` faction clause against
  `services.task.list_tasks`'s `viewer_sees_retired` — I read that logic but
  did not touch `task.py`; worth a second pair of eyes that the two really
  agree before #2868 repoints it

**Visual QA is outstanding** — this is a pure backend refactor with no route
or schema surface, verified via `pytest`/`ruff` only, no browser/dev-stack
access from this environment.
