### PR TITLE
Migrate components/ tests onto sourceScan's shared walk (#2885)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/covenBadgeRetired.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/covenBadgeRetired.test.tsx
@@ -37,28 +37,19 @@
  * sparkle) and `CovenCat` (the turning watermark) are untouched — different
  * devices with different jobs, and `covenSlip`'s own header gives the reason.
  */
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 
 import { CovenSigil } from "../../sigil/CovenSigil";
+import { sourceFiles } from "../../../test/sourceScan";
 
 const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
 /** The badge's five-point star, in its own 44-unit box. */
 const BADGE_STAR = "M22 8 L30.2 33.3 L8.7 17.7 L35.3 17.7 L13.8 33.3 Z";
-
-function sourceFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...sourceFiles(path));
-    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(path);
-  }
-  return out;
-}
 
 /**
  * Source with its comments removed, because a TOMBSTONE has to be able to name
@@ -74,9 +65,9 @@ function withoutComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
 }
 
-const FILES = sourceFiles(SRC).map(
-  (path) => [path, withoutComments(readFileSync(path, "utf8"))] as const,
-);
+const FILES = sourceFiles({ dir: SRC, includeTests: true })
+  .filter((path) => !/\.test\.tsx?$/.test(path))
+  .map((path) => [path, withoutComments(readFileSync(path, "utf8"))] as const);
 
 function code(relative: string): string {
   return readFileSync(join(SRC, relative), "utf8");
@@ -104,7 +95,7 @@ const COMPOSER = "pages/editPraxis/archetypes/CovenEditPraxis.tsx";
 describe("Coven's retired pentagram badge (#2726)", () => {
   it("is named in no source file — not exported, not imported, not re-drawn", () => {
     // Whole-tree, because a dir-scoped scan has hidden mounts in this repo
-    // before. Tests are excluded by `sourceFiles`, comments by
+    // before. `*.test.tsx?` files are filtered out of `FILES`, comments by
     // `withoutComments` — see that helper for why the second exclusion exists.
     const offenders = FILES.filter(([, source]) => source.includes("SigilMark")).map(([path]) => path);
     expect(offenders, "`SigilMark` survives in these files").toEqual([]);

--- a/frontend/src/components/factionMarks/__tests__/covenCat.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/covenCat.test.tsx
@@ -30,30 +30,23 @@
  * `covenBadgeRetired.test.tsx` guards that. This file is still only about the
  * thing under `.cvn-wheel`.
  */
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 
 import { CovenCat } from "../covenSlip";
+import { sourceFiles } from "../../../test/sourceScan";
 
 const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
 /** The five-pointed star every Coven surface used to turn. */
 const PENTAGRAM = "M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z";
 
-function sourceFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...sourceFiles(path));
-    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(path);
-  }
-  return out;
-}
-
-const FILES = sourceFiles(SRC).map((path) => [path, readFileSync(path, "utf8")] as const);
+const FILES = sourceFiles({ dir: SRC, includeTests: true })
+  .filter((path) => !/\.test\.tsx?$/.test(path))
+  .map((path) => [path, readFileSync(path, "utf8")] as const);
 
 describe("the Coven watermark", () => {
   it("draws the retired pentagram nowhere", () => {

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsChamferPlate.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsChamferPlate.test.tsx
@@ -24,8 +24,7 @@
  *     markup assertion pins the plates that exist today; the failure mode #2150
  *     describes is the NEXT plate hand-rolling a chamfer and a border again.
  */
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
@@ -33,6 +32,7 @@ import '../../../i18n'
 import type { PraxisCardOut } from '../../../api/praxis'
 import EphemeristsScoreStamp from '../../praxisCard/scoreStamp/EphemeristsScoreStamp'
 import { chamferMount, chamferSheet, chamferSheetLeg } from '../ephemeristsPlate'
+import { sourceFiles, stripComments } from '../../../test/sourceScan'
 
 /** The rule brass — a frame is a line, so never the mark brass (#2141/#2142). */
 const RULE = 'var(--faction-ephemerists-plate-brass-rule)'
@@ -140,29 +140,11 @@ describe('the Ephemerists score stamp carries its rule through the clip (#2314)'
   })
 })
 
-const SRC = fileURLToPath(new URL('../../..', import.meta.url))
 const KIT = fileURLToPath(new URL('../ephemeristsPlate.tsx', import.meta.url))
 
 /** Every shipped `.ts`/`.tsx` under `src/`, comments stripped, tests skipped. */
 function sources(): { path: string; source: string }[] {
-  const found: { path: string; source: string }[] = []
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === '__tests__') continue
-      const full = join(dir, entry.name)
-      if (entry.isDirectory()) walk(full)
-      else if (/\.tsx?$/.test(entry.name)) {
-        found.push({
-          path: full,
-          source: readFileSync(full, 'utf8')
-            .replace(/\/\*[\s\S]*?\*\//g, '')
-            .replace(/^\s*\/\/.*$/gm, ''),
-        })
-      }
-    }
-  }
-  walk(SRC)
-  return found
+  return sourceFiles().map((path) => ({ path, source: stripComments(readFileSync(path, 'utf8')) }))
 }
 
 describe('the chamfer has exactly one door (#2150)', () => {

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
@@ -32,8 +32,7 @@
  *    generator, which a copy must carry however it is renamed, inlined or split
  *    up, and the mount census is a separate, looser thing.
  */
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
@@ -44,8 +43,8 @@ import {
   type NotationSide,
 } from "../EphemeristsNotationBand";
 import { ruleBodies, stripComments } from "../../../utils/__tests__/cssVars";
+import { sourceFiles, toRelative } from "../../../test/sourceScan";
 
-const SRC = fileURLToPath(new URL("../../..", import.meta.url));
 const BAND = fileURLToPath(new URL("../EphemeristsNotationBand.tsx", import.meta.url));
 const sheet = (name: string): string =>
   stripComments(readFileSync(fileURLToPath(new URL(`../../../${name}`, import.meta.url)), "utf8"));
@@ -334,16 +333,7 @@ describe("the two sheets: resting frame here, motion over there", () => {
 
 describe("it is drawn ONCE — keyed on the drawing, not the name (#2230, #2341)", () => {
   /** Every source file under `src/`, tests excluded. */
-  const files: [string, string][] = [];
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === "__tests__") continue;
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (/\.tsx?$/.test(entry.name)) files.push([full, readFileSync(full, "utf8")]);
-    }
-  };
-  walk(SRC);
+  const files: [string, string][] = sourceFiles().map((path) => [path, readFileSync(path, "utf8")]);
 
   it("declares the mark pool in exactly one file", () => {
     // THE guard #2230 asks for. `DRIFT` was a 32-mark array on `.epg-glyph` in
@@ -359,7 +349,7 @@ describe("it is drawn ONCE — keyed on the drawing, not the name (#2230, #2341)
     // invisible — both rows still look random.
     const found = files
       .filter(([, source]) => source.includes("0x6d2b79f5"))
-      .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
+      .map(([path]) => toRelative(path));
     expect(found).toEqual(["components/factionMarks/ephemeristsPlate.tsx"]);
   });
 
@@ -369,7 +359,7 @@ describe("it is drawn ONCE — keyed on the drawing, not the name (#2230, #2341)
     // clock, and both are worth failing on.
     const found = files
       .filter(([path, source]) => path !== BAND && /--epg-(op|delay)/.test(source))
-      .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
+      .map(([path]) => toRelative(path));
     expect(found).toEqual([]);
   });
 
@@ -389,7 +379,7 @@ describe("it is drawn ONCE — keyed on the drawing, not the name (#2230, #2341)
     // stamping itself on content that is not its own.
     const mounts = files
       .filter(([, source]) => source.includes("<EphemeristsNotationBand"))
-      .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
+      .map(([path]) => toRelative(path));
     expect(mounts.sort()).toEqual([
       "components/factionHero/EphemeristsFactionHero.tsx",
       "components/factionMarks/EphemeristsMasthead.tsx",

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsScriptTurn.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsScriptTurn.test.tsx
@@ -30,7 +30,7 @@
  * easily: all five frames are laid in ONE grid cell, so the slot is the widest
  * of them by layout rather than by a measurement pass a test could not run.
  */
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -63,12 +63,10 @@ const INDEX_CSS = readFileSync(join(SRC, 'index.css'), 'utf-8')
 const WORDS = Object.keys(catalog) as GlossWord[]
 
 /** Every English copy catalog but the gloss catalog itself. */
-const catalogs = (): string[] => {
-  const dir = join(SRC, 'locales', 'en')
-  return readdirSync(dir)
-    .filter((entry) => entry.endsWith('.json') && entry !== 'glosses.json')
-    .map((entry) => join(dir, entry))
-}
+const catalogs = (): string[] =>
+  sourceFiles({ dir: join(SRC, 'locales', 'en'), match: /\.json$/ }).filter(
+    (path) => !path.endsWith('glosses.json'),
+  )
 
 const TASK = aTask({ in_progress_count: 2 })
 

--- a/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
@@ -20,15 +20,14 @@
  *      issue asked to remove rather than the symptom. Pinned the way #1638 and
  *      #1654 pinned the Ephemerists plate: against the source tree.
  */
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 import "../../../i18n";
 import SingularityFeedFrame from "../../feed/SingularityFeedFrame";
+import { sourceFiles, stripComments, toRelative } from "../../../test/sourceScan";
 
-const SRC = fileURLToPath(new URL("../../..", import.meta.url));
 const KIT = fileURLToPath(new URL("../SingularityLamps.tsx", import.meta.url));
 
 /** The one palette. */
@@ -39,29 +38,14 @@ const TRIO = [
 ] as const;
 
 /**
- * Every shipped `.ts`/`.tsx` under `src/`, comments stripped and tests skipped.
- * Both exclusions matter: this file names the retired constants in prose, and a
+ * Every shipped `.ts`/`.tsx` under `src/`, comments stripped and tests skipped
+ * (the shared walk — `sourceFiles()` skips `__tests__` by default; nothing
+ * under `src/` is `node_modules`, so that former exclusion was never live).
+ * The test-skip matters: this file names the retired constants in prose, and a
  * docblock explaining what was deleted must not answer for a live copy.
  */
 function sources(): { path: string; source: string }[] {
-  const found: { path: string; source: string }[] = [];
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (/\.tsx?$/.test(entry.name)) {
-        found.push({
-          path: full,
-          source: readFileSync(full, "utf8")
-            .replace(/\/\*[\s\S]*?\*\//g, "")
-            .replace(/^\s*\/\/.*$/gm, ""),
-        });
-      }
-    }
-  };
-  walk(SRC);
-  return found;
+  return sourceFiles().map((path) => ({ path, source: stripComments(readFileSync(path, "utf8")) }));
 }
 
 describe("the feed frame's window bar wears the same lamps as every other (#1979)", () => {
@@ -138,9 +122,8 @@ describe("the lamp cluster is declared once, and in the kit (#1979)", () => {
     // this list further should check they are removing a mount and not a
     // SURFACE: a card that stopped drawing the bar at all is the regression this
     // roll-call exists to catch, and it looks identical to this edit from here.
-    const rel = (path: string) => path.slice(SRC.length).replace(/\\/g, "/");
     const mounts = sources().filter(({ source }) => source.includes("<SingularityLamps"));
-    expect(mounts.map((file) => rel(file.path)).sort()).toEqual([
+    expect(mounts.map((file) => toRelative(file.path)).sort()).toEqual([
       "components/cardMasthead/factionBands.tsx",
       "components/feed/SingularityFeedFrame.tsx",
       // The sixth window bar (#2353): character creation, dressed as a terminal

--- a/frontend/src/components/factionMarks/__tests__/singularityProcessLight.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/singularityProcessLight.test.tsx
@@ -17,48 +17,30 @@
  * an explicit list. A count is what let a wrong mount pass, so the roll-call
  * below is written out and a new surface has to add its own line.
  */
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
+import { sourceFiles, stripComments, toRelative } from "../../../test/sourceScan";
 
-const SRC = fileURLToPath(new URL("../../..", import.meta.url));
 const KIT = fileURLToPath(new URL("../SingularityProcessLight.tsx", import.meta.url));
 
 /**
- * Every shipped `.ts`/`.tsx` under `src/`, comments stripped and tests skipped —
- * both exclusions matter, because this file and the mark's own docblock name the
- * retired shape in prose and prose must not answer for a live copy.
+ * Every shipped `.ts`/`.tsx` under `src/`, comments stripped and tests skipped
+ * (the shared walk — `sourceFiles()` skips `__tests__` by default; nothing
+ * under `src/` is `node_modules`, so that former exclusion was never live).
+ * The test-skip matters, because this file and the mark's own docblock name
+ * the retired shape in prose and prose must not answer for a live copy.
  */
 function sources(): { path: string; source: string }[] {
-  const found: { path: string; source: string }[] = [];
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (/\.tsx?$/.test(entry.name)) {
-        found.push({
-          path: full,
-          source: readFileSync(full, "utf8")
-            .replace(/\/\*[\s\S]*?\*\//g, "")
-            .replace(/^\s*\/\/.*$/gm, ""),
-        });
-      }
-    }
-  };
-  walk(SRC);
-  return found;
+  return sourceFiles().map((path) => ({ path, source: stripComments(readFileSync(path, "utf8")) }));
 }
-
-const rel = (path: string) => path.slice(SRC.length).replace(/\\/g, "/");
 
 describe("the process light is declared once, in the kit (#2092)", () => {
   it("mounts the kit on every surface that shows one", () => {
     const mounts = sources().filter(({ source }) =>
       source.includes("<SingularityProcessLight"),
     );
-    expect(mounts.map((file) => rel(file.path)).sort()).toEqual([
+    expect(mounts.map((file) => toRelative(file.path)).sort()).toEqual([
       "components/taskCard/SingularityTaskCard.tsx",
       "pages/editPraxis/archetypes/SingularityEditPraxis.tsx",
       "pages/taskDetail/archetypes/SingularityTaskDetail.tsx",
@@ -77,7 +59,7 @@ describe("the process light is declared once, in the kit (#2092)", () => {
       ({ path, source }) =>
         path !== KIT && /(?:sg|ep)-pulse/.test(source) && /width: 7,/.test(source),
     );
-    expect(copies.map((file) => rel(file.path))).toEqual([]);
+    expect(copies.map((file) => toRelative(file.path))).toEqual([]);
   });
 
   it("keeps the hue and the bloom in the kit — one pairing, not three", () => {

--- a/frontend/src/components/praxisCard/__tests__/columnMountGuard.test.ts
+++ b/frontend/src/components/praxisCard/__tests__/columnMountGuard.test.ts
@@ -27,21 +27,9 @@
  * being a flex item on a column main axis. It cannot prove nothing is clipped;
  * it proves no mount is shaped so that it can be.
  */
-import { readFileSync, readdirSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
-
-const SRC = fileURLToPath(new URL("../../../", import.meta.url));
-
-function tsxFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const path = `${dir}${entry.name}`;
-    if (entry.isDirectory()) return tsxFiles(`${path}/`);
-    return entry.isFile() && path.endsWith(".tsx") && !path.includes("__tests__")
-      ? [path]
-      : [];
-  });
-}
+import { sourceFiles, toRelative } from "../../../test/sourceScan";
 
 /** A line that opens a JSX element — the mount's nearest enclosing candidate. */
 const OPENS_ELEMENT = /^<[A-Za-z]/;
@@ -78,11 +66,11 @@ const isComment = (text: string) => /^(\*|\/\/|\/\*)/.test(text.trim());
 /** The element, not `PraxisCardOut` in a `useState<PraxisCardOut[]>`. */
 const MOUNT = /<PraxisCard(?!Out)/;
 
-const mounts: Mount[] = tsxFiles(SRC).flatMap((file) => {
+const mounts: Mount[] = sourceFiles({ match: /\.tsx$/ }).flatMap((file) => {
   const lines = readFileSync(file, "utf8").split(/\r?\n/);
   return lines.flatMap((text, i) =>
     MOUNT.test(text) && !isComment(text)
-      ? [{ file: file.slice(SRC.length), line: i + 1, tag: enclosingTag(lines, i) }]
+      ? [{ file: toRelative(file), line: i + 1, tag: enclosingTag(lines, i) }]
       : [],
   );
 });

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/canonicalStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/canonicalStamp.test.tsx
@@ -35,11 +35,13 @@
  * draws the separating rule and no subtotal at all.
  */
 import { describe, it, expect } from 'vitest'
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactElement } from 'react'
 import '../../../../i18n'
+import { sourceFiles } from '../../../../test/sourceScan'
 import i18n from '../../../../i18n'
 import praxisCatalog from '../../../../locales/en/praxis.json'
 import type { PraxisCardOut } from '../../../../api/praxis'
@@ -138,9 +140,9 @@ describe('the subtotal is the multiplier applied to the base (#2634)', () => {
 
 describe('the subtotal is computed once, in the shared half (#2634)', () => {
   const dir = fileURLToPath(new URL('../', import.meta.url))
-  const skins = readdirSync(dir).filter(
-    (name) => name.endsWith('ScoreStamp.tsx') && name !== 'ScoreStamp.tsx',
-  )
+  const skins = sourceFiles({ dir, match: /ScoreStamp\.tsx$/ })
+    .map((path) => basename(path))
+    .filter((name) => name !== 'ScoreStamp.tsx')
 
   it('finds all nine skins, so absence cannot be vacuous', () => {
     expect(skins).toHaveLength(9)

--- a/frontend/src/components/vote/__tests__/testSeamsStayOutOfTheBundle.test.ts
+++ b/frontend/src/components/vote/__tests__/testSeamsStayOutOfTheBundle.test.ts
@@ -32,30 +32,17 @@
  * functions, `npm run build`, and diff `dist/` against a build from `main`.
  * Identical output means they are still free.
  */
-import { readdirSync, readFileSync } from 'node:fs'
-import { dirname, join, relative, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
 import { describe, it, expect } from 'vitest'
-
-const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+import { sourceFiles, toRelative } from '../../../test/sourceScan'
 
 /**
  * Vitest helpers loaded through `setupFiles`, which are not in the application
  * graph and may legitimately hold a shared reset. Exempted by path so the
  * exemption is visible; everything else under `src/` is application code until
- * proven otherwise.
+ * proven otherwise. `toRelative` always reports forward slashes.
  */
-const TEST_HELPER_DIR = `test${sep}`
-
-function sourceFiles(dir: string): string[] {
-  const out: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name)
-    if (entry.isDirectory()) out.push(...sourceFiles(path))
-    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(path)
-  }
-  return out
-}
+const TEST_HELPER_DIR = `test/`
 
 /**
  * Source with its comments removed, because this file's own reasoning — and the
@@ -68,9 +55,10 @@ function withoutComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
 }
 
-const FILES = sourceFiles(SRC)
+const FILES = sourceFiles({ includeTests: true })
+  .filter((path) => !/\.test\.tsx?$/.test(path))
   .map((path) => ({
-    path: relative(SRC, path),
+    path: toRelative(path),
     code: withoutComments(readFileSync(path, 'utf8')),
   }))
   .filter(({ path }) => !path.startsWith(TEST_HELPER_DIR))
@@ -85,7 +73,7 @@ const SEAMS = FILES.flatMap(({ path, code }) =>
 
 describe('test seams are reachable only from tests (#2697)', () => {
   it('scans the source tree, so a bad path cannot pass this by vacuum', () => {
-    // Without this, an SRC that resolved somewhere empty would give no files,
+    // Without this, a walk that resolved somewhere empty would give no files,
     // no seams, and a green run that proved nothing at all.
     expect(FILES.length).toBeGreaterThan(400)
   })


### PR DESCRIPTION
## Summary

Migrates the nine private `readdirSync` filesystem walks under `components/` onto the
shared `sourceFiles()`/`toRelative()`/`readStripped()`/`stripComments()` helpers in
`frontend/src/test/sourceScan.ts`, per the "the walk is shared, the predicate stays
local" rule from #2885 (part of #2862).

Closes #2885

## Files migrated

Re-derived from `origin/main` at dispatch time (PR #2904/#2815 had already migrated
five `components/` files an hour earlier, and those were excluded correctly):

1. `components/factionMarks/__tests__/covenBadgeRetired.test.tsx`
2. `components/factionMarks/__tests__/covenCat.test.tsx`
3. `components/factionMarks/__tests__/ephemeristsChamferPlate.test.tsx`
4. `components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx`
5. `components/factionMarks/__tests__/ephemeristsScriptTurn.test.tsx` — this one already
   imported `sourceFiles`/`readStripped`/`toRelative` for its tree-wide cast scan; the
   remaining private walk was a *second*, non-recursive `readdirSync` over
   `locales/en/*.json` (a `catalogs()` helper), which also had to go per the acceptance
   criterion "no test under `components/` calls `readdirSync` directly."
6. `components/factionMarks/__tests__/singularityLamps.test.tsx`
7. `components/factionMarks/__tests__/singularityProcessLight.test.tsx`
8. `components/praxisCard/scoreStamp/__tests__/canonicalStamp.test.tsx`
9. `components/praxisCard/__tests__/columnMountGuard.test.ts`
10. `components/vote/__tests__/testSeamsStayOutOfTheBundle.test.ts`

**That's 10, not 9** — see the ephemeristsScriptTurn note above. The issue's "nine"
covered the nine files with a private *recursive source-tree* walk; I found one of
those nine also had a second, non-recursive `readdirSync` (a locale-catalog listing)
that the acceptance criterion ("no test under `components/` calls `readdirSync`
directly") also reaches. Nine files touched, ten walks converted.

## Behaviour preserved — per-file notes

- `covenBadgeRetired.test.tsx` / `testSeamsStayOutOfTheBundle.test.ts`: these private
  walks recursed into `__tests__` directories (only excluding files named
  `*.test.tsx?`), unlike `sourceFiles()`'s default (`includeTests: false`, which skips
  whole `__tests__` directories). Migrated with `sourceFiles({ includeTests: true })`
  plus an explicit `.filter((path) => !/\.test\.tsx?$/.test(path))`, which reproduces
  the exact old population (verified: `src/locales/__tests__/findDuplicateJsonKeys.ts`
  and similar non-test helpers under `__tests__` dirs are picked up by both the old and
  new code). Their local, line-head-only comment strippers (`withoutComments`, which
  avoids breaking `https://` mid-line) were kept local rather than swapped for the
  shared `stripComments` — that's the "predicate stays local" part.
- `covenCat.test.tsx`, `columnMountGuard.test.ts`: same recurse-everywhere-but-tests
  shape; migrated the same way.
- `ephemeristsChamferPlate.test.tsx`, `singularityLamps.test.tsx`,
  `singularityProcessLight.test.tsx`: these walks already skipped `__tests__`
  directories entirely and matched `.tsx?`, i.e. exactly `sourceFiles()`'s defaults —
  straight swap, no options needed. Where their private comment-stripper was also
  line-head-only, I followed the precedent set by the already-migrated
  `ephemeristsPlateSurfaces.test.tsx` (PR #2904) and swapped to the shared
  `stripComments`, since that PR established this swap is safe (its own diff shows the
  same replacement) and every affected test still passes.
  `singularityLamps.test.tsx`/`singularityProcessLight.test.tsx` also excluded a
  `node_modules` directory name that can never occur under `src/`, so dropping that
  exclusion changes nothing.
- `ephemeristsNotationBand.test.tsx`: same shape (skip `__tests__`, match `.tsx?`), no
  comment-stripping involved for this one's walk — straight swap plus `toRelative()`
  for the three `path.slice(SRC.length).replace(/\\/g, "/")` call sites.
- `ephemeristsScriptTurn.test.tsx`: the pre-existing tree scan was untouched (already
  on `sourceFiles`); only the new-to-me `catalogs()` helper — a non-recursive,
  single-directory JSON listing — was converted, using
  `sourceFiles({ dir: ..., match: /\.json$/ })` (no subdirectories exist under
  `locales/en`, so recursive-vs-non-recursive is moot here).
- `canonicalStamp.test.tsx`: non-recursive single-directory `.tsx` listing of the nine
  score-stamp skins, converted the same way the already-migrated `sealMasthead.test.tsx`
  (PR #2904) converted its `SKINS` listing — `sourceFiles({ dir, match }).map(basename)`.

No guard's assertions were edited to make them pass; the full suite (477 test files,
9932 tests) is green unmodified, `tsc --noEmit`, `tsc -p tsconfig.design-sync.json
--noEmit`, and `eslint` are all clean, and `vite build` succeeds. The byte-budget script
prints a pre-existing WARN (not a fail) unrelated to this change — test files never
enter the production bundle.

`#2887`'s ratchet can land after this and #2886 (the twelve files outside `components/`)
both merge.

## What to eyeball

This is test-infrastructure-only — **no rendered surface changed**, so there is nothing
to visually QA. Every migrated file's own test suite was run individually and passes
unmodified, plus the full suite passes. The seam I tested at: each file's existing
`describe`/`it` assertions, unmodified — if a migration had changed which files a walk
sees, the existing "found all nine skins" / "exactly these N mounts" / ">400 files" /
"exactly these two seams" assertions would have caught it, and none did.
