### PR TITLE
Each composer control declares the slice it draws (#2882)

### DIFF
--- a/frontend/src/pages/editPraxis/__tests__/imageEditFailure.test.tsx
+++ b/frontend/src/pages/editPraxis/__tests__/imageEditFailure.test.tsx
@@ -92,7 +92,8 @@ describe("the failure lands on a line the player can see", () => {
     const line = "sunset.heic — that image could not be processed";
     const markup = renderToStaticMarkup(
       <FilePicker
-        state={{ fileError: line, handleFileChange: () => {} } as unknown as EditPraxisState}
+        fileError={line}
+        handleFileChange={() => {}}
         skin={{ buttonStyle: {}, buttonLabel: "Add proof" }}
       />,
     );

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -568,7 +568,8 @@ export default function CovenEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: { ...fieldBox, fontFamily: DISPLAY },
@@ -585,7 +586,13 @@ export default function CovenEditPraxis({ state }: Props) {
             labelStyle={labelStyle}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -639,7 +646,24 @@ export default function CovenEditPraxis({ state }: Props) {
             labelStyle={labelStyle}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: CHROME,
                 inputBg: FIELD,
@@ -720,7 +744,11 @@ export default function CovenEditPraxis({ state }: Props) {
               still be a tab stop and still be submitted by a form. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
@@ -741,7 +769,7 @@ export default function CovenEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: { ...fieldBox, minHeight: 180 },
                 markdownStyle: {
@@ -811,7 +839,8 @@ export default function CovenEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: composerLabelStyle({
                     fontFamily: CHROME,
@@ -859,11 +888,16 @@ export default function CovenEditPraxis({ state }: Props) {
           start={
             <>
               <SaveDraftButton
-                state={state}
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
                 skin={{ style: { color: LABEL, fontFamily: CHROME } }}
               />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: composerLabelStyle({
                     fontFamily: CHROME,
@@ -880,7 +914,19 @@ export default function CovenEditPraxis({ state }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -388,7 +388,8 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: {
@@ -409,7 +410,13 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
             labelStyle={labelStyle}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -459,7 +466,24 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
             labelStyle={labelStyle}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: TITLE_FACE,
                 inputBg: FIELD,
@@ -534,7 +558,11 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
               both would put the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
@@ -548,7 +576,7 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: {
                   ...fieldBox,
@@ -618,7 +646,8 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: composerLabelStyle({
                     cursor: "pointer",
@@ -660,9 +689,17 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
         <ComposerFooter
           start={
             <>
-              <SaveDraftButton state={state} skin={{ style: { color: FAINT } }} />
+              <SaveDraftButton
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
+                skin={{ style: { color: FAINT } }}
+              />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: composerLabelStyle({
                     background: "transparent",
@@ -678,7 +715,19 @@ export default function DefaultEditPraxis({ state, ornament }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -511,7 +511,8 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: { ...fieldBox, fontFamily: CAPS },
@@ -528,7 +529,13 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             labelStyle={sectionLabel}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -579,7 +586,24 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             labelStyle={sectionLabel}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: READING,
                 inputBg: INNER,
@@ -657,7 +681,11 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               both would put the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
@@ -671,7 +699,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: { ...fieldBox, minHeight: 180 },
                 markdownStyle: {
@@ -742,7 +770,8 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: composerLabelStyle({
                     ...label,
@@ -786,7 +815,10 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           start={
             <>
               <SaveDraftButton
-                state={state}
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
                 skin={{
                   className: "hover:underline",
                   style: composerLabelStyle({
@@ -800,7 +832,9 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 }}
               />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: composerLabelStyle({
                     ...label,
@@ -831,7 +865,19 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                   The card and the task page carry both strips. */}
               <EphemeristsNotationBand side="top" seed={`praxis:${praxis.id}`} />
               <PublishButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                isPublished={state.isPublished}
+                duel={state.duel}
+                duelMode={state.duelMode}
+                title={state.title}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                publish={state.publish}
+                propose={state.propose}
+                pullBack={state.pullBack}
+                markDone={state.markDone}
+                requestDuelSeal={state.requestDuelSeal}
                 skin={{
                   /* THE ONE PLATE CTA (#2146). The band takes its ground and
                      its ink from `.eph-cta` — this is the same control the task

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -430,7 +430,8 @@ export default function EverymenEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: {
@@ -451,7 +452,13 @@ export default function EverymenEditPraxis({ state }: Props) {
             labelStyle={stencil({ color: INK })}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -508,7 +515,24 @@ export default function EverymenEditPraxis({ state }: Props) {
             labelStyle={stencil({ color: INK })}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: COURIER,
                 inputBg: PANEL,
@@ -584,7 +608,11 @@ export default function EverymenEditPraxis({ state }: Props) {
               would put the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
@@ -606,7 +634,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: {
                   ...fieldBox,
@@ -676,7 +704,8 @@ export default function EverymenEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: stencil({
                     display: "inline-flex",
@@ -719,9 +748,17 @@ export default function EverymenEditPraxis({ state }: Props) {
           band
           start={
             <>
-              <SaveDraftButton state={state} skin={{ style: { color: MUTED } }} />
+              <SaveDraftButton
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
+                skin={{ style: { color: MUTED } }}
+              />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: stencil({
                     background: "transparent",
@@ -737,7 +774,19 @@ export default function EverymenEditPraxis({ state }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -523,7 +523,8 @@ export default function SingularityEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: { ...fieldBox, color: ACCENT },
@@ -540,7 +541,13 @@ export default function SingularityEditPraxis({ state }: Props) {
             labelStyle={{ fontFamily: FACE, color: INK }}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -591,7 +598,24 @@ export default function SingularityEditPraxis({ state }: Props) {
             labelStyle={{ fontFamily: FACE, color: INK }}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: FACE,
                 inputBg: PANEL,
@@ -667,7 +691,11 @@ export default function SingularityEditPraxis({ state }: Props) {
               both would put the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 /* The second surface that re-points the house disabled pair
                    (#2574), and for the same reason the publish band does: the
@@ -697,7 +725,7 @@ export default function SingularityEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: { ...fieldBox, minHeight: 200 },
                 markdownStyle: {
@@ -767,7 +795,8 @@ export default function SingularityEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: termLabel({
                     cursor: "pointer",
@@ -813,11 +842,16 @@ export default function SingularityEditPraxis({ state }: Props) {
           start={
             <>
               <SaveDraftButton
-                state={state}
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
                 skin={{ style: termLabel({ color: INK }) }}
               />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: termLabel({
                     background: "transparent",
@@ -833,7 +867,19 @@ export default function SingularityEditPraxis({ state }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 /* The one surface that re-points the house disabled pair
                    (#2573). `controls.tsx` adds `.control-off` itself when the

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -434,7 +434,8 @@ export default function SnideEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: { ...fieldBox, fontFamily: TITLE_FACE },
@@ -451,7 +452,13 @@ export default function SnideEditPraxis({ state }: Props) {
             labelStyle={{ color: MUTED }}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -500,7 +507,24 @@ export default function SnideEditPraxis({ state }: Props) {
             labelStyle={{ color: MUTED }}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: BODY_FACE,
                 inputBg: FIELD,
@@ -594,7 +618,11 @@ export default function SnideEditPraxis({ state }: Props) {
               still submits, and drawing both puts the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
@@ -614,7 +642,7 @@ export default function SnideEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: { ...fieldBox, minHeight: 180 },
                 markdownStyle: {
@@ -684,7 +712,8 @@ export default function SnideEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: punkLabel({
                     cursor: "pointer",
@@ -729,11 +758,16 @@ export default function SnideEditPraxis({ state }: Props) {
           start={
             <>
               <SaveDraftButton
-                state={state}
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
                 skin={{ style: { color: FAINT, fontFamily: BODY_FACE } }}
               />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: punkLabel({
                     background: "transparent",
@@ -749,7 +783,19 @@ export default function SnideEditPraxis({ state }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -348,7 +348,8 @@ export default function UaEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: {
@@ -369,7 +370,13 @@ export default function UaEditPraxis({ state }: Props) {
             labelStyle={labelStyle}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -420,7 +427,24 @@ export default function UaEditPraxis({ state }: Props) {
             labelStyle={labelStyle}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: UA_TEXT,
                 inputBg: FIELD,
@@ -496,7 +520,11 @@ export default function UaEditPraxis({ state }: Props) {
               both would put the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
@@ -517,7 +545,7 @@ export default function UaEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: { ...fieldBox, minHeight: 180 },
                 markdownStyle: {
@@ -587,7 +615,8 @@ export default function UaEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: composerLabelStyle({
                     fontFamily: UA_TEXT,
@@ -630,11 +659,16 @@ export default function UaEditPraxis({ state }: Props) {
           start={
             <>
               <SaveDraftButton
-                state={state}
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
                 skin={{ style: { fontFamily: UA_TEXT, color: BODY } }}
               />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: composerLabelStyle({
                     fontFamily: UA_TEXT,
@@ -651,7 +685,19 @@ export default function UaEditPraxis({ state }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -440,7 +440,8 @@ export default function WowEditPraxis({ state }: Props) {
             `TitleField`, so there is nothing per-faction here. */}
         <ComposerSection rule={false}>
           <TitleField
-            state={state}
+            title={state.title}
+            setTitle={state.setTitle}
             skin={{
               placeholder: t("editPraxis.composer.titlePlaceholder"),
               inputStyle: { ...fieldBox, fontFamily: MED },
@@ -457,7 +458,13 @@ export default function WowEditPraxis({ state }: Props) {
             labelStyle={LABEL_STYLE}
           >
             <ModePicker
-              state={state}
+              praxis={praxis}
+              task={task}
+              duelMode={state.duelMode}
+              duelChipVisible={state.duelChipVisible}
+              modeIsLocked={state.modeIsLocked}
+              switchingMode={state.switchingMode}
+              changeMode={state.changeMode}
               skin={{
                 containerStyle: {
                   display: "flex",
@@ -510,7 +517,24 @@ export default function WowEditPraxis({ state }: Props) {
             labelStyle={LABEL_STYLE}
           >
             <InviteSearch
-              state={state}
+              praxis={praxis}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              currentCharacterId={state.currentCharacterId}
+              autoSubmitDays={state.autoSubmitDays}
+              inviteQuery={state.inviteQuery}
+              setInviteQuery={state.setInviteQuery}
+              inviteResults={state.inviteResults}
+              inviteOpen={state.inviteOpen}
+              setInviteOpen={state.setInviteOpen}
+              inviting={state.inviting}
+              sendInvite={state.sendInvite}
+              sendChallenge={state.sendChallenge}
+              cancelInvite={state.cancelInvite}
+              kickMember={state.kickMember}
+              leaveCollab={state.leaveCollab}
+              cancelDuel={state.cancelDuel}
+              dissolveDuel={state.dissolveDuel}
               skin={{
                 fontFamily: LORA,
                 inputBg: FIELD,
@@ -579,7 +603,11 @@ export default function WowEditPraxis({ state }: Props) {
               still submits, and drawing both puts the body in the DOM twice. */}
           {tab === "write" ? (
             <BodyTextarea
-              state={state}
+              praxis={praxis}
+              controlsLocked={state.controlsLocked}
+              setBody={state.setBody}
+              proposalConfirmArmed={state.proposalConfirmArmed}
+              confirmProposalEdit={state.confirmProposalEdit}
               skin={{
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
@@ -600,7 +628,7 @@ export default function WowEditPraxis({ state }: Props) {
             />
           ) : (
             <BodyPreview
-              state={state}
+              body={state.body}
               skin={{
                 wrapperStyle: {
                   ...fieldBox,
@@ -677,7 +705,8 @@ export default function WowEditPraxis({ state }: Props) {
             })}
             {!state.controlsLocked && (
               <FilePicker
-                state={state}
+                fileError={state.fileError}
+                handleFileChange={state.handleFileChange}
                 skin={{
                   buttonStyle: composerLabelStyle({
                     fontFamily: MED,
@@ -720,11 +749,16 @@ export default function WowEditPraxis({ state }: Props) {
           start={
             <>
               <SaveDraftButton
-                state={state}
+                controlsLocked={state.controlsLocked}
+                submitting={state.submitting}
+                switchingMode={state.switchingMode}
+                saveDraft={state.saveDraft}
                 skin={{ style: { fontFamily: LORA, color: LABEL } }}
               />
               <DropButton
-                state={state}
+                praxis={praxis}
+                currentCharacterId={state.currentCharacterId}
+                cancel={state.cancel}
                 skin={{
                   style: composerLabelStyle({
                     fontFamily: LORA,
@@ -741,7 +775,19 @@ export default function WowEditPraxis({ state }: Props) {
           }
           end={
             <PublishButton
-              state={state}
+              praxis={praxis}
+              currentCharacterId={state.currentCharacterId}
+              isPublished={state.isPublished}
+              duel={state.duel}
+              duelMode={state.duelMode}
+              title={state.title}
+              submitting={state.submitting}
+              switchingMode={state.switchingMode}
+              publish={state.publish}
+              propose={state.propose}
+              pullBack={state.pullBack}
+              markDone={state.markDone}
+              requestDuelSeal={state.requestDuelSeal}
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
@@ -85,7 +85,11 @@ function duelState(
 }
 
 function chipHtml(state: EditPraxisState): string {
-  return renderToStaticMarkup(<InviteSearch state={state} skin={SKIN} />);
+  // `praxis!` because the control now asks for a loaded praxis rather than
+  // asserting one itself (#2882); every fixture below builds one.
+  return renderToStaticMarkup(
+    <InviteSearch {...state} praxis={state.praxis!} skin={SKIN} />,
+  );
 }
 
 describe("InviteSearch — the duel pair names the other side (#1226, #1417)", () => {

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
@@ -94,14 +94,14 @@ function collabState(
 function renderButton(state: EditPraxisState): ReactElement<{
   onClick: () => void;
 }> {
-  return PublishButton({ state, skin: SKIN }) as ReactElement<{
+  return PublishButton({ ...state, skin: SKIN }) as ReactElement<{
     onClick: () => void;
   }>;
 }
 
 /** Same, for the states where the button is expected to render nothing. */
 function renderMaybe(state: EditPraxisState): ReactElement | null {
-  return PublishButton({ state, skin: SKIN }) as ReactElement | null;
+  return PublishButton({ ...state, skin: SKIN }) as ReactElement | null;
 }
 
 function duelSide(characterId: number, submitted: boolean) {

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
@@ -48,7 +48,7 @@ function renderThroughProbe(state: EditPraxisState): ReactElement<{
 }> | null {
   let captured: ReactElement | null = null;
   function Probe() {
-    captured = SaveDraftButton({ state });
+    captured = SaveDraftButton({ ...state });
     return null;
   }
   renderToStaticMarkup(<Probe />);
@@ -60,7 +60,7 @@ function renderThroughProbe(state: EditPraxisState): ReactElement<{
 
 describe("SaveDraftButton — the third exit (#1081)", () => {
   it("offers the neutral shared label on an open draft", () => {
-    const html = renderToStaticMarkup(<SaveDraftButton state={draftState()} />);
+    const html = renderToStaticMarkup(<SaveDraftButton {...draftState()} />);
     expect(html).toContain(LABEL);
   });
 
@@ -75,7 +75,7 @@ describe("SaveDraftButton — the third exit (#1081)", () => {
   it("is not drawn once the praxis is cast or moderated — there is no draft left", () => {
     const html = renderToStaticMarkup(
       <SaveDraftButton
-        state={draftState({ controlsLocked: true, isPublished: true })}
+        {...draftState({ controlsLocked: true, isPublished: true })}
       />,
     );
     expect(html).toBe("");
@@ -93,7 +93,7 @@ describe("SaveDraftButton — the third exit (#1081)", () => {
 
   it("takes a faction's own voice when an archetype supplies one", () => {
     const html = renderToStaticMarkup(
-      <SaveDraftButton state={draftState()} skin={{ label: "PARK IT" }} />,
+      <SaveDraftButton {...draftState()} skin={{ label: "PARK IT" }} />,
     );
     expect(html).toContain("PARK IT");
     expect(html).not.toContain(LABEL);

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
@@ -7,33 +7,34 @@
  * draft to keep, and per the house rule that state hides the control rather
  * than greying it out.
  */
-import type { ReactElement } from "react";
+import type { ComponentProps, ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect, vi } from "vitest";
 import "../../../../i18n";
 import i18n from "../../../../i18n";
-import type { PraxisOut } from "../../../../api/praxis";
-import type { EditPraxisState } from "../../useEditPraxis";
 import { SaveDraftButton } from "../controls";
 
 const LABEL = i18n.t("forms:editPraxis.saveDraft");
 
-function draftState(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
+type DraftProps = ComponentProps<typeof SaveDraftButton>;
+
+/**
+ * The four facts the button reads, and nothing else (#2882).
+ *
+ * This used to be a fake composer state behind a cast — a praxis, a character
+ * id and a published flag this control has never looked at — because the prop
+ * was the whole 81-member object. Now that the control asks for its own slice,
+ * the fixture IS the slice: nothing invented, and a re-widened prop fails to
+ * compile here rather than passing silently.
+ */
+function draftProps(overrides: Partial<DraftProps> = {}): DraftProps {
   return {
-    praxis: {
-      id: 1,
-      type: "solo",
-      members: [],
-      task_faction_slug: null,
-    } as unknown as PraxisOut,
     submitting: false,
     switchingMode: null,
     controlsLocked: false,
-    isPublished: false,
-    currentCharacterId: 1,
     saveDraft: async () => {},
     ...overrides,
-  } as unknown as EditPraxisState;
+  };
 }
 
 /**
@@ -42,13 +43,13 @@ function draftState(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
  * renderer to live in while still handing back the element, whose onClick is
  * what proves the wiring — renderToStaticMarkup emits no handlers.
  */
-function renderThroughProbe(state: EditPraxisState): ReactElement<{
+function renderThroughProbe(props: DraftProps): ReactElement<{
   onClick: () => void;
   disabled: boolean;
 }> | null {
   let captured: ReactElement | null = null;
   function Probe() {
-    captured = SaveDraftButton({ ...state });
+    captured = SaveDraftButton(props);
     return null;
   }
   renderToStaticMarkup(<Probe />);
@@ -60,13 +61,13 @@ function renderThroughProbe(state: EditPraxisState): ReactElement<{
 
 describe("SaveDraftButton — the third exit (#1081)", () => {
   it("offers the neutral shared label on an open draft", () => {
-    const html = renderToStaticMarkup(<SaveDraftButton {...draftState()} />);
+    const html = renderToStaticMarkup(<SaveDraftButton {...draftProps()} />);
     expect(html).toContain(LABEL);
   });
 
   it("calls saveDraft — and asks nothing first, because it destroys nothing", () => {
     const saveDraft = vi.fn(async () => {});
-    const element = renderThroughProbe(draftState({ saveDraft }));
+    const element = renderThroughProbe(draftProps({ saveDraft }));
 
     element?.props.onClick();
     expect(saveDraft).toHaveBeenCalledTimes(1);
@@ -74,26 +75,24 @@ describe("SaveDraftButton — the third exit (#1081)", () => {
 
   it("is not drawn once the praxis is cast or moderated — there is no draft left", () => {
     const html = renderToStaticMarkup(
-      <SaveDraftButton
-        {...draftState({ controlsLocked: true, isPublished: true })}
-      />,
+      <SaveDraftButton {...draftProps({ controlsLocked: true })} />,
     );
     expect(html).toBe("");
   });
 
   it("stands down while a publish is in flight", () => {
-    const element = renderThroughProbe(draftState({ submitting: true }));
+    const element = renderThroughProbe(draftProps({ submitting: true }));
     expect(element?.props.disabled).toBe(true);
   });
 
   it("stands down while a mode switch is in flight", () => {
-    const element = renderThroughProbe(draftState({ switchingMode: "collab" }));
+    const element = renderThroughProbe(draftProps({ switchingMode: "collab" }));
     expect(element?.props.disabled).toBe(true);
   });
 
   it("takes a faction's own voice when an archetype supplies one", () => {
     const html = renderToStaticMarkup(
-      <SaveDraftButton {...draftState()} skin={{ label: "PARK IT" }} />,
+      <SaveDraftButton {...draftProps()} skin={{ label: "PARK IT" }} />,
     );
     expect(html).toContain("PARK IT");
     expect(html).not.toContain(LABEL);

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyProposalLive.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyProposalLive.test.tsx
@@ -63,7 +63,7 @@ function html(proposalConfirmArmed: boolean, controlsLocked = false): string {
   // the same decode the confirm-copy and praxis-detail suites carry.
   return renderToStaticMarkup(
     <BodyTextarea
-      state={state(proposalConfirmArmed, controlsLocked)}
+      {...state(proposalConfirmArmed, controlsLocked)}
       skin={{ textareaStyle: {} }}
     />,
   ).replace(/&#x27;|&#39;/g, "'");
@@ -91,7 +91,7 @@ describe("a live proposal, at the write-up", () => {
     } as unknown as EditPraxisState;
     expect(
       renderToStaticMarkup(
-        <BodyTextarea state={agreedAlready} skin={{ textareaStyle: {} }} />,
+        <BodyTextarea {...agreedAlready} skin={{ textareaStyle: {} }} />,
       ).replace(/&#x27;|&#39;/g, "'"),
     ).toContain(liveLine);
   });

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
@@ -28,7 +28,7 @@ const state = {
 
 function html(): string {
   return renderToStaticMarkup(
-    <BodyTextarea state={state} skin={{ textareaStyle: {} }} />,
+    <BodyTextarea {...state} skin={{ textareaStyle: {} }} />,
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyUnavailableDress.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyUnavailableDress.test.tsx
@@ -66,7 +66,7 @@ function html(current: PraxisRoom | null): string {
   room.current = current;
   try {
     return renderToStaticMarkup(
-      <BodyTextarea state={state} skin={{ textareaStyle: {} }} />,
+      <BodyTextarea {...state} skin={{ textareaStyle: {} }} />,
     ).replace(/&#x27;|&#39;/g, "'");
   } finally {
     room.current = null;

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/collabExits.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/collabExits.test.tsx
@@ -45,7 +45,9 @@ function praxisState({
   currentCharacterId: number;
   memberIds?: number[];
   type?: string;
-}): EditPraxisState {
+  // The two controls under test now ask for a loaded praxis rather than
+  // asserting one themselves (#2882), so the fixture says it has one.
+}): EditPraxisState & { praxis: PraxisOut } {
   const praxis = {
     id: 1,
     type,
@@ -73,7 +75,7 @@ function praxisState({
     cancelInvite: async () => {},
     leaveCollab: async () => {},
     cancel: async () => {},
-  } as unknown as EditPraxisState;
+  } as unknown as EditPraxisState & { praxis: PraxisOut };
 }
 
 const LEAVE_LABEL = i18n.t("forms:editPraxis.leaveAction");
@@ -82,28 +84,28 @@ const DROP_SKIN = { label: "ARCHETYPE_DROP", style: {} };
 describe("Leave — every member's exit, the creator included (#1074)", () => {
   it("offers Leave to the member who started the collab", () => {
     const html = renderToStaticMarkup(
-      <InviteSearch state={praxisState({ currentCharacterId: CREATOR_ID })} skin={{}} />,
+      <InviteSearch {...praxisState({ currentCharacterId: CREATOR_ID })} skin={{}} />,
     );
     expect(html).toContain(LEAVE_LABEL);
   });
 
   it("still offers Leave to a member who joined", () => {
     const html = renderToStaticMarkup(
-      <InviteSearch state={praxisState({ currentCharacterId: JOINER_ID })} skin={{}} />,
+      <InviteSearch {...praxisState({ currentCharacterId: JOINER_ID })} skin={{}} />,
     );
     expect(html).toContain(LEAVE_LABEL);
   });
 
   it("says what leaving does — the crew keeps the praxis", () => {
     const html = renderToStaticMarkup(
-      <InviteSearch state={praxisState({ currentCharacterId: CREATOR_ID })} skin={{}} />,
+      <InviteSearch {...praxisState({ currentCharacterId: CREATOR_ID })} skin={{}} />,
     );
     expect(html).toContain(collabCopy(null, "leaveDescription"));
   });
 
   it("offers nothing to leave to someone who is not a member", () => {
     const html = renderToStaticMarkup(
-      <InviteSearch state={praxisState({ currentCharacterId: 99 })} skin={{}} />,
+      <InviteSearch {...praxisState({ currentCharacterId: 99 })} skin={{}} />,
     );
     expect(html).not.toContain(LEAVE_LABEL);
   });
@@ -111,7 +113,7 @@ describe("Leave — every member's exit, the creator included (#1074)", () => {
   it("offers nothing to leave on a solo praxis", () => {
     const html = renderToStaticMarkup(
       <InviteSearch
-        state={praxisState({
+        {...praxisState({
           currentCharacterId: CREATOR_ID,
           memberIds: [CREATOR_ID],
           type: "solo",
@@ -127,7 +129,7 @@ describe("Delete — the creator's alone, and it names its cost (#1074)", () => 
   it("names the consequence when other members' parts are at stake", () => {
     const html = renderToStaticMarkup(
       <DropButton
-        state={praxisState({ currentCharacterId: CREATOR_ID })}
+        {...praxisState({ currentCharacterId: CREATOR_ID })}
         skin={DROP_SKIN}
       />,
     );
@@ -142,7 +144,7 @@ describe("Delete — the creator's alone, and it names its cost (#1074)", () => 
   it("is not drawn at all for a member who did not start the collab", () => {
     const html = renderToStaticMarkup(
       <DropButton
-        state={praxisState({ currentCharacterId: JOINER_ID })}
+        {...praxisState({ currentCharacterId: JOINER_ID })}
         skin={DROP_SKIN}
       />,
     );
@@ -152,7 +154,7 @@ describe("Delete — the creator's alone, and it names its cost (#1074)", () => 
   it("keeps the archetype's own label on a solo praxis", () => {
     const html = renderToStaticMarkup(
       <DropButton
-        state={praxisState({
+        {...praxisState({
           currentCharacterId: CREATOR_ID,
           memberIds: [CREATOR_ID],
           type: "solo",
@@ -167,7 +169,7 @@ describe("Delete — the creator's alone, and it names its cost (#1074)", () => 
   it("keeps the archetype's own label on a collab with nobody else in it", () => {
     const html = renderToStaticMarkup(
       <DropButton
-        state={praxisState({
+        {...praxisState({
           currentCharacterId: CREATOR_ID,
           memberIds: [CREATOR_ID],
         })}

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/collabSignals.test.tsx
@@ -252,7 +252,7 @@ interface TestButton {
 
 /** The group on its own, so a click can be fired without a DOM. */
 function signals(scenario: Scenario): TestButton[] {
-  const element = CollabSignals({ state: state(scenario), skin: SKIN }) as {
+  const element = CollabSignals({ ...state(scenario), skin: SKIN }) as {
     props: { children: unknown };
   };
   const children = Array.isArray(element.props.children)

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
@@ -90,12 +90,12 @@ describe("the composer's focus ring", () => {
 
   it("puts the hook the rule selects on the title input and the body's host", () => {
     const title = renderToStaticMarkup(
-      <TitleField state={state} skin={{ inputStyle: {} }} />,
+      <TitleField {...state} skin={{ inputStyle: {} }} />,
     );
     expect(title).toContain("data-composer-field");
 
     const body = renderToStaticMarkup(
-      <BodyTextarea state={state} skin={{ textareaStyle: {} }} />,
+      <BodyTextarea {...state} skin={{ textareaStyle: {} }} />,
     );
     expect(body).toContain("data-composer-body");
   });

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerQuietInk.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerQuietInk.test.tsx
@@ -87,7 +87,7 @@ function html(
   try {
     return renderToStaticMarkup(
       <BodyTextarea
-        state={state(options.proposalLive ?? false)}
+        {...state(options.proposalLive ?? false)}
         skin={{ textareaStyle: {} }}
       />,
     ).replace(/&#x27;|&#39;/g, "'");

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/sharedComposerLayout.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/sharedComposerLayout.test.tsx
@@ -51,7 +51,7 @@ const TOOLBAR_ROSTER = [
 describe("markdown toolbar roster", () => {
   it("draws the design's seven commands, in order", () => {
     const markup = renderToStaticMarkup(
-      <BodyTextarea state={bodyState} skin={{ textareaStyle: {} }} />,
+      <BodyTextarea {...bodyState} skin={{ textareaStyle: {} }} />,
     );
     // Buttons only — the toolbar element carries an aria-label of its own.
     const labels = [...markup.matchAll(/<button[^>]*aria-label="([^"]+)"/g)].map(

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -14,7 +14,7 @@ import { defaultKeymap } from "@codemirror/commands";
 import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
 import { factionCssVar, factionName } from "../../../utils/factions";
 import { useFormFactor } from "../../../hooks/useFormFactor";
-import type { PraxisType } from "../../../api/praxis";
+import type { PraxisOut, PraxisType } from "../../../api/praxis";
 import type { DuelSideOut } from "../../../api/duel";
 import MarkdownPreview from "../blocks/MarkdownPreview";
 import { applyMarkdown, minimalReplacement } from "../blocks/markdownToolbar";
@@ -161,15 +161,17 @@ function DuelPairSide({
  * challenge back.
  */
 function DuelPair({
-  state,
+  praxis,
+  duel,
+  cancelDuel,
+  dissolveDuel,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<EditPraxisState, "duel" | "cancelDuel" | "dissolveDuel"> & {
+  /** Non-null: the pair only mounts once a challenge is attached. */
+  praxis: PraxisOut;
   skin: InviteSearchSkin;
 }) {
   const { t } = useTranslation("forms");
-  const praxis = state.praxis!;
-  const duel = state.duel;
   // The sides name the OTHER player, not the fixed `opponent` ROLE — accepting a
   // challenge puts the viewer's own praxis in that role, which is what used to
   // print the viewer's own name as the rival (#1226). `praxis.created_by_id` is
@@ -239,7 +241,7 @@ function DuelPair({
           {canRescind && (
             <button
               type="button"
-              onClick={() => void state.cancelDuel()}
+              onClick={() => void cancelDuel()}
               aria-label={t("editPraxis.invite.cancelChallengeAria")}
               style={{
                 background: "transparent",
@@ -257,11 +259,11 @@ function DuelPair({
           {/* Once accepted, either participant can still dissolve the duel
               neutrally (#956) — the backend recalculates both sides back to solo
               scoring, no forfeit. It's a heavier action than the ×, so it's a
-              labelled button behind a confirm (state.dissolveDuel). */}
+              labelled button behind a confirm (dissolveDuel). */}
           {accepted && (
             <button
               type="button"
-              onClick={() => void state.dissolveDuel()}
+              onClick={() => void dissolveDuel()}
               aria-label={t("editPraxis.invite.dissolveDuelAria")}
               className="label-caption"
               style={{
@@ -283,14 +285,50 @@ function DuelPair({
 }
 
 export function InviteSearch({
-  state,
+  praxis,
+  duel,
+  duelMode,
+  currentCharacterId,
+  autoSubmitDays,
+  inviteQuery,
+  setInviteQuery,
+  inviteResults,
+  inviteOpen,
+  setInviteOpen,
+  inviting,
+  sendInvite,
+  sendChallenge,
+  cancelInvite,
+  kickMember,
+  leaveCollab,
+  cancelDuel,
+  dissolveDuel,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<
+  EditPraxisState,
+  | "duel"
+  | "duelMode"
+  | "currentCharacterId"
+  | "autoSubmitDays"
+  | "inviteQuery"
+  | "setInviteQuery"
+  | "inviteResults"
+  | "inviteOpen"
+  | "setInviteOpen"
+  | "inviting"
+  | "sendInvite"
+  | "sendChallenge"
+  | "cancelInvite"
+  | "kickMember"
+  | "leaveCollab"
+  | "cancelDuel"
+  | "dissolveDuel"
+> & {
+  /** Non-null: every archetype mounts this below its own praxis guard. */
+  praxis: PraxisOut;
   skin: InviteSearchSkin;
 }) {
   const { t } = useTranslation("forms");
-  const praxis = state.praxis!;
   // The one roster mount that sits inside a room, and so the only one that can
   // say who is here (#1744). Every other mount — the eight detail pages, the
   // waiting surface — passes nothing and draws no dot at all.
@@ -302,9 +340,8 @@ export function InviteSearch({
   // Duel mode reuses this same box as a one-opponent challenge picker (#311):
   // picking issues a challenge; once attached, the pair replaces it and the
   // search input is hidden (a duel has exactly one opponent).
-  const duelMode = state.duelMode;
   const challengeAttached = duelMode && praxis.duel_id != null;
-  const onPick = duelMode ? state.sendChallenge : state.sendInvite;
+  const onPick = duelMode ? sendChallenge : sendInvite;
   // No chip in duel mode: choosing an opponent is the whole purpose of the pane
   // the player just opened, so hiding the picker behind a disclosure would put a
   // click in front of the one thing there is to do. The chip is the collab's,
@@ -323,7 +360,7 @@ export function InviteSearch({
   const canLeaveCollab =
     !duelMode &&
     praxis.type === "collab" &&
-    praxis.members.some((member) => member.character_id === state.currentCharacterId);
+    praxis.members.some((member) => member.character_id === currentCharacterId);
   // The face comes free from the field every skin already sets, so eight
   // archetypes do not restate it; `collab.fontFamily` stays as the override for
   // a skin whose roster speaks in a different voice from its invite box.
@@ -334,7 +371,15 @@ export function InviteSearch({
         style={{ display: "flex", gap: "var(--space-sm)", flexWrap: "wrap", marginBottom: "var(--space-sm)" }}
       >
         {duelMode
-          ? challengeAttached && <DuelPair state={state} skin={skin} />
+          ? challengeAttached && (
+              <DuelPair
+                praxis={praxis}
+                duel={duel}
+                cancelDuel={cancelDuel}
+                dissolveDuel={dissolveDuel}
+                skin={skin}
+              />
+            )
           : (
               // Live status roster replaces the flat member pills (#591) and,
               // since #1416, the pending-invite chips that used to sit beside
@@ -349,7 +394,7 @@ export function InviteSearch({
                   praxisType={praxis.type}
                   members={praxis.members}
                   invites={praxis.invites}
-                  currentCharacterId={state.currentCharacterId}
+                  currentCharacterId={currentCharacterId}
                   factionSlug={praxis.task_faction_slug}
                   taskPointValue={praxis.task_point_value}
                   presentCharacterIds={room?.present}
@@ -358,8 +403,8 @@ export function InviteSearch({
                   // dress (#2269). The praxis-detail and waiting mounts pass
                   // none and keep the `card-*` family they are measured on.
                   skin={collabSkin}
-                  onKick={state.kickMember}
-                  onRescindInvite={state.cancelInvite}
+                  onKick={kickMember}
+                  onRescindInvite={cancelInvite}
                 />
                 {/* The ADR-0012 countdown, for the holdout only (#1164). It
                     renders itself to nothing for every other viewer and for a
@@ -368,10 +413,10 @@ export function InviteSearch({
                     skins, which is the same reason the roster sits here. */}
                 <HoldoutPublishNotice
                   members={praxis.members}
-                  currentCharacterId={state.currentCharacterId}
+                  currentCharacterId={currentCharacterId}
                   factionSlug={praxis.task_faction_slug}
                   submitProposedAt={praxis.submit_proposed_at}
-                  autoSubmitDays={state.autoSubmitDays}
+                  autoSubmitDays={autoSubmitDays}
                 />
               </div>
             )}
@@ -433,8 +478,8 @@ export function InviteSearch({
           // Opened by the chip, so it takes the caret with it — the click that
           // asked for a search box is not also a request to go and find it.
           autoFocus={pickerOpen}
-          value={state.inviteQuery}
-          onChange={(event) => state.setInviteQuery(event.target.value)}
+          value={inviteQuery}
+          onChange={(event) => setInviteQuery(event.target.value)}
           placeholder={
             skin.placeholder ??
             (duelMode
@@ -456,11 +501,11 @@ export function InviteSearch({
             border: skin.inputBorder ?? "1px solid currentColor",
           }}
           onFocus={() => {
-            if (state.inviteResults.length > 0) state.setInviteOpen(true);
+            if (inviteResults.length > 0) setInviteOpen(true);
           }}
-          onBlur={() => setTimeout(() => state.setInviteOpen(false), 200)}
+          onBlur={() => setTimeout(() => setInviteOpen(false), 200)}
         />
-        {state.inviteOpen && state.inviteResults.length > 0 && (
+        {inviteOpen && inviteResults.length > 0 && (
           <div
             role="listbox"
             style={{
@@ -476,11 +521,11 @@ export function InviteSearch({
               overflowY: "auto",
             }}
           >
-            {state.inviteResults.map((character) => (
+            {inviteResults.map((character) => (
               <button
                 key={character.id}
                 type="button"
-                disabled={state.inviting}
+                disabled={inviting}
                 onMouseDown={() => {
                   // Back to the chip once somebody is asked: the roster below
                   // grows their row, and the next invite is another click on it.
@@ -495,7 +540,7 @@ export function InviteSearch({
                   padding: "var(--space-sm) var(--space-md)",
                   background: "transparent",
                   border: "none",
-                  cursor: state.inviting ? "wait" : "pointer",
+                  cursor: inviting ? "wait" : "pointer",
                   textAlign: "left",
                   fontFamily: skin.fontFamily,
                   fontSize: "var(--text-lg)",
@@ -548,7 +593,7 @@ export function InviteSearch({
       {canLeaveCollab && (
         <button
           type="button"
-          onClick={() => void state.leaveCollab()}
+          onClick={() => void leaveCollab()}
           // Spelling out the outcome next to a delete control that reads
           // superficially similar: this one only removes you (#1074).
           title={collabCopy(praxis.task_faction_slug, "leaveDescription")}
@@ -594,10 +639,10 @@ interface FilePickerSkin {
 }
 
 export function FilePicker({
-  state,
+  fileError,
+  handleFileChange,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<EditPraxisState, "fileError" | "handleFileChange"> & {
   skin: FilePickerSkin;
 }) {
   const { t } = useTranslation("forms");
@@ -622,11 +667,11 @@ export function FilePicker({
         type="file"
         multiple
         accept="image/*,video/*,audio/*"
-        onChange={state.handleFileChange}
+        onChange={handleFileChange}
         style={{ display: "none" }}
       />
       {skin.helperText && <div style={skin.helperStyle}>{skin.helperText}</div>}
-      {state.fileError && (
+      {fileError && (
         <p
           style={{
             fontSize: "var(--text-md)",
@@ -634,7 +679,7 @@ export function FilePicker({
             marginTop: "var(--space-sm)",
           }}
         >
-          {state.fileError}
+          {fileError}
         </p>
       )}
     </div>
@@ -648,20 +693,20 @@ interface DropButtonSkin {
 }
 
 export function DropButton({
-  state,
+  praxis,
+  currentCharacterId,
+  cancel,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<EditPraxisState, "praxis" | "currentCharacterId" | "cancel"> & {
   skin?: DropButtonSkin;
 }) {
   const { t } = useTranslation("forms");
-  const praxis = state.praxis;
   const isCollab = praxis?.type === "collab";
   // Deleting destroys the praxis for the whole crew, so it stays the creator's
   // alone — the backend is the authority (`delete_praxis`), this only declines to
   // draw a control the viewer could never use. Every other member's exit is
   // Leave, which is now theirs too (#1074, ADR-0013).
-  const isCreator = praxis?.created_by_id === state.currentCharacterId;
+  const isCreator = praxis?.created_by_id === currentCharacterId;
   if (isCollab && !isCreator) return null;
   // With other people's parts inside it, the archetype's "drop task" label
   // undersells what the button does. Both the label and the consequence come
@@ -674,7 +719,7 @@ export function DropButton({
   return (
     <button
       type="button"
-      onClick={() => void state.cancel()}
+      onClick={() => void cancel()}
       title={
         crewAtStake
           ? collabCopy(praxis.task_faction_slug, "deleteDescription")
@@ -712,24 +757,29 @@ interface SaveDraftButtonSkin {
 }
 
 export function SaveDraftButton({
-  state,
+  controlsLocked,
+  submitting,
+  switchingMode,
+  saveDraft,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<
+  EditPraxisState,
+  "controlsLocked" | "submitting" | "switchingMode" | "saveDraft"
+> & {
   skin?: SaveDraftButtonSkin;
 }) {
   const { t } = useTranslation("forms");
   // A cast or moderated praxis has no draft to keep — the room refuses a change
   // in the same states, and the archetype is read-only in them. Hide rather
   // than disable, as everywhere else.
-  if (state.controlsLocked) return null;
+  if (controlsLocked) return null;
   return (
     <button
       type="button"
-      onClick={() => void state.saveDraft()}
+      onClick={() => void saveDraft()}
       // Not while a publish or a mode switch is in flight: both end up writing
       // the same fields, and both change where the player should be sent.
-      disabled={state.submitting || state.switchingMode !== null}
+      disabled={submitting || switchingMode !== null}
       className={skin?.className ?? "font-body label-caption hover:underline"}
       style={{
         background: "none",
@@ -789,10 +839,10 @@ interface TitleFieldSkin {
 const TITLE_PUBLISH_DEBOUNCE_MS = 600;
 
 export function TitleField({
-  state,
+  title,
+  setTitle,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<EditPraxisState, "title" | "setTitle"> & {
   skin: TitleFieldSkin;
 }) {
   const { t } = useTranslation("forms");
@@ -802,10 +852,10 @@ export function TitleField({
   const publishTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Read through refs so the observer below can be installed once per room
   // rather than re-subscribed on every keystroke.
-  const setTitleRef = useRef(state.setTitle);
-  setTitleRef.current = state.setTitle;
-  const titleRef = useRef(state.title);
-  titleRef.current = state.title;
+  const setTitleRef = useRef(setTitle);
+  setTitleRef.current = setTitle;
+  const titleRef = useRef(title);
+  titleRef.current = title;
 
   const publish = (value: string) => {
     if (publishTimerRef.current) clearTimeout(publishTimerRef.current);
@@ -884,10 +934,10 @@ export function TitleField({
       // no label of its own and `skin.ariaLabel` when one does, so there is no
       // one string to reach for.
       data-testid="praxis-title"
-      value={state.title}
+      value={title}
       onChange={(event) => {
         const next = event.target.value;
-        state.setTitle(next);
+        setTitle(next);
         if (publishTimerRef.current) clearTimeout(publishTimerRef.current);
         publishTimerRef.current = setTimeout(
           () => publish(next),
@@ -902,7 +952,7 @@ export function TitleField({
 }
 
 /* -------------------------------------------------------------------------- */
-/* BodyTextarea — the body textarea bound to state.body / state.setBody.       */
+/* BodyTextarea — the body editor, bound to `body` / `setBody`.               */
 /* Kept separate from BodyPreview so archetypes that wrap the textarea in      */
 /* bespoke chrome (line-number gutters, etc.) can still consume the shared     */
 /* binding.                                                                    */
@@ -1080,10 +1130,20 @@ const BODY_UNAVAILABLE_STYLE: CSSProperties = {
 };
 
 export function BodyTextarea({
-  state,
+  praxis,
+  controlsLocked,
+  setBody,
+  proposalConfirmArmed,
+  confirmProposalEdit,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<
+  EditPraxisState,
+  | "praxis"
+  | "controlsLocked"
+  | "setBody"
+  | "proposalConfirmArmed"
+  | "confirmProposalEdit"
+> & {
   skin: BodyTextareaSkin;
 }) {
   const { t } = useTranslation("forms");
@@ -1103,19 +1163,19 @@ export function BodyTextarea({
   // that still renders a composer read-only. #1745's freeze was a third, and it
   // is gone (ADR-0079): the room takes writes in every status a member can
   // reach. The rule is one line in `roomSeal.ts`, where the harness can call it.
-  const writable = composerWritable(seeded, state.controlsLocked);
-  const setBodyRef = useRef(state.setBody);
-  setBodyRef.current = state.setBody;
+  const writable = composerWritable(seeded, controlsLocked);
+  const setBodyRef = useRef(setBody);
+  setBodyRef.current = setBody;
   // The live proposal's guard (#1811, ADR-0079), read through a ref so the
   // editor is reconfigured by nothing and rebuilt by nothing when it flips.
   // The filter below runs at dispatch time and reads it then.
   const proposalGuardRef = useRef({
-    armed: state.proposalConfirmArmed,
-    ask: state.confirmProposalEdit,
+    armed: proposalConfirmArmed,
+    ask: confirmProposalEdit,
   });
   proposalGuardRef.current = {
-    armed: state.proposalConfirmArmed,
-    ask: state.confirmProposalEdit,
+    armed: proposalConfirmArmed,
+    ask: confirmProposalEdit,
   };
 
   const contentAttributes = useMemo(
@@ -1161,8 +1221,8 @@ export function BodyTextarea({
     if (!host || !ytext) return;
     const view = new EditorView({
       // The room's current text, which is empty until the server's seed lands.
-      // Deliberately not `state.body`: a client that writes the praxis body
-      // into the document ends up merging a second copy of it (ADR-0073).
+      // Deliberately not the composer's `body`: a client that writes the praxis
+      // body into the document ends up merging a second copy of it (ADR-0073).
       doc: ytext.toString(),
       parent: host,
       extensions: [
@@ -1247,13 +1307,13 @@ export function BodyTextarea({
     });
   }, [writable, editableSlot]);
 
-  // ---- The room's text → `state.body` ----
+  // ---- The room's text → `body` ----
   //
-  // One direction only, and now the ONLY direction: `state.body` feeds
+  // One direction only, and now the ONLY direction: `body` feeds
   // `BodyPreview`, and since #2086 took the word count out, nothing
   // else. Since #1743 no client
   // write exists to feed, so there is not even a reason to be tempted — and
-  // nothing may push `state.body` back into the document, or the praxis would
+  // nothing may push `body` back into the document, or the praxis would
   // seed the room it is supposed to be seeded BY.
   useEffect(() => {
     if (!ytext) return;
@@ -1309,7 +1369,7 @@ export function BodyTextarea({
 
   return (
     <div>
-      {skin.hideToolbar || awaitingRoom || state.controlsLocked ? null : (
+      {skin.hideToolbar || awaitingRoom || controlsLocked ? null : (
       <div
         role="toolbar"
         aria-label={t("editPraxis.toolbar.label")}
@@ -1405,7 +1465,7 @@ export function BodyTextarea({
           Gated on the PRAXIS, not on `proposalConfirmArmed`. The latch is about
           the dialog, which fires once; this line is about the state, which is
           still true afterwards and is what the member is deciding against. */}
-      {proposalIsLive(state.praxis) && (
+      {proposalIsLive(praxis) && (
         <div style={{ marginTop: "var(--space-xs)" }}>
           {/* The ink is the class's and only the class's (#1819): an inline
               `color` here beats `--label-ink`, and the three near-black sheets
@@ -1482,7 +1542,7 @@ export function WriteUpTabs({
 }
 
 /* -------------------------------------------------------------------------- */
-/* BodyPreview — the live markdown preview block. Owns the `state.body.trim()` */
+/* BodyPreview — the live markdown preview block. Owns the `body.trim()`      */
 /* guard (renders nothing until the body has content) and reuses the shared    */
 /* MarkdownPreview block component. The archetype supplies the bespoke wrapper, */
 /* eyebrow label, and markdown typography via the skin.                        */
@@ -1506,13 +1566,12 @@ interface BodyPreviewSkin {
 }
 
 export function BodyPreview({
-  state,
+  body,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<EditPraxisState, "body"> & {
   skin: BodyPreviewSkin;
 }) {
-  if (!state.body.trim()) {
+  if (!body.trim()) {
     return skin.emptyState == null ? null : (
       <div style={skin.wrapperStyle}>
         {skin.label}
@@ -1528,7 +1587,7 @@ export function BodyPreview({
           The literal class lives on TitleField/BodyTextarea so Tailwind emits
           it even though this one is assembled. */}
       <MarkdownPreview
-        source={state.body}
+        source={body}
         className={`content-text ${skin.markdownClassName ?? "markdown-preview"}`}
         style={skin.markdownStyle}
       />
@@ -1558,13 +1617,27 @@ interface ModePickerSkin<O extends { key: PraxisType }> {
 }
 
 export function ModePicker<O extends { key: PraxisType }>({
-  state,
+  praxis,
+  task,
+  duelMode,
+  duelChipVisible,
+  modeIsLocked,
+  switchingMode,
+  changeMode,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<
+  EditPraxisState,
+  | "task"
+  | "duelMode"
+  | "duelChipVisible"
+  | "modeIsLocked"
+  | "switchingMode"
+  | "changeMode"
+> & {
+  /** Non-null: every archetype mounts this below its own praxis guard. */
+  praxis: PraxisOut;
   skin: ModePickerSkin<O>;
 }) {
-  const praxis = state.praxis!;
   // The allowed modes are the TASK's, computed server-side against the viewer's
   // level (`allowed_praxis_modes`). An unknown task means unknown permission, so
   // this FAILS CLOSED (#1709): no options until the task lands. Each of the
@@ -1572,7 +1645,7 @@ export function ModePicker<O extends { key: PraxisType }>({
   // three modes, which handed a level-0 viewer the Collab the API would refuse.
   // Derived here, from the state the picker already holds, so there is one
   // statement of the rule and nothing left to drift.
-  const allowedModes = state.task?.allowed_modes ?? [];
+  const allowedModes = task?.allowed_modes ?? [];
   return (
     <div style={skin.containerStyle}>
       {skin.options
@@ -1580,7 +1653,7 @@ export function ModePicker<O extends { key: PraxisType }>({
           // Duel isn't in task.allowed_modes (it's issued via challenge, ADR-0011);
           // it's gated on the viewer's level instead (#311). Hide, don't disable.
           option.key === "duel"
-            ? state.duelChipVisible
+            ? duelChipVisible
             : allowedModes.includes(option.key),
         )
         .map((option, index) => {
@@ -1588,17 +1661,17 @@ export function ModePicker<O extends { key: PraxisType }>({
           // state is driven by duelMode, not praxis.type.
           const active =
             option.key === "duel"
-              ? state.duelMode
-              : praxis.type === option.key && !state.duelMode;
+              ? duelMode
+              : praxis.type === option.key && !duelMode;
           const disabled =
-            state.modeIsLocked || state.switchingMode !== null;
-          if (state.modeIsLocked && !active) return null;
+            modeIsLocked || switchingMode !== null;
+          if (modeIsLocked && !active) return null;
           return skin.renderOption(option, {
             active,
             disabled,
             index,
             onSelect: () => {
-              if (!disabled) void state.changeMode(option.key);
+              if (!disabled) void changeMode(option.key);
             },
           });
         })}
@@ -1624,7 +1697,7 @@ export function ModePicker<O extends { key: PraxisType }>({
  * was written for simply stops being reachable — and the server's own
  * `title.trim()` refusal stays too. This is an affordance, not a validation
  * move, and it is derived here rather than added to `EditPraxisState` because
- * `state.title` is already on it and nothing else needs to know.
+ * `title` is already on it and nothing else needs to know.
  *
  * Untitled is the NORMAL entry state, not a slip: `handleSignup` posts a task id
  * and a type, and `accept_duel` mints the opponent's side with no title at all.
@@ -1632,8 +1705,8 @@ export function ModePicker<O extends { key: PraxisType }>({
  * which is why the reason is drawn (below) rather than implied — a dead control
  * with no explanation is worse than the silent failure it replaces.
  */
-function publishNeedsTitle(state: EditPraxisState): boolean {
-  return !state.title.trim();
+function publishNeedsTitle(title: string): boolean {
+  return !title.trim();
 }
 
 /**
@@ -1721,13 +1794,38 @@ export interface PublishButtonSkin {
 }
 
 export function PublishButton({
-  state,
+  praxis,
+  currentCharacterId,
+  isPublished,
+  duel,
+  duelMode,
+  title,
+  submitting,
+  switchingMode,
+  publish,
+  propose,
+  pullBack,
+  markDone,
+  requestDuelSeal,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<
+  EditPraxisState,
+  | "praxis"
+  | "currentCharacterId"
+  | "isPublished"
+  | "duel"
+  | "duelMode"
+  | "title"
+  | "submitting"
+  | "switchingMode"
+  | "publish"
+  | "propose"
+  | "pullBack"
+  | "markDone"
+  | "requestDuelSeal"
+> & {
   skin: PublishButtonSkin;
 }) {
-  const praxis = state.praxis;
   // The one published state that keeps its footer button (#1077) — but NOT for
   // the reason #1077 wrote it, and #1177 is the record of that. DO NOT DELETE
   // THIS BRANCH as unreachable; read the next three paragraphs first.
@@ -1760,14 +1858,27 @@ export function PublishButton({
   // detail page, and a `declined` challenge leaves an ordinary published solo
   // praxis, which stays unpublishable-back.
   const duelPullBack =
-    state.isPublished &&
-    state.duelMode &&
-    (state.duel?.status === "active" || state.duel?.status === "pending");
-  if (state.isPublished && !duelPullBack) return null;
+    isPublished &&
+    duelMode &&
+    (duel?.status === "active" || duel?.status === "pending");
+  if (isPublished && !duelPullBack) return null;
   // A multi-member collab has three things to say, not one (ADR-0079), so it
   // gets its own control below rather than a fourth relabelling of this button.
   if (!duelPullBack && praxis?.type === "collab" && praxis.members.length > 1) {
-    return <CollabSignals state={state} skin={skin} />;
+    return (
+      <CollabSignals
+        praxis={praxis}
+        currentCharacterId={currentCharacterId}
+        title={title}
+        submitting={submitting}
+        switchingMode={switchingMode}
+        publish={publish}
+        propose={propose}
+        pullBack={pullBack}
+        markDone={markDone}
+        skin={skin}
+      />
+    );
   }
   // Neutral wording, deliberately: no forfeit language and no consequence
   // dialog before the duel settles (#718 rejected that framing once already;
@@ -1781,12 +1892,12 @@ export function PublishButton({
   // opponent is actually attached — duel mode with an empty opponent slot casts
   // as an ordinary solo praxis, so there is nothing to warn about. Once cast,
   // the same button reverses it through `pullBack` and asks nothing.
-  const sealsADuel = state.duelMode && state.duel != null;
+  const sealsADuel = duelMode && duel != null;
   const onClick = duelPullBack
-    ? state.pullBack
+    ? pullBack
     : sealsADuel
-      ? async () => state.requestDuelSeal()
-      : state.publish;
+      ? async () => requestDuelSeal()
+      : publish;
   // Every branch of this button but ONE publishes: the solo cast calls
   // `publish()` outright, and the duel's `requestDuelSeal()` opens the sheet
   // whose confirm is that same `publish()` — so the gate belongs on both, or the
@@ -1794,7 +1905,7 @@ export function PublishButton({
   // exception and stays live: reopening a side that is already cast has nothing
   // to do with the title, and it is the moderated composer's only way back into
   // the text a moderator just asked the author to fix (#1177).
-  const needsTitle = !duelPullBack && publishNeedsTitle(state);
+  const needsTitle = !duelPullBack && publishNeedsTitle(title);
   const button = (
     <button
       type="button"
@@ -1808,12 +1919,12 @@ export function PublishButton({
       // the reason is reachable without hunting the sheet for a caption.
       aria-describedby={needsTitle ? PUBLISH_NEEDS_TITLE_ID : undefined}
       onClick={() => void onClick()}
-      disabled={needsTitle || state.submitting || state.switchingMode !== null}
+      disabled={needsTitle || submitting || switchingMode !== null}
       className={offClassName(skin.className, needsTitle)}
       style={skin.style}
     >
       {skin.ornament}
-      {state.submitting ? skin.busyLabel : idleLabel}
+      {submitting ? skin.busyLabel : idleLabel}
       {skin.trailingOrnament}
     </button>
   );
@@ -1887,22 +1998,39 @@ const SECONDARY_SIGNAL_STYLE: CSSProperties = {
  * {@link PublishButtonSkin} the single button wears.
  */
 export function CollabSignals({
-  state,
+  praxis,
+  currentCharacterId,
+  title,
+  submitting,
+  switchingMode,
+  publish,
+  propose,
+  pullBack,
+  markDone,
   skin,
-}: {
-  state: EditPraxisState;
+}: Pick<
+  EditPraxisState,
+  | "praxis"
+  | "currentCharacterId"
+  | "title"
+  | "submitting"
+  | "switchingMode"
+  | "publish"
+  | "propose"
+  | "pullBack"
+  | "markDone"
+> & {
   skin: PublishButtonSkin;
 }) {
-  const praxis = state.praxis;
   if (!praxis) return null;
   const slug = praxis.task_faction_slug;
-  const gate = deriveCollabGate(praxis.members, state.currentCharacterId);
+  const gate = deriveCollabGate(praxis.members, currentCharacterId);
   const proposalLive = proposalIsLive(praxis);
   const iAmDone = praxis.members.some(
     (member) =>
-      member.character_id === state.currentCharacterId && member.is_done,
+      member.character_id === currentCharacterId && member.is_done,
   );
-  const busy = state.submitting || state.switchingMode !== null;
+  const busy = submitting || switchingMode !== null;
   // The last approval outstanding, so the button can say what pressing it does
   // instead of leaving the player to count the roster.
   const finalApproval = gate.castCount === gate.memberCount - 1;
@@ -1914,14 +2042,14 @@ export function CollabSignals({
   // the server tells apart by state — so both need a title to send. **Done** is
   // a social toggle and **Withdraw proposal** takes one back; neither publishes,
   // and neither goes dead because the write-up has not been named yet.
-  const needsTitle = publishNeedsTitle(state);
+  const needsTitle = publishNeedsTitle(title);
   return (
     <div className="flex flex-wrap items-center gap-2">
       <button
         type="button"
         aria-pressed={iAmDone}
         title={collabCopy(slug, "doneDescription")}
-        onClick={() => void state.markDone(!iAmDone)}
+        onClick={() => void markDone(!iAmDone)}
         disabled={busy}
         className="label-caption"
         style={SECONDARY_SIGNAL_STYLE}
@@ -1949,13 +2077,13 @@ export function CollabSignals({
                 )
           }
           aria-describedby={needsTitle ? PUBLISH_NEEDS_TITLE_ID : undefined}
-          onClick={() => void (proposalLive ? state.publish() : state.propose())}
+          onClick={() => void (proposalLive ? publish() : propose())}
           disabled={needsTitle || busy}
           className={offClassName(skin.className, needsTitle)}
           style={skin.style}
         >
           {skin.ornament}
-          {state.submitting ? skin.busyLabel : primaryLabel}
+          {submitting ? skin.busyLabel : primaryLabel}
           {skin.trailingOrnament}
         </button>
       )}
@@ -1963,7 +2091,7 @@ export function CollabSignals({
         <button
           type="button"
           title={collabCopy(slug, "withdrawDescription")}
-          onClick={() => void state.pullBack()}
+          onClick={() => void pullBack()}
           disabled={busy}
           className="label-caption"
           style={SECONDARY_SIGNAL_STYLE}


### PR DESCRIPTION
Closes #2882

`archetypes/controls.tsx` declared `state: EditPraxisState` on **eleven** component
props — verified against the file before starting, at the eleven signatures the issue
names. Each control read about twelve of the 81 members and forwarded the whole object,
so `SaveDraftButton` (a button and a skin spread) was type-coupled to the duel flow, the
metatask picker and the invite search.

## The seam

**The control's props, as a value a test can build.** Every control now takes a
`Pick<EditPraxisState, …>` of exactly what it reads, destructured at the signature, and
the eight archetypes bind those props by name. The check left behind is at that seam:
`SaveDraftButton.test.tsx`'s fixture is now the button's four props — no cast, no
composer state, nothing invented — and a prop re-widened to `state: EditPraxisState`
fails to compile there rather than passing silently. That file went red on the real
change first (the whole-state fixture stopped fitting), then green on the four props.

## Why `Pick<>` and not the sub-hooks' return types

The issue's framing was that with #2878–#2880 landed the slices would be "the sub-hooks'
own return types". Reading them, that is not quite available: `ComposerRoster.sendInvite`
returns `Promise<RosterOutcome>`, `MetataskApply.addMetatask` returns
`Promise<SealOutcome>`, and so on — the sub-hooks report outcomes and `useEditPraxis`
wraps them in the void-returning affordances the controls actually call (that is #2945's
one write-back). So the state contract, not the hook return, is what a control consumes,
and `Pick<>` keeps one source of truth rather than a hand-written second copy that can
drift. Each control's props are visible in full at its own signature.

`praxis` is non-null (`PraxisOut`) on the three controls that used to assert it
themselves (`const praxis = state.praxis!` in `DuelPair`, `InviteSearch`, `ModePicker`).
Every archetype already holds a non-null `const praxis = state.praxis!` in scope at the
mount, so the assertion leaves the shared control rather than moving anywhere new. The
controls that handled `praxis` as nullable (`DropButton`, `PublishButton`,
`CollabSignals`, `BodyTextarea`) keep their defensive branches unchanged.

## No visual or behavioural change

Every binding is the same value under the same name — `title={state.title}`, never a
rename — which is machine-checkable and checked: no `X={state.Y}` where `X !== Y` exists
in the eight archetypes. `publishNeedsTitle` now takes the title instead of the state
(same predicate). The only JSX that moved is `DuelPair`'s mount, wrapped in parens to fit
five props on separate lines.

- `tsc --noEmit` clean, `typecheck:design-sync` clean (the preview kit mounts the
  archetypes' own `state` prop, which is untouched, so `previews/_state.tsx` needed no
  change — no contract field was added, removed or weakened)
- `npm run lint` clean; `npm test` 504 files / 10,407 passed; `npm run build` clean
- `npm run budget` exits 0 — the JS WARN is the standing pre-existing one (149.6 KB), not
  from this change; editPraxis is not on the initial load

## Tests that had to change, and how

Eleven suites passed their whole `as unknown as EditPraxisState` fixture as one `state`
prop and stopped compiling. **The casts stay — they are #2883.** The minimal fix is that
the fixture is spread into the narrowed props instead:
`bodyProposalLive`, `bodyToolbarTabOrder`, `bodyUnavailableDress`, `collabExits`,
`collabSignals`, `composerFocusRing`, `composerQuietInk`, `sharedComposerLayout`,
`InviteSearch`, `PublishButton`, `SaveDraftButton`.

Three needed slightly more than a spread, all named here:

- `collabExits.test.tsx` — its `praxisState()` fixture now says its praxis is non-null
  (one type annotation), because `InviteSearch` asks for a loaded praxis.
- `InviteSearch.test.tsx` — `chipHtml` passes `praxis={state.praxis!}` for the same reason.
- `imageEditFailure.test.tsx` — its fixture was already a two-field literal behind a cast
  (`{ fileError, handleFileChange } as unknown as EditPraxisState`); with `FilePicker`
  narrowed, the cast simply has nothing left to do and is gone.

`SaveDraftButton.test.tsx` is the one fixture converted rather than spread, deliberately:
it is the control the issue names as the victim, and it is the demonstration that the
narrowing is what gives the other 26 casts a replacement.

## Scope

Only `controls.tsx` and its callers, per the issue. The repo-wide idiom (103 components,
seven `archetypes/` folders) is untouched; `PraxisDetailState`, `TaskDetailState` and
`TasksState` are not in this PR.

Two mounts in the archetypes still forward the whole state and are **not** `controls.tsx`
components: `PraxisWaitingSurface` (the archetype's alternative whole-surface render) and
`MetataskSealStack`. The seal family — `MetataskSealStack`, `MetataskPicker`,
`MetataskRemoveConfirm` in `components/metataskSeal/` — reads 13 members between them and
maps almost exactly onto `MetataskApply`, the sub-hook's already-exported return type. It
is the obvious next slice and would be a clean small issue; it is not this one.

## Verification not done here

No browser and no dev stack in this worktree, so **visual QA is outstanding**. Nothing in
the diff changes markup, style or a rendered value, but that is an argument, not a
screenshot.

## What to eyeball

Open a composer (`/praxis/:id/edit`) on a couple of faction sheets and confirm each of
these renders and behaves exactly as before — these are the controls whose props moved:

- [ ] **Save draft** — appears on an open draft, hidden on a moderated/cast one, greys
      out while a publish or mode switch is in flight, and the click lands on your profile
- [ ] **Submit / the primary** — label, ornament and busy state; disabled with the
      "needs a title" line while the title box is empty; the collab trio (Done / Propose /
      Approve / Withdraw) on a multi-member collab
- [ ] **Media tray** — the pick button's faction label, the helper line, and a rejected
      file's error text under it
- [ ] **Seal stack** — untouched by this PR, but it sits in the same sheet: confirm the
      stack, the picker and a seal's × still work
- [ ] **Metatask picker** — likewise untouched; open and close it from Section D
- [ ] **Invite search** — the `+ invite` chip, the dropdown rows (avatar · name · @handle ·
      faction), the roster with its presence dots, the holdout countdown, and the leave link
- [ ] **Duel pane** — the challenge picker, the attached pair with both faces across the
      `vs`, the rescind ×, and the dissolve button on an accepted duel
- [ ] **Title and write-up** — typing in the title still reaches a co-author's box on the
      debounce; the write-up's toolbar, the connecting/unreachable notice, and the
      live-proposal line under it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
