### PR TITLE
Guard the walk shut: no private directory walk outside sourceScan.ts (#2887)

### DIFF
--- a/frontend/src/test/__tests__/indexCss.test.ts
+++ b/frontend/src/test/__tests__/indexCss.test.ts
@@ -14,12 +14,13 @@
  * across two parts would be a different sheet even with every byte preserved.
  * Both are asserted here because neither is visible in a source diff.
  */
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { stripComments } from '../../utils/__tests__/cssVars'
 import { INDEX_CSS_MAP, indexCssParts, readIndexCss } from '../indexCss'
+import { sourceFiles } from '../sourceScan'
 
 const CSS_DIR = join(INDEX_CSS_MAP, '..', 'css')
 const MAP = readFileSync(INDEX_CSS_MAP, 'utf8')
@@ -72,7 +73,12 @@ describe('the import map', () => {
   })
 
   it('imports every part in `src/css/`, exactly once, in filename order', () => {
-    const onDisk = readdirSync(CSS_DIR).filter((name) => name.endsWith('.css')).sort()
+    // Through the shared walk, not a private one (#2887) — `src/css/` is flat,
+    // and a part hidden in a subdirectory would show up here as an unimported
+    // file, which is exactly the answer this assertion wants.
+    const onDisk = sourceFiles({ dir: CSS_DIR, match: /\.css$/ })
+      .map((path) => basename(path))
+      .sort()
     expect(onDisk.length).toBeGreaterThan(1)
     // The numeric prefixes ARE the cascade: filename order must be import order,
     // or a reader sorting by name gets a different sheet than the browser paints.

--- a/frontend/src/test/__tests__/noPrivateSourceWalk.test.ts
+++ b/frontend/src/test/__tests__/noPrivateSourceWalk.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The walk is shut: one directory walk in `frontend/src`, and it is the seam.
+ *
+ * `src/test/sourceScan.ts` exists because nine guards each carried their own
+ * copy of the same recursive walk, and the copies drifted in three directions —
+ * some skipped `__tests__`, some did not, one wanted `.css` too. A guard whose
+ * private walk silently stopped reaching files reports a perfect board, which
+ * is the only failure mode that never gets noticed. Consolidating them fixed
+ * that twice (#2885, #2886); nothing stopped a tenth copy appearing, so this is
+ * that stop (#2887).
+ *
+ * The rule is a bright line rather than a judgement: no file under `src` may
+ * enumerate a directory. Reading a KNOWN path with `readFileSync` is untouched
+ * and stays common — the fragile part was never the read, it was deciding which
+ * files to read.
+ *
+ * WHY THIS FILE IS NOT ITS OWN FINDING. It has to name the calls to look for
+ * them, and it does so as an alternation: every name below is followed by `|`
+ * or `)`, never by the `(` the pattern requires. Keep it that way — if a future
+ * edit writes one of them as a call, this guard fails pointing at itself, which
+ * is a loud and accurate way to say the pattern went wrong.
+ *
+ * Comments are stripped before matching for the same reason: prose above (and
+ * in `designSyncSrcMap.test.ts`) names the call while calling nothing.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { readStripped, sourceFiles, toRelative } from '../sourceScan'
+
+/** A call that enumerates a directory — the first line of any hand-rolled walk. */
+const ENUMERATES_A_DIRECTORY = /\b(?:readdirSync|readdir|opendirSync|opendir|globSync)\s*\(/
+
+/**
+ * Exempt by construction, with the reason. This list only ever shrinks: a new
+ * walk is routed through `sourceFiles()` instead, and an entry is added here
+ * only with a written reason in the PR that adds it.
+ */
+const EXEMPT: readonly string[] = [
+  // The seam itself. This IS the walk every other guard borrows.
+  'test/sourceScan.ts',
+]
+
+/** Every file under `src` that enumerates a directory, as the guards report paths. */
+const walkers = (): string[] =>
+  sourceFiles({ includeTests: true })
+    .filter((path) => ENUMERATES_A_DIRECTORY.test(readStripped(path)))
+    .map(toRelative)
+    .sort()
+
+describe('the directory walk lives in one file (#2887)', () => {
+  // The tripwire, anchored on a named entry rather than a count: this guard's
+  // whole output is a list of things that are WRONG, so a scan that stopped
+  // matching — a renamed seam, a regex that drifted, a walk that no longer
+  // reaches `src/test/` — would report a clean board forever.
+  it('still sees the seam, so it cannot pass by matching nothing', () => {
+    expect(
+      walkers(),
+      'the scan no longer finds the shared walk — the pattern or the scan has drifted',
+    ).toContain('test/sourceScan.ts')
+  })
+
+  it('adds no private walk anywhere under src', () => {
+    expect(
+      walkers().filter((path) => !EXEMPT.includes(path)),
+      'Route this through `sourceFiles()` from `src/test/sourceScan.ts` — it already handles ' +
+        'recursion, the `__tests__` skip and path relativising, and a private copy drifts. ' +
+        'If it genuinely cannot, add it to EXEMPT with the reason in your PR.',
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #2887

## The seam

`frontend/src/test/sourceScan.ts` — the one directory walk every source-scanning guard
borrows. The guard is itself a source-scanning guard, so it uses the seam it protects:
it reaches files through `sourceFiles({ includeTests: true })` and `readStripped`, and
adds no walk of its own.

## What it asserts

One bright line, not a judgement call: **no file under `frontend/src` may enumerate a
directory.** Reading a known path with `readFileSync` is untouched and stays common —
the fragile part was never the read, it was deciding which files to read. The pattern
catches `readdirSync`, `readdir`, `opendirSync`, `opendir` and `globSync` at a call site.

`EXEMPT` holds exactly one entry, with its reason: `test/sourceScan.ts`, the seam itself.

## Written test-first, and it went red on the real defect

Committed the guard first (`608fa4e9`), knowingly red: it found
`test/__tests__/indexCss.test.ts`, the last private directory read in the tree. That file
lists `src/css/*.css` to assert the import map matches what is on disk — a *listing*, not
a tree walk, so it could legitimately have been an exemption. Converting it to
`sourceFiles({ dir: CSS_DIR, match: /\.css$/ })` costs two lines and does the same job, so
it is converted rather than exempted, and the allowlist is left holding only the seam.
(A part hidden in a subdirectory now surfaces as an unimported file, which is exactly the
answer that assertion wants.)

## Proof the guard is not vacuous

`sourceFiles()` skips `__tests__` by default, so a guard that must see test files and
forgets `includeTests: true` is **vacuously green**. Verified by hand rather than by
inspection:

1. Appended `const __probe = () => readdirSync(SRC_DIR)` to
   `src/test/__tests__/sourceScan.test.ts`.
2. Re-ran the guard — **RED**, reporting `test/__tests__/sourceScan.test.ts`. So the scan
   reaches inside `__tests__`.
3. `git checkout --` on that file; tree clean, full suite green.

The scanner-sanity tripwire is **not** a count floor (the owner's ruling on #2815: a count
floor on a list meant to reach zero is a guard fighting the work it guards). It is anchored
on a named entry — the scan must still find `test/sourceScan.ts`. That entry can never go
stale while the seam exists, and it reddens if the seam is renamed, the pattern drifts, or
the walk stops reaching `src/test/`.

Also confirmed the guard does not find *itself*: it names the calls as an alternation, where
each name is followed by `|` or `)` and never by the `(` the pattern requires. That is stated
in the file header so a future edit does not undo it by accident.

## Verification (every step in `.github/workflows/test.yml`'s `frontend` job, locally)

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit`) — **0 errors**
- `npm run typecheck:design-sync` — clean
- `npm test` — **480 files, 9,959 passed, 1 skipped, 0 failed**
- `npm run build` — built
- `npm run budget` — JS `WARN 151.2 KB` (warn>130.9, fail>175.8), CSS `ok`. Pre-existing and
  not blocking; this diff is test-only and cannot enter the bundle.

The `test` and `api-schema` jobs are untouched — no backend, route, schema or generated-client
file is in this diff.

Note on the local environment: the junctioned `node_modules` from the main checkout was still
on React 18 and produced a false `RefObject` error in `PortraitPicker.tsx`. Replaced it with a
real `npm ci` in the worktree (`@types/react` 19.2.18) before believing any of the above.

## What to eyeball

Nothing visual. This is a test-only change: one new guard file and a two-line conversion
inside another test. No component, route, token or stylesheet is touched, and no rendered
surface changes. Live visual QA is not applicable here — the meaningful review is whether
the bright line ("no directory enumeration outside the seam") is the rule you want, and
whether converting `indexCss.test.ts` rather than exempting it is the right call.
