### PR TITLE
The drawn caret gets an empty-document height floor (#2970)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyEditorCaret.test.ts
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyEditorCaret.test.ts
@@ -32,6 +32,15 @@ const rules = EditorState.create({ extensions: [BODY_EDITOR_BASE_THEME] })
   .map((module) => module.getRules())
   .join("\n");
 
+// The caret rule this module mounts. style-mod prefixes it with the theme's
+// own generated class (`.ͼ5 .cm-cursor {…}`), which is the specificity the
+// comment in `bodyEditorTheme.ts` is about, so the selector is matched at its
+// tail rather than its head.
+const cursorRules = rules
+  .split("\n")
+  .filter((rule) => /\.cm-cursor\s*\{/.test(rule))
+  .join("\n");
+
 describe("the composer body editor's caret (#1852)", () => {
   it("registers drawSelection, so the caret is drawn rather than native", () => {
     // `drawSelection()`'s signature contribution, and the only extension in
@@ -45,7 +54,20 @@ describe("the composer body editor's caret (#1852)", () => {
   it("paints the drawn caret from the skin's ink, not the base theme's black", () => {
     // `.cm-cursor` base-themes to `1.2px solid black`, and the `&dark` override
     // never fires here. Half these skins draw a dark field.
-    expect(rules).toMatch(/\.cm-cursor \{border-left-color: currentColor;\}/);
+    expect(cursorRules).toContain("border-left-color: currentColor");
+  });
+
+  it("floors the drawn caret's height, so an empty document paints one", () => {
+    // #2970. `RectangleMarker.forRange` measures the TEXT NODE's box, and an
+    // empty line has no text node — only the placeholder widget — so the
+    // marker is built at ~zero height and paints nothing until the first
+    // keystroke. `min-height` loses to a larger inline `height`, so it acts
+    // only as a floor and a measured caret on a line with text is untouched.
+    // `1em` is `.cm-content`'s own font-size, i.e. text height — NOT the
+    // 1.6–1.85 line box #1852 moved away from. A `line-height` basis here
+    // would be that regression coming back.
+    expect(cursorRules).toContain("min-height: 1em");
+    expect(cursorRules).not.toContain("line-height");
   });
 
   it("paints the selection from currentColor, once, not eight literals", () => {

--- a/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
+++ b/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
@@ -162,7 +162,17 @@ const BODY_EDITOR_SKIN_THEME = EditorView.theme({
   // `EditorView.theme` rule and a base-theme rule of equal specificity are
   // separated only by mount order, and this module mounts after the base theme.
   // (0,2,0) here therefore beats the base theme's (0,2,0).
-  ".cm-cursor": { borderLeftColor: "currentColor" },
+  //
+  // `minHeight` is the empty-document floor (#2970). The drawn cursor is sized
+  // from the TEXT NODE's box (see the docblock on `BODY_EDITOR_SELECTION`), and
+  // an empty write-up has no text node — the line holds only the placeholder
+  // widget — so `RectangleMarker` builds the marker at ~zero height and it
+  // paints nothing until the first keystroke. `min-height` only ever raises the
+  // inline `height` the marker writes, so it is a floor: a measured caret on a
+  // line with text is untouched. `1em` resolves against `.cm-content`'s own
+  // font-size, i.e. the text height this whole mechanism is about — a
+  // line-height basis here would be the #1852 regression coming back.
+  ".cm-cursor": { borderLeftColor: "currentColor", minHeight: "1em" },
 
   // The selection background base-themes to `#d9d9d9`/`#222` unfocused and
   // `#d7d4f0`/`#233` focused — code-editor greys and an indigo, on eight
@@ -244,6 +254,14 @@ const BODY_EDITOR_SKIN_THEME = EditorView.theme({
  * it is text-height by construction. No magic number, and nothing to re-tune
  * when a skin's line-height moves. The skins' line-heights are the body copy's
  * reading measure and were not the bug.
+ *
+ * That basis has one edge case, found on prod (#2970): a text node is a thing
+ * an EMPTY document does not have. The composer opens empty and the line holds
+ * only the placeholder widget, so `coordsAtPos` measures ~nothing, the marker
+ * is built at ~zero height, and clicking into the box put no visible caret in
+ * it until the first keystroke created a text node. The measurement stays the
+ * basis; the `min-height: 1em` floor on `.cm-cursor` above only catches the
+ * case where there is nothing to measure.
  *
  * Shipped WITH the theme rather than beside it in the extension list, because
  * the two halves are inert apart: `drawSelection()` alone drops CodeMirror's


### PR DESCRIPTION
Closes #2970

Clicking into an empty write-up box put no visible caret in it until the first keystroke. `drawSelection()` (#1852) hides the native caret and paints `.cm-cursor`, and `RectangleMarker.forRange` sizes that from `coordsAtPos` — `pos.bottom - pos.top`, **the text node's box**. An empty document has no text node; the line holds only the `cmPlaceholder` widget. So the marker was built at ~zero height and painted nothing.

The diagnostic fork the issue asks for is closed: the owner ran the confirming click on 2026-09-01 and reports the caret is **visible on a box that already has text, invisible only on an empty box**. That is the empty-document mechanism, not the colour rule.

## The change

One declaration, in the same theme block as the colour rule:

```ts
".cm-cursor": { borderLeftColor: "currentColor", minHeight: "1em" },
```

`min-height` only ever raises the inline `height` `RectangleMarker` writes, so it is a **floor** — a measured caret on a line with text is untouched. `1em` resolves against `.cm-content`'s own font-size, i.e. text height, **not** the 1.6–1.85 line box #1852 moved away from. `drawSelection()` stays; deleting it would restore the oversized native caret on all eight skins.

The docblock on `BODY_EDITOR_SELECTION` stated the text-node measurement basis as if it had no edge case. It now records the empty-document one and that the floor catches only the case where there is nothing to measure.

## Seam tested

`BODY_EDITOR_BASE_THEME` **as a value** — `EditorState.create` needs no DOM, and `EditorView.styleModule` holds the exact CSS the extension will mount. `bodyEditorCaret.test.ts` gained a case asserting the generated `.cm-cursor` rule carries `min-height: 1em` and carries no `line-height` basis (the #1852 regression guard). It went red on exactly that assertion before the fix and green after. The two existing `.cm-cursor` assertions were re-pointed at a filtered `cursorRules` string, because style-mod emits the rule prefixed with the theme's generated class (`.ͼ5 .cm-cursor {…}`).

## What a green suite does NOT prove

Nothing here proves a caret is *visible*. The harness has no DOM, `renderToStaticMarkup` cannot see a painted element, and the test asserts a CSS rule exists — not that anything shows on a screen. No browser was available in this worktree, so **visual QA is outstanding**.

Local verification, every step in the `frontend` job of `.github/workflows/test.yml`: lint, `typecheck`, `typecheck:design-sync`, `npm test` (505 files, 10415 passed), `build`, `budget` (exit 0; the JS `WARN` at 149.6 KB is pre-existing and unmoved by a CSS-in-JS declaration).

## What to eyeball

- **An empty write-up box, on all eight faction skins, in both site themes** — click in, before typing, and confirm a caret is there.
- **The caret is still text-height, not line-height.** Compare it against the text beside it on a skin with a 1.85 line-height; if it stands a third taller than the letters, the #1852 regression is back.
- **A box that already has text is unchanged** — same caret height as before this PR.
- Worth a glance while you are in there: the caret at a soft wrap and inside an IME preedit, both listed as unverified costs in the #1852 docblock and both still unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
