### PR TITLE
Note why the four stateful hooks export their internals (#2693)

### DIFF
--- a/frontend/src/hooks/useMotion.tsx
+++ b/frontend/src/hooks/useMotion.tsx
@@ -50,6 +50,29 @@ import {
  * `useMotionTick` below and schedule nothing while motion is off. Anything else
  * that animates from JS belongs on the same clock for the same reason.
  */
+/**
+ * WHY THE PARTS BELOW ARE EXPORTED WHEN ONLY A TEST IMPORTS THEM
+ * --------------------------------------------------------------
+ * A dead-export audit (#2693) reference-counted every export under `src` and
+ * listed `MOTION_ATTRIBUTE`, `DEFAULT_MOTION`, `nextMotion`,
+ * `resolveInitialMotion`, `effectiveMotion`, `applyMotion` and
+ * `readReducedMotion` as reachable only from `__tests__`. That is true and it
+ * is not a defect. They are not internals somebody reached past a seam to
+ * grab — they ARE the seam, because it is the only one this harness can reach.
+ *
+ * `vite.config.ts` declares the vitest block with no `environment`, so tests
+ * run in node: no jsdom, no happy-dom, no `@testing-library/*`. Every frontend
+ * test is a single `renderToStaticMarkup` pass — no effects, no state
+ * transitions, no `matchMedia`. `MotionProvider` therefore cannot be mounted
+ * and driven here at all, and the thing this file exists to guarantee (the OS
+ * ask outranks the stored choice, so the switch can only ever subtract) is
+ * assertable on these functions or nowhere.
+ *
+ * Owner ruling 2026-08-28 on #2693: keep them, note why. Deleting them drops
+ * live coverage of the reduced-motion gate and buys nothing. If the harness
+ * ever gains a DOM they become re-examinable; until then an audit that lists
+ * them again is measuring the harness, not this module.
+ */
 export type Motion = 'on' | 'off'
 
 export const MOTION_STORAGE_KEY = 'wz-motion'

--- a/frontend/src/hooks/usePagedResource.ts
+++ b/frontend/src/hooks/usePagedResource.ts
@@ -4,6 +4,24 @@ import type { KeyedResourceCache } from './cachedResource'
 import { CACHE_EPOCH } from '../utils/cacheEpoch'
 import type { CurrentUser } from '../api/auth'
 
+/**
+ * WHY `DEFAULT_PAGE_SIZE`, `pageHasMore`, `growLimit`, `pageCacheKey` AND
+ * `loadPage` ARE EXPORTED WHEN ONLY A TEST IMPORTS THEM
+ * ---------------------------------------------------------------------
+ * A dead-export audit (#2693) listed all five as reachable only from
+ * `__tests__`. True, and not a defect. `vite.config.ts` declares vitest with
+ * no `environment`, so tests run in node: no jsdom, effects never run, and
+ * every frontend test is one `renderToStaticMarkup` pass. `usePagedResource`
+ * cannot be mounted and grown here, so the load-more contract (grow iff the
+ * page came back full), the cache key's collision-safety, and "page 2 is never
+ * cached" are asserted on these functions or nowhere. Each is also pure and
+ * stands alone, which is the shape the audit's own carve-out calls a good seam.
+ *
+ * Owner ruling 2026-08-28 on #2693: keep them, note why. If the harness ever
+ * gains a DOM they become re-examinable; until then an audit that lists them
+ * again is measuring the harness, not this module.
+ */
+
 /** Default page size — one "load more" grows the window by this step. */
 export const DEFAULT_PAGE_SIZE = 50
 

--- a/frontend/src/hooks/useSidebarPanelLayout.ts
+++ b/frontend/src/hooks/useSidebarPanelLayout.ts
@@ -24,6 +24,25 @@ import { useCallback, useMemo, useState } from 'react'
  * The storage idiom is `useSidebarCollapsed`'s, unchanged: a pure resolver, a
  * lazy `useState` initializer that wraps the browser read in try/catch (the
  * repo's tests render with no DOM), and a write on every change.
+ *
+ * WHY THE DECISIONS BELOW ARE EXPORTED WHEN ONLY A TEST IMPORTS THEM
+ * ------------------------------------------------------------------
+ * A dead-export audit (#2693) listed `DEFAULT_PANEL_ORDER`,
+ * `DEFAULT_PANEL_LAYOUT`, `sidebarPanelLayoutStorageKey`,
+ * `serializePanelLayout`, `movePanelTo` and `movePanelBy` as reachable only
+ * from `__tests__`. True, and not a defect — they are the only seam this
+ * harness can reach. `vite.config.ts` declares vitest with no `environment`,
+ * so tests run in node: no jsdom, no DOM events, no `localStorage`, effects
+ * never run, and every test is one `renderToStaticMarkup` pass. Neither the
+ * pointer drag nor the round trip through storage can be exercised through
+ * `useSidebarPanelLayout` itself, so the reorder rules — the keyboard path's
+ * no-op at the ends, the drop-on-itself identity return, the per-ACCOUNT key
+ * the 2026-08-02 ruling above requires — are asserted on these or not at all.
+ * `useSidebarPanelLayout.test.ts` states the same constraint in its header.
+ *
+ * Owner ruling 2026-08-28 on #2693: keep them, note why. If the harness ever
+ * gains a DOM they become re-examinable; until then an audit that lists them
+ * again is measuring the harness, not this module.
  */
 
 /** Panel ids, in the order a player who has never reordered anything sees. */

--- a/frontend/src/pages/factionDetail/sectionDisclosure.tsx
+++ b/frontend/src/pages/factionDetail/sectionDisclosure.tsx
@@ -38,6 +38,21 @@
  * tests render with no DOM), and a write on every change. What is deliberately
  * NOT reused is `SidebarPanelId` — these are not sidebar panels and registering
  * them there would put them in the rail's blob and in its collapsible ruling.
+ *
+ * WHY THE DECISIONS BELOW ARE EXPORTED WHEN ONLY A TEST IMPORTS THEM. A
+ * dead-export audit (#2693) listed `FACTION_SECTION_IDS`,
+ * `factionSectionStorageKey`, `factionSectionBodyId`,
+ * `resolveCollapsedSections`, `serializeCollapsedSections` and
+ * `toggleCollapsedSection` as reachable only from `__tests__`. True, and not a
+ * defect — they are the only seam this harness can reach. `vite.config.ts`
+ * declares vitest with no `environment`, so tests run in node: no jsdom, no
+ * click events, no `localStorage`, effects never run, and every test is one
+ * `renderToStaticMarkup` pass. `useFactionSections` cannot be mounted and
+ * toggled here, so what a stored blob is allowed to be, what junk it tolerates,
+ * and the `aria-controls` id that must match the panel it names are asserted on
+ * these or not at all. Owner ruling 2026-08-28 on #2693: keep them, note why —
+ * if the harness ever gains a DOM they become re-examinable, and until then an
+ * audit that lists them again is measuring the harness, not this module.
  */
 import { useCallback, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";


### PR DESCRIPTION
Refs #2693

> **This PR deliberately does NOT say `Closes #2693`.** It satisfies the first
> bullet of that issue's acceptance list and none of the other three. Read
> "Scope, and why this is not a close" below before merging — closing the issue
> here would silently drop ~126 exports the owner explicitly kept in scope.

## The seam

The export boundary of four stateful hooks. No runtime code changed — this PR
is four block comments.

## What happened

My dispatch brief said to un-export the internals of these four modules and
re-assert their behaviour through the hooks' public surface:

```
frontend/src/hooks/useMotion.tsx
frontend/src/hooks/useSidebarPanelLayout.ts
frontend/src/pages/factionDetail/sectionDisclosure.tsx
frontend/src/hooks/usePagedResource.ts
```

That instruction comes from the issue **body**. The issue's most recent comment
— an owner ruling, 2026-08-28, during `/planner-bot` — **reverses it**:

> **Do not delete these four.** Deleting them would drop live coverage —
> `movePanelBy`'s keyboard path, `resolveCollapsedSections`,
> `growLimit`/`pageHasMore`, the motion gate — and buy nothing. [...]
> **Leave a note at each of the four** saying why the export exists, so the next
> dead-export audit does not re-file them. That note is the deliverable for this
> half, not a deletion.

I verified the ruling's premise rather than taking it on trust, and it holds:

- `frontend/vite.config.ts` declares the vitest block with **no `environment`
  key**, so tests run in the default `node` env. The comment above it says so:
  *"renderToStaticMarkup needs no DOM, so the default 'node' environment is fine."*
- `frontend/package.json` matches nothing for `testing-library|jsdom|happy-dom|react-test`.
- `src/hooks/__tests__/useSidebarPanelLayout.test.ts:5` already states the
  constraint in its own header, before any import.

So there is no way to mount and drive any of these four hooks in this harness:
one static pass, no effects, no state transitions, no `matchMedia`, no
`localStorage`. Converting the tests would have deleted the assertions, not
moved them — which is the outcome my brief's own quality bar names as
legitimate ("KEEP that export and write the reason at the export site"). The
brief's fallback and the owner's ruling land on the same place, so that is what
I built.

## Premise re-measured

The audit's figures are from 2026-08-25. I re-counted against `origin/main` @
`3d70fd3a` — every export in `frontend/src`, `e2e`, `.ds-kit` and
`.design-sync`, splitting test importers from production ones. All 21 exports
named across the four modules still have **zero** production importers, so
nothing here has gained a caller since the snapshot. Three neighbours in the
same files do have production callers and were left alone accordingly
(`MOTION_STORAGE_KEY`, `SIDEBAR_PANEL_COLLAPSIBLE`, `viewerCacheKey`,
`FACTION_SECTION_STORAGE_KEY`).

The scan also re-derives the headline number: **152** test-only exports across
74 modules today (the issue said 143 on 2026-08-25), plus **161** exports with
no importer at all — the latter being #2694's question, not this one's.

## What changed

One block comment per module, at the export site, naming: the audit that listed
them (#2693), the harness fact that makes the export the only reachable seam,
what specifically would stop being asserted if they were deleted, and the owner
ruling. Each ends with the same escape hatch — if the harness ever gains a DOM,
these become re-examinable.

## Scope, and why this is not a close

The ruling leaves the issue owning **the rest of the 143**: "a runtime export
whose only importer is a test, where the exported thing is NOT a stateful
hook's internals reached for harness reasons." My scan puts that residue at
~126 exports across ~70 modules, each a judgement call. My brief explicitly
scoped me off it ("Do NOT touch `toRoman`, `readOneOf`, `formatCommentTime` or
the rest of the 143"), so it is untouched and the issue stays open for it.

`useMetataskApply.ts` / `toggleMetatask` is **#2877's** — a parallel agent is
deleting that one and cites this issue. Not touched here.

## Checks

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 479 files, 9957 passed, 1 skipped — same as before |
| `npm run build` | built |
| `npm run budget` | CSS ok; JS `WARN 151.2 KB` — pre-existing, unrelated (React 19 dissolved the react-dom vendor chunk), and comments do not survive minification |

`api-schema` is not implicated: no route, `response_model` or Pydantic schema
was touched.

## What to eyeball

Nothing in this PR can change behaviour — it adds comments and no executable
bytes, and the test suite count is unchanged. So live visual QA is genuinely
optional here. What is worth a look is **whether these two behaviours actually
work**, because this PR is the record that says they are untestable in CI and
therefore only a human ever sees them:

- **Reduced motion (`useMotion`).** Settings → Appearance. With the OS
  "reduce motion" preference ON, the switch should render **off and disabled** —
  that disabled state is deliberate, not a bug and not a loading state. With the
  OS preference off, flipping the switch should still every animation on the
  page, including the JS-driven ones (`SingularityVote`'s scramble clock and
  `AlbescentVote`'s morph clock). Reload and confirm the choice survives.
- **Sidebar panel drag order persisting across reloads
  (`useSidebarPanelLayout`).** On desktop, drag "Active tasks" and "Recent
  activity" past each other in the rail below the character card, then reload —
  the order must persist. Then do the same with the **keyboard** grip, which is
  `movePanelBy`'s path: it must no-op at both ends rather than wrapping. Switch
  to another character on the same account and confirm the rail keeps ONE shape
  (it is keyed by account, not character — the 2026-08-02 ruling).
- **Faction detail disclosures (`sectionDisclosure`).** Fold Tasks and Praxis on
  a faction page, reload, confirm they stay folded; confirm Charter, Roll and
  Members have no disclosure at all.
- **Load more (`usePagedResource`).** Any long list: "load more" should
  disappear exactly when a short page comes back, and changing a filter should
  collapse the window back to one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
