### PR TITLE
Extract services/praxis_duel.py: praxis.py's five deferred duel imports go to zero (#2872)

### DIFF
--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -6,6 +6,12 @@ pending → declined (on decline/cancel).
 
 Voting opens when the Duel is settled (both praxes submitted). Votes target
 each praxis directly; no per-member routing is needed.
+
+This module owns the duel-id-keyed flow: challenge, respond, cancel, read.
+The praxis-id-keyed surface (which duel is this praxis a side of, settle on
+submit, discard on delete) lives in ``services.praxis_duel`` — a leaf, so
+``services.praxis`` can reach it without the cycle this module's own
+``get_praxis`` import creates (#2872).
 """
 
 from datetime import datetime, timezone
@@ -34,6 +40,7 @@ from services.nudge import latest_nudge_at
 from services.vote_tally import get_tally, tally_votes
 from services.era import get_current_era_row, get_or_create_stats
 from services.praxis import get_praxis
+from services.praxis_duel import get_duel_for_praxis
 from services.signup_eligibility import (
     count_in_progress_praxes,
     is_active_member_of_task,
@@ -138,18 +145,6 @@ async def get_duel(duel_id: int, session: AsyncSession) -> Duel:
     if duel is None:
         raise HTTPException(status_code=404, detail="Duel not found.")
     return duel
-
-
-async def get_duel_for_praxis(praxis_id: int, session: AsyncSession) -> Optional[Duel]:
-    """Return the active Duel row for a praxis side, or None if not a duel."""
-    result = await session.execute(
-        select(Duel).where(
-            (Duel.challenger_praxis_id == praxis_id)
-            | (Duel.opponent_praxis_id == praxis_id),
-            Duel.status.in_([DuelStatus.pending, DuelStatus.active, DuelStatus.settled]),
-        )
-    )
-    return result.scalar_one_or_none()
 
 
 async def get_duel_detail(
@@ -463,59 +458,6 @@ async def respond_to_duel_challenge(
     return loaded_praxis, duel
 
 
-async def discard_dissolved_duels_for_praxis(
-    praxis_id: int, session: AsyncSession
-) -> None:
-    """Drop the ``declined`` Duel rows a praxis is about to be deleted with (#1831).
-
-    Called from :func:`services.praxis.delete_praxis`. Every FK into ``praxis.id``
-    cascades except the two duel columns, which are deliberately NO ACTION — so
-    without this, a praxis that has ever carried a challenge could never be
-    dropped again, however the duel ended. Dissolving the challenge first does not
-    help: ``cancel_duel_challenge`` only sets ``status``, and
-    ``challenger_praxis_id`` is NOT NULL.
-
-    Owner ruling (2026-08-15). The two documented rulings this looks like it
-    reverses are each about a *different* duel than this one:
-
-    - "a duel is a contract between two players … it should refuse the delete
-      rather than vanish with it" (``models/praxis.py``, migration 0006) was
-      written about a **live contract**. Still true, and still enforced: a
-      ``pending``/``active`` duel is not touched here and the FK refuses.
-    - "Duel row is kept for history" (``models/duel.py``) is about a duel that
-      **happened**. Still true: ``settled`` and ``resolved`` are not touched here,
-      so a forfeited side that unsubmits back to editing still cannot be dropped.
-
-    A challenge dissolved before the contest ever happened is neither. It is an
-    abandoned draft, and there is no history in it worth keeping, so it goes with
-    the praxis.
-
-    **Why the status is the whole predicate.** ``declined`` is only ever written
-    on the decline path (from ``pending``) and by ``cancel_duel_challenge`` (from
-    ``pending``/``active``), and nothing transitions out of it. A duel produces a
-    result only by becoming votable (``settled``) or by having its outcome frozen
-    at era close (``resolved``), and a declined duel has been neither. Once its
-    praxis is gone the row is unreachable from every read besides: this module and
-    ``services.vote`` exclude ``declined``, ``services.badge`` counts only
-    active/settled/resolved, the era sweep in ``services.era`` takes only
-    active/settled, and the feed's challenge query inner-joins the challenger praxis.
-
-    Plural on purpose: ``issue_duel_challenge``'s already-in-a-duel guard is
-    :func:`get_duel_for_praxis`, which excludes ``declined``, so challenge →
-    cancel → challenge again leaves a praxis carrying several declined rows.
-    """
-    result = await session.execute(
-        select(Duel).where(
-            (Duel.challenger_praxis_id == praxis_id)
-            | (Duel.opponent_praxis_id == praxis_id),
-            Duel.status == DuelStatus.declined,
-        )
-    )
-    for duel in result.scalars().all():
-        await session.delete(duel)
-    await session.flush()
-
-
 async def cancel_duel_challenge(
     duel_id: int,
     character_id: int,
@@ -556,30 +498,3 @@ async def cancel_duel_challenge(
             )
     await session.flush()
     return duel
-
-
-async def maybe_settle_duel(praxis_id: int, session: AsyncSession) -> None:
-    """If this praxis is a duel side and both sides are now submitted, settle the duel.
-
-    Called from submit_praxis after a solo praxis transitions to submitted.
-    A no-op if the praxis is not part of an active duel.
-    """
-    duel = await get_duel_for_praxis(praxis_id, session)
-    if duel is None or duel.status != DuelStatus.active:
-        return
-
-    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
-    opponent_praxis = (
-        await session.get(Praxis, duel.opponent_praxis_id)
-        if duel.opponent_praxis_id
-        else None
-    )
-
-    if (
-        challenger_praxis
-        and challenger_praxis.status == PraxisStatus.submitted
-        and opponent_praxis
-        and opponent_praxis.status == PraxisStatus.submitted
-    ):
-        duel.status = DuelStatus.settled
-        await session.flush()

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -62,6 +62,11 @@ from services.media import (
     restore_media_to_mount,
     withdraw_media_from_mount,
 )
+from services.praxis_duel import (
+    discard_dissolved_duels_for_praxis,
+    get_duel_for_praxis,
+    maybe_settle_duel,
+)
 from services.praxis_room import close_member_sockets
 from services.signup_eligibility import (
     # Re-exported for existing `from services.praxis import ...` call sites
@@ -789,8 +794,6 @@ async def unsubmit_praxis(
     # ADR-0011 §Forfeit (#307): unsubmitting a *settled* duel side forfeits the
     # contest. Mark the forfeit (first one sticks) and recalc the winner below so
     # their guaranteed-win modifier lands immediately.
-    from services.duel import get_duel_for_praxis
-
     duel = await get_duel_for_praxis(praxis_id, session)
     forfeit_winner_character_id: Optional[int] = None
     if duel is not None and duel.status == DuelStatus.settled:
@@ -868,8 +871,6 @@ async def change_praxis_type(
         return praxis
 
     # A duel side is a solo praxis + Duel row; dissolve the duel before switching.
-    from services.duel import get_duel_for_praxis
-
     if await get_duel_for_praxis(praxis_id, session) is not None:
         raise HTTPException(
             status_code=409, detail="End the duel before changing this praxis's mode."
@@ -912,8 +913,8 @@ async def delete_praxis(
     declined Duel row goes with the praxis, because the two duel FKs are the one
     pair into ``praxis.id`` that does not cascade. A live or resolved duel still
     refuses the delete — the reasoning is on
-    :func:`services.duel.discard_dissolved_duels_for_praxis`, which owns the
-    predicate.
+    :func:`services.praxis_duel.discard_dissolved_duels_for_praxis`, which owns
+    the predicate.
     """
     praxis = await get_praxis(praxis_id, session)
     if praxis.created_by_id != character_id:
@@ -923,9 +924,6 @@ async def delete_praxis(
             status_code=400,
             detail="Cannot delete a submitted praxis. Move it to editing first.",
         )
-    # Local import: services.duel imports this module at module scope (#307).
-    from services.duel import discard_dissolved_duels_for_praxis
-
     await discard_dissolved_duels_for_praxis(praxis_id, session)
     await session.delete(praxis)
     await session.flush()
@@ -1592,9 +1590,8 @@ async def submit_praxis(
     went_live = await collab_consensus.on_submit(praxis, character_id, session, era)
     if went_live:
         # Settle any duel BEFORE the stats recalc — the outcome feeds the duel
-        # multiplier. Kept here (not in collab_consensus) because it depends on
-        # services.duel, which imports services.praxis (import-cycle avoidance).
-        from services.duel import maybe_settle_duel
+        # multiplier. Kept here rather than in collab_consensus so the whole
+        # duel side effect of a submit reads in one place.
         await maybe_settle_duel(praxis_id, session)
         await recalculate_members_stats(praxis, session, era)
     return await get_praxis(praxis_id, session)
@@ -1704,8 +1701,6 @@ async def _duel_opponent_character_id(
     ADR-0052 says a frozen outcome never recomputes), or a challenge with no
     opponent praxis yet.
     """
-    from services.duel import get_duel_for_praxis
-
     duel = await get_duel_for_praxis(praxis_id, session)
     if duel is None:
         return None

--- a/backend/services/praxis_duel.py
+++ b/backend/services/praxis_duel.py
@@ -1,0 +1,123 @@
+"""The duel a praxis is a side of — the by-praxis-id duel surface (ADR-0011).
+
+Three functions keyed by ``praxis_id`` rather than ``duel_id``: the lookup
+(:func:`get_duel_for_praxis`) and the two lifecycle nudges the praxis lifecycle
+fires at it (:func:`maybe_settle_duel` on submit, and
+:func:`discard_dissolved_duels_for_praxis` on delete). They read ``Duel`` and
+``Praxis`` rows and nothing else, so they are dependency-free of both service
+modules that want them:
+
+- ``services.praxis`` — submit, delete, unsubmit and the duel-aware reads.
+- ``services.vote`` — the duel-participant vote guard (#309).
+- ``services.duel`` — its own already-in-a-duel guard, and the settle rule.
+
+``services.duel`` imports ``services.praxis`` (``get_praxis``), so these three
+could not live there without a cycle: every consumer above had to defer its
+import into a function body, five of them in ``services.praxis`` alone, past
+``SPEC-backend-architecture`` section 11's "more than three" tripwire (#1391,
+#2872). Same shape and same reason as ``services.duel_outcome``. A pure move —
+no behaviour change.
+"""
+
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.duel import Duel, DuelStatus
+from models.praxis import Praxis, PraxisStatus
+
+
+async def get_duel_for_praxis(praxis_id: int, session: AsyncSession) -> Optional[Duel]:
+    """Return the active Duel row for a praxis side, or None if not a duel."""
+    result = await session.execute(
+        select(Duel).where(
+            (Duel.challenger_praxis_id == praxis_id)
+            | (Duel.opponent_praxis_id == praxis_id),
+            Duel.status.in_(
+                [DuelStatus.pending, DuelStatus.active, DuelStatus.settled]
+            ),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def maybe_settle_duel(praxis_id: int, session: AsyncSession) -> None:
+    """If this praxis is a duel side and both sides are now submitted, settle the duel.
+
+    Called from submit_praxis after a solo praxis transitions to submitted.
+    A no-op if the praxis is not part of an active duel.
+    """
+    duel = await get_duel_for_praxis(praxis_id, session)
+    if duel is None or duel.status != DuelStatus.active:
+        return
+
+    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+    opponent_praxis = (
+        await session.get(Praxis, duel.opponent_praxis_id)
+        if duel.opponent_praxis_id
+        else None
+    )
+
+    if (
+        challenger_praxis
+        and challenger_praxis.status == PraxisStatus.submitted
+        and opponent_praxis
+        and opponent_praxis.status == PraxisStatus.submitted
+    ):
+        duel.status = DuelStatus.settled
+        await session.flush()
+
+
+async def discard_dissolved_duels_for_praxis(
+    praxis_id: int, session: AsyncSession
+) -> None:
+    """Drop the ``declined`` Duel rows a praxis is about to be deleted with (#1831).
+
+    Called from :func:`services.praxis.delete_praxis`. Every FK into ``praxis.id``
+    cascades except the two duel columns, which are deliberately NO ACTION — so
+    without this, a praxis that has ever carried a challenge could never be
+    dropped again, however the duel ended. Dissolving the challenge first does not
+    help: ``cancel_duel_challenge`` only sets ``status``, and
+    ``challenger_praxis_id`` is NOT NULL.
+
+    Owner ruling (2026-08-15). The two documented rulings this looks like it
+    reverses are each about a *different* duel than this one:
+
+    - "a duel is a contract between two players … it should refuse the delete
+      rather than vanish with it" (``models/praxis.py``, migration 0006) was
+      written about a **live contract**. Still true, and still enforced: a
+      ``pending``/``active`` duel is not touched here and the FK refuses.
+    - "Duel row is kept for history" (``models/duel.py``) is about a duel that
+      **happened**. Still true: ``settled`` and ``resolved`` are not touched here,
+      so a forfeited side that unsubmits back to editing still cannot be dropped.
+
+    A challenge dissolved before the contest ever happened is neither. It is an
+    abandoned draft, and there is no history in it worth keeping, so it goes with
+    the praxis.
+
+    **Why the status is the whole predicate.** ``declined`` is only ever written
+    on the decline path (from ``pending``) and by ``cancel_duel_challenge`` (from
+    ``pending``/``active``), and nothing transitions out of it. A duel produces a
+    result only by becoming votable (``settled``) or by having its outcome frozen
+    at era close (``resolved``), and a declined duel has been neither. Once its
+    praxis is gone the row is unreachable from every read besides: this module,
+    ``services.duel`` and ``services.vote`` exclude ``declined``,
+    ``services.badge`` counts only active/settled/resolved, the era sweep in
+    ``services.era`` takes only
+    active/settled, and the feed's challenge query inner-joins the challenger praxis.
+
+    Plural on purpose: ``issue_duel_challenge``'s already-in-a-duel guard is
+    :func:`get_duel_for_praxis`, which excludes ``declined``, so challenge →
+    cancel → challenge again leaves a praxis carrying several declined rows.
+    """
+    result = await session.execute(
+        select(Duel).where(
+            (Duel.challenger_praxis_id == praxis_id)
+            | (Duel.opponent_praxis_id == praxis_id),
+            Duel.status == DuelStatus.declined,
+        )
+    )
+    for duel in result.scalars().all():
+        await session.delete(duel)
+    await session.flush()

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -21,6 +21,7 @@ from models.praxis import (
 from models.vote import Vote
 from services.character_stats import recalculate_members_stats
 from services.era import get_current_era_row, get_or_create_stats
+from services.praxis_duel import get_duel_for_praxis
 from services.scoring import compute_votes_available
 from services.vote_tally import VoteTally, tally_votes
 
@@ -333,10 +334,8 @@ async def _voter_in_praxis_duel(
     praxis's duel, on either side. A duel participant — any life on their
     account — cannot rate EITHER side of a duel they're in, not just their own.
     Uses the same active-duel window (pending/active/settled) as
-    :func:`services.duel.get_duel_for_praxis`.
+    :func:`services.praxis_duel.get_duel_for_praxis`.
     """
-    from services.duel import get_duel_for_praxis
-
     duel = await get_duel_for_praxis(praxis.id, session)
     if duel is None:
         return False

--- a/backend/tests/integration/test_praxis_delete_and_signup_race.py
+++ b/backend/tests/integration/test_praxis_delete_and_signup_race.py
@@ -178,8 +178,8 @@ async def test_signing_up_holds_a_lock_keyed_on_the_character(
 #
 # Owner ruling (2026-08-15): the *declined* row goes with the praxis; a duel that
 # reached a result keeps refusing the delete. The reasoning and the exact
-# predicate live on ``services.duel.discard_dissolved_duels_for_praxis``. Both
-# halves are pinned below — the dissolve-then-drop sequence the composer's
+# predicate live on ``services.praxis_duel.discard_dissolved_duels_for_praxis``.
+# Both halves are pinned below — the dissolve-then-drop sequence the composer's
 # ``cancel`` runs, and the settled duel that still refuses.
 
 

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 638
+RUFF_FINDING_TOTAL = 637
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -164,7 +164,7 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "services/character_stats.py::E501": 4,
     "services/character_stats.py::I001": 1,
     "services/collab_consensus.py::E501": 3,
-    "services/duel.py::E501": 5,
+    "services/duel.py::E501": 4,
     "services/duel.py::I001": 1,
     "services/era.py::E501": 1,
     "services/era.py::I001": 1,

--- a/backend/tests/unit/test_service_function_body_imports.py
+++ b/backend/tests/unit/test_service_function_body_imports.py
@@ -29,7 +29,7 @@ def _deferred_service_imports(source: str) -> list[str]:
             continue
         if node.module and node.module.split(".")[0] == "services":
             found.append((node.lineno, node.module))
-    return [f"line {lineno}: from {module} import ..." for lineno, module in sorted(found)]
+    return [f"line {n}: from {module} import ..." for n, module in sorted(found)]
 
 
 def test_no_service_exceeds_the_deferred_import_tripwire():

--- a/backend/tests/unit/test_service_function_body_imports.py
+++ b/backend/tests/unit/test_service_function_body_imports.py
@@ -1,0 +1,48 @@
+"""No service may hide more than three ``from services.X import`` in a function body.
+
+``SPEC-backend-architecture.md`` section 11 makes the count a tripwire: "More than
+three ``from services.X import ...`` inside function bodies — indicates real
+coupling that a module reshuffle would fix." A deferred import exists only to break
+an import cycle, so several of them aimed at one module means the cycle is
+structural and wants a leaf module (the ``services/duel_outcome.py`` precedent).
+
+#1391 measured this by hand and #2872 found the same five still there a month
+later. This is that measurement, run by a machine, so the next one cannot rot.
+"""
+
+import ast
+from pathlib import Path
+
+SERVICES_DIR = Path(__file__).resolve().parents[2] / "services"
+
+# Section 11's wording is "more than three", so three is allowed.
+MAX_FUNCTION_BODY_SERVICE_IMPORTS = 3
+
+
+def _deferred_service_imports(source: str) -> list[str]:
+    """Every ``from services.X import ...`` that is not at module level."""
+    tree = ast.parse(source)
+    module_level = {id(node) for node in tree.body}
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or id(node) in module_level:
+            continue
+        if node.module and node.module.split(".")[0] == "services":
+            found.append((node.lineno, node.module))
+    return [f"line {lineno}: from {module} import ..." for lineno, module in sorted(found)]
+
+
+def test_no_service_exceeds_the_deferred_import_tripwire():
+    offenders = {}
+    for path in sorted(SERVICES_DIR.glob("*.py")):
+        deferred = _deferred_service_imports(path.read_text(encoding="utf-8"))
+        if len(deferred) > MAX_FUNCTION_BODY_SERVICE_IMPORTS:
+            offenders[path.name] = deferred
+
+    assert not offenders, (
+        "SPEC-backend-architecture section 11: more than "
+        f"{MAX_FUNCTION_BODY_SERVICE_IMPORTS} function-body service imports in one "
+        "module means a real import cycle — extract the shared surface into a leaf "
+        "module both sides can import at module level (services/duel_outcome.py and "
+        f"services/praxis_duel.py are the precedents). Offenders: {offenders}"
+    )

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -594,8 +594,9 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     // as "a duel row never goes": `delete_praxis` now discards the DECLINED
     // rows first, which is why the dissolve below is what unblocks the delete.
     // A live (`pending`/`active`) or finished (`settled`/`resolved`) duel is
-    // still refused outright — see `services.duel.discard_dissolved_duels_for_praxis`,
-    // which owns that predicate and the owner ruling behind it.
+    // still refused outright — see
+    // `services.praxis_duel.discard_dissolved_duels_for_praxis`, which owns that
+    // predicate and the owner ruling behind it.
     const inDuel = praxis.duel_id != null;
     const crewAtStake = praxis.type === "collab" && praxis.members.length > 1;
     const confirmed = await askConfirm(


### PR DESCRIPTION
Closes #2872

`services/praxis.py` held five function-body `from services.duel import ...` — past
`SPEC-backend-architecture`'s "more than three" tripwire. All five pointed at one module, so
the cycle was structural: `services.duel` imports `services.praxis` (`get_praxis`) at module
level, which is why every consumer of the praxis-id-keyed duel functions had to defer.

## The seam

The seam is *module import time*, not runtime: does `services.praxis` reach its duel surface at
module level, or does it still have to defer? The failing test is
`backend/tests/unit/test_service_function_body_imports.py` — an AST scan of `services/*.py`
counting non-module-level `from services.X import`, asserting none exceeds the spec's threshold
of three. It went red on the real defect first (`praxis.py: 5`), then green.

## What changed

New leaf `backend/services/praxis_duel.py` — the three praxis-id-keyed duel functions moved
verbatim out of `services/duel.py`:

- `get_duel_for_praxis` — which duel is this praxis a side of
- `maybe_settle_duel` — settle on submit
- `discard_dissolved_duels_for_praxis` — drop declined rows on delete

They read `Duel` and `Praxis` rows and nothing else, so the leaf imports only `models.*` and
SQLAlchemy — the same shape and the same reason as the `services/duel_outcome.py` precedent the
spec names. `services.praxis`, `services.vote` and `services.duel` now all import from it at
module level.

- `services/praxis.py`: 5 function-body service imports → **0**.
- `services/vote.py`: the sixth site (`_voter_in_praxis_duel`) was the same defect one module
  over — same cycle, `vote → duel → praxis → vote` — so it was fixed at the same seam rather
  than left to rot. 1 → **0**.
- `services/duel.py` keeps the duel-id-keyed flow (challenge / respond / cancel / read) and
  imports `get_duel_for_praxis` from the leaf for its own already-in-a-duel guard. Existing
  `from services.duel import get_duel_for_praxis` call sites (one integration test) still work.

**Survivors: none.** Nothing had to be left deferred, so there is no "these three survive"
list to report — `praxis.py` is at zero, and the repo-wide max is now `services/character.py`
at three, which is *at* the threshold, not past it, and the new test holds it there.

No behaviour change: the three function bodies and their docstrings are unmodified apart from
one 89-char line rewrapped (new files must be ruff-clean) and two doc cross-references
repointed at the new module. `services/duel.py` lost one grandfathered `E501`, so
`tests/unit/ruff_allowlist.py` shrinks 638 → 637.

## Verification

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://.../wz2872_test \
  pytest --cov=. --cov-report=term-missing --cov-fail-under=92
```
→ **1751 passed**, coverage 94.44% (dedicated DB `wz2872_test`, not the shared
`worldzero_test`). Duel/praxis/vote integration files were run on their own first (47 passed).
Ruff ratchet green. No route, `response_model` or Pydantic schema was touched, so no
`openapi.json` / `schema.d.ts` regeneration applies; frontend untouched. No visual QA — this
change has no surface.

## What to eyeball

- `backend/services/praxis_duel.py` — is the module docstring the right story, and is
  `praxis_duel` the right name (vs. `duel_side`, `duel_link`)? It sits in the `praxis_*` family
  but is named for the *duel* the praxis is a side of.
- The rewrapped `Duel.status.in_([...])` line in `get_duel_for_praxis` — the only text inside a
  moved function that is not byte-identical to what was in `duel.py`.
- `discard_dissolved_duels_for_praxis`'s docstring: "unreachable from every read besides: this
  module, `services.duel` and `services.vote` exclude `declined`…" — "this module" changed
  meaning when the function moved, so that clause was updated. Check it still reads true.
- Whether `services/vote.py` belonged in this PR at all — it was one import, under the
  threshold, but the identical cycle.
- `tests/unit/test_service_function_body_imports.py` — the threshold constant is 3, read off
  the spec's "More than three" bullet. Note that bullet now lives in **section 11** ("When to
  revisit this posture"), not section 10 ("Intentional v2 deferrals") as #2872 and #1391 cite;
  the numbering drifted, the rule did not. Worth a one-line fix to the issue-side citation
  habit, not to the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
