### PR TITLE
The gravity field takes its width from the container, not its viewBox (#2957)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/ephemeristsGravity.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsGravity.test.tsx
@@ -90,12 +90,28 @@ describe("the Ephemerists gravity field", () => {
   });
 
   it("anchors its canvas to the right edge so the well cannot drift", () => {
-    // A phone wider than the nominal 360 scales the rows up rather than
-    // stranding the well mid-sheet.
+    // A card wider than the nominal scales the rows up rather than stranding
+    // the well mid-sheet.
     const markup = field();
     expect(markup).toContain('preserveAspectRatio="xMaxYMin slice"');
     expect(markup).toContain(`viewBox="0 0 ${WIDTH + 40} ${HEIGHT}"`);
-    expect(markup).toContain("right:-40px");
+  });
+
+  it("takes its width from the container, not from the viewBox (#2957)", () => {
+    // THE SEAM. An `<svg>` is a REPLACED element: with `width: auto` the used
+    // width is the INTRINSIC one — the viewBox span — so `left` and `right`
+    // are over-constrained and `right` is dropped. Measured in prod, the field
+    // was 434px (394 + 40) on a 624px card: 0.696 coverage, and `slice` never
+    // scaled anything because the element always matched its own viewBox.
+    //
+    // An explicit width is what stops the intrinsic size winning, and it is
+    // the ONE declaration that makes the docblock above true. `100%` is the
+    // container; the `+40` is `WELL_MARGIN`, the overhang the well is drawn in.
+    const markup = field();
+    expect(markup).toContain("width:calc(100% + 40px)");
+    // And the offset pair is no longer set at all, so nothing can be dropped:
+    // the box is `left` + `width`, which is never over-constrained.
+    expect(markup).not.toContain("right:");
   });
 
   it("is inert: decorative, unreachable and unable to eat a click", () => {

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -464,10 +464,22 @@ const PULL_FALLOFF = 620;
  * flattest where a field or a panel covers the ground, so what you see of the
  * field is exactly what the layout does not use.
  *
- * `width` is the sheet's nominal width — the well's position is measured from
- * its right edge. The canvas is anchored to that edge (`xMaxYMin slice`), so a
- * viewport wider than the nominal keeps the well where it belongs and scales
- * the rows up rather than stranding them mid-sheet.
+ * `width` is the sheet's NOMINAL width, and only that: it sets the viewBox span
+ * and measures the well in from the canvas's right edge. It is not the width
+ * the element renders at — `width: calc(100% + WELL_MARGIN)` takes that from
+ * the container, so the canvas is anchored to the sheet's right edge
+ * (`xMaxYMin slice`) and a sheet wider than the nominal keeps the well where it
+ * belongs and scales the rows up rather than stranding them mid-sheet.
+ *
+ * THAT EXPLICIT WIDTH IS LOAD-BEARING (#2957), and it is one declaration you
+ * cannot drop back to an offset pair. An `<svg>` is a REPLACED element, so
+ * `width: auto` resolves to its INTRINSIC width — the viewBox span — rather
+ * than from `left`/`right`, which are then over-constrained and `right` is
+ * dropped. This element used to be laid out that way, and every consequence
+ * above failed silently: measured in prod a 394-nominal field drew 434px wide
+ * on a 624px card (0.696 of it, the rest bare ground), `slice` never scaled
+ * anything because the element always matched its own viewBox, and on a card
+ * narrower than the span the well was cropped off entirely.
  *
  * DEVIATION, named: the design's canvas stops at 1500px because its own preview
  * sheet does. A composer's sheet grows with what you write, and a field that
@@ -500,7 +512,7 @@ export function GravityField({ width, height }: { width: number; height: number 
         position: "absolute",
         top: 0,
         left: 0,
-        right: -WELL_MARGIN,
+        width: `calc(100% + ${WELL_MARGIN}px)`,
         height,
         pointerEvents: "none",
       }}


### PR DESCRIPTION
Closes #2957

## The defect, and the seam

An `<svg>` is a **replaced** element, so `width: auto` resolves to its *intrinsic* width — the viewBox span — rather than from the `left`/`right` offset pair. The pair is then over-constrained and `right` is dropped. `GravityField`'s root was laid out exactly that way (`position: absolute; top: 0; left: 0; right: -WELL_MARGIN; height`), so the field drew at `width + 40` px on every card no matter how wide the card was: measured in prod, **434px on a 624px card, 0.696 coverage**.

Every consequence was one of the docblock's own promises failing silently — the element never stretched, `preserveAspectRatio="xMaxYMin slice"` never scaled anything (element size always equalled viewBox size, so the scale was always exactly 1), and on a card narrower than the span the well was cropped off entirely.

**Seam tested:** the root `<svg>`'s inline style, via `renderToStaticMarkup` — the same no-DOM shape the rest of `ephemeristsGravity.test.tsx` uses. The new case `takes its width from the container, not from the viewBox (#2957)` was written first and went **red on the real defect** (`expected '<svg …>' to contain 'width:calc(100% + 40px)'`, received `…left:0;right:-40px;height:2400px…`) before the fix landed. It asserts both halves: the explicit width is present, and no `right:` offset remains to be dropped.

## The change

One declaration in `frontend/src/components/factionMarks/ephemeristsPlate.tsx`:

```diff
-        right: -WELL_MARGIN,
+        width: `calc(100% + ${WELL_MARGIN}px)`,
```

`left: 0` stays; `right` goes, so the box is `left` + `width` and can never be over-constrained again. The `width` **prop** keeps its job — it still sets the viewBox span and the well's `cx` — it simply stops being the element's rendered width too. No mount file is touched.

The docblock at `GravityField` was rewritten so the anchoring paragraph describes what now happens rather than what was intended, and it names the replaced-element trap explicitly so the declaration cannot be "tidied" back into an offset pair.

**`CARD_FIELD_HEIGHT`'s `ponytail:` note is untouched.** The field covers ~159% of the card's height; that ceiling has not been reached and is still a real future limit.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (505 files, 10415 passed), `npm run build`, `npm run budget` (exit 0; the pre-existing JS warn is unchanged — this diff adds no initial-payload bytes). Backend is untouched, so no `api-schema` artifact regeneration applies.

**Visual QA is outstanding.** I have no browser and no dev stack; everything above is tests, tsc, eslint and the bundler.

## The landmine, resolved

#2763 has already landed. `EphemeristsTaskCard` no longer passes `size.cardWidth` to the field — that change split the two, and the card now passes a separate `fieldWidth: number` whose own docblock says it "may never be a string". The arithmetic (`width + WELL_X`, `width + WELL_MARGIN`) is safe; nothing here turns the prop into a CSS length.

## Six mounts, not four

The issue lists four. `git grep -ln 'GravityField' origin/main -- frontend/src` returns six, excluding tests and the definition — `EphemeristsEditCharacter` and `EphemeristsProposeTask` arrived in the #2537/#2538 fan-outs, after the issue was filed. All six are repaired by the one declaration.

## What to eyeball

Check each at **375px, 768px and 1440px**. **None of these six has ever rendered as designed** — the field has always stopped at its nominal span. So on the character-creation, character-edit, propose-task and composer surfaces, **"looks unchanged" is the surprising answer, not the safe one**; if one of them is unchanged, the field is not reaching its container there and that is a finding, not a pass.

What to look for at every stop: the rows reach **both** edges of the ground, and the well (a dot and three ochre rings) sits at the **right** edge — cropped into arcs by the container's own `overflow: hidden`, never floating mid-sheet, and never absent.

| # | Surface | Mount | What specifically changes |
|---|---|---|---|
| 1 | Praxis card (desktop) | `components/praxisCard/desktop/EphemeristsPraxisCard.tsx:123` | Nominal 394. This is the reported card: at 1440 the field goes 434 → ~662px and covers past the right edge. At 375 the card is narrow enough that the well is drawn instead of being clipped away. |
| 2 | Task card | `components/taskCard/EphemeristsTaskCard.tsx:258` | Nominal 384 desktop / 340 mobile. On a phone the card now fills its column (#2763), so this is where the field previously fell shortest of its own card — watch the right-hand margin at 375. |
| 3 | Character creation | `pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx:294` | `GRAVITY_WIDTH[factor]`. Full-sheet ground; the rows should now scale up with the sheet rather than stopping at the nominal. |
| 4 | Character edit | `pages/characterPaths/archetypes/EphemeristsEditCharacter.tsx:303` | Same shape as #3. **Not in the issue** — arrived with #2537/#2538. |
| 5 | Propose task | `pages/proposeTask/archetypes/EphemeristsProposeTask.tsx:333` | Same shape as #3. **Not in the issue.** Note #2973 is editing this directory concurrently. |
| 6 | Praxis composer (edit praxis) | `pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx:390` | Its own width; the sheet grows with what you write, so scroll the composer with a long body and confirm the field stays full-width all the way down. Note #2977 is editing this directory concurrently. |

Mounts 5 and 6 sit in directories two other agents in this batch are editing. **This PR does not touch any mount file** — the fix is entirely inside `ephemeristsPlate.tsx` — so there is no overlap to serialize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
