### PR TITLE
Extract signup_eligibility module from services/praxis.py (#2870)

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -15,7 +15,7 @@ from models.account import Account
 from models.character import Character
 from schemas.task import TaskCreate, TaskOut, TaskSignupOut
 from services.auth import get_current_account
-from services.praxis import gather_signup_facts
+from services.signup_eligibility import gather_signup_facts
 from services.task import (
     UNKNOWN_TASK_AUTHOR,
     authors_for_tasks,

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -106,7 +106,8 @@ class TaskOut(WireModel):
     #
     # VIEWER-SCOPED, and this is the one that would be worth a leak. A popular
     # task has many submissions and only ONE of them is the requesting
-    # character's: the id comes from `services.praxis.submitted_praxis_ids`,
+    # character's: the id comes from
+    # `services.signup_eligibility.submitted_praxis_ids`,
     # whose query joins `PraxisMember` on the viewer's own character id, and it
     # is None for a viewer who has not submitted. It defaults None for anonymous
     # callers exactly as the flags above do.

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -787,7 +787,7 @@ async def list_characters_for_viewer(
     roster question or a prober's (#2422). ``None`` — anonymous, or a caller who
     passed none — keeps the anti-oracle answer.
     """
-    from services.praxis import multi_membership_faction_slugs
+    from services.signup_eligibility import multi_membership_faction_slugs
 
     era_row = await get_current_era_row_safe(session)
     era_id = era_row.id if era_row else None

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -33,9 +33,9 @@ from services.character_stats import recalculate_character_stats
 from services.nudge import latest_nudge_at
 from services.vote_tally import get_tally, tally_votes
 from services.era import get_current_era_row, get_or_create_stats
-from services.praxis import (
-    _count_in_progress_praxes,
-    get_praxis,
+from services.praxis import get_praxis
+from services.signup_eligibility import (
+    count_in_progress_praxes,
     is_active_member_of_task,
 )
 
@@ -409,7 +409,7 @@ async def respond_to_duel_challenge(
         )
 
     # Opponent bank cap check.
-    in_progress_count = await _count_in_progress_praxes(character_id, session)
+    in_progress_count = await count_in_progress_praxes(character_id, session)
     if in_progress_count >= era.max_task_signups:
         raise_coded(
             400,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -4,10 +4,9 @@ Handles all three praxis types: solo, collab, and duel.
 """
 
 import os
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Collection, List, Mapping, Optional
+from typing import List, Optional
 
 from fastapi import HTTPException, UploadFile
 from sqlalchemy import and_, exists, func, not_, or_, select
@@ -25,6 +24,7 @@ from faction_slugs import faction_filter_slugs
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
 from models.character import Character
+from models.duel import Duel, DuelStatus
 from models.flag import Flag, FlagReason, stored_flag_reason
 from models.praxis import (
     MediaItem,
@@ -36,8 +36,7 @@ from models.praxis import (
     PraxisStatus,
     PraxisType,
 )
-from models.character_stats import CharacterStats
-from models.task import Task, TaskStatus, TaskType
+from models.task import Task, TaskStatus
 from models.vote import Vote
 from schemas.praxis import (
     MediaItemOut,
@@ -49,24 +48,35 @@ from services.character_stats import (
     recalculate_character_stats,
     recalculate_members_stats,
 )
-from services.faction_service import faction_permits
-from services.media import (
-    process_and_save_media,
-    resolve_stored_media_path,
-    restore_media_to_mount,
-    withdraw_media_from_mount,
-)
 from services.era import (
     get_current_era_row,
     get_current_era_row_safe,
     get_era_row_for_praxis,
     get_or_create_stats,
 )
-from services.level_jump import available_level_reach, consume_level_jump
+from services.faction_service import faction_permits
+from services.level_jump import consume_level_jump
+from services.media import (
+    process_and_save_media,
+    resolve_stored_media_path,
+    restore_media_to_mount,
+    withdraw_media_from_mount,
+)
 from services.praxis_room import close_member_sockets
+from services.signup_eligibility import (
+    # Re-exported for existing `from services.praxis import ...` call sites
+    # (SIGNUP_REASON_MULTI_MEMBERSHIP, gather_signup_facts) that this module
+    # does not call itself — the definitions live in signup_eligibility now.
+    SIGNUP_REASON_MULTI_MEMBERSHIP,  # noqa: F401 - re-export, see comment above
+    SignupDenialReason,
+    allowed_praxis_modes,
+    count_in_progress_praxes,
+    evaluate_signup,
+    gather_signup_facts,  # noqa: F401 - re-export, see comment above
+    is_active_member_of_task,
+    meets_task_level,
+)
 from services.vote import void_account_vote_on_join
-from models.duel import Duel, DuelStatus
-
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -81,22 +91,6 @@ def _require_member(praxis: Praxis, character_id: int, action: str) -> None:
     """
     if character_id not in {m.character_id for m in praxis.members}:
         raise HTTPException(status_code=403, detail=f"Only a member can {action} this praxis.")
-
-
-async def _count_in_progress_praxes(character_id: int, session: AsyncSession) -> int:
-    """Count in-progress praxis memberships for bank capacity enforcement."""
-    result = await session.execute(
-        select(func.count())
-        .select_from(PraxisMember)
-        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
-        .where(
-            PraxisMember.character_id == character_id,
-            # pending = a collab mid-consensus; still an open, slot-consuming
-            # membership for bank-cap purposes (#590).
-            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.pending]),
-        )
-    )
-    return result.scalar_one()
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +315,8 @@ async def list_praxes(
     ``member_id`` is the raw membership filter with no status default, for
     callers that want in-flight work (the sidebar's in-progress list). Both
     spell membership via :func:`praxis_membership_condition`, which also backs
-    :func:`_count_in_progress_praxes`'s rule, so a membership-based list can
-    never disagree with the slot count.
+    :func:`services.signup_eligibility.count_in_progress_praxes`'s rule, so a
+    membership-based list can never disagree with the slot count.
 
     ``search`` is a free-text ``ilike`` over the praxis title, its body, the
     linked task's title, and **any member's** handle / display name. One box
@@ -534,247 +528,6 @@ async def list_praxes(
     for praxis in praxes:
         await collab_consensus.settle_if_window_lapsed(praxis, session, era)
     return praxes
-
-
-def meets_task_level(
-    character_level: int, task: Task, level_reach: int = 0
-) -> bool:
-    """Whether ``character_level`` clears the task's own level bar (#292).
-
-    The single home for the **task-level** gate — the "level half", stated once
-    here rather than ANDed inline into both
-    :func:`is_task_eligible_for_character` and the sign-up predicate. A distinct
-    axis from :func:`~services.faction_service.faction_permits`
-    (the faction half, #171) and from the era-config thresholds
-    (collab/flag/comment/metatask-apply), which each already sit in their own
-    purpose-named predicate and share a single ``era.*`` source for their value.
-
-    ``level_reach`` is the faction level-jump allowance (#811): levels above the
-    character's own that they may currently reach. It is 0 for everyone without
-    the ability and for anyone who has already spent it at this level — see
-    :func:`services.level_jump.available_level_reach`, which is the only thing
-    that should compute it. Extending the gate here (rather than per mode) is
-    what gives the ability identical behaviour across solo signup, collab
-    signup, and duel *initiation* (the challenger's own praxis, gated via
-    :func:`create_praxis` → :func:`evaluate_signup`).
-
-    Duel *acceptance* (the opponent, via
-    :func:`services.duel.respond_to_duel_challenge`) is a deliberate exception:
-    it never calls this predicate. The opponent's only level check is the flat
-    ``era.duel_level_required`` floor — reaching above your own level is the
-    point of a duel. See ADR-0051.
-    """
-    return character_level + level_reach >= task.level_required
-
-
-#: The one reason sign-up can be *open* that "you have not started this" does not
-#: explain: the viewer is already on the task and their faction may hold more than
-#: one membership on it (Double Dipper — ``can_hold_multiple_memberships``). It is
-#: never inferred from a slug; see :func:`signup_reason`, which derives it from the
-#: raw membership fact and the predicate's own verdict (#1497).
-SIGNUP_REASON_MULTI_MEMBERSHIP = "multi_membership"
-
-
-class SignupDenialReason(str, Enum):
-    """Why the type-agnostic sign-up gates reject a claim (ADR-0008)."""
-
-    below_level = "below_level"
-    task_status_closed = "task_status_closed"
-    already_active_member = "already_active_member"
-    bank_full = "bank_full"
-    is_metatask = "is_metatask"
-
-
-@dataclass(frozen=True)
-class SignupEligibility:
-    """Result of :func:`evaluate_signup`. ``reason`` is set iff ``allowed`` is False."""
-
-    allowed: bool
-    reason: Optional[SignupDenialReason] = None
-
-
-@dataclass(frozen=True)
-class SignupFacts:
-    """The character-scoped DB facts :func:`evaluate_signup` needs, read once.
-
-    Every gate in that predicate except the task's own columns comes from three
-    reads that are identical for every task a single request asks about: the
-    viewer's current-era stats, their in-progress praxis count (the bank cap),
-    and which of the tasks in hand they already hold a membership on. Gathered
-    per page by :func:`gather_signup_facts`, a 50-row browse pays for them once
-    instead of 50 times (#1377).
-
-    ``task_ids`` is the page these facts were gathered for. Both membership sets
-    are only meaningful within it, so :func:`evaluate_signup` and
-    :func:`signup_reason` fall back to their own query for a task outside the set
-    rather than reading absence as "not a member".
-
-    The two membership sets answer different questions and differ by exactly the
-    Double Dipper ability: ``active_member_task_ids`` is what *blocks* a fresh
-    claim, ``held_membership_task_ids`` is what the viewer is on at all. The wire
-    needs both to say "begin again" rather than "you are already on this" (#1497).
-    """
-
-    stats: CharacterStats
-    in_progress_praxis_count: int
-    task_ids: frozenset[int]
-    active_member_task_ids: frozenset[int]
-    held_membership_task_ids: frozenset[int]
-    #: Task id → the viewer's OPEN DRAFT on it, for ``TaskOut.in_progress_praxis_id``
-    #: (#2359). A third population, and neither of the two above: see
-    #: :func:`in_progress_praxis_ids` for why it can be folded into neither.
-    in_progress_praxis_ids: Mapping[int, int]
-    #: Task id → the viewer's FILED praxis on it, for ``TaskOut.submitted_praxis_id``
-    #: (#2643). A fourth, for :func:`submitted_praxis_ids`'s reason — the same
-    #: denial, the other side of it.
-    submitted_praxis_ids: Mapping[int, int]
-
-
-async def gather_signup_facts(
-    character: Character,
-    task_ids: Collection[int],
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> SignupFacts:
-    """Read one page's worth of :class:`SignupFacts` in seven queries, not per row.
-
-    ``era`` is threaded into the membership read so a caller evaluating against a
-    non-current ruleset gets facts from that same ruleset — precomputed facts
-    that disagree with the predicate would be the #1377 bug wearing a new hat.
-
-    The fifth read is the raw membership set (#1497). It is a second page-wide
-    query rather than a Python derivation of the first because deriving it would
-    mean restating the Double Dipper carve-out outside the SQL that owns it — the
-    #1359 defect exactly.
-
-    The sixth is the open-draft map (#2359) and the seventh its filed twin
-    (#2643). Both are *page-wide* queries like the other five, so the browse
-    still costs a constant number of reads however many rows are on it — the
-    only property this file's #1377 work defends. Seven constant reads is that
-    property held, not spent: what it forbids is a read that scales with the
-    page, and neither of these does.
-    """
-    era_row = await get_current_era_row(session)
-    return SignupFacts(
-        stats=await get_or_create_stats(session, character.id, era_row.id),
-        in_progress_praxis_count=await _count_in_progress_praxes(character.id, session),
-        task_ids=frozenset(task_ids),
-        active_member_task_ids=await active_member_task_ids(
-            character, task_ids, session, era
-        ),
-        held_membership_task_ids=await held_membership_task_ids(
-            character, task_ids, session
-        ),
-        in_progress_praxis_ids=await in_progress_praxis_ids(
-            character, task_ids, session
-        ),
-        submitted_praxis_ids=await submitted_praxis_ids(character, task_ids, session),
-    )
-
-
-async def evaluate_signup(
-    character: Optional[Character],
-    task: Task,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-    *,
-    facts: Optional[SignupFacts] = None,
-) -> SignupEligibility:
-    """The single sign-up predicate — true iff ``create_praxis``'s **type-agnostic**
-    gates would accept (ADR-0008). Owns the gates every claim shares: the task is
-    not a metatask, level, retired/pending faction carve-out, active-member, and
-    the task-bank cap. The
-    mode-specific gates (duel-via-challenge, collab level) stay in
-    :func:`allowed_praxis_modes` and are applied by :func:`_check_create_preconditions`.
-
-    Anonymous viewers are never eligible (``allowed=False``, no ``reason``).
-
-    ``facts`` is the page-wide precompute (:func:`gather_signup_facts`) a list
-    route passes in so this predicate is not an N+1 (#1377). It must have been
-    gathered for ``character``; omitting it makes every read here instead. It
-    changes no answer — only how many queries the answer costs.
-    """
-    if character is None:
-        return SignupEligibility(allowed=False)
-
-    # Metatasks are stickers applied to a praxis (edit-praxis seal stack), never
-    # signup targets — reject before any level/status work (#1001).
-    if task.task_type == TaskType.metatask:
-        return SignupEligibility(False, SignupDenialReason.is_metatask)
-
-    if facts is not None:
-        stats = facts.stats
-    else:
-        era_row = await get_current_era_row(session)
-        stats = await get_or_create_stats(session, character.id, era_row.id)
-
-    level_reach = available_level_reach(
-        character.faction_slug, stats.level, stats.level_jump_used_at_level, era
-    )
-    if not meets_task_level(stats.level, task, level_reach):
-        return SignupEligibility(False, SignupDenialReason.below_level)
-
-    if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
-        return SignupEligibility(False, SignupDenialReason.task_status_closed)
-    if task.status == TaskStatus.pending and character.faction_slug not in era.allow_praxis_on_pending_task_factions:
-        return SignupEligibility(False, SignupDenialReason.task_status_closed)
-
-    if facts is not None and task.id in facts.task_ids:
-        already_member = task.id in facts.active_member_task_ids
-    else:
-        already_member = await is_active_member_of_task(character, task, session, era)
-    if already_member:
-        return SignupEligibility(False, SignupDenialReason.already_active_member)
-
-    in_progress_count = (
-        facts.in_progress_praxis_count
-        if facts is not None
-        else await _count_in_progress_praxes(character.id, session)
-    )
-    if in_progress_count >= era.max_task_signups:
-        return SignupEligibility(False, SignupDenialReason.bank_full)
-
-    return SignupEligibility(allowed=True)
-
-
-async def signup_reason(
-    character: Optional[Character],
-    task: Task,
-    eligibility: SignupEligibility,
-    session: AsyncSession,
-    *,
-    facts: Optional[SignupFacts] = None,
-) -> Optional[str]:
-    """The ``TaskOut.signup_reason`` the wire carries — *why* this viewer may or may
-    not claim this task (#1497).
-
-    ``None`` means "nothing to explain": an ordinary first claim, or an anonymous
-    viewer who has no standing to be given a reason. Otherwise it is either a
-    :class:`SignupDenialReason` value (the blocked state, so the client can say
-    which gate closed) or :data:`SIGNUP_REASON_MULTI_MEMBERSHIP`.
-
-    The allowed-but-notable case is derived, never branched on a slug: if
-    :func:`evaluate_signup` says yes *and* the viewer already holds a membership,
-    the only rule that can have let both be true is the multi-membership ability.
-    That is why this reads the raw membership set rather than
-    ``active_member_task_ids``, which the ability empties by construction.
-
-    ``facts`` is the page-wide precompute and carries #1377's property: an id
-    outside ``facts.task_ids`` falls back to its own read instead of taking the
-    absence as "not a member".
-    """
-    if eligibility.reason is not None:
-        return eligibility.reason.value
-    if not eligibility.allowed or character is None:
-        return None
-
-    if facts is not None and task.id in facts.task_ids:
-        holds_membership = task.id in facts.held_membership_task_ids
-    else:
-        holds_membership = task.id in await held_membership_task_ids(
-            character, [task.id], session
-        )
-    return SIGNUP_REASON_MULTI_MEMBERSHIP if holds_membership else None
 
 
 def _signup_denial_to_http(
@@ -1413,286 +1166,6 @@ async def can_flag_praxis(
     return stats.level >= era.flag_level_required
 
 
-def multi_membership_faction_slugs(era: EraConfig = CURRENT_ERA) -> tuple[str, ...]:
-    """Slugs whose members may hold more than one active membership on a task.
-
-    The "Double Dipper" ability (Everymen in Era 1) read off ``era`` rather than
-    branched on a slug — it is a ``FactionConfig.can_hold_multiple_memberships``
-    field, the same shape as WOW's level jump (#1359).
-
-    This is the *only* statement of the rule. :func:`active_member_task_ids_subquery`
-    applies it in SQL and every Python caller reaches that subquery, so the
-    browse list and the sign-up predicate cannot answer differently.
-    """
-    return tuple(
-        sorted(
-            slug
-            for slug, faction in era.factions.items()
-            if faction.can_hold_multiple_memberships
-        )
-    )
-
-
-def _held_membership_task_ids_subquery(character_id: int):
-    """Task IDs where ``character_id`` holds an active praxis membership — **the raw
-    fact, with no ability applied**.
-
-    "Active" means the praxis status is ``in_progress``, ``pending`` or ``submitted``.
-
-    "Am I on this task" is not the same question as "does being on this task stop me
-    claiming it again". Double Dipper is precisely the gap between the two, and
-    ``TaskOut.signup_reason`` needs both sides of it to tell "begin again" from
-    "you have never started this" (#1497).
-    :func:`active_member_task_ids_subquery` is this select plus the carve-out, so
-    the carve-out is still written exactly once.
-    """
-    return (
-        select(Praxis.task_id)
-        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
-        .join(Character, Character.id == PraxisMember.character_id)
-        .where(
-            PraxisMember.character_id == character_id,
-            Praxis.status.in_(
-                [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
-            ),
-        )
-    )
-
-
-def active_member_task_ids_subquery(
-    character_id: int, era: EraConfig = CURRENT_ERA
-):
-    """SQL subquery returning task IDs whose membership **blocks** a fresh claim.
-
-    Used by the task-list query to exclude tasks the character is already working on,
-    and by :func:`active_member_task_ids` for the Python answer.
-
-    The Double Dipper carve-out lives *here*, in the SQL, and not in a Python
-    branch above it: the browse exclusion (``services.task.list_tasks``) reaches
-    this function without going through the predicate, so a carve-out stated
-    anywhere else is one the browse silently ignores — which is exactly how a
-    task an Everymen character could legitimately claim again went missing from
-    their own list (#1359). The join is on the membership's character, whose id
-    is a primary key, so it adds a row lookup and no fan-out.
-    """
-    return _held_membership_task_ids_subquery(character_id).where(
-        Character.faction_slug.notin_(multi_membership_faction_slugs(era))
-    )
-
-
-async def held_membership_task_ids(
-    character: Character,
-    task_ids: Collection[int],
-    session: AsyncSession,
-) -> frozenset[int]:
-    """Which of ``task_ids`` ``character`` is on **at all** — ONE query, no carve-out.
-
-    The batch sibling of :func:`active_member_task_ids`, reading
-    :func:`_held_membership_task_ids_subquery` instead. Takes no ``era`` because no
-    ruleset changes the raw fact; only what the fact *means* is era-dependent, and
-    that lives in :func:`multi_membership_faction_slugs`.
-    """
-    if not task_ids:
-        return frozenset()
-    result = await session.execute(
-        _held_membership_task_ids_subquery(character.id).where(
-            Praxis.task_id.in_(task_ids)
-        )
-    )
-    return frozenset(result.scalars().all())
-
-
-async def active_member_task_ids(
-    character: Character,
-    task_ids: Collection[int],
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> frozenset[int]:
-    """Which of ``task_ids`` ``character`` already holds an active membership on — ONE query.
-
-    "Active" is the same population as :func:`active_member_task_ids_subquery`,
-    which is also where the Double Dipper carve-out is applied: a member of a
-    faction that may hold multiple memberships matches no row, so the gate never
-    closes for them.
-
-    The batch form of :func:`is_active_member_of_task`, which delegates here
-    — one implementation, so the page-wide answer and the single-task answer
-    cannot drift (#1377).
-    """
-    if not task_ids:
-        return frozenset()
-    result = await session.execute(
-        active_member_task_ids_subquery(character.id, era).where(
-            Praxis.task_id.in_(task_ids)
-        )
-    )
-    return frozenset(result.scalars().all())
-
-
-async def in_progress_praxis_ids(
-    character: Character,
-    task_ids: Collection[int],
-    session: AsyncSession,
-) -> dict[int, int]:
-    """Which of ``task_ids`` ``character`` holds an OPEN DRAFT on, and which praxis
-    — ONE query. The source of ``TaskOut.in_progress_praxis_id`` (#2359).
-
-    A THIRD population, and it can be folded into neither of its two siblings
-    above, which is why it is its own read rather than a column added to one of
-    them:
-
-    * :func:`held_membership_task_ids` is wider — it counts ``pending`` and
-      ``submitted`` too. A submitted praxis shuts sign-up but leaves nothing to
-      edit, so borrowing its rows would hand out ids to editors that will refuse
-      them. ``in_progress`` is what the task detail page means by "your draft"
-      (``useTaskDetail.ts`` fetches exactly ``status=in_progress``), and the two
-      surfaces must not disagree about which praxis is yours.
-    * :func:`active_member_task_ids` is narrower — the Double Dipper carve-out
-      empties it for factions that may hold several memberships. "Do I have a
-      draft here" is a raw fact no ability changes.
-
-    No ``era``, for :func:`held_membership_task_ids`'s reason: no ruleset changes
-    the raw fact.
-
-    A character may hold more than one open draft on one task (Double Dipper);
-    the ordering makes the newest one the answer rather than an arbitrary one.
-    """
-    return await _own_praxis_ids(character, task_ids, PraxisStatus.in_progress, session)
-
-
-async def submitted_praxis_ids(
-    character: Character,
-    task_ids: Collection[int],
-    session: AsyncSession,
-) -> dict[int, int]:
-    """Which of ``task_ids`` ``character`` has FILED a praxis on, and which praxis
-    — ONE query. The source of ``TaskOut.submitted_praxis_id`` (#2643).
-
-    The twin of :func:`in_progress_praxis_ids` one status further on, and it
-    exists for the same reason: ``already_active_member`` is the denial a card
-    spends its only slot on, and for a *submitted* praxis the useful thing —
-    reading it — is one hop away with no id to reach it by. Same viewer scoping,
-    same page-wide shape, same absence of ``era``.
-
-    ``submitted`` ONLY, deliberately narrower than the denial's own population
-    (``in_progress``, ``pending``, ``submitted``). ``pending`` is a praxis
-    awaiting moderation and is nobody's "read your praxis"; it keeps falling
-    through to the plain label, exactly as it did before this field existed.
-
-    A character may have submitted MORE THAN ONCE to one task — re-signing up
-    after a first praxis is filed is a live path (``ctaAgain``, Double Dipper) —
-    so this holds the MOST RECENT one. That is the ordering below and not the
-    query's default: ascending ``Praxis.id`` with a last-write-wins dict leaves
-    the highest id, and ids are monotonic. A stale first attempt would be the
-    wrong door to offer someone who has already filed a second.
-    """
-    return await _own_praxis_ids(character, task_ids, PraxisStatus.submitted, session)
-
-
-async def _own_praxis_ids(
-    character: Character,
-    task_ids: Collection[int],
-    status: PraxisStatus,
-    session: AsyncSession,
-) -> dict[int, int]:
-    """Task id → ``character``'s own praxis in ``status`` on it, newest wins.
-
-    The one query behind both readers above, so the two cannot drift on the part
-    that matters most: **the membership join is what scopes this to the viewer**.
-    Written once, it cannot be dropped from one of them and leak a stranger's
-    praxis id onto a task with many submissions.
-
-    Private because the two named readers are the vocabulary — a caller wanting
-    "the viewer's praxis in status X" for some third X is a population that
-    should arrive with its own docstring saying what it means, as those two do.
-    """
-    if not task_ids:
-        return {}
-    result = await session.execute(
-        select(Praxis.task_id, Praxis.id)
-        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
-        .where(
-            PraxisMember.character_id == character.id,
-            Praxis.status == status,
-            Praxis.task_id.in_(task_ids),
-        )
-        .order_by(Praxis.id)
-    )
-    return {task_id: praxis_id for task_id, praxis_id in result.all()}
-
-
-async def is_active_member_of_task(
-    character: Character,
-    task: Task,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> bool:
-    """Return True if ``character`` holds an active praxis membership for ``task``.
-
-    False for a faction the era grants Double Dipper to — see
-    :func:`multi_membership_faction_slugs`.
-    """
-    return task.id in await active_member_task_ids(character, [task.id], session, era)
-
-
-def allowed_praxis_modes(
-    character: Optional[Character],
-    character_level: int,
-    era: EraConfig = CURRENT_ERA,
-) -> list[PraxisType]:
-    """Return the praxis modes a character may create directly.
-
-    Single source for the mode-by-level gates — enforcement in
-    :func:`_check_create_preconditions` and the UI flag on
-    :class:`~schemas.task.TaskOut` both derive from this list.
-
-    - Solo: always allowed once a viewer is authenticated.
-    - Collab: requires ``character_level >= era.collaboration_level_required``.
-    - Duel: issued via the challenge endpoint (ADR-0011), not direct creation.
-
-    Anonymous viewers (``character is None``) receive an empty list so the
-    UI can hide the mode picker entirely.
-    """
-    if character is None:
-        return []
-    modes: list[PraxisType] = [PraxisType.solo]
-    if character_level >= era.collaboration_level_required:
-        modes.append(PraxisType.collab)
-    return modes
-
-
-def is_task_eligible_for_character(
-    character: Optional[Character],
-    task: Task,
-    character_level: int,
-    level_reach: int = 0,
-) -> bool:
-    """Return True if ``character`` is eligible to act on ``task``.
-
-    The gate is ``task.level_required`` plus whatever
-    :func:`services.faction_service.faction_permits` enforces — presently
-    nothing, as metatasks are faction-open. Anonymous viewers are
-    never eligible.
-
-    Note this mirrors the metatask scoring gate in
-    :func:`services.meta_task.get_meta_task_points_bulk`
-    (``character_level >= task.level_required``)
-    rather than the stricter :func:`apply_metatask` service gate. The flag is
-    intended for UI affordances such as "metatasks this character could use
-    if they had one" — apply time still runs the full guard.
-    """
-    if character is None:
-        return False
-    # Two named single-purpose gates, no bundled inline checks (#171, #292).
-    # ``level_reach`` (#811) is threaded through so the "eligible" affordance
-    # matches what evaluate_signup would actually allow.
-    if not meets_task_level(character_level, task, level_reach):
-        return False
-    if not faction_permits(character, task):
-        return False
-    return True
-
-
 async def flag_praxis(
     praxis_id: int,
     flagged_by: Character,
@@ -1910,7 +1383,7 @@ async def respond_to_invite(
     # Check bank capacity — unless this era's collab door lifts it too (#1511).
     already_member = any(m.character_id == character_id for m in praxis.members)
     if not era.collab_invite_bypasses_task_bank and not already_member:
-        in_progress_count = await _count_in_progress_praxes(character_id, session)
+        in_progress_count = await count_in_progress_praxes(character_id, session)
         if in_progress_count >= era.max_task_signups:
             raise_coded(
                 409,

--- a/backend/services/signup_eligibility.py
+++ b/backend/services/signup_eligibility.py
@@ -1,0 +1,579 @@
+"""Can this Character sign up for this Task — the type-agnostic gate (ADR-0008).
+
+Owns the level gate (:func:`meets_task_level`), the sign-up predicate itself
+(:func:`evaluate_signup`) and the DB facts it reads (:func:`gather_signup_facts`,
+:class:`SignupFacts`), the wire-facing reason string (:func:`signup_reason`), the
+Double Dipper membership machinery (:func:`multi_membership_faction_slugs` and
+everything built on :func:`active_member_task_ids_subquery`), the mode gate
+(:func:`allowed_praxis_modes`), and the eligibility flag used outside sign-up
+proper (:func:`is_task_eligible_for_character`).
+
+Split out of ``services/praxis.py`` (#1391 cut 3, #2870) — a pure move, no
+behaviour change. ``services.task`` wanted exactly this concept and nothing else
+from ``praxis.py``; importing it from a module named for the concept (rather than
+nine symbols and one private one from the praxis module) is the whole point.
+``services.praxis`` is a caller too, for the pieces its own create/invite flow
+still needs (:func:`evaluate_signup`, :func:`allowed_praxis_modes`,
+:func:`meets_task_level`, :func:`is_active_member_of_task`,
+:func:`count_in_progress_praxes`) — it imports them from here rather than
+keeping a second definition.
+
+``in_progress_praxis_ids`` and ``submitted_praxis_ids`` live here rather than in
+the SQL-visibility module #2871 carves out next: both are read directly by
+:func:`gather_signup_facts` in this file, so keeping them here avoids a call
+back across that module boundary. #2871 inherits this as settled.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Collection, Mapping, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus, TaskType
+from services.era import get_current_era_row, get_or_create_stats
+from services.faction_service import faction_permits
+from services.level_jump import available_level_reach
+
+
+async def count_in_progress_praxes(character_id: int, session: AsyncSession) -> int:
+    """Count in-progress praxis memberships for bank capacity enforcement."""
+    result = await session.execute(
+        select(func.count())
+        .select_from(PraxisMember)
+        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+        .where(
+            PraxisMember.character_id == character_id,
+            # pending = a collab mid-consensus; still an open, slot-consuming
+            # membership for bank-cap purposes (#590).
+            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.pending]),
+        )
+    )
+    return result.scalar_one()
+
+
+def meets_task_level(
+    character_level: int, task: Task, level_reach: int = 0
+) -> bool:
+    """Whether ``character_level`` clears the task's own level bar (#292).
+
+    The single home for the **task-level** gate — the "level half", stated once
+    here rather than ANDed inline into both
+    :func:`is_task_eligible_for_character` and the sign-up predicate. A distinct
+    axis from :func:`~services.faction_service.faction_permits`
+    (the faction half, #171) and from the era-config thresholds
+    (collab/flag/comment/metatask-apply), which each already sit in their own
+    purpose-named predicate and share a single ``era.*`` source for their value.
+
+    ``level_reach`` is the faction level-jump allowance (#811): levels above the
+    character's own that they may currently reach. It is 0 for everyone without
+    the ability and for anyone who has already spent it at this level — see
+    :func:`services.level_jump.available_level_reach`, which is the only thing
+    that should compute it. Extending the gate here (rather than per mode) is
+    what gives the ability identical behaviour across solo signup, collab
+    signup, and duel *initiation* (the challenger's own praxis, gated via
+    :func:`services.praxis.create_praxis` → :func:`evaluate_signup`).
+
+    Duel *acceptance* (the opponent, via
+    :func:`services.duel.respond_to_duel_challenge`) is a deliberate exception:
+    it never calls this predicate. The opponent's only level check is the flat
+    ``era.duel_level_required`` floor — reaching above your own level is the
+    point of a duel. See ADR-0051.
+    """
+    return character_level + level_reach >= task.level_required
+
+
+#: The one reason sign-up can be *open* that "you have not started this" does not
+#: explain: the viewer is already on the task and their faction may hold more than
+#: one membership on it (Double Dipper — ``can_hold_multiple_memberships``). It is
+#: never inferred from a slug; see :func:`signup_reason`, which derives it from the
+#: raw membership fact and the predicate's own verdict (#1497).
+SIGNUP_REASON_MULTI_MEMBERSHIP = "multi_membership"
+
+
+class SignupDenialReason(str, Enum):
+    """Why the type-agnostic sign-up gates reject a claim (ADR-0008)."""
+
+    below_level = "below_level"
+    task_status_closed = "task_status_closed"
+    already_active_member = "already_active_member"
+    bank_full = "bank_full"
+    is_metatask = "is_metatask"
+
+
+@dataclass(frozen=True)
+class SignupEligibility:
+    """Result of :func:`evaluate_signup`. ``reason`` is set iff ``allowed`` is False."""
+
+    allowed: bool
+    reason: Optional[SignupDenialReason] = None
+
+
+@dataclass(frozen=True)
+class SignupFacts:
+    """The character-scoped DB facts :func:`evaluate_signup` needs, read once.
+
+    Every gate in that predicate except the task's own columns comes from three
+    reads that are identical for every task a single request asks about: the
+    viewer's current-era stats, their in-progress praxis count (the bank cap),
+    and which of the tasks in hand they already hold a membership on. Gathered
+    per page by :func:`gather_signup_facts`, a 50-row browse pays for them once
+    instead of 50 times (#1377).
+
+    ``task_ids`` is the page these facts were gathered for. Both membership sets
+    are only meaningful within it, so :func:`evaluate_signup` and
+    :func:`signup_reason` fall back to their own query for a task outside the set
+    rather than reading absence as "not a member".
+
+    The two membership sets answer different questions and differ by exactly the
+    Double Dipper ability: ``active_member_task_ids`` is what *blocks* a fresh
+    claim, ``held_membership_task_ids`` is what the viewer is on at all. The wire
+    needs both to say "begin again" rather than "you are already on this" (#1497).
+    """
+
+    stats: CharacterStats
+    in_progress_praxis_count: int
+    task_ids: frozenset[int]
+    active_member_task_ids: frozenset[int]
+    held_membership_task_ids: frozenset[int]
+    #: Task id → the viewer's OPEN DRAFT on it, for ``TaskOut.in_progress_praxis_id``
+    #: (#2359). A third population, and neither of the two above: see
+    #: :func:`in_progress_praxis_ids` for why it can be folded into neither.
+    in_progress_praxis_ids: Mapping[int, int]
+    #: Task id → the viewer's FILED praxis on it, for ``TaskOut.submitted_praxis_id``
+    #: (#2643). A fourth, for :func:`submitted_praxis_ids`'s reason — the same
+    #: denial, the other side of it.
+    submitted_praxis_ids: Mapping[int, int]
+
+
+async def gather_signup_facts(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> SignupFacts:
+    """Read one page's worth of :class:`SignupFacts` in seven queries, not per row.
+
+    ``era`` is threaded into the membership read so a caller evaluating against a
+    non-current ruleset gets facts from that same ruleset — precomputed facts
+    that disagree with the predicate would be the #1377 bug wearing a new hat.
+
+    The fifth read is the raw membership set (#1497). It is a second page-wide
+    query rather than a Python derivation of the first because deriving it would
+    mean restating the Double Dipper carve-out outside the SQL that owns it — the
+    #1359 defect exactly.
+
+    The sixth is the open-draft map (#2359) and the seventh its filed twin
+    (#2643). Both are *page-wide* queries like the other five, so the browse
+    still costs a constant number of reads however many rows are on it — the
+    only property this file's #1377 work defends. Seven constant reads is that
+    property held, not spent: what it forbids is a read that scales with the
+    page, and neither of these does.
+    """
+    era_row = await get_current_era_row(session)
+    return SignupFacts(
+        stats=await get_or_create_stats(session, character.id, era_row.id),
+        in_progress_praxis_count=await count_in_progress_praxes(character.id, session),
+        task_ids=frozenset(task_ids),
+        active_member_task_ids=await active_member_task_ids(
+            character, task_ids, session, era
+        ),
+        held_membership_task_ids=await held_membership_task_ids(
+            character, task_ids, session
+        ),
+        in_progress_praxis_ids=await in_progress_praxis_ids(
+            character, task_ids, session
+        ),
+        submitted_praxis_ids=await submitted_praxis_ids(character, task_ids, session),
+    )
+
+
+async def evaluate_signup(
+    character: Optional[Character],
+    task: Task,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+    *,
+    facts: Optional[SignupFacts] = None,
+) -> SignupEligibility:
+    """The single sign-up predicate — true iff ``create_praxis``'s **type-agnostic**
+    gates would accept (ADR-0008). Owns the gates every claim shares: the task is
+    not a metatask, level, retired/pending faction carve-out, active-member, and
+    the task-bank cap. The
+    mode-specific gates (duel-via-challenge, collab level) stay in
+    :func:`allowed_praxis_modes` and are applied by
+    :func:`services.praxis._check_create_preconditions`.
+
+    Anonymous viewers are never eligible (``allowed=False``, no ``reason``).
+
+    ``facts`` is the page-wide precompute (:func:`gather_signup_facts`) a list
+    route passes in so this predicate is not an N+1 (#1377). It must have been
+    gathered for ``character``; omitting it makes every read here instead. It
+    changes no answer — only how many queries the answer costs.
+    """
+    if character is None:
+        return SignupEligibility(allowed=False)
+
+    # Metatasks are stickers applied to a praxis (edit-praxis seal stack), never
+    # signup targets — reject before any level/status work (#1001).
+    if task.task_type == TaskType.metatask:
+        return SignupEligibility(False, SignupDenialReason.is_metatask)
+
+    if facts is not None:
+        stats = facts.stats
+    else:
+        era_row = await get_current_era_row(session)
+        stats = await get_or_create_stats(session, character.id, era_row.id)
+
+    level_reach = available_level_reach(
+        character.faction_slug, stats.level, stats.level_jump_used_at_level, era
+    )
+    if not meets_task_level(stats.level, task, level_reach):
+        return SignupEligibility(False, SignupDenialReason.below_level)
+
+    if task.status == TaskStatus.retired and character.faction_slug not in era.allow_praxis_on_retired_task_factions:
+        return SignupEligibility(False, SignupDenialReason.task_status_closed)
+    if task.status == TaskStatus.pending and character.faction_slug not in era.allow_praxis_on_pending_task_factions:
+        return SignupEligibility(False, SignupDenialReason.task_status_closed)
+
+    if facts is not None and task.id in facts.task_ids:
+        already_member = task.id in facts.active_member_task_ids
+    else:
+        already_member = await is_active_member_of_task(character, task, session, era)
+    if already_member:
+        return SignupEligibility(False, SignupDenialReason.already_active_member)
+
+    in_progress_count = (
+        facts.in_progress_praxis_count
+        if facts is not None
+        else await count_in_progress_praxes(character.id, session)
+    )
+    if in_progress_count >= era.max_task_signups:
+        return SignupEligibility(False, SignupDenialReason.bank_full)
+
+    return SignupEligibility(allowed=True)
+
+
+async def signup_reason(
+    character: Optional[Character],
+    task: Task,
+    eligibility: SignupEligibility,
+    session: AsyncSession,
+    *,
+    facts: Optional[SignupFacts] = None,
+) -> Optional[str]:
+    """The ``TaskOut.signup_reason`` the wire carries — *why* this viewer may or may
+    not claim this task (#1497).
+
+    ``None`` means "nothing to explain": an ordinary first claim, or an anonymous
+    viewer who has no standing to be given a reason. Otherwise it is either a
+    :class:`SignupDenialReason` value (the blocked state, so the client can say
+    which gate closed) or :data:`SIGNUP_REASON_MULTI_MEMBERSHIP`.
+
+    The allowed-but-notable case is derived, never branched on a slug: if
+    :func:`evaluate_signup` says yes *and* the viewer already holds a membership,
+    the only rule that can have let both be true is the multi-membership ability.
+    That is why this reads the raw membership set rather than
+    ``active_member_task_ids``, which the ability empties by construction.
+
+    ``facts`` is the page-wide precompute and carries #1377's property: an id
+    outside ``facts.task_ids`` falls back to its own read instead of taking the
+    absence as "not a member".
+    """
+    if eligibility.reason is not None:
+        return eligibility.reason.value
+    if not eligibility.allowed or character is None:
+        return None
+
+    if facts is not None and task.id in facts.task_ids:
+        holds_membership = task.id in facts.held_membership_task_ids
+    else:
+        holds_membership = task.id in await held_membership_task_ids(
+            character, [task.id], session
+        )
+    return SIGNUP_REASON_MULTI_MEMBERSHIP if holds_membership else None
+
+
+def multi_membership_faction_slugs(era: EraConfig = CURRENT_ERA) -> tuple[str, ...]:
+    """Slugs whose members may hold more than one active membership on a task.
+
+    The "Double Dipper" ability (Everymen in Era 1) read off ``era`` rather than
+    branched on a slug — it is a ``FactionConfig.can_hold_multiple_memberships``
+    field, the same shape as WOW's level jump (#1359).
+
+    This is the *only* statement of the rule. :func:`active_member_task_ids_subquery`
+    applies it in SQL and every Python caller reaches that subquery, so the
+    browse list and the sign-up predicate cannot answer differently.
+    """
+    return tuple(
+        sorted(
+            slug
+            for slug, faction in era.factions.items()
+            if faction.can_hold_multiple_memberships
+        )
+    )
+
+
+def _held_membership_task_ids_subquery(character_id: int):
+    """Task IDs where ``character_id`` holds an active praxis membership — **the raw
+    fact, with no ability applied**.
+
+    "Active" means the praxis status is ``in_progress``, ``pending`` or ``submitted``.
+
+    "Am I on this task" is not the same question as "does being on this task stop me
+    claiming it again". Double Dipper is precisely the gap between the two, and
+    ``TaskOut.signup_reason`` needs both sides of it to tell "begin again" from
+    "you have never started this" (#1497).
+    :func:`active_member_task_ids_subquery` is this select plus the carve-out, so
+    the carve-out is still written exactly once.
+    """
+    return (
+        select(Praxis.task_id)
+        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
+        .join(Character, Character.id == PraxisMember.character_id)
+        .where(
+            PraxisMember.character_id == character_id,
+            Praxis.status.in_(
+                [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
+            ),
+        )
+    )
+
+
+def active_member_task_ids_subquery(
+    character_id: int, era: EraConfig = CURRENT_ERA
+):
+    """SQL subquery returning task IDs whose membership **blocks** a fresh claim.
+
+    Used by the task-list query to exclude tasks the character is already working on,
+    and by :func:`active_member_task_ids` for the Python answer.
+
+    The Double Dipper carve-out lives *here*, in the SQL, and not in a Python
+    branch above it: the browse exclusion (``services.task.list_tasks``) reaches
+    this function without going through the predicate, so a carve-out stated
+    anywhere else is one the browse silently ignores — which is exactly how a
+    task an Everymen character could legitimately claim again went missing from
+    their own list (#1359). The join is on the membership's character, whose id
+    is a primary key, so it adds a row lookup and no fan-out.
+    """
+    return _held_membership_task_ids_subquery(character_id).where(
+        Character.faction_slug.notin_(multi_membership_faction_slugs(era))
+    )
+
+
+async def held_membership_task_ids(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+) -> frozenset[int]:
+    """Which of ``task_ids`` ``character`` is on **at all** — ONE query, no carve-out.
+
+    The batch sibling of :func:`active_member_task_ids`, reading
+    :func:`_held_membership_task_ids_subquery` instead. Takes no ``era`` because no
+    ruleset changes the raw fact; only what the fact *means* is era-dependent, and
+    that lives in :func:`multi_membership_faction_slugs`.
+    """
+    if not task_ids:
+        return frozenset()
+    result = await session.execute(
+        _held_membership_task_ids_subquery(character.id).where(
+            Praxis.task_id.in_(task_ids)
+        )
+    )
+    return frozenset(result.scalars().all())
+
+
+async def active_member_task_ids(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> frozenset[int]:
+    """Which of ``task_ids`` ``character`` already holds an active membership on — ONE query.
+
+    "Active" is the same population as :func:`active_member_task_ids_subquery`,
+    which is also where the Double Dipper carve-out is applied: a member of a
+    faction that may hold multiple memberships matches no row, so the gate never
+    closes for them.
+
+    The batch form of :func:`is_active_member_of_task`, which delegates here
+    — one implementation, so the page-wide answer and the single-task answer
+    cannot drift (#1377).
+    """
+    if not task_ids:
+        return frozenset()
+    result = await session.execute(
+        active_member_task_ids_subquery(character.id, era).where(
+            Praxis.task_id.in_(task_ids)
+        )
+    )
+    return frozenset(result.scalars().all())
+
+
+async def in_progress_praxis_ids(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+) -> dict[int, int]:
+    """Which of ``task_ids`` ``character`` holds an OPEN DRAFT on, and which praxis
+    — ONE query. The source of ``TaskOut.in_progress_praxis_id`` (#2359).
+
+    A THIRD population, and it can be folded into neither of its two siblings
+    above, which is why it is its own read rather than a column added to one of
+    them:
+
+    * :func:`held_membership_task_ids` is wider — it counts ``pending`` and
+      ``submitted`` too. A submitted praxis shuts sign-up but leaves nothing to
+      edit, so borrowing its rows would hand out ids to editors that will refuse
+      them. ``in_progress`` is what the task detail page means by "your draft"
+      (``useTaskDetail.ts`` fetches exactly ``status=in_progress``), and the two
+      surfaces must not disagree about which praxis is yours.
+    * :func:`active_member_task_ids` is narrower — the Double Dipper carve-out
+      empties it for factions that may hold several memberships. "Do I have a
+      draft here" is a raw fact no ability changes.
+
+    No ``era``, for :func:`held_membership_task_ids`'s reason: no ruleset changes
+    the raw fact.
+
+    A character may hold more than one open draft on one task (Double Dipper);
+    the ordering makes the newest one the answer rather than an arbitrary one.
+    """
+    return await _own_praxis_ids(character, task_ids, PraxisStatus.in_progress, session)
+
+
+async def submitted_praxis_ids(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+) -> dict[int, int]:
+    """Which of ``task_ids`` ``character`` has FILED a praxis on, and which praxis
+    — ONE query. The source of ``TaskOut.submitted_praxis_id`` (#2643).
+
+    The twin of :func:`in_progress_praxis_ids` one status further on, and it
+    exists for the same reason: ``already_active_member`` is the denial a card
+    spends its only slot on, and for a *submitted* praxis the useful thing —
+    reading it — is one hop away with no id to reach it by. Same viewer scoping,
+    same page-wide shape, same absence of ``era``.
+
+    ``submitted`` ONLY, deliberately narrower than the denial's own population
+    (``in_progress``, ``pending``, ``submitted``). ``pending`` is a praxis
+    awaiting moderation and is nobody's "read your praxis"; it keeps falling
+    through to the plain label, exactly as it did before this field existed.
+
+    A character may have submitted MORE THAN ONCE to one task — re-signing up
+    after a first praxis is filed is a live path (``ctaAgain``, Double Dipper) —
+    so this holds the MOST RECENT one. That is the ordering below and not the
+    query's default: ascending ``Praxis.id`` with a last-write-wins dict leaves
+    the highest id, and ids are monotonic. A stale first attempt would be the
+    wrong door to offer someone who has already filed a second.
+    """
+    return await _own_praxis_ids(character, task_ids, PraxisStatus.submitted, session)
+
+
+async def _own_praxis_ids(
+    character: Character,
+    task_ids: Collection[int],
+    status: PraxisStatus,
+    session: AsyncSession,
+) -> dict[int, int]:
+    """Task id → ``character``'s own praxis in ``status`` on it, newest wins.
+
+    The one query behind both readers above, so the two cannot drift on the part
+    that matters most: **the membership join is what scopes this to the viewer**.
+    Written once, it cannot be dropped from one of them and leak a stranger's
+    praxis id onto a task with many submissions.
+
+    Private because the two named readers are the vocabulary — a caller wanting
+    "the viewer's praxis in status X" for some third X is a population that
+    should arrive with its own docstring saying what it means, as those two do.
+    """
+    if not task_ids:
+        return {}
+    result = await session.execute(
+        select(Praxis.task_id, Praxis.id)
+        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
+        .where(
+            PraxisMember.character_id == character.id,
+            Praxis.status == status,
+            Praxis.task_id.in_(task_ids),
+        )
+        .order_by(Praxis.id)
+    )
+    return {task_id: praxis_id for task_id, praxis_id in result.all()}
+
+
+async def is_active_member_of_task(
+    character: Character,
+    task: Task,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> bool:
+    """Return True if ``character`` holds an active praxis membership for ``task``.
+
+    False for a faction the era grants Double Dipper to — see
+    :func:`multi_membership_faction_slugs`.
+    """
+    return task.id in await active_member_task_ids(character, [task.id], session, era)
+
+
+def allowed_praxis_modes(
+    character: Optional[Character],
+    character_level: int,
+    era: EraConfig = CURRENT_ERA,
+) -> list[PraxisType]:
+    """Return the praxis modes a character may create directly.
+
+    Single source for the mode-by-level gates — enforcement in
+    :func:`services.praxis._check_create_preconditions` and the UI flag on
+    :class:`~schemas.task.TaskOut` both derive from this list.
+
+    - Solo: always allowed once a viewer is authenticated.
+    - Collab: requires ``character_level >= era.collaboration_level_required``.
+    - Duel: issued via the challenge endpoint (ADR-0011), not direct creation.
+
+    Anonymous viewers (``character is None``) receive an empty list so the
+    UI can hide the mode picker entirely.
+    """
+    if character is None:
+        return []
+    modes: list[PraxisType] = [PraxisType.solo]
+    if character_level >= era.collaboration_level_required:
+        modes.append(PraxisType.collab)
+    return modes
+
+
+def is_task_eligible_for_character(
+    character: Optional[Character],
+    task: Task,
+    character_level: int,
+    level_reach: int = 0,
+) -> bool:
+    """Return True if ``character`` is eligible to act on ``task``.
+
+    The gate is ``task.level_required`` plus whatever
+    :func:`services.faction_service.faction_permits` enforces — presently
+    nothing, as metatasks are faction-open. Anonymous viewers are
+    never eligible.
+
+    Note this mirrors the metatask scoring gate in
+    :func:`services.meta_task.get_meta_task_points_bulk`
+    (``character_level >= task.level_required``)
+    rather than the stricter :func:`apply_metatask` service gate. The flag is
+    intended for UI affordances such as "metatasks this character could use
+    if they had one" — apply time still runs the full guard.
+    """
+    if character is None:
+        return False
+    # Two named single-purpose gates, no bundled inline checks (#171, #292).
+    # ``level_reach`` (#811) is threaded through so the "eligible" affordance
+    # matches what evaluate_signup would actually allow.
+    if not meets_task_level(character_level, task, level_reach):
+        return False
+    if not faction_permits(character, task):
+        return False
+    return True

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -17,30 +17,27 @@ from models.praxis import Praxis, PraxisMember, PraxisStatus
 from models.task import Task, TaskStatus, TaskType
 from schemas.task import TaskCreate, TaskOut, TaskSignupOut
 from seed import ONBOARDING_TASK_TITLE
+from services.albescent_reveal import is_albescent_revealed
 from services.era import (
     get_current_era_row,
     get_current_era_row_safe,
     get_or_create_stats,
 )
-from services.albescent_reveal import is_albescent_revealed
 from services.faction_service import hidden_faction_slugs
+from services.level_jump import available_level_reach
 from services.meta_task import character_sees_metatasks
-from services.praxis import (
-    # Private, but the bank-cap count has exactly one correct implementation and
-    # services.duel already imports it the same way. A second COUNT here is how
-    # the filter and the sign-up predicate would start disagreeing.
-    _count_in_progress_praxes,
+from services.signup_eligibility import (
+    SignupFacts,
     active_member_task_ids_subquery,
     allowed_praxis_modes,
+    count_in_progress_praxes,
     evaluate_signup,
-    in_progress_praxis_ids,
     gather_signup_facts,
+    in_progress_praxis_ids,
     is_task_eligible_for_character,
     signup_reason,
     submitted_praxis_ids,
-    SignupFacts,
 )
-from services.level_jump import available_level_reach
 
 
 async def propose_task(
@@ -323,7 +320,7 @@ async def build_task_out_for_viewer(
     every viewer-relative flag below reads the era row, the viewer's stats,
     their bank count and their membership on this task, and all four are
     identical for every task on a page. List routes gather them once via
-    :func:`services.praxis.gather_signup_facts` for the whole page — without
+    :func:`services.signup_eligibility.gather_signup_facts` for the whole page — without
     that, a 50-row page paid six queries per row. Single-task routes may leave
     the default and let this builder gather facts for the one task.
     """
@@ -681,7 +678,7 @@ async def list_tasks(
     no special interaction with ``exclude_character_id``, faction, or status.
 
     ``can_sign_up`` (#1130) narrows the list to the tasks ``viewer`` could claim
-    right now — the SQL half of :func:`services.praxis.evaluate_signup`, the
+    right now — the SQL half of :func:`services.signup_eligibility.evaluate_signup`, the
     single sign-up predicate (ADR-0008). A plain level filter cannot express
     either of the faction abilities that bend the level bar (WOW's once-a-level
     jump, Ephemerists' retired-task access), which is why the whole predicate is
@@ -844,7 +841,7 @@ async def list_tasks(
         # Gate 6 — the bank cap is a gate on the character, not on any task, so
         # it cannot be a predicate. When it is what emptied the list, EVERY row
         # is ineligible and the honest answer is nothing at all.
-        in_progress_count = await _count_in_progress_praxes(viewer.id, session)
+        in_progress_count = await count_in_progress_praxes(viewer.id, session)
         if in_progress_count >= era.max_task_signups:
             return []
         # Gate 1 — metatasks are applied to a praxis, never signed up for.

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -2954,15 +2954,15 @@ async def test_pending_collab_counts_against_bank_cap(
     db_session: AsyncSession,
 ):
     """A pending (mid-consensus) collab is still an open, slot-consuming membership."""
-    from services.praxis import _count_in_progress_praxes
+    from services.signup_eligibility import count_in_progress_praxes
 
     praxis_id = await _two_member_collab(
         client, active_task, auth_headers2, character.id, auth_headers
     )
     resp = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
     assert resp.json()["status"] == "pending"
-    assert await _count_in_progress_praxes(character2.id, db_session) == 1
-    assert await _count_in_progress_praxes(character.id, db_session) == 1
+    assert await count_in_progress_praxes(character2.id, db_session) == 1
+    assert await count_in_progress_praxes(character.id, db_session) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_task_list_query_count.py
+++ b/backend/tests/integration/test_task_list_query_count.py
@@ -32,7 +32,7 @@ from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.task import Task, TaskStatus
 from services.era import get_or_create_stats
 from services.level_jump import available_level_reach
-from services.praxis import (
+from services.signup_eligibility import (
     allowed_praxis_modes,
     evaluate_signup,
     is_task_eligible_for_character,

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 640
+RUFF_FINDING_TOTAL = 638
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -173,8 +173,7 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "services/media.py::I001": 1,
     "services/media_sweep.py::E501": 5,
     "services/media_sweep.py::I001": 1,
-    "services/praxis.py::E501": 21,
-    "services/praxis.py::I001": 1,
+    "services/praxis.py::E501": 18,
     "services/praxis_metatask.py::E501": 1,
     "services/praxis_out.py::E501": 8,
     "services/praxis_out.py::I001": 1,
@@ -183,8 +182,8 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "services/relationship_service.py::E501": 1,
     "services/relationship_service.py::I001": 1,
     "services/scoring.py::E501": 1,
+    "services/signup_eligibility.py::E501": 3,
     "services/task.py::E501": 6,
-    "services/task.py::I001": 1,
     "services/vote.py::E501": 3,
     "tests/integration/conftest.py::E501": 6,
     "tests/integration/factories.py::E501": 3,

--- a/backend/tests/unit/test_faction_config.py
+++ b/backend/tests/unit/test_faction_config.py
@@ -19,7 +19,7 @@ is the drift that produced Coven's and Albescent's since-corrected false claims
 from dataclasses import replace
 
 from game_config import _ANY_PERK_FIELDS, ERA_1
-from services.praxis import multi_membership_faction_slugs
+from services.signup_eligibility import multi_membership_faction_slugs
 
 # Albescent holds every other faction's perk (#1871), so "only faction X has
 # perk P" is now a claim about the factions that DECLARE P. Read the inheritors


### PR DESCRIPTION
Closes #2870

## What changed

`services/praxis.py` was 2,242 lines and growing — larger than the 2,174 that
triggered #1391, whose cuts 1 and 2 (`praxis_out.py`, `praxis_metatask.py`)
never touched the signup-gate cluster. This PR is cut 3: **pure move, no
behaviour change.**

Moved into a new `backend/services/signup_eligibility.py`:

- `meets_task_level`, `SIGNUP_REASON_MULTI_MEMBERSHIP`, `SignupDenialReason`,
  `SignupEligibility`, `SignupFacts`, `gather_signup_facts`, `evaluate_signup`,
  `signup_reason`
- `multi_membership_faction_slugs`, `active_member_task_ids_subquery`,
  `held_membership_task_ids`, `active_member_task_ids`, `in_progress_praxis_ids`,
  `submitted_praxis_ids`, `is_active_member_of_task`, `allowed_praxis_modes`,
  `is_task_eligible_for_character`, plus the private
  `_held_membership_task_ids_subquery` / `_own_praxis_ids` helpers
- `_count_in_progress_praxes` → **renamed to `count_in_progress_praxes`** (now
  public — it crossed the `services.task`/`services.duel` module boundary as a
  private symbol before this move; it no longer crosses as one)

`services/praxis.py` shrinks from **2,242 → 1,706 lines** (a 536-line, 24% cut).
It now imports the cluster back from `signup_eligibility` for the pieces its
own `create_praxis`/`invite_to_praxis` flow still needs (`evaluate_signup`,
`allowed_praxis_modes`, `meets_task_level`, `is_active_member_of_task`,
`count_in_progress_praxes`, `SignupDenialReason`), plus two names
(`SIGNUP_REASON_MULTI_MEMBERSHIP`, `gather_signup_facts`) it re-exports
(`# noqa: F401`, named) purely so the three protected test files below keep
working via `from services.praxis import ...` unmodified.

**`services/task.py` no longer imports anything from `services.praxis`.** Its
`from services.praxis import (...)` block — the ten symbols #2870 named,
including the private `_count_in_progress_praxes` crossing — is gone; it now
imports the same ten (nine renamed-public) symbols from `services.signup_eligibility`.
That was the *only* reason `task.py` depended on `praxis.py`, so the dependency
is **fully removed**, confirmed by `grep -n "services.praxis" backend/services/task.py`
returning nothing but a couple of now-updated docstring cross-references.

Other call sites updated to import from the new module directly (not
protected, so not left crossing through a re-export): `services/duel.py`,
`services/character.py` (a deferred/function-local import — kept deferred,
since `signup_eligibility` → `faction_service` → `character` is the same
import cycle the original deferral existed to avoid), `routers/tasks.py`,
`tests/unit/test_faction_config.py`, `tests/integration/test_praxes.py`,
`tests/integration/test_task_list_query_count.py`.

## The #2871 boundary — decided here, landing first

**`in_progress_praxis_ids` and `submitted_praxis_ids` live in `signup_eligibility.py`.**
Both are called directly by `gather_signup_facts` in this same module — moving
them to #2871's SQL-visibility module would mean `signup_eligibility` calling
back across that boundary. Keeping them here means #2871 inherits a settled
decision rather than a conflict, per its own body's note. Stated in the new
module's docstring too.

## Ruff ratchet

`tests/unit/ruff_allowlist.py` rebalances grandfathered `E501` counts across
the split (`services/praxis.py::E501` 21→18, new
`services/signup_eligibility.py::E501: 3` — the same three pre-existing long
lines, moved verbatim, not new ones). Fixed two genuine `I001` findings while
the import blocks were open anyway (`services/praxis.py`, `services/task.py`).
`RUFF_FINDING_TOTAL` 640 → 638. `tests/unit/test_ruff_clean.py` passes.

## Testing

Dedicated test DB (`wz2870_test`), `backend/.venv` from the main checkout
(worktrees carry no venv):

```
DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/worldzero \
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz2870_test \
python -m pytest --cov=. --cov-fail-under=92 -q
```

`1750 passed, 1 warning in 179.76s`, coverage `94.44%` (floor 92%).

The three protected files — `test_signup_eligibility.py`,
`test_task_signup_reason.py`, `test_task_can_sign_up_filter.py` — pass
**byte-for-byte unmodified** (verified via `git diff`, zero changes to any of
the three). `tests/unit/test_ruff_clean.py` (8/8) and
`tests/unit/test_model_conventions.py` / `test_uncoded_error_ratchet.py` also
pass.

`python scripts/regen_api_client.py` run and confirmed zero diff to
`backend/openapi.json` / `frontend/src/api/generated/schema.d.ts` — expected,
since no route signature, `response_model`, or Pydantic schema changed.

## What to eyeball

- **Visual QA is outstanding** — I have no browser/dev-stack access. This is a
  backend-only, non-behaviour-changing refactor (no route, schema, or DB
  change), so the seam I tested at is `pytest` + `ruff`, not the UI.
- The `# noqa: F401` re-exports in `services/praxis.py` (`SIGNUP_REASON_MULTI_MEMBERSHIP`,
  `gather_signup_facts`) — confirm this reads as an intentional, named
  backward-compat shim rather than dead weight to clean up in a later pass.
- The #2871 boundary call (`in_progress_praxis_ids`/`submitted_praxis_ids`
  staying in `signup_eligibility.py`) — confirm that's the home you'd want
  before #2871 lands.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
