### PR TITLE
Fold the six-times-composed optional-admin check into one dependency

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -117,6 +117,22 @@ async def require_admin(
     return account
 
 
+async def get_viewer_is_admin(
+    account: Optional[Account] = Depends(get_current_account_optional),
+    session: AsyncSession = Depends(get_db),
+) -> bool:
+    """Resolve "is the viewer an admin", anonymous-safe.
+
+    For routes that stay reachable by anonymous callers but let an admin see
+    more (#2400-style reveals). Never raises — an anonymous caller resolves to
+    ``False`` rather than 401. Use :func:`require_admin` instead when admin is
+    a hard gate rather than a behaviour modifier.
+    """
+    if account is None:
+        return False
+    return await account_has_admin_role(account.id, session)
+
+
 async def account_has_admin_role(account_id: int, session: AsyncSession) -> bool:
     """Return True if the given account has the 'admin' role.
 

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -9,10 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
 from dependencies import (
-    account_has_admin_role,
     get_current_account_optional,
     get_current_character,
     get_current_character_optional,
+    get_viewer_is_admin,
 )
 from models.account import Account
 from models.character import Character, CharacterStatus
@@ -45,6 +45,7 @@ async def list_characters(
     session: AsyncSession = Depends(get_db),
     viewer: Optional[Character] = Depends(get_current_character_optional),
     account: Optional[Account] = Depends(get_current_account_optional),
+    viewer_is_admin: bool = Depends(get_viewer_is_admin),
 ):
     """List all active characters. Optionally filter by name or faction.
 
@@ -76,9 +77,7 @@ async def list_characters(
         # callers are unaffected — `account` is None and the fold stands. An
         # admin counts as revealed for that question and no other (#2400).
         viewer_account=account,
-        viewer_is_admin=(
-            account is not None and await account_has_admin_role(account.id, session)
-        ),
+        viewer_is_admin=viewer_is_admin,
         limit=limit,
         offset=offset,
     )

--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import account_has_admin_role, get_current_account_optional
+from dependencies import get_current_account_optional, get_viewer_is_admin
 from game_config import CURRENT_ERA
 from models.account import Account
 from schemas.game_config import (
@@ -20,6 +20,7 @@ router = APIRouter()
 async def get_game_config(
     account: Account | None = Depends(get_current_account_optional),
     session: AsyncSession = Depends(get_db),
+    is_admin: bool = Depends(get_viewer_is_admin),
 ) -> GameConfigOut:
     # NOTE — this docstring ships verbatim to the PUBLIC ``/openapi.json``, so
     # it says what the route does without naming what it hides. The reason lives
@@ -33,9 +34,6 @@ async def get_game_config(
     # Deliberately outside the docstring, per the NOTE above: the reason a
     # moderation role is read here is #2400, and naming it publicly would name
     # what it unhides. `services.albescent_reveal` holds the reason.
-    is_admin = account is not None and await account_has_admin_role(
-        account.id, session
-    )
     factions = [
         FactionConfigOut(
             slug=faction.slug,

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
-from dependencies import account_has_admin_role, get_current_account_optional
+from dependencies import get_current_account_optional, get_viewer_is_admin
 from models.account import Account
 from schemas.character import CharacterOut
 from services.character import build_character_outs, list_characters_for_viewer
@@ -19,6 +19,7 @@ async def get_leaderboard(
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
     account: Optional[Account] = Depends(get_current_account_optional),
+    viewer_is_admin: bool = Depends(get_viewer_is_admin),
 ):
     """Top characters by current era score, optionally filtered by faction.
 
@@ -32,9 +33,7 @@ async def get_leaderboard(
         faction_slug=faction,
         viewer_account=account,
         # An admin counts as revealed for that question and no other (#2400).
-        viewer_is_admin=(
-            account is not None and await account_has_admin_role(account.id, session)
-        ),
+        viewer_is_admin=viewer_is_admin,
         limit=limit,
         offset=offset,
     )

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -23,10 +23,10 @@ from sqlalchemy.orm import selectinload
 from config import settings
 from db import get_db
 from dependencies import (
-    account_has_admin_role,
     get_current_account_optional,
     get_current_character,
     get_current_character_optional,
+    get_viewer_is_admin,
 )
 from errors import DETAIL_CONTEXT_PARAM, ErrorCode, raise_coded
 from game_config import CURRENT_ERA
@@ -138,6 +138,7 @@ async def list_praxes_route(
     session: AsyncSession = Depends(get_db),
     viewer: Optional[Character] = Depends(get_current_character_optional),
     account: Optional[Account] = Depends(get_current_account_optional),
+    viewer_is_admin: bool = Depends(get_viewer_is_admin),
 ):
     # Five rejections of the same shape — a query parameter naming a value no
     # enum member matches — so they share one code and name their field in
@@ -221,9 +222,7 @@ async def list_praxes_route(
         # Optional auth; only the Albescent reveal flag is read from it (#2422),
         # for which an admin counts as revealed (#2400).
         viewer_account=account,
-        viewer_is_admin=(
-            account is not None and await account_has_admin_role(account.id, session)
-        ),
+        viewer_is_admin=viewer_is_admin,
         limit=limit,
         offset=offset,
     )

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -9,6 +9,7 @@ from dependencies import (
     get_current_account_optional,
     get_current_character,
     get_current_character_optional,
+    get_viewer_is_admin,
 )
 from models.account import Account
 from models.character import Character
@@ -51,6 +52,7 @@ async def list_tasks(
     session: AsyncSession = Depends(get_db),
     viewer: Optional[Character] = Depends(get_current_character_optional),
     account: Optional[Account] = Depends(get_current_account_optional),
+    is_admin: bool = Depends(get_viewer_is_admin),
 ):
     # An unrecognised sort is an error, not a silent fall-back to the level
     # default (#1443) — matching GET /praxes, which has always raised here.
@@ -64,9 +66,6 @@ async def list_tasks(
         except ValueError:
             raise HTTPException(status_code=422, detail=f"Invalid task sort: {sort}")
 
-    is_admin = account is not None and await account_has_admin_role(
-        account.id, session
-    )
     # `exclude_character_id` is passed through untouched (#2264). The route used
     # to default it to the viewer for #1229's "the browse hides tasks you have
     # already started" — but a route default reaches EVERY caller of GET /tasks,
@@ -155,6 +154,7 @@ async def get_task(
     session: AsyncSession = Depends(get_db),
     viewer: Optional[Character] = Depends(get_current_character_optional),
     account: Optional[Account] = Depends(get_current_account_optional),
+    is_admin: bool = Depends(get_viewer_is_admin),
 ):
     # Deliberately no docstring: a route's docstring is published in the public
     # `openapi.json`, and the reasoning below is not something to hand out.
@@ -164,9 +164,6 @@ async def get_task(
     # an absent id gets: task ids are sequential, so a 403 would confirm the row
     # exists and make the review window enumerable. `retired` and `active` are
     # unaffected — praxis link back to retired tasks.
-    is_admin = account is not None and await account_has_admin_role(
-        account.id, session
-    )
     task = await get_task_for_viewer(session, task_id, viewer, is_admin=is_admin)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found.")


### PR DESCRIPTION
Closes #2894

## What changed

`account is not None and await account_has_admin_role(account.id, session)` was
composed inline at six call sites across five routers. Adds `get_viewer_is_admin`
beside `require_admin` in `backend/dependencies.py`:

```python
async def get_viewer_is_admin(
    account: Optional[Account] = Depends(get_current_account_optional),
    session: AsyncSession = Depends(get_db),
) -> bool:
    if account is None:
        return False
    return await account_has_admin_role(account.id, session)
```

All six sites now declare `viewer_is_admin: bool = Depends(get_viewer_is_admin)` (or
`is_admin` where that was the existing local name) instead of composing the
expression:

- `backend/routers/characters.py` — `list_characters`
- `backend/routers/game_config.py` — `get_game_config`
- `backend/routers/leaderboard.py` — `get_leaderboard`
- `backend/routers/praxes.py` — `list_praxes_route`
- `backend/routers/tasks.py` — `list_tasks`, `get_task`

`tasks.py`'s `propose_task_route` still imports and calls `account_has_admin_role`
directly — that call takes a *required* `account` (via `get_current_account`, which
401s), not the optional/anonymous-safe case this issue is about, so it's untouched.

No service code touched (`routers/` and `dependencies.py` only), per the note that
`services/praxis.py` and friends are contended by parallel work on this epic (#2870-#2875).

## Testing seam

Tested at the route level: the existing integration suite exercises every one of the
six routes both as an anonymous caller and as an authenticated admin caller (the
Albescent-reveal tests in particular assert the `viewer_is_admin`-gated behaviour).
Since this is a pure refactor — same boolean, same computation, just resolved once
via `Depends` instead of composed inline — an unmodified green suite is the proof of
no-behaviour-change, per the task brief.

- `pytest tests/integration/test_characters.py tests/integration/test_game_config.py tests/integration/test_leaderboard.py tests/integration/test_praxes.py tests/integration/test_tasks.py tests/integration/test_admin.py tests/integration/test_albescent_admin_reveal.py -q` → **286 passed**
- Full suite: `pytest -q` → **1750 passed**, 0 failed, 0 skipped, run unmodified against a dedicated `wz2894_test` database (`alembic upgrade head` applied cleanly, no drift)
- `ruff check` on every touched file: no new findings (the pre-existing E402/E501/I001 debt in `characters.py`/`praxes.py`/`tasks.py` is unchanged before vs. after — confirmed via `git stash`/`stash pop` diff of the ruff run)

**`regen_api_client.py`: ran it from the repo root. It produced no diff** —
`backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` are unchanged
(`git status --short` on both paths is empty after running). The new dependency
only composes other `Depends(...)` values (no `Query`/`Body`/`Path` markers), so it
adds nothing to the OpenAPI parameter list, as expected.

## What to eyeball

Visual QA is outstanding — I have no browser/dev-stack access in this environment,
so nothing here has been checked by eye. This is a backend-only, routes-and-dependencies
refactor with no response-shape change, so the intended blast radius is zero pixels, but
please still eyeball:

- [ ] `GET /characters` (list, anonymous vs admin) — Albescent roster reveal for an admin caller
- [ ] `GET /game-config` (anonymous vs admin) — level-profile visibility unaffected
- [ ] `GET /leaderboard` (anonymous vs admin) — same Albescent reveal behaviour
- [ ] `GET /praxes` (anonymous vs admin) — same
- [ ] `GET /tasks` and `GET /tasks/{id}` (anonymous vs admin) — pending-task 404 vs visible for admin unaffected

None of these routes' response shapes or query parameters changed (confirmed by the
empty `regen_api_client.py` diff above), so the eyeball is about the resolved
`is_admin`/`viewer_is_admin` boolean still landing correctly, not about a new
surface.