### PR TITLE
Migrate the remaining private readdirSync walks outside components/ onto sourceScan

### DIFF
--- a/frontend/src/__tests__/albescentSpectraMove.test.tsx
+++ b/frontend/src/__tests__/albescentSpectraMove.test.tsx
@@ -47,7 +47,7 @@
  * no compositor in CI (SPEC-testing.md), so nothing here proves a pixel. The
  * pixels are visual QA and stated outstanding on the PR.
  */
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
@@ -57,6 +57,7 @@ import '../i18n'
 import { stripComments, ruleBodies } from '../utils/__tests__/cssVars'
 import AlbescentSeal from '../components/metataskSeal/skins/AlbescentSeal'
 import type { TaskOut } from '../api/tasks'
+import { sourceFiles, toRelative } from '../test/sourceScan'
 
 const read = (path: string) =>
   readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8')
@@ -289,11 +290,9 @@ function ruleMounts(source: string): { line: number; childless: boolean }[] {
 /** Every file under `src/` that mounts one, tests aside — so a NEW file cannot
  *  grow a spectrum without appearing in the table above. */
 const filesWithARule = () =>
-  readdirSync(SRC, { recursive: true, encoding: 'utf8' })
-    .map((entry) => entry.split(/[\\/]/).join('/'))
-    .filter((rel) => rel.endsWith('.tsx') && !rel.includes('__tests__'))
-    .filter((rel) => ruleMounts(readFileSync(`${SRC}${rel}`, 'utf8')).length > 0)
-    .map((rel) => `../${rel}`)
+  sourceFiles({ dir: SRC, match: /\.tsx$/ })
+    .filter((path) => ruleMounts(readFileSync(path, 'utf8')).length > 0)
+    .map((path) => `../${toRelative(path)}`)
     .sort()
 
 describe('the census, per mount: which spectra travel and which frame content', () => {

--- a/frontend/src/__tests__/catalogLexicon.test.ts
+++ b/frontend/src/__tests__/catalogLexicon.test.ts
@@ -28,7 +28,7 @@
  *    segment. `votes.json`'s `Mark {{value}}` DOES, and is exempted by name
  *    below, for a reason that is about grammar rather than about UA.
  */
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import { SRC_DIR, readStripped, sourceFiles, toRelative } from '../test/sourceScan'
@@ -42,10 +42,7 @@ const MARK = /\bmarks?\b/i
 const EMOJI_ARROW = '\u2197'
 const TEXT_TRIANGLE = '\u25b8'
 
-const catalogs = (): string[] =>
-  readdirSync(LOCALE_DIR)
-    .filter((entry) => entry.endsWith('.json'))
-    .map((entry) => join(LOCALE_DIR, entry))
+const catalogs = (): string[] => sourceFiles({ dir: LOCALE_DIR, match: /\.json$/ })
 
 // Docstrings may name a retired word; only what ships to a screen counts, which
 // is what the shared `readStripped` is for.

--- a/frontend/src/__tests__/designSyncSrcMap.test.ts
+++ b/frontend/src/__tests__/designSyncSrcMap.test.ts
@@ -54,27 +54,28 @@
  * outside every CI net) but not a fix: this guard resolves paths and
  * typechecks nothing, so it would not catch a preview whose props drifted.
  */
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
+
+import { sourceFiles } from '../test/sourceScan'
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url))
 const FRONTEND_DIR = join(REPO_ROOT, 'frontend')
 const CONFIG_PATH = join(REPO_ROOT, '.design-sync', 'config.json')
 
-function filesUnder(dir: string): string[] {
-  return readdirSync(dir).flatMap((entry: string) => {
-    const path = join(dir, entry)
-    return statSync(path).isDirectory() ? filesUnder(path) : [path]
-  })
-}
-
 /** Map values are relative to `frontend/`, POSIX-separated. */
 const toMapPath = (path: string) => relative(FRONTEND_DIR, path).split('\\').join('/')
 
-/** Real on-disk casing — see the case-exactness note above. */
-const realPaths = new Set(filesUnder(join(FRONTEND_DIR, 'src')).map(toMapPath))
+/**
+ * Real on-disk casing — see the case-exactness note above. Every file, of
+ * every extension, `__tests__` included: the map can pin any of them, so the
+ * walk must not pre-filter by name the way the default does.
+ */
+const realPaths = new Set(
+  sourceFiles({ dir: join(FRONTEND_DIR, 'src'), includeTests: true, match: /./ }).map(toMapPath),
+)
 
 const componentSrcMap: Record<string, string | null> = JSON.parse(
   readFileSync(CONFIG_PATH, 'utf8'),

--- a/frontend/src/__tests__/e2eAnchors.test.ts
+++ b/frontend/src/__tests__/e2eAnchors.test.ts
@@ -46,37 +46,27 @@
  * `frontend/` with the whole tree on disk — the same reason
  * `designSyncSrcMap.test.ts` sits here.
  */
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 import forms from '../locales/en/forms.json'
+import { sourceFiles } from '../test/sourceScan'
 
 const FRONTEND_DIR = fileURLToPath(new URL('../..', import.meta.url))
 const E2E_DIR = join(FRONTEND_DIR, 'e2e')
 const SRC_DIR = join(FRONTEND_DIR, 'src')
 
-function filesUnder(dir: string): string[] {
-  return readdirSync(dir).flatMap((entry: string) => {
-    const path = join(dir, entry)
-    return statSync(path).isDirectory() ? filesUnder(path) : [path]
-  })
-}
-
 const readAll = (paths: string[]) =>
   paths.map((path) => readFileSync(path, 'utf8')).join('\n')
 
-const e2eSource = readAll(filesUnder(E2E_DIR).filter((p) => p.endsWith('.ts')))
+const e2eSource = readAll(sourceFiles({ dir: E2E_DIR, match: /\.ts$/ }))
 // The app itself, minus its own tests — a testid that survives only in a
-// `__tests__` fixture is exactly the rot this guard is for.
+// `__tests__` fixture is exactly the rot this guard is for. `__tests__` is
+// excluded by sourceFiles()'s own default; the co-located `.test.ts(x)` files
+// it does not know about are folded into the match instead.
 const appSource = readAll(
-  filesUnder(SRC_DIR).filter(
-    (path) =>
-      (path.endsWith('.tsx') || path.endsWith('.ts')) &&
-      !path.includes('__tests__') &&
-      !path.endsWith('.test.ts') &&
-      !path.endsWith('.test.tsx'),
-  ),
+  sourceFiles({ dir: SRC_DIR, match: /^(?!.*\.test\.).*\.tsx?$/ }),
 )
 
 const matchAll = (source: string, pattern: RegExp) =>

--- a/frontend/src/__tests__/labelTierSweep.test.ts
+++ b/frontend/src/__tests__/labelTierSweep.test.ts
@@ -34,10 +34,11 @@
  * site to reach for it — and the two-tier split (`.label-heading` /
  * `.label-caption`) would be a third option rather than the only one.
  */
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
+
+import { sourceFiles } from '../test/sourceScan'
 
 const SRC = fileURLToPath(new URL('..', import.meta.url))
 const CSS = fileURLToPath(new URL('../index.css', import.meta.url))
@@ -45,18 +46,10 @@ const CSS = fileURLToPath(new URL('../index.css', import.meta.url))
 /** Every shipped `.ts`/`.tsx` under `src/`, tests included — a test fixture may
  *  not resurrect the class either, and this file names it only in prose. */
 function sources(): { path: string; source: string }[] {
-  const found: { path: string; source: string }[] = []
-  const walk = (dir: string) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name)
-      if (entry.isDirectory()) walk(full)
-      else if (/\.tsx?$/.test(entry.name)) {
-        found.push({ path: full, source: readFileSync(full, 'utf8') })
-      }
-    }
-  }
-  walk(SRC)
-  return found
+  return sourceFiles({ dir: SRC, includeTests: true, match: /\.tsx?$/ }).map((path) => ({
+    path,
+    source: readFileSync(path, 'utf8'),
+  }))
 }
 
 /**

--- a/frontend/src/__tests__/praxisPlural.test.ts
+++ b/frontend/src/__tests__/praxisPlural.test.ts
@@ -19,8 +19,8 @@
  * and is not a finding. Import specifiers are stripped too — `pages/praxes/` is
  * a real directory, and renaming directories is out of scope for #1136.
  */
-import { readdirSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { basename, join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 // `includeTests` is on: this sweep is about every `/praxes` in the tree, and it
 // excuses its own fixtures by name (FIXTURE_FILES) rather than by directory.
@@ -108,7 +108,9 @@ describe('no user-visible string says "praxes" (#1136)', () => {
     return []
   }
 
-  const catalogs = readdirSync(LOCALES_DIR).filter((entry) => entry.endsWith('.json'))
+  const catalogs = sourceFiles({ dir: LOCALES_DIR, match: /\.json$/ }).map((path) =>
+    basename(path),
+  )
 
   it.each(catalogs)('%s', (catalog) => {
     const values = stringValues(JSON.parse(readFileSync(join(LOCALES_DIR, catalog), 'utf8')))

--- a/frontend/src/api/__tests__/noSchemaMirrors.test.ts
+++ b/frontend/src/api/__tests__/noSchemaMirrors.test.ts
@@ -21,10 +21,12 @@
  * (`TaskImportRowError`) and client-side unions (`CommentTarget`) mirror
  * nothing. This only guards the names the schema already owns.
  */
-import { readdirSync, readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
+
+import { sourceFiles } from '../../test/sourceScan'
 
 const API_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
 const SCHEMA_PATH = join(API_DIR, 'generated', 'schema.d.ts')
@@ -95,9 +97,13 @@ const DELIBERATE_MIRRORS: Record<string, string> = {
   RelationshipListItem: 'type and status are bare str, not enums',
 }
 
-const API_MODULES = readdirSync(API_DIR)
-  .filter((name) => name.endsWith('.ts'))
-  .map((name) => ({ name, source: readFileSync(join(API_DIR, name), 'utf8') }))
+// Top-level api/*.ts only — `sourceFiles()` recurses into api/generated/ and
+// api/__tests__/ too, and neither belongs here: generated/schema.d.ts is the
+// schema itself, not a hand-written module, and it ends in ".ts" so a plain
+// extension match would pull it in as a "mirror" of every type it declares.
+const API_MODULES = sourceFiles({ dir: API_DIR, match: /\.ts$/ })
+  .filter((path) => dirname(path) === API_DIR)
+  .map((path) => ({ name: basename(path), source: readFileSync(path, 'utf8') }))
 
 describe('api modules do not re-declare a type the schema already defines', () => {
   const schemaNames = schemaTypeNames()

--- a/frontend/src/factions/__tests__/archetypeReachability.test.ts
+++ b/frontend/src/factions/__tests__/archetypeReachability.test.ts
@@ -24,24 +24,21 @@
  * has already forgotten. Only the filesystem remembers the corpse.
  */
 import { describe, it, expect } from 'vitest'
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join, basename, relative, sep } from 'node:path'
 
 import { SURFACE_KEYS } from '..'
+import { sourceFiles } from '../../test/sourceScan'
 
 const SRC = join(process.cwd(), 'src')
 
 /** Directories whose contents are dispatched skins rather than plain modules. */
 const SKIN_DIRS = ['archetypes', 'mobileArchetypes', 'voices', 'skins']
 
-function walk(dir: string): string[] {
-  return readdirSync(dir).flatMap((entry) => {
-    const full = join(dir, entry)
-    return statSync(full).isDirectory() ? walk(full) : [full]
-  })
-}
-
-const ALL_FILES = walk(SRC).filter((path) => /\.tsx?$/.test(path))
+// includeTests: true, because the IS_TEST filter below does that job itself —
+// it also excludes a `.test.tsx?` file living OUTSIDE a `__tests__` dir, which
+// `sourceFiles()`'s own default does not know to do.
+const ALL_FILES = sourceFiles({ dir: SRC, includeTests: true, match: /\.tsx?$/ })
 const IS_TEST = (path: string) => /\.test\.tsx?$/.test(path) || path.includes(`${sep}__tests__${sep}`)
 
 /** Every dispatched skin on disk: a non-test module inside a skin directory. */

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
@@ -19,13 +19,15 @@
  * Verified against the BUILT stylesheet by hand as well, per #1941: a
  * brace-balanced source edit proves nothing about the Tailwind layer merge.
  */
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 import "../../../../i18n";
 import type { EditPraxisState } from "../../useEditPraxis";
 import { BodyTextarea, TitleField } from "../controls";
+import { sourceFiles } from "../../../../test/sourceScan";
 import { stripComments } from "../../../../utils/__tests__/cssVars";
 
 const CSS = stripComments(
@@ -36,12 +38,10 @@ const ARCHETYPE_DIR = fileURLToPath(new URL("..", import.meta.url));
 
 /** Every source file the composer is built from (the eight skins + the shared controls). */
 function composerSources(): Array<{ name: string; source: string }> {
-  return readdirSync(ARCHETYPE_DIR)
-    .filter((name) => name.endsWith(".tsx") || name.endsWith(".ts"))
-    .map((name) => ({
-      name,
-      source: readFileSync(`${ARCHETYPE_DIR}/${name}`, "utf8"),
-    }));
+  return sourceFiles({ dir: ARCHETYPE_DIR, match: /\.tsx?$/ }).map((path) => ({
+    name: basename(path),
+    source: readFileSync(path, "utf8"),
+  }));
 }
 
 /** An `outline: "none"` in an inline style object, in any spacing. */

--- a/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
@@ -27,7 +27,7 @@
  *      stack is precisely how the canvas came to say 30 days.
  *   4. A CANVAS FALSEHOOD BEING "RESTORED" from the design file.
  */
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -51,6 +51,7 @@ import { THEME_STORAGE_KEY } from '../../../hooks/useTheme'
 import { FACTION_SECTION_STORAGE_KEY } from '../../factionDetail/sectionDisclosure'
 import { ONBOARDING_HANDOFF_KEY } from '../../../utils/onboardingResume'
 import { SETTINGS_SECTIONS } from '../../Settings'
+import { sourceFiles } from '../../../test/sourceScan'
 import CookiesSection, {
   SESSION_COOKIE_DAYS,
   STORED_ENTRIES,
@@ -100,17 +101,9 @@ const KNOWN_WRITERS = [
   'utils/onboardingResume.ts',
 ]
 
-function sourceFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : sourceFiles(full)
-    return /\.tsx?$/.test(entry.name) ? [full] : []
-  })
-}
-
 describe('nothing writes to a browser store without being disclosed', () => {
   it('finds exactly the writers this card knows about', () => {
-    const writers = sourceFiles(SRC)
+    const writers = sourceFiles({ dir: SRC })
       .filter((file) => /(?:local|session)Storage\.setItem\(/.test(readFileSync(file, 'utf8')))
       .map((file) => relative(SRC, file).split('\\').join('/'))
       .sort()

--- a/frontend/src/utils/__tests__/factionFaceSplit.test.ts
+++ b/frontend/src/utils/__tests__/factionFaceSplit.test.ts
@@ -1,7 +1,9 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+import { sourceFiles as walkSource } from "../../test/sourceScan";
 
 /**
  * The critical-path half of the font kit (#2079).
@@ -60,17 +62,9 @@ const ENTRY_MODULE = join(SRC_DIR, "main.tsx");
  */
 const SHELL_FAMILIES = new Set(["lora", "courier prime", "bebas neue"]);
 
-function sourceFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) {
-      return entry.name === "__tests__" || entry.name === "assets" ? [] : sourceFiles(path);
-    }
-    return /\.(ts|tsx|css)$/.test(entry.name) ? [path] : [];
-  });
-}
-
-const ALL_FILES = sourceFiles(SRC_DIR);
+// `assets` holds no `.ts`/`.tsx`/`.css` file today, so no explicit exclusion is
+// needed beyond the extension match `walkSource` already applies.
+const ALL_FILES = walkSource({ dir: SRC_DIR, match: /\.(ts|tsx|css)$/ });
 const relative = (file: string): string => file.slice(SRC_DIR.length + 1).replace(/\\/g, "/");
 
 /** The families a generated sheet ships an `@font-face` rule for. */
@@ -265,9 +259,9 @@ function staticallyReachable(roots: string[]): Set<string> {
 
 /** The archetype modules the eight faction manifests name in an `import()`. */
 const ARCHETYPE_ROOTS = new Set(
-  readdirSync(join(SRC_DIR, "factions"))
-    .filter((name) => name.endsWith(".ts"))
-    .flatMap((name) => DYNAMIC_EDGES.get(join(SRC_DIR, "factions", name)) ?? []),
+  walkSource({ dir: join(SRC_DIR, "factions"), match: /\.ts$/ }).flatMap(
+    (file) => DYNAMIC_EDGES.get(file) ?? [],
+  ),
 );
 
 /** Everything the app can begin loading on its own: the entry, and every chunk. */

--- a/frontend/src/utils/__tests__/factionRoleFallbacks.test.ts
+++ b/frontend/src/utils/__tests__/factionRoleFallbacks.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -11,6 +11,7 @@ import {
   type FactionGround,
   type FactionRole,
 } from "../factionRoles";
+import { sourceFiles } from "../../test/sourceScan";
 
 /**
  * THE STANDING RULE FOR "a faction supplies a MAP, not values" (#2659, #2689).
@@ -78,7 +79,8 @@ import {
  */
 
 const SRC_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
-const SOURCE_EXTENSIONS = [".ts", ".tsx"];
+/** TS/TSX source, excluding a test file even where one is not under `__tests__`. */
+const SOURCE_MATCH = /^(?!.*\.test\.).*\.tsx?$/;
 
 /** A map declared with both slug and prefix written out, optionally a ground. */
 const LITERAL_DECLARATION =
@@ -118,17 +120,6 @@ const CORE_SUFFIXES = [
  */
 function stripComments(text: string): string {
   return text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(?<!:)\/\/[^\n]*/g, "");
-}
-
-function collectSourceFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) {
-      return entry.name === "__tests__" ? [] : collectSourceFiles(path);
-    }
-    if (!SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) return [];
-    return entry.name.includes(".test.") ? [] : [path];
-  });
 }
 
 /**
@@ -189,7 +180,7 @@ interface Surface {
 
 function harvest(): Surface[] {
   const surfaces: Surface[] = [];
-  for (const path of collectSourceFiles(SRC_DIR)) {
+  for (const path of sourceFiles({ dir: SRC_DIR, match: SOURCE_MATCH })) {
     const text = stripComments(readFileSync(path, "utf-8"));
     const file = path.slice(SRC_DIR.length + 1).replace(/\\/g, "/");
 

--- a/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
+++ b/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
@@ -1,9 +1,10 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { FACTION_ROLES, factionRoleProperty } from "../factionRoles";
+import { sourceFiles } from "../../test/sourceScan";
 import { readThemes, stripComments } from "./cssVars";
 
 /**
@@ -24,7 +25,6 @@ import { readThemes, stripComments } from "./cssVars";
  */
 
 const SRC_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
-const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".css"];
 
 /**
  * A custom property declared by a CSS rule — ANY rule, not just the `:root` /
@@ -51,20 +51,10 @@ const DECLARED_IN_STYLE_OBJECT =
  */
 const REFERENCE = /var\(\s*(--[A-Za-z0-9_-]+)\s*[,)]/g;
 
-function collectSourceFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    // Tests never render; they quote token names as prose and fixtures.
-    // (This file's own docstring trips the guard otherwise — which is a
-    // pleasant demonstration that the guard works.)
-    if (entry.isDirectory()) {
-      return entry.name === "__tests__" ? [] : collectSourceFiles(path);
-    }
-    return SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))
-      ? [path]
-      : [];
-  });
-}
+// Tests never render; they quote token names as prose and fixtures.
+// (This file's own docstring trips the guard otherwise — which is a
+// pleasant demonstration that the guard works.) `sourceFiles()` excludes
+// `__tests__` by default, which is exactly that exemption.
 
 /** Comments quote token names as prose; a mention is not a declaration. */
 // `stripComments` comes from `cssVars` — the CSS-only stripper, which leaves
@@ -74,7 +64,7 @@ function matchAll(text: string, pattern: RegExp): string[] {
   return [...text.matchAll(pattern)].map((match) => match[1]);
 }
 
-const sources = collectSourceFiles(SRC_DIR).map((path) => ({
+const sources = sourceFiles({ dir: SRC_DIR, match: /\.(?:tsx?|jsx?|css)$/ }).map((path) => ({
   path,
   text: stripComments(readFileSync(path, "utf-8")),
 }));

--- a/frontend/src/utils/__tests__/factionTokensReferenced.test.ts
+++ b/frontend/src/utils/__tests__/factionTokensReferenced.test.ts
@@ -1,9 +1,10 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { FACTION_RAINBOW_ORDER, factionCssVar } from "../factions";
+import { sourceFiles } from "../../test/sourceScan";
 import { stripComments } from "./cssVars";
 
 /**
@@ -35,12 +36,11 @@ import { stripComments } from "./cssVars";
  * sweep (references from non-test sources only) reports five more names, among
  * them `--faction-wow-vote-on` / `-off`, which nothing but `frozenThemeAliases`
  * has read since the vote caption row was struck in #2166. Upgrade path when
- * someone wants those bytes: drop `__tests__` from `collectSourceFiles` and
+ * someone wants those bytes: drop `includeTests: true` from the `sourceFiles()` call and
  * carry the survivors as a named, dated allowlist.
  */
 
 const SRC_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
-const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".css"];
 
 /** The namespaces this rule polices. Everything else is out of #2535's scope. */
 const GOVERNED = /^--(faction|spectrum)-/;
@@ -99,17 +99,6 @@ const DYNAMICALLY_BUILT = new Set([
  */
 const SELF = fileURLToPath(import.meta.url);
 
-function collectSourceFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) return collectSourceFiles(path);
-    if (path === SELF) return [];
-    return SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))
-      ? [path]
-      : [];
-  });
-}
-
 /** A declaration: `--x: value`. Comments are stripped before this runs. */
 const DECLARED_IN_CSS = /(?:^|[;{\s])(--[\w-]+)\s*:/g;
 /** A `var()` reference; the trailing `[,)]` excludes interpolated names. */
@@ -135,10 +124,16 @@ function matchAll(text: string, pattern: RegExp): string[] {
  * a JS docblock therefore counts as read here. That is the safe direction: this
  * rule DELETES things.
  */
-const sources = collectSourceFiles(SRC_DIR).map((path) => {
-  const text = readFileSync(path, "utf-8");
-  return { path, text: path.endsWith(".css") ? stripComments(text) : text };
-});
+const sources = sourceFiles({
+  dir: SRC_DIR,
+  includeTests: true,
+  match: /\.(?:tsx?|jsx?|css)$/,
+})
+  .filter((path) => path !== SELF)
+  .map((path) => {
+    const text = readFileSync(path, "utf-8");
+    return { path, text: path.endsWith(".css") ? stripComments(text) : text };
+  });
 
 const declared = new Map<string, string>();
 for (const { path, text } of sources) {

--- a/frontend/src/utils/__tests__/fontsLoaded.test.ts
+++ b/frontend/src/utils/__tests__/fontsLoaded.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { dirname, join, resolve as resolvePath } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -8,7 +8,7 @@ import {
   type FactionGround,
   type FactionRole,
 } from "../factionRoles";
-import { resolveRoleReads } from "../../test/sourceScan";
+import { resolveRoleReads, sourceFiles } from "../../test/sourceScan";
 
 /**
  * Guard for the silently-unloaded font family (#839).
@@ -49,7 +49,6 @@ import { resolveRoleReads } from "../../test/sourceScan";
 
 const FRONTEND_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..", "..");
 const SRC_DIR = join(FRONTEND_DIR, "src");
-const SOURCE_EXTENSIONS = [".ts", ".tsx", ".css"];
 
 /**
  * The generated stylesheets are the LOADER, never a source that names families.
@@ -94,16 +93,10 @@ const GENERIC_FAMILIES = new Set([
   "trajan pro",
 ]);
 
-function collectSourceFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) {
-      // Tests quote family names as prose and fixtures.
-      return entry.name === "__tests__" ? [] : collectSourceFiles(path);
-    }
-    if (FONT_SHEETS.includes(path)) return [];
-    return SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext)) ? [path] : [];
-  });
+function collectSourceFiles(): string[] {
+  return sourceFiles({ dir: SRC_DIR, match: /\.(tsx?|css)$/ }).filter(
+    (path) => !FONT_SHEETS.includes(path),
+  );
 }
 
 /** One `@font-face` block's body, in source order, across both sheets. */
@@ -193,7 +186,7 @@ function withoutDeclarations(source: string, tokens: string[]): string {
 
 describe("font families are loaded (#839)", () => {
   const loaded = loadedFamilies();
-  const sources = collectSourceFiles(SRC_DIR).map((file) =>
+  const sources = collectSourceFiles().map((file) =>
     readFileSync(file, "utf-8").toLowerCase(),
   );
 
@@ -224,7 +217,7 @@ describe("font families are loaded (#839)", () => {
 
   it("names no family that the loader never requests", () => {
     const missing = new Set<string>();
-    for (const file of [...collectSourceFiles(SRC_DIR)]) {
+    for (const file of [...collectSourceFiles()]) {
       for (const family of namedFamilies(readFileSync(file, "utf-8"))) {
         if (!GENERIC_FAMILIES.has(family) && !loaded.has(family)) {
           missing.add(`${family} (named in ${file})`);
@@ -497,7 +490,7 @@ function declaredFaces(loadedFamilyNames: Set<string>): Face[] {
     }
   };
 
-  for (const file of collectSourceFiles(SRC_DIR)) {
+  for (const file of collectSourceFiles()) {
     const raw = readFileSync(file, "utf-8");
     const source = file.endsWith(".css") ? raw : inlineConstants(file, raw);
 
@@ -773,7 +766,9 @@ describe("used weights are requested (#1294)", () => {
  */
 describe("an inherited page face is not asked to fake a bold (#2487)", () => {
   const COMPOSER_DIR = join(SRC_DIR, "pages", "editPraxis", "archetypes");
-  const composers = readdirSync(COMPOSER_DIR).filter((name) => name.endsWith("EditPraxis.tsx"));
+  const composers = sourceFiles({ dir: COMPOSER_DIR, match: /EditPraxis\.tsx$/ }).map((path) =>
+    basename(path),
+  );
   const faces = loadedFaces();
   const familyNames = new Set(faces.map((face) => face.family));
 
@@ -1001,7 +996,7 @@ describe("a one-cut family is never asked for a weight (#2597)", () => {
 
   it("names no weight in a scope that pins a single-cut family", () => {
     const asked: string[] = [];
-    for (const file of collectSourceFiles(SRC_DIR)) {
+    for (const file of collectSourceFiles()) {
       if (FONT_SHEETS.includes(file)) continue;
       const rel = file.slice(SRC_DIR.length + 1).replace(/\\/g, "/");
       if (LOAD_BEARING.has(rel)) continue;


### PR DESCRIPTION
Closes #2886

## What changed

Re-derived the census against latest `origin/main` (after #2904 and #2913 both merged) rather than trusting the issue's "twelve" — walk count, not file count, per the issue's own instruction. Found **15 files, 20 private walks**, all outside `components/`:

- `utils/__tests__/`: fontsLoaded.test.ts (2 walks), factionTokensDeclared.test.ts, factionTokensReferenced.test.ts, factionFaceSplit.test.ts (2 walks), factionRoleFallbacks.test.ts — **5 files** (issue said 4; #2904 didn't touch any of these)
- root `__tests__/`: praxisPlural.test.ts, designSyncSrcMap.test.ts, e2eAnchors.test.ts (2 walks), labelTierSweep.test.ts, catalogLexicon.test.ts, albescentSpectraMove.test.tsx — **6 files** (issue said 4)
- `pages/`: settings/__tests__/cookiesSection.test.tsx, editPraxis/archetypes/__tests__/composerFocusRing.test.tsx — **2 files**, matches
- `factions/__tests__/archetypeReachability.test.ts` — **1 file**, matches
- `api/__tests__/noSchemaMirrors.test.ts` — **1 file**, matches

Two files (`praxisPlural.test.ts`, `catalogLexicon.test.ts`) had **already** partly migrated — they imported `sourceFiles`/`toRelative` from `sourceScan` for one walk but still carried a second, private `readdirSync` for a flat `locales/en/*.json` listing. Exactly the "already looks migrated is where a census stops looking" trap #2913 named, just recurring on this side of the tree.

Every migrated call site follows the existing idiom (`sourceFiles({ dir, includeTests, match })` + `toRelative`), matched against how #2904/#2913 did it.

## Cases worth flagging

- **`factionTokensReferenced.test.ts`** and **`archetypeReachability.test.ts`** and **`labelTierSweep.test.ts`** and **`designSyncSrcMap.test.ts`** all deliberately pass `includeTests: true` — each one's own docs/comments say the walk is supposed to see `__tests__` (a token read only by a fixture still counts as read; an orphan-file check needs the corpse whether or not it kept a render test; etc). Population is unchanged from before migration — verified by running each file's own sanity-check assertion (`SKIN_FILES.length > 50`, `realPaths.size > 100`, etc.) after the change.
- **`archetypeReachability.test.ts`** additionally needed `includeTests: true` for a second reason: its `IS_TEST` filter excludes a `.test.tsx?` file that lives *outside* `__tests__/` (`metataskCompose.test.tsx`, `useEditPraxis.test.ts` both exist). `sourceFiles()`'s own default only skips the `__tests__` *directory*, so pre-filtering with the default would have silently kept those two files in as "production" source. Same shape hit `e2eAnchors.test.ts` and `factionRoleFallbacks.test.ts`, which fold the `.test.` exclusion into the `match` regex as a negative lookahead instead.
- **`noSchemaMirrors.test.ts`** (`api/`) is the one place a plain recursive `sourceFiles()` would have changed the file population: the original walk is **non-recursive** (flat `readdirSync(API_DIR)`), and `api/generated/schema.d.ts` ends in `.ts`, so a recursive walk would misread the generated schema itself as a hand-written "mirror" of every type it declares. Handled by filtering the recursive result to `dirname(path) === API_DIR` rather than extending `sourceScan.ts` for a one-off non-recursive mode.
- **`designSyncSrcMap.test.ts`** needed `match: /./ ` (i.e. no extension filter) plus `includeTests: true`, because the map it guards can pin *any* file under `src/`, of any extension, `__tests__` included.

## `sourceScan.ts`

Not extended. Every case was reachable with the existing `dir`/`includeTests`/`match` options, plus an ordinary `.filter()` after the call where the walk was non-recursive (`noSchemaMirrors.test.ts`) or the value needed a basename rather than a full path (`fontsLoaded.test.ts`'s composer listing, `composerFocusRing.test.tsx`, `albescentSpectraMove.test.tsx`).

## Verification

- `tsc --noEmit`, `tsc -p tsconfig.e2e.json --noEmit`, `tsc -p tsconfig.design-sync.json --noEmit` — all clean
- `eslint src .ds-kit e2e` — clean
- Full `vitest run` — 477 files, 9932 passed / 1 skipped (pre-existing skip, unrelated) — **unmodified**, no assertion was touched anywhere
- `vite build` — succeeds (the one warning is a pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` note about `FactionSigil.tsx`, unrelated to this change)
- `node scripts/bundle-budget.mjs` — pre-existing WARN (not a fail) on JS bytes; this PR touches only `__tests__` files, which Vite never bundles, so it cannot have caused it

Ratchet readiness for **#2887** (banning `readdirSync` in tests outside `sourceScan.ts`): after this PR, `src/test/sourceScan.ts` is the only file under `frontend/src` outside `components/` calling `readdirSync` directly (one hit in `designSyncSrcMap.test.ts` is prose in a docblock, not a call — verified). Whether anything under `components/` still blocks the ratchet is #2885's territory, not checked here.

## What to eyeball

Visual QA is outstanding — this is a test-infrastructure-only change (no rendered surface, component, or page touched), so there is nothing to look at in a browser. The seam tested at is: each migrated guard's own existing assertions, run unmodified against the new walk, must produce the identical pass/fail verdict and (where the file asserts a count or an exact set) the identical population. That held for all 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
