### PR TITLE
SPEC-testing.md gets the frontend unit suite (#2884)

### DIFF
--- a/docs/spec/SPEC-testing.md
+++ b/docs/spec/SPEC-testing.md
@@ -36,6 +36,113 @@ def test_level_1_threshold():
 For live examples read `backend/tests/unit/` (`test_scoring.py`, `test_era_config.py`, …)
 rather than trusting inlined snippets, which drift from the real service signatures.
 
+## The frontend unit suite
+
+The largest body of test code in the repo, and the one with the tightest constraint.
+
+### The harness — stated once
+
+Vitest runs in the **`node` environment**: `frontend/vite.config.ts` declares no
+`environment`, so there is no DOM — no `document`, no layout, no browser APIs.
+Components are rendered with `renderToStaticMarkup` and asserted against the resulting
+HTML string, usually with `toContain()`. **Effects never run**, so nothing in this suite
+exercises a fetch, a subscription, a focus move, or a cleanup-on-unmount.
+
+That is the whole constraint. A test file that needs to explain why it cannot watch a
+component *do* something should cite this section rather than restate it.
+
+### The three classes of invariant
+
+Ruled in #2864. Every frontend invariant is one of three classes, and each has one home:
+
+| class | what it is | home |
+|---|---|---|
+| **structure** | markup — what renders, with what text, in what order | the `renderToStaticMarkup` + `toContain()` harness above. It is the right tool for this. |
+| **behaviour** | effects, request plans, ordering, conditional fetches | **extracted as a value** and asserted directly — see below |
+| **geometry** | layout, computed style, contrast ratios, pixel measurement | the rendered sweep / Playwright (#2888) |
+
+### Behaviour is reached by extracting a value, not by reaching for a DOM
+
+Where a component's behaviour is only observable by running an effect, the effect's
+*decision* — which requests, in what order, under what condition — becomes a plain value
+the component consumes. That value is directly assertable in the harness that already
+exists.
+
+`pages/editPraxis/initialLoadPlan.ts` is the reference implementation (#2881): the
+composer's mount-time load became `planInitialLoad`, and
+`pages/editPraxis/__tests__/composerWaterfall.test.ts` drives it directly. The next such
+extraction copies that shape rather than inventing one.
+
+**Source-text assertion is banned as a way of reaching runtime behaviour.** Slicing a
+hook's source between a comment banner and a dependency-array prefix makes a comment
+load-bearing: rename either boundary and the slice silently empties, and every assertion
+passes on air. `composerWaterfall.test.ts` did exactly that before #2881; its docblock
+records the before and the after. Where a test wants such an invariant, the fix is to
+extract the plan — not to write a guard-the-guard test around the slice.
+
+What the ban does **not** cover:
+
+- It is a rule for **new** tests. The files that already read their own source are not
+  swept; the ones in scope convert as their surface is touched.
+- It does not touch the **source-scan repo rules** — `rawColourRule`, `factionInkRule`,
+  the `src/test/sourceScan.ts` guards. Those are *structure* rules about the shape of the
+  tree, not behaviour, and they stay.
+- Where a behavioural claim has no value seam at all, the residue stays source-reading
+  and says so loudly. `pages/editPraxis/__tests__/composerMountSourceScan.test.ts` is
+  what the #2881 conversion left behind: two claims with no plan to extract, kept with
+  the comment-bounded slice removed and the guard-the-guard retained.
+
+### `src/test/sourceScan.ts` is the only walk
+
+A source-scanning guard answers a question no render can: *does any file, anywhere under
+`frontend/src`, still reach for X?* The offending line usually sits in a branch no
+fixture reaches, so one scan covers every surface, present and future, without
+instantiating any of them.
+
+**Do not re-derive that walk.** `src/test/sourceScan.ts` owns the directory traversal,
+the comment stripper, the path relativiser and `resolveRoleReads()`. A new guard supplies
+only its *predicate*, which is the only part that was ever different.
+(See #2885, #2886, #2887.)
+
+### ESLint rule, or vitest guard?
+
+Both mechanisms are load-bearing. They answer different shapes of question:
+
+- Reach for an **ESLint rule** when the invariant is a property of **one file, visible in
+  that file's AST**, and you want it enforced in the editor as it is typed — and
+  especially when an existing population has to be migrated off it. `eslint.config.js` is
+  where the shrink-only ratchet machinery lives (`.eslint-legacy-raw-styles.txt`,
+  `.eslint-legacy-raw-colours.txt`, `.eslint-legacy-faction-ink.txt`); note that a ratchet
+  entry turns a whole *rule* off for a file, so two arms must never share a rule id.
+- Reach for a **vitest source-scan guard** when the question is about **the tree as a
+  whole** — "does anything, anywhere, still do X", a relationship between files, or a
+  comparison against rendered output. That is not expressible per-file, so it is not an
+  ESLint rule.
+
+### No DOM environment — and the trigger that would change that
+
+`jsdom`/`happy-dom` is **deferred, not refused** (#2864). It does no layout, so it
+catches none of the geometry failures that are actually shipping green; the suite mocks
+`useFormFactor` in enough files that a real DOM is not opt-in-per-file in practice; and it
+is a new dependency and an environment split, bought for a capability — clicks, focus,
+cleanup-on-unmount — that nothing is currently blocked on.
+
+The named trigger for revisiting it:
+
+> Revisit the DOM environment when a bug ships that a value-extraction test structurally
+> could not have caught — one whose root cause is a click, a focus move, a subscription
+> or a cleanup-on-unmount, rather than a request plan or a piece of markup.
+
+**The ceiling, stated plainly.** Value-extraction does not test interaction. Nothing in
+the unit harness will exercise a click. That gap is accepted and named, and Playwright
+owns it — with the standing caveat that the e2e suite is currently red (#2453, #2463,
+epic #1674), so "Playwright owns it" only becomes true when the nightly goes green.
+
+### Faction architecture
+
+Adding or changing a faction has its own procedure and its own checklist; it is not
+repeated here. Read `docs/spec/SPEC-faction-ui-profile.md` §4 (#2719).
+
 ## Running e2e (Playwright lifecycle suites)
 
 Browser end-to-end tests live in `frontend/e2e/` (`playwright.config.ts` next to


### PR DESCRIPTION
Closes #2884

Writes #2864's ruling into `docs/spec/SPEC-testing.md`. Docs-only: +107 lines, 0 deletions, one file.

## The seam

There is no code seam here — the change is a spec section, so **no test is added** (YAGNI applies to tests too). The seam that matters is a *documentation* one, and it was already leaking: four files across the frontend already cite `SPEC-testing.md` for the no-DOM harness constraint, and the spec did not contain it. Those citations were dangling at a section that did not exist:

- `src/api/__tests__/justCreatedPraxis.test.ts`
- `src/hooks/__tests__/pagedResourceCache.test.ts`
- `src/utils/cacheEpoch.ts`
- `src/utils/__tests__/requestsBusWiring.test.ts`

The new "The harness — stated once" subsection is what they were pointing at. That is acceptance criterion 4, discharged against files that already exist rather than against a hypothetical.

## What the section covers

Inserted between "Config-Driven Test Principle" and "Running e2e", so the document reads backend → frontend unit → e2e → CI.

- **The harness, once.** Vitest in `node`, `renderToStaticMarkup`, no DOM, effects never run.
- **The three classes** — structure / behaviour / geometry — transcribed as a table from the ruling, each with one home.
- **The behaviour ruling.** Extraction as a value, `initialLoadPlan.ts` (#2881) as the reference implementation, and the ban on source-text assertion for runtime behaviour — scoped to new tests, explicitly not touching the legitimate source-scan repo rules, converting as surfaces are touched rather than in a sweep.
- **`src/test/sourceScan.ts` is the only walk** (#2885, #2886, #2887).
- **ESLint rule vs vitest guard** — a stated rule (see the flag below).
- **The deferred DOM environment**, its named trigger, and the ceiling it names, with the standing e2e-is-red caveat (#2453, #2463, epic #1674).
- **#2719's faction procedure is cited, not restated** — pointer to `docs/spec/SPEC-faction-ui-profile.md` §4.

## Three things I want on the record

**1. The ruling's example is stale in tense, and I did not transcribe it as-is.** #2864 says source-slicing is "what `pages/editPraxis/__tests__/composerWaterfall.test.ts` does today". On `origin/main` that is no longer true — #2881 (merged as #2962) already converted that file; its docblock now records the slice's removal. Writing the ruling's present tense into the spec would have shipped a false statement. I recorded it as the **converted** example instead ("did exactly that before #2881"), which is what both the ruling and the code support. The rule itself is transcribed unchanged.

**2. #2864 did not rule on ESLint-vs-vitest — that rule is derived from code, not transcribed.** The issue asks for it; the ruling is silent on it. Rather than invent a preference, I derived the seam from what the two mechanisms can actually each do on `main`: ESLint rules are per-file and AST-shaped and own the shrink-only ratchet machinery (the three `.eslint-legacy-*.txt` lists, with the documented hazard that a ratchet entry disables a whole rule for a file); source-scan guards answer whole-tree questions that are not expressible per-file, which is exactly how `sourceScan.ts`'s own docblock justifies its existence. **If you want a different rule, this is the paragraph to overrule** — it is the one normative claim not traceable to the ruling.

**3. The ruling did not cover behavioural residue with no value seam.** `pages/editPraxis/__tests__/composerMountSourceScan.test.ts` exists on `main` and deliberately still reads source for two claims that #2881 gave no plan to extract — with the comment-bounded slice removed and the guard-the-guard kept. That is a live case the ban does not cleanly cover, so I recorded what the code does rather than pretending the case does not exist. Flagging it rather than silently legislating it.

Separately, I **omitted every count** the issue and ruling quote — 96 lines, 1,130 eslint lines (actually 1,191 today), 37,587, 475 files, 95,752 lines, "105 test files mock `useFormFactor`". They are state mirrors and would rot; the arguments that depended on scale are preserved without the figures. Per the repo's docs doctrine.

## Verification

I read `.github/workflows/test.yml` rather than assuming. It has **no `paths:` filter**, so all three jobs (`test`, `frontend`, `api-schema`) run on this PR — but nothing in any of them reads `docs/spec/`. I checked specifically:

- The only markdown guards are `backend/tests/test_adr_index.py` and `test_adr_numbers_are_unique.py`, both scoped to `docs/adr/`.
- No vitest or pytest guard asserts on `docs/spec` content; the only repo-wide references to `docs/spec/SPEC-testing.md` are the docblock citations listed above.
- Banned-copy check: the new section contains zero instances of the banned plural. The file has one pre-existing instance on line 13 (`praxes` in the backend tree comment), untouched by this diff — flagged for a separate PR rather than widening a transcription change.

No frontend or backend source is touched, so `tsc`, vitest and the byte budget are unaffected by construction. Visual QA is not applicable — this is a markdown file.

## What to eyeball

- **Read the new section against #2864's comment and confirm nothing was invented.** That is the whole review. The table, the behaviour rule, the ban and its three carve-outs, the trigger blockquote and the ceiling paragraph should all be traceable to the ruling.
- **Adjudicate the three flags above** — particularly flag 2, the ESLint-vs-vitest rule, which is derived from the code rather than ruled, and flag 1, where I departed from the ruling's tense because `main` had moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
