### PR TITLE
Bump pycrdt 0.14.3 -> 0.14.4 (re-ships #2907 under owner authorship)

### DIFF
--- a/backend/requirements-prod.txt
+++ b/backend/requirements-prod.txt
@@ -15,5 +15,5 @@ httpx
 # file: these two agree on a CRDT wire format and on a document's stored shape,
 # and a silent minor bump on either side is a data-compatibility change, not a
 # library upgrade.
-pycrdt==0.14.3
+pycrdt==0.14.4
 pycrdt-websocket==0.16.4


### PR DESCRIPTION
Supersedes #2907.

## Why re-ship instead of merging Dependabot's PR

`scripts/hooks/guard_pr_merge.py` gate 1 requires the PR's **author** and its head repository owner to both be the repo owner. Dependabot PRs are authored by `dependabot[bot]`, so `gh pr merge` is refused on them no matter how green their checks are. Re-shipping the identical version set under owner authorship is the route this repo has taken before (#2444 / #2445 / #2446, #2438).

Dependabot's #2907 was green on all three required checks before this was opened; the change here is byte-identical to its diff.

## Why this bump is safe despite the pin's own warning

The docblock above the pin says these two packages agree on a CRDT wire format and that "a silent minor bump on either side is a data-compatibility change, not a library upgrade."

That warning is not tripped here. `pycrdt-websocket==0.16.4` declares `pycrdt<0.15.0,>=0.14.0`, so `0.14.4` sits inside the range upstream itself certifies as compatible, and the minor stays at `0.14`. The pinning discipline is unchanged — `pycrdt` remains pinned exactly, not floated.

## What to eyeball

Nothing visual. The risk surface is the praxis collaborative room (ADR-0073) — the CodeMirror/Yjs composer on **Edit Praxis**. Worth one manual check that two browsers can still join a praxis room, type, and see each other's edits, since that is the only path `pycrdt` serves and no automated test drives the live websocket.

The backend suite and the three required checks are the automated evidence. Live QA of the praxis room is outstanding.
