### PR TITLE
Derive eight more faction loop lists; na was missing from four of them (#2815)

### DIFF
--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -16,6 +16,7 @@ import type { ActivityFeedItem } from '../../api/activityFeed'
 import i18n from '../../i18n'
 import { collabCopy } from '../collab/collabCopy'
 import { AA_NORMAL, contrastRatio, formatRatio, parseColor, requiredRatio } from '../../utils/contrast'
+import { FACTION_RAINBOW_ORDER } from '../../utils/factions'
 import { readThemes, resolveVar } from '../../utils/__tests__/cssVars'
 
 function item(type: string, payload: Record<string, unknown>): ActivityFeedItem {
@@ -524,7 +525,15 @@ describe('FeedRowContent skin seam', () => {
  */
 describe('the monogram disc is inked with the faction pair, not a global neutral', () => {
   const THEMES = readThemes(readFileSync(fileURLToPath(new URL('../../index.css', import.meta.url)), 'utf8'))
-  const FILL_SLUGS = ['ua', 'wow', 'everymen', 'coven', 'snide', 'ephemerists', 'singularity']
+  // Derived, not typed (#2815): the pairing under test is `--faction-<slug>`
+  // against its `-on-fill`, so the population is exactly the slugs that HAVE a
+  // fill. `FACTION_RAINBOW_ORDER` is that set — it is the hue wheel, so a slug
+  // is in it iff index.css declares a `--faction-<slug>` colour. The two kits
+  // outside it are outside it for that reason: `albescent` ships no
+  // `--faction-albescent-*` block at all (#783 — a bar built from the wheel
+  // would leak the secret society), and `na` is a state, not a faction, so it
+  // paints no monogram disc. A tenth kit with a hue joins this loop by existing.
+  const FILL_SLUGS = FACTION_RAINBOW_ORDER
 
   it.each(FILL_SLUGS)('%s: the emitted glyph ink clears AA on the disc fill in both themes', (slug) => {
     const html = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow(slug)} avatarUrl={null} /></MemoryRouter>)

--- a/frontend/src/components/__tests__/invitationPerks.test.tsx
+++ b/frontend/src/components/__tests__/invitationPerks.test.tsx
@@ -62,9 +62,24 @@ import { AuthContext } from '../../auth/AuthContext'
 import InvitationLetterPopup from '../InvitationLetterPopup'
 import AlbescentInvitation from '../AlbescentInvitation'
 import type { CharacterOut, CurrentUser } from '../../api/auth'
+import { FACTION_MANIFESTS } from '../../factions'
 
-/** The seven slugs with an `invitation` block — the shared popup's whole range. */
-const SLUGS = ['coven', 'ephemerists', 'everymen', 'singularity', 'snide', 'ua', 'wow'] as const
+/**
+ * The shared popup's whole range: every registered kit whose catalog entry
+ * carries an `invitation` block.
+ *
+ * Derived, not typed (#2815) — the kits come from the manifest, so a tenth joins
+ * this loop the moment it ships a letter, and the filter states its own
+ * exclusions rather than hiding them in a written-out list. Two kits fall out
+ * of it today, both on purpose: `na` is a state rather than a faction and has
+ * no catalog block at all, and `albescent` keeps its letter under
+ * `albescent.letter` on its own component — the describe block below is that
+ * letter's test, so it is covered, just not here.
+ */
+const CATALOG = factions as unknown as Record<string, { invitation?: unknown }>
+const SLUGS = FACTION_MANIFESTS.map((manifest) => manifest.slug).filter(
+  (slug) => CATALOG[slug]?.invitation !== undefined,
+)
 
 /** Where the mechanic sits in every letter (`MECHANIC_INDEX`). */
 const MECHANIC = 1
@@ -75,7 +90,7 @@ interface Perk {
   desc: string
 }
 
-function perksOf(slug: (typeof SLUGS)[number]): Perk[] {
+function perksOf(slug: string): Perk[] {
   return (factions as unknown as Record<string, { invitation: { perks: Perk[] } }>)[slug]
     .invitation.perks
 }
@@ -125,6 +140,12 @@ function albescentLetter(): string {
   } as unknown as CharacterOut
   return withAuth(<AlbescentInvitation lives={[life]} onJoined={() => {}} />)
 }
+
+// A filtered derivation can go quietly EMPTY, and `describe.each([])` reports a
+// perfect board when it does. Seven of the nine kits ship a shared letter.
+it('resolves to every kit that ships a shared letter', () => {
+  expect(SLUGS).toHaveLength(7)
+})
 
 describe.each(SLUGS)('the %s letter spends its one box on the perks (#2298)', (slug) => {
   it('prints the mechanic as a name over a description, and the flavour rows as description alone (#2774)', () => {
@@ -268,7 +289,7 @@ describe('the eight real perks ship the corrected copy (#2298 §3)', () => {
   ]
 
   it.each(MECHANICS)('%s states its mechanic in the middle slot', (slug, name, desc) => {
-    const perk = perksOf(slug as (typeof SLUGS)[number])[MECHANIC]
+    const perk = perksOf(slug)[MECHANIC]
     expect(perk.name).toBe(name)
     expect(perk.desc).toBe(desc)
   })

--- a/frontend/src/components/collab/__tests__/collabCopy.test.ts
+++ b/frontend/src/components/collab/__tests__/collabCopy.test.ts
@@ -13,19 +13,18 @@ import i18n from '../../../i18n'
 import { collabCopy } from '../collabCopy'
 import type { CollabCopyKey } from '../collabCopy'
 import forms from '../../../locales/en/forms.json'
+import { FACTION_MANIFESTS } from '../../../factions'
 
-/** Every slug a task can carry, including the ninth (WoW) and `na`. */
-const FACTION_SLUGS = [
-  'na',
-  'ephemerists',
-  'everymen',
-  'snide',
-  'singularity',
-  'ua',
-  'coven',
-  'albescent',
-  'wow',
-] as const
+/**
+ * Every slug a task can carry, `na` included.
+ *
+ * Derived from the manifest rather than typed (#2815). The describe block below
+ * says its first assertion is "written against the catalog's SHAPE rather than a
+ * slug list, so a tenth faction is caught without editing it" — that was true of
+ * the shape assertion and false of the two loops under it, which are the ones a
+ * tenth faction would actually have had to be added to. Both halves derive now.
+ */
+const FACTION_SLUGS = FACTION_MANIFESTS.map((manifest) => manifest.slug)
 
 const SHARED_KEYS = Object.keys(forms.editPraxis.collab) as CollabCopyKey[]
 

--- a/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
@@ -32,14 +32,8 @@ vi.mock('../../../hooks/useFormFactor', () => ({
 }))
 
 // Imported after the mock is registered.
-import CovenTaskCard from '../CovenTaskCard'
-import EphemeristsTaskCard from '../EphemeristsTaskCard'
-import EverymenTaskCard from '../EverymenTaskCard'
 import AlbescentTaskCard from '../AlbescentTaskCard'
-import SingularityTaskCard from '../SingularityTaskCard'
 import SnideTaskCard from '../SnideTaskCard'
-import UaTaskCard from '../UaTaskCard'
-import WowTaskCard from '../WowTaskCard'
 import DefaultTaskCard from '../DefaultTaskCard'
 import { surfaceMap } from '../../../factions'
 import { aTask } from '../../../test/fixtures'
@@ -63,16 +57,24 @@ interface Skin {
  */
 const SIGNUP = i18n.t('feed:taskCard.signup')
 
-const SKINS: Skin[] = [
-  { slug: 'coven', Card: CovenTaskCard },
-  { slug: 'ephemerists', Card: EphemeristsTaskCard },
-  { slug: 'everymen', Card: EverymenTaskCard },
-  { slug: 'albescent', Card: AlbescentTaskCard },
-  { slug: 'singularity', Card: SingularityTaskCard },
-  { slug: 'snide', Card: SnideTaskCard },
-  { slug: 'ua', Card: UaTaskCard },
-  { slug: 'wow', Card: WowTaskCard },
-]
+/**
+ * Every skin the taskCard surface dispatches to, read off the registry rather
+ * than listed here (#2815).
+ *
+ * The table used to name eight components by hand, which made the range
+ * something someone had to remember: a tenth kit could register a card and
+ * never be rendered by this file. `surfaceMap('taskCard')` IS the dispatch, so
+ * the loop now covers whatever the app can actually reach — including `na`,
+ * whose `DefaultTaskCard` answers the same {@link CardProps} contract and had
+ * simply been left off.
+ *
+ * The wrappers render synchronously here because `src/test/preloadArchetypes.ts`
+ * warms every archetype before the suite runs; see `factions/lazyArchetype.tsx`.
+ */
+const SKINS: Skin[] = Object.entries(surfaceMap('taskCard')).map(([slug, Card]) => ({
+  slug,
+  Card,
+}))
 
 /**
  * Every value of `services/praxis.py`'s `SignupDenialReason`, with the copy the
@@ -254,10 +256,13 @@ describe.each(SKINS)('$slug task card v2 — one component, two form factors (AD
   })
 })
 
-describe.each(SKINS)('$slug renders through the taskCard manifest surface', (skin) => {
-  it('is the registered skin for its slug', () => {
-    expect(surfaceMap('taskCard')[skin.slug]).toBeDefined()
-  })
+// `$slug renders through the taskCard manifest surface` stood here and asserted
+// `surfaceMap('taskCard')[skin.slug]` was defined. Once SKINS comes from that
+// very map (#2815) it asserts the map equals itself, so it is gone rather than
+// left to read like coverage. What it was really guarding — which slugs are
+// registered on which surface — is `factions/__tests__/surfaceDispatch.test.ts`.
+it('covers every skin the app can dispatch taskCard to', () => {
+  expect(SKINS).toHaveLength(9)
 })
 
 /* -------------------------------------------------------------------------- */

--- a/frontend/src/components/taskCard/__tests__/mobileCardFillsColumn.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/mobileCardFillsColumn.test.tsx
@@ -35,15 +35,7 @@ vi.mock('../../../hooks/useFormFactor', async (importOriginal) => ({
 }))
 
 // Imported after the mock is registered.
-import AlbescentTaskCard from '../AlbescentTaskCard'
-import CovenTaskCard from '../CovenTaskCard'
-import DefaultTaskCard from '../DefaultTaskCard'
-import EphemeristsTaskCard from '../EphemeristsTaskCard'
-import EverymenTaskCard from '../EverymenTaskCard'
-import SingularityTaskCard from '../SingularityTaskCard'
-import SnideTaskCard from '../SnideTaskCard'
-import UaTaskCard from '../UaTaskCard'
-import WowTaskCard from '../WowTaskCard'
+import { surfaceMap } from '../../../factions'
 import { aTask } from '../../../test/fixtures'
 
 const TASK = aTask({
@@ -53,18 +45,17 @@ const TASK = aTask({
   in_progress_count: 6,
 })
 
-/** Albescent is in the table as itself: its own wrapper is the outermost box. */
-const SKINS: [string, ComponentType<CardProps>][] = [
-  ['default (na)', DefaultTaskCard],
-  ['albescent', AlbescentTaskCard],
-  ['coven', CovenTaskCard],
-  ['ephemerists', EphemeristsTaskCard],
-  ['everymen', EverymenTaskCard],
-  ['singularity', SingularityTaskCard],
-  ['snide', SnideTaskCard],
-  ['ua', UaTaskCard],
-  ['wow', WowTaskCard],
-]
+/**
+ * Albescent is in the table as itself: its own wrapper is the outermost box.
+ *
+ * Read off `surfaceMap('taskCard')` rather than typed (#2815) — a card that a
+ * tenth kit registers has the same column to fill, and a table naming nine
+ * components is a range someone has to remember to widen. Annotated as a tuple
+ * array rather than inferred, the way `duelSkinSlots.test.tsx` does it:
+ * `Object.entries` widens to `(string | ComponentType)[]` otherwise and
+ * `it.each` then cannot match the two-arg callback.
+ */
+const SKINS: [string, ComponentType<CardProps>][] = Object.entries(surfaceMap('taskCard'))
 
 function markup(element: ReactElement): string {
   return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
@@ -88,6 +79,10 @@ function widthOf(tag: string): string | undefined {
 }
 
 describe('below 768px every task card asks for the whole column (#2763)', () => {
+  it('covers every skin the app can dispatch taskCard to', () => {
+    expect(SKINS).toHaveLength(9)
+  })
+
   it.each(SKINS)('%s: the outermost box fills the line on a phone', (_name, Card) => {
     dispatch.formFactor = 'mobile'
     // 340px is the number the report is about, and `fit-content` is

--- a/frontend/src/components/taskCard/__tests__/taskCardsV3.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/taskCardsV3.test.tsx
@@ -27,15 +27,7 @@ vi.mock('../../../hooks/useFormFactor', () => ({
 }))
 
 // Imported after the mock is registered.
-import AlbescentTaskCard from '../AlbescentTaskCard'
-import CovenTaskCard from '../CovenTaskCard'
-import DefaultTaskCard from '../DefaultTaskCard'
-import EphemeristsTaskCard from '../EphemeristsTaskCard'
-import EverymenTaskCard from '../EverymenTaskCard'
-import SingularityTaskCard from '../SingularityTaskCard'
-import SnideTaskCard from '../SnideTaskCard'
-import UaTaskCard from '../UaTaskCard'
-import WowTaskCard from '../WowTaskCard'
+import { surfaceMap } from '../../../factions'
 import { aTask } from '../../../test/fixtures'
 import { factionName } from '../../../utils/factions'
 
@@ -49,18 +41,21 @@ interface Skin {
   Card: ComponentType<CardProps>
 }
 
-/** All nine, `na` and `albescent` included — they are cards, not exceptions. */
-const SKINS: Skin[] = [
-  { slug: 'na', Card: DefaultTaskCard },
-  { slug: 'albescent', Card: AlbescentTaskCard },
-  { slug: 'coven', Card: CovenTaskCard },
-  { slug: 'ephemerists', Card: EphemeristsTaskCard },
-  { slug: 'everymen', Card: EverymenTaskCard },
-  { slug: 'singularity', Card: SingularityTaskCard },
-  { slug: 'snide', Card: SnideTaskCard },
-  { slug: 'ua', Card: UaTaskCard },
-  { slug: 'wow', Card: WowTaskCard },
-]
+/**
+ * All nine, `na` and `albescent` included — they are cards, not exceptions.
+ *
+ * Read off `surfaceMap('taskCard')` rather than typed (#2815): the three shared
+ * passes are properties of the KIT, so the range has to be whatever the kit
+ * dispatches to, not a list that has to be edited when a tenth one arrives.
+ */
+const SKINS: Skin[] = Object.entries(surfaceMap('taskCard')).map(([slug, Card]) => ({
+  slug,
+  Card,
+}))
+
+it('covers every skin the app can dispatch taskCard to', () => {
+  expect(SKINS).toHaveLength(9)
+})
 
 function render({ Card }: Skin): { html: string; text: string } {
   const html = renderToStaticMarkup(

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx
@@ -41,17 +41,18 @@ const ME = 1;
 const THEM = 2;
 const PROPOSED_AT = "2026-08-17T10:00:00Z";
 
-/** Every slug that registers `editPraxis`, plus the two that fall through. */
-const SLUGS = [
+/**
+ * Every slug the `editPraxis` surface dispatches to, plus `null`.
+ *
+ * Derived from the registry rather than typed (#2815): all nine kits register
+ * a composer, so a tenth is covered here by existing. `null` is prepended
+ * because it is not a slug — it is the viewer whose character has no faction,
+ * a distinct input `resolveVariant` sends to the na kit (ADR-0065 §4), and
+ * nothing in the map stands in for it.
+ */
+const SLUGS: (string | null)[] = [
   null,
-  "albescent",
-  "coven",
-  "ephemerists",
-  "everymen",
-  "singularity",
-  "snide",
-  "ua",
-  "wow",
+  ...Object.keys(surfaceMap("editPraxis")),
 ];
 
 function member(

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -278,18 +278,18 @@ describe("every skin swaps in the waiting surface (#1189)", () => {
       } as unknown as PraxisOut,
     });
 
-  // Every slug that registers `editPraxis`, plus the two that fall through to
-  // the na kit (ADR-0065 §4).
-  const SLUGS = [
+  /**
+   * Every slug the `editPraxis` surface dispatches to, plus `null`.
+   *
+   * Derived from the registry rather than typed (#2815): all nine kits register
+   * a composer, so a tenth is covered here by existing. `null` is prepended
+   * because it is not a slug — it is the viewer whose character has no faction,
+   * a distinct input `resolveVariant` sends to the na kit (ADR-0065 §4), and
+   * nothing in the map stands in for it.
+   */
+  const SLUGS: (string | null)[] = [
     null,
-    "albescent",
-    "coven",
-    "ephemerists",
-    "everymen",
-    "singularity",
-    "snide",
-    "ua",
-    "wow",
+    ...Object.keys(surfaceMap("editPraxis")),
   ];
 
   it.each(SLUGS)("%s draws the waiting reading, not its composer", (slug) => {

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx
@@ -182,17 +182,18 @@ const SLIP_TITLE = new RegExp(
   `<div style="([^"]*)">(<a [^>]*>)${TASK_TITLE}</a></div>`,
 );
 
-/** Every slug registering `editPraxis`, plus the two that fall through (§4). */
-const SLUGS = [
+/**
+ * Every slug the `editPraxis` surface dispatches to, plus `null`.
+ *
+ * Derived from the registry rather than typed (#2815): all nine kits register
+ * a composer, so a tenth is covered here by existing. `null` is prepended
+ * because it is not a slug — it is the viewer whose character has no faction,
+ * a distinct input `resolveVariant` sends to the na kit (ADR-0065 §4), and
+ * nothing in the map stands in for it.
+ */
+const SLUGS: (string | null)[] = [
   null,
-  "albescent",
-  "coven",
-  "ephemerists",
-  "everymen",
-  "singularity",
-  "snide",
-  "ua",
-  "wow",
+  ...Object.keys(surfaceMap("editPraxis")),
 ];
 
 const STAGES = ["composing", "waiting"] as const;

--- a/frontend/src/test/__tests__/loopListsAreDerived.test.ts
+++ b/frontend/src/test/__tests__/loopListsAreDerived.test.ts
@@ -46,7 +46,11 @@ const DERIVED =
  * Shrinks as #2815 converts them; it must never grow without a reason.
  */
 const GRANDFATHERED: ReadonlySet<string> = new Set([
-  'components/__tests__/feedRow.test.tsx|FILL_SLUGS',
+  // DELIBERATE, not pending: `MECHANICS` is a copy DECISION RECORD — seven
+  // [slug, name, desc] triples pinning the owner's finished mechanic copy by
+  // value. The slugs are the subject beside the strings, not the iteration
+  // range, and the range question (does every letter still have a written
+  // mechanic?) is answered by the derived SLUGS loop in the same file.
   'components/__tests__/invitationPerks.test.tsx|MECHANICS',
   'components/collab/__tests__/collabCopy.test.ts|FACTION_SLUGS',
   'components/comments/__tests__/commentFootRule.test.tsx|VOICES',
@@ -57,10 +61,7 @@ const GRANDFATHERED: ReadonlySet<string> = new Set([
   'components/praxisCard/__tests__/praxisMasthead.test.tsx|BANDED',
   'components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx|UNIFIED',
   'components/sigil/__tests__/factionSigil.test.tsx|SLUGS',
-  'components/taskCard/__tests__/factionTaskCardsV2.test.tsx|SKINS',
   'components/taskCard/__tests__/mastheadFactionLink.test.tsx|MASTHEADED',
-  'components/taskCard/__tests__/mobileCardFillsColumn.test.tsx|SKINS',
-  'components/taskCard/__tests__/taskCardsV3.test.tsx|SKINS',
   'pages/characterPaths/__tests__/placeholderInk.test.ts|FIELDS',
   'pages/characterPaths/__tests__/singularityCreateCharacterRegister.test.tsx|WIDTHS',
   'pages/characterProfile/__tests__/factionProfileBody.test.tsx|SLUGS',

--- a/frontend/src/test/__tests__/loopListsAreDerived.test.ts
+++ b/frontend/src/test/__tests__/loopListsAreDerived.test.ts
@@ -52,7 +52,6 @@ const GRANDFATHERED: ReadonlySet<string> = new Set([
   // range, and the range question (does every letter still have a written
   // mechanic?) is answered by the derived SLUGS loop in the same file.
   'components/__tests__/invitationPerks.test.tsx|MECHANICS',
-  'components/collab/__tests__/collabCopy.test.ts|FACTION_SLUGS',
   'components/comments/__tests__/commentFootRule.test.tsx|VOICES',
   'components/comments/__tests__/mentionPopoverClip.test.tsx|VOICES',
   'components/factionHero/__tests__/factionWordmarkWrap.test.tsx|HEROES',
@@ -66,9 +65,6 @@ const GRANDFATHERED: ReadonlySet<string> = new Set([
   'pages/characterPaths/__tests__/singularityCreateCharacterRegister.test.tsx|WIDTHS',
   'pages/characterProfile/__tests__/factionProfileBody.test.tsx|SLUGS',
   'pages/characterProfile/__tests__/profileAbout.test.tsx|BRANCHES',
-  'pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx|SLUGS',
-  'pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx|SLUGS',
-  'pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx|SLUGS',
   'pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx|WALL_ALARM',
   'pages/tasks/__tests__/equalHeightRow.test.tsx|SKINS',
 ])
@@ -102,6 +98,11 @@ describe('a list driving per-kit iteration is derived from the manifest', () => 
   // The tripwire. This guard's whole output is a list of things that are WRONG,
   // so a scanner that silently stopped matching would report a perfect board.
   it('still finds the typed lists it is meant to be watching', () => {
+    // THE FLOOR IS ONE CONVERSION AWAY. `GRANDFATHERED` is down to sixteen, so
+    // the next #2815 pass makes this fail on a correct change. That is the
+    // signal to swap the count for a fixed anchor — the survivor named below —
+    // and NOT to relax the number: a scanner that stopped matching would report
+    // a perfect board, which is the only thing this line exists to catch.
     expect(TYPED.length, 'the scan matched nothing — the regexes have drifted').toBeGreaterThan(15)
     // homeTrackBand (the issue's worked example) converted in #2815 and its
     // GRANDFATHERED entry came off with it. Any still-typed survivor works as


### PR DESCRIPTION
**The seam: the slug list a `.each` loops over** — the range a parameterised
faction test claims to be exhaustive across. A typed list is a loop that cannot
notice a tenth kit, and two of these could not notice the ninth.

Continues the conversion #2904 started. Eight lists across nine files come off
`GRANDFATHERED`, which goes 24 → 16.

> **⚠️ `Closes #2815` is on this PR because the dispatch asked for it, but the
> issue is NOT fully satisfied and the close line should probably be cut before
> this leaves draft.** Sixteen typed lists remain. The reason is the ratchet's
> own tripwire: `expect(TYPED.length).toBeGreaterThan(15)` fails the moment the
> seventeenth is converted, and re-cutting a ratchet's number is exactly what
> this repo does not do in a conversion PR. So 16 is the floor a PR that only
> converts can reach; finishing #2815 needs one more PR that *also* swaps that
> count for a fixed anchor. Owner's call whether to keep the auto-close and
> re-file the remainder, or downgrade this to `Part of #2815`.

## The rule applied, per file

| file | was | is |
|---|---|---|
| `components/__tests__/feedRow` `FILL_SLUGS` | 7 typed | `FACTION_RAINBOW_ORDER` |
| `components/__tests__/invitationPerks` `SLUGS` | 7 typed | manifest ∩ catalog, filtered on "has an `invitation` block" |
| `components/collab/…/collabCopy` `FACTION_SLUGS` | 9 typed | `FACTION_MANIFESTS.map(m => m.slug)` |
| `components/taskCard/…/factionTaskCardsV2` `SKINS` | **8** typed pairs | `Object.entries(surfaceMap('taskCard'))` |
| `components/taskCard/…/taskCardsV3` `SKINS` | 9 typed pairs | same |
| `components/taskCard/…/mobileCardFillsColumn` `SKINS` | 9 typed pairs | same |
| `pages/editPraxis/…/collabSignals` `SLUGS` | `null` + **8** typed | `[null, ...Object.keys(surfaceMap('editPraxis'))]` |
| `pages/editPraxis/…/composerDispatch` `SLUGS` | same | same |
| `pages/editPraxis/…/taskSlipLink` `SLUGS` | same | same |

### Two more holes of the `homeTrackBand` kind

Neither is a rendering bug — both are coverage that was silently missing:

- **`factionTaskCardsV2` named eight skins and left `na`'s `DefaultTaskCard`
  off.** The ninth card the app dispatches `taskCard` to had never been rendered
  through the v2 contract. It passes all 108 assertions unchanged.
- **The three `editPraxis` suites typed `null` plus eight slugs under a comment
  reading "every slug that registers `editPraxis`".** All nine register one;
  `na`'s `DefaultEditPraxis` was reachable only through the `null` input. Passes
  all 159 assertions unchanged.

**No newly-covered kit failed, so there is nothing to file.** The widening was
done on its own, with no assertion touched alongside it.

### Exclusions are stated, never written out

- `feedRow` measures `--faction-<slug>` against its `-on-fill`, so the range is
  the slugs that *have* a fill — which is what the hue wheel is.
  `albescent` ships no `--faction-albescent-*` block at all (#783) and `na`
  paints no monogram disc; both fall out of the derivation for those reasons
  rather than by being left off a list.
- `invitationPerks` filters the manifest on "the catalog entry carries an
  `invitation` block". `na` has no catalog block; `albescent`'s letter lives
  under `albescent.letter` on its own component and is tested by the describe
  block below it.
- `null` stays prepended to the `editPraxis` lists: it is not a slug, it is the
  viewer whose character has no faction, and nothing in the map stands in for it.

### One test deleted rather than kept

`factionTaskCardsV2`'s `$slug renders through the taskCard manifest surface`
asserted `surfaceMap('taskCard')[skin.slug]` was defined. Built from that very
map, it now asserts the map equals itself — the exact tautology the issue's
correction warns about. `factions/__tests__/surfaceDispatch.test.ts` owns that
question. A `toHaveLength(9)` tripwire replaces it, which on a *derived* list is
a real guard: it fires if the registry shrinks, and `describe.each([])` reports a
perfect board otherwise. No typed list gained a length assertion.

### The ratchet

`GRANDFATHERED` is down to sixteen. `invitationPerks|MECHANICS` is the one entry
that stays for a *reason* rather than pending conversion, and now says so in
place: it is a copy decision record — seven `[slug, name, desc]` triples pinning
the owner's finished mechanic copy by value — so its slugs are the subject beside
the strings, not the iteration range. The range question it might have been
answering ("does every letter still have a written mechanic?") is answered by the
derived `SLUGS` loop in the same file.

**Heads-up for the next pass:** the tripwire's `toBeGreaterThan(15)` is now one
conversion from failing on a correct change. It carries a note saying to swap the
count for the survivor it already names by hand, and *not* to relax the number —
a scanner that stopped matching would report a perfect board, which is the only
thing that line exists to catch. #2887 is blocked on this and can follow.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (478 files, 9950 passed / 1 skipped), `npm run build`, `npm run budget`
— all run locally, all green. The budget's JS `WARN` is pre-existing: the diff is
test files only, so nothing here reaches the bundle. `api-schema` is not engaged
(no route, `response_model` or Pydantic schema touched).

**Visual QA is not applicable** — no shipped component or stylesheet changed.

## What to eyeball

1. **The two widenings are honest.** `na` genuinely belongs in the v2 task-card
   contract loop and in the three `editPraxis` composer loops — I read them as
   coverage that was missing, not as a range someone had narrowed on purpose.
2. **The deleted `$slug renders through the taskCard manifest surface` block.**
   It is the one assertion this PR removes; the claim is that
   `surfaceDispatch.test.ts` already carries what it was guarding.
3. **`feedRow`'s exclusion reasoning.** "The slugs with a fill" == the rainbow
   wheel rests on `albescent` having no `--faction-albescent-*` block, which I
   verified against `index.css` — worth a second pair of eyes.
4. **`invitationPerks`' `MECHANICS` staying grandfathered.** If you read it as
   an iteration range rather than a copy record, it should be converted instead.
5. **The tripwire note.** It documents a floor rather than moving it; confirm
   that is the call you want rather than re-cutting the number here.

Part of #2815.

**Orchestrator ruling (builder-bot, 2026-08-29): downgraded from `Closes` to `Part of`.**
The agent was right to flag it. My dispatch prompt carried a hard "never edit a ratio"
rule lifted from the contrast BASELINE ratchet, and that rule does not apply to
`toBeGreaterThan(15)` in `loopListsAreDerived.test.ts` — see the ruling comment on #2815.
If GitHub still auto-closes #2815 on merge (linkage forms at PR creation and survives a
body edit), reopen it; the remaining conversions are real work, not bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

