### PR TITLE
The disabled-control sweep reads the archetype directory instead of a hand-typed list

### DIFF
--- a/frontend/src/pages/characterPaths/__tests__/disabledControlContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/disabledControlContrast.test.ts
@@ -64,34 +64,37 @@ import {
   type Theme,
 } from '../../../utils/__tests__/cssVars'
 import { readIndexCss } from '../../../test/indexCss'
+import { sourceFiles, toRelative } from '../../../test/sourceScan'
 
 const CSS = readIndexCss()
 const THEMES = readThemes(CSS)
 const BOTH_THEMES: Theme[] = ['light', 'dark']
 
-const ARCHETYPE_DIR = fileURLToPath(new URL('..', import.meta.url))
+const ARCHETYPE_DIR = fileURLToPath(new URL('../archetypes', import.meta.url))
 
-/** Every file in this tree that draws a control which starts out disabled. */
-const SITES = [
-  'archetypes/CovenCreateCharacter.tsx',
-  'archetypes/DefaultCreateCharacter.tsx',
-  'archetypes/EphemeristsCreateCharacter.tsx',
-  'archetypes/EverymenCreateCharacter.tsx',
-  'archetypes/SingularityCreateCharacter.tsx',
-  'archetypes/SnideCreateCharacter.tsx',
-  'archetypes/UaCreateCharacter.tsx',
-  'archetypes/WowCreateCharacter.tsx',
-  'archetypes/DefaultEditCharacter.tsx',
-  // #2537's fan-out. An edit archetype's Save is gated on the same
-  // `canSubmitName` the create band is, so it is the same control and owes the
-  // same class; the rows below are the guard against the eleventh site spelling
-  // `opacity: 0.5` again, and a file that is not listed is not swept.
-  'archetypes/WowEditCharacter.tsx',
-]
+/**
+ * Every character-path archetype, READ OFF THE DIRECTORY (#2955).
+ *
+ * This was a hand-typed array of ten, and its own comment said the consequence
+ * out loud: a file that is not listed is not swept. #2537's fan-out landed
+ * seven edit archetypes in seven isolated lanes; one of them found this list
+ * and added itself, and the other six had no way to know it existed. Eight of
+ * the eighteen files here were outside the sweep and nothing went red.
+ *
+ * So the *shape* of the name is the membership test. A new archetype is swept
+ * the moment it lands, with no edit to this file, which is the only version of
+ * this guard that does not decay every time the directory grows.
+ */
+const SITES = sourceFiles({ dir: ARCHETYPE_DIR, match: /(?:Create|Edit)Character\.tsx$/ })
 
-function source(file: string): string {
-  return readFileSync(`${ARCHETYPE_DIR}${file}`, 'utf8')
-}
+const source = (path: string): string => readFileSync(path, 'utf8')
+
+/**
+ * `disabled={!x}` is a control gated on a form's own state — the one that is
+ * disabled when the page OPENS. `disabled={deleting}` and friends are transient
+ * busy states and are deliberately not swept in here.
+ */
+const gatedControls = (text: string): number => text.match(/disabled=\{!/g)?.length ?? 0
 
 function resolve(token: string, theme: Theme): Rgba {
   const raw = resolveVar(token, theme, THEMES)
@@ -148,9 +151,36 @@ describe('a disabled primary action keeps a legible label', () => {
   }
 })
 
+/**
+ * THE FLOOR, moved off the file and onto the set (#2955).
+ *
+ * A source scan that reads nothing passes, so a derived list owes a number. Two
+ * of them: the walk found every archetype on disk, and the set it found still
+ * contains the ones that actually DRAW the control. The second is what the old
+ * per-file `gated > 0` was for — an archetype that quietly stopped drawing its
+ * gated control still has to be caught, and now a wrapper that never drew one
+ * does not have to be exempted by name to say so.
+ *
+ * Both are floors, never equalities: an archetype added tomorrow is swept
+ * without touching this file, which is the entire point.
+ */
+describe('the sweep reads the whole archetype directory', () => {
+  it('walks a set no smaller than the one on disk today', () => {
+    expect(SITES.length, 'archetypes found by the walk').toBeGreaterThanOrEqual(18)
+  })
+
+  it('still reaches the archetypes that draw a gated control', () => {
+    const drawing = SITES.filter(file => gatedControls(source(file)) > 0)
+    expect(drawing.length, 'archetypes drawing a start-disabled control').toBeGreaterThanOrEqual(
+      16,
+    )
+  })
+})
+
 describe('no character-path control fades itself out of legibility', () => {
   for (const file of SITES) {
-    it(`${file} dims through the class, not through opacity`, () => {
+    const name = toRelative(file)
+    it(`${name} dims through the class, not through opacity`, () => {
       const text = source(file)
       // The exact defect: an `opacity` keyed on the submit gate. Anything else
       // spelling `opacity` here is ornament (Coven's haze, the Ephemerists'
@@ -160,18 +190,19 @@ describe('no character-path control fades itself out of legibility', () => {
       )
     })
 
-    it(`${file} marks every start-disabled control .control-off`, () => {
+    it(`${name} marks every start-disabled control .control-off`, () => {
       const text = source(file)
-      // `disabled={!x}` is a control gated on a form's own state — the one that
-      // is disabled when the page OPENS. `disabled={deleting}` and friends are
-      // transient busy states and are deliberately not swept in here.
-      const gated = text.match(/disabled=\{!/g)?.length ?? 0
+      const gated = gatedControls(text)
       // Counted as CLASS LISTS, not as occurrences of the word: the Singularity
       // band carries `control-off sg-control-off`, which is one marked control
       // and two substring hits, and the prose around these sites names the
       // class too.
       const marked = text.match(/className="[^"]*\bcontrol-off\b[^"]*"/g)?.length ?? 0
-      expect(gated, 'the file still draws a gated control').toBeGreaterThan(0)
+      // No per-file floor on `gated`: a delegating wrapper draws no control of
+      // its own — the Albescent pair is a classed div around its Default twin —
+      // and 0 marked of 0 gated is the right answer for it, not a failure. The
+      // floor that catches a file which STOPPED drawing its control lives over
+      // the whole swept set instead, above.
       expect(marked, `${gated} gated control(s) carry the class`).toBe(gated)
     })
   }


### PR DESCRIPTION
Closes #2955

## The seam

**The sweep-list itself** — how `disabledControlContrast.test.ts` decides *which* files it reads, not what it asserts about them. The two per-file assertions are unchanged in substance; only their membership set is.

## Red first

Deriving the list while leaving the old per-file floor in place ran red on exactly the predicted defect, and nothing else:

```
 Test Files  1 failed (1)
      Tests  2 failed | 38 passed (40)
  × archetypes/AlbescentCreateCharacter.tsx marks every start-disabled control .control-off
  × archetypes/AlbescentEditCharacter.tsx   marks every start-disabled control .control-off
AssertionError: the file still draws a gated control: expected 0 to be greater than 0
```

40 tests where the hand-list gave 24 — the walk reached the eight unswept files — and the only failures were the two delegating wrappers. That is the planner's verification reproduced: **the six unswept edit archetypes pass both assertions today, so this is a pure coverage change with no paint touched.**

## What changed

- `SITES` is now `sourceFiles({ dir: ARCHETYPE_DIR, match: /(?:Create|Edit)Character\.tsx$/ })`. The shape of the filename is the membership test, so a new archetype is swept the moment it lands with no edit to this file. No thirty-first filesystem walk — this is the same helper the other source-scan guards use.
- **The `gated > 0` floor moves from the file to the set.** It was catching a listed file that stopped drawing its control, which is still worth catching, but it is the wrong question for a delegating wrapper: `AlbescentCreateCharacter` / `AlbescentEditCharacter` are a classed div around their Default twin and draw no control of their own, so 0 marked of 0 gated is correct for them. Two set-level floors replace it:
  - the walk found **≥ 18** archetypes (the directory holds 18 today);
  - **≥ 16** of them still draw a start-disabled control (18 minus the two wrappers).

  Floors, never equalities, so growth is free and truncation is loud.
- **No exemption list was needed.** The issue offered one as the fallback; recognising "draws no control" structurally means no file has to be named, which is strictly better than an allowlist that has to be maintained.

## Vacuous-green

A scan that reads nothing passes, so both floors carry real numbers rather than `> 0`. A wrong `dir` throws out of `readdirSync` at import; a wrong `match` empties `SITES` and fails the first floor; a walk that silently stopped finding the drawing archetypes fails the second. The CSS half was already non-vacuous (it goes through `readIndexCss()`).

## Verification

Every step of the `frontend` job, run locally from `.github/workflows/test.yml`:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **505 files, 10432 passed**, 1 skipped |
| `npm run build` | built |
| `npm run budget` | exit 0 — JS WARN is pre-existing, untouched by a one-test-file diff |

The guard itself is **42 passed** (was 24). `api-schema` and the backend job are not reachable from this diff: no route, `response_model`, or Pydantic schema is touched.

## Scope

One file changed. **No archetype was edited** — none needed it. `editCharacterSlots.tsx` and the archetypes are left alone for #2956, which is serialized after this.

## What to eyeball

**Nothing visual.** This is a test guard; it renders nothing and ships no bytes to the browser. The only judgement calls worth a reviewer's eye are in the code, not on screen:

- the two floor numbers (18 / 16) and that they are `toBeGreaterThanOrEqual`, not `toBe`;
- that dropping the per-file `gated > 0` is a move rather than a deletion — the set-level version is above the sweep loop, and the per-file site says where it went;
- that "delegating wrapper draws no control" is judged structurally rather than by naming Albescent in an exemption list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
