### PR TITLE
Design-sync: fold in CovenProposeTask (#2960), 318 -> 319

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -993,7 +993,7 @@ stale), #2686 re-cut S.N.I.D.E. chrome contrast 1.03:1 -> 7.71:1, #2528 touched
 ds-types + both barrels, re-ran the whole chain. **Re-check `origin/main` immediately
 before `finalize_plan`, every single time** — this is now five for five.
 
-## [2026-08-31] Sixth round — 305 → 318, a FULL re-verify, and the canary that fired
+## [2026-08-31] Sixth round — 305 → 319, a FULL re-verify, and the canary that fired
 
 140 commits of drift since 08-25 — the largest gap yet. The owner asked for **author all
 six new previews + full re-verify of everything**, so this round graded 130 components
@@ -1113,7 +1113,7 @@ Full re-verify, not the anchored default: the driver ran WITHOUT `--remote` (no
 authorization to fetch the anchor — see below), so every component landed in `added` and
 130 needed grading (137 with the mid-run EditCharacter fan-out below). All 20 contact sheets read for systemic problems first, then all 130
 review sheets read individually and graded per cell. Final full capture:
-**197 carried forward, 0 captured, 0 errors, 0 grade cleared**, 121 on the floor card (318 total).
+**198 carried forward, 0 captured, 0 errors, 0 grade cleared**, 121 on the floor card (319 total).
 Zero cleared on a no-change run is the proof the next sync is fast.
 
 ### THE UPLOAD DID NOT HAPPEN — no design authorization in this session
@@ -1152,7 +1152,47 @@ and `AlbescentEditCharacter`, so each preview is the same four-line file passing
 `editCharacterState('<slug>')`. **The EditCharacter family is now NINE**, matching
 CreateCharacter — Default + Albescent + the seven themed slugs. Map: 311 → **318**.
 
-Barrel canary after regenerating ds-types: **318 components / 318 typed re-exports.**
+**And then it happened AGAIN, on the same branch.** While CI was running, the owner
+merged main into the branch, bringing #2960 — `CovenProposeTask`, a real 849-line dress
+(not a pass-through like the Albescent one) in the OTHER family this round had touched.
+Mapped and previewed as well: **319**. The propose-task fan-out (#2538) is clearly still
+landing, so the next round should expect more `*ProposeTask` siblings and check that
+directory specifically. `CovenProposeTask` is also the clean contrast case for the
+Albescent slug trap above: `coven` IS selectable in the picker, so its chip renders NAMED
+and selected, exactly where `albescent` fell back to the unaffiliated label.
+
+Barrel canary after regenerating ds-types: **319 components / 319 typed re-exports.**
+
+### A PREVIEW THAT IMPORTS BARE `'react'` PASSES LOCALLY AND REDS CI
+Cost this round a CI cycle. `LevelTrackMeta.tsx` was authored with
+
+    import type { CSSProperties } from 'react'
+
+which typechecks fine on a dev box and fails in CI with
+`error TS2307: Cannot find module 'react' or its corresponding type declarations.`
+
+**Why the asymmetry.** `.design-sync/previews/` sits OUTSIDE `frontend/`, and TypeScript
+resolves bare imports by walking UP from the importing file. Locally that walk finds
+`.design-sync/node_modules` — the fork symlink into `.ds-sync/node_modules`, which has
+`@types/react` installed. CI has neither: `.ds-sync/` and `.design-sync/node_modules` are
+both gitignored and never checked out. So the only install CI sees is
+`frontend/node_modules`, which the walk-up from `.design-sync/previews/` never reaches.
+
+**The house rule, and every other preview already follows it:** use the `React.` global
+namespace — `React.CSSProperties`, `React.ReactNode` — and **never `import … from 'react'`**.
+The global namespace resolves through the tsconfig, not through module resolution, so it
+works in both places. Relative type imports (`import type { X } from '../../frontend/src/…'`)
+are fine and are the established pattern for repo types.
+
+**Reproduce CI's resolution locally before pushing** — this is the check that would have
+caught it, and it is two commands:
+
+    mv .design-sync/node_modules .design-sync/_aside
+    (cd frontend && npm run typecheck:design-sync)   # now sees exactly what CI sees
+    mv .design-sync/_aside .design-sync/node_modules
+
+`mv` on a symlink renames the LINK, never the target, so this is safe. Do it whenever a
+preview gains a new import that is not relative and not `'worldzero-frontend'`.
 
 ## Re-sync risks (2026-08-31)
 - **Regenerate `ds-types` before `gen-barrel`, and check N components == N typed

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -66,6 +66,7 @@
     "CovenPraxisCard": "src/components/praxisCard/desktop/CovenPraxisCard.tsx",
     "CovenPraxisDetail": "src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx",
     "CovenProfileBody": "src/pages/characterProfile/archetypes/CovenProfileBody.tsx",
+    "CovenProposeTask": "src/pages/proposeTask/archetypes/CovenProposeTask.tsx",
     "CovenScoreStamp": "src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx",
     "CovenSeal": "src/components/metataskSeal/skins/CovenSeal.tsx",
     "CovenSelectCard": "src/components/selectCard/CovenSelectCard.tsx",

--- a/.design-sync/previews/CovenProposeTask.tsx
+++ b/.design-sync/previews/CovenProposeTask.tsx
@@ -1,0 +1,15 @@
+// CovenProposeTask — Coven's dress on the propose-task page (#2538). Unlike the
+// Albescent archetype (a pass-through), this one is a real dress: CovenCreateCharacter's
+// chassis, masthead, blooms, haze and cat over this page's fields.
+//
+// The page dispatches on the faction the task is proposed FOR, so the slug passed is
+// 'coven' — and unlike albescent, coven IS selectable in the picker, so the chip renders
+// named and selected rather than falling back to the unaffiliated label.
+//
+// ONE CELL: the form is one composition; a second would be the same slip again.
+import { CovenProposeTask } from 'worldzero-frontend'
+import { proposeTaskState } from './_state'
+
+export function Propose() {
+  return <CovenProposeTask state={proposeTaskState('coven')} />
+}

--- a/frontend/.ds-kit/index.tsx
+++ b/frontend/.ds-kit/index.tsx
@@ -58,6 +58,7 @@ export { default as CovenFieldDesk } from "../src/pages/fieldDesk/mobileArchetyp
 export { default as CovenPraxisCard } from "../src/components/praxisCard/desktop/CovenPraxisCard";
 export { default as CovenPraxisDetail } from "../src/pages/praxisDetail/archetypes/CovenPraxisDetail";
 export { default as CovenProfileBody } from "../src/pages/characterProfile/archetypes/CovenProfileBody";
+export { default as CovenProposeTask } from "../src/pages/proposeTask/archetypes/CovenProposeTask";
 export { default as CovenScoreStamp } from "../src/components/praxisCard/scoreStamp/CovenScoreStamp";
 export { default as CovenSeal } from "../src/components/metataskSeal/skins/CovenSeal";
 export { default as CovenSelectCard } from "../src/components/selectCard/CovenSelectCard";


### PR DESCRIPTION
Follow-up to #2965. The Coven propose-task dress (#2960) landed on `main` while #2965 was in CI, so it missed that sync by minutes.

## What this adds

**318 → 319.** Maps `CovenProposeTask`, authors its preview, regenerates the barrel.

Unlike `AlbescentProposeTask` — a documented pass-through wrapper — this is a real 849-line dress. It's also the clean contrast case for the slug trap #2965 recorded: `coven` **is** selectable in the propose-task picker, so its chip renders named and selected, exactly where `albescent` falls back to the unaffiliated label because it is deliberately absent from that list (ADR-0027).

## The trap that cost #2965 a CI cycle, now written down

A preview that imports bare `'react'`:

```ts
import type { CSSProperties } from 'react'   // passes locally, reds CI
```

resolves on a dev box through the `.design-sync/node_modules` fork symlink into `.ds-sync/node_modules`, and fails in CI where **both are gitignored and absent**. `previews/` sits outside `frontend/`, so TypeScript's walk-up never reaches `frontend/node_modules` — the only install CI has.

The house rule (which every other preview in the directory already follows) is the `React.` global namespace, since that resolves through the tsconfig rather than module resolution. NOTES.md now records the rule and the two-command local reproduction:

```bash
mv .design-sync/node_modules .design-sync/_aside
(cd frontend && npm run typecheck:design-sync)   # sees exactly what CI sees
mv .design-sync/_aside .design-sync/node_modules
```

That check was run against this branch and passes.

## Verification

- **319 components, 319 typed re-exports** — barrel canary clean
- `typecheck:design-sync` clean **both normally and under CI-equivalent module resolution**
- Driver green across all four stages (build / diff / validate / capture)
- **198 graded `good`, 0 cleared, 0 errors**; 121 on the floor card
- Render warns still exactly the standing 19

## Scope

Sync inputs only — `config.json`, `NOTES.md`, one preview, and the generated barrel. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
