### PR TITLE
Cozy Coven gets its demo praxis back, and a guard that counts the era

### DIFF
--- a/backend/scripts/seed_demo_praxes.py
+++ b/backend/scripts/seed_demo_praxes.py
@@ -91,6 +91,12 @@ PLAYERS = [
     # is an own-faction one and `collab_own_modifier` is the multiplier read.
     ("demo_kettle", "Kettle", None),
     ("demo_thimble", "Thimble", None),
+    # Appended for the same reason, after the collab pair (#2895): Coven had no
+    # DEMOS author. Its coverage used to come from the collab fixture, which was
+    # pinned to `coven` until #2710 de-pinned it onto the era's third real slug
+    # — `wow` for Era 1, which DEMOS already covered — so Coven went to zero
+    # without anything failing.
+    ("demo_hazel", "Hazel", "coven"),
 ]
 
 # faction -> (author_username, title, body, type, [stars from other players])
@@ -104,6 +110,10 @@ DEMOS = {
     "wow": ("demo_marigold", "Threw a stranger a parade",
                 "Confetti, a kazoo, one very confused commuter. The bus stop will never recover.",
                 PraxisType.solo, [5, 4, 5]),
+    "coven": ("demo_hazel", "Left a tin on every landing",
+              "Baked all afternoon, wrote nine notes. Three tins came back "
+              "with notes already in them.",
+              PraxisType.solo, [5, 4, 5]),
     "snide": ("demo_riot", "Flyposted the quiet block",
               "Stuck it where they said not to. Allegedly.",
               PraxisType.solo, [3, 4, 2]),

--- a/backend/tests/integration/test_seed_demo_praxes.py
+++ b/backend/tests/integration/test_seed_demo_praxes.py
@@ -19,6 +19,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from eras.era_2 import ERA_2
 from faction_slugs import real_faction_slugs
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
@@ -40,14 +41,20 @@ from services.praxis import list_praxes
 async def _board(
     db_session: AsyncSession, author: Character, era: EraConfig = CURRENT_ERA
 ) -> None:
-    """Every era faction plus one task per faction `seed()` needs.
+    """Every era faction, plus one task per faction the **era** carries.
 
-    Covers the per-faction `DEMOS` slugs, the score-fixture slugs
-    (`fixture_faction_slugs`, which `seed()` also drives) and every joinable
-    faction the era declares. The last one is not redundant with the first: it
-    is what stops the coverage guard below being fed by the very dict it is
-    checking, so a faction `DEMOS` has forgotten still gets a task on the board
-    and the guard fails on the missing *praxis* rather than on a missing task.
+    The board is derived from `era` alone — every joinable slug
+    (`real_faction_slugs`) plus the score-fixture slugs
+    (`fixture_faction_slugs`, which `seed()` also drives). `DEMOS` is
+    deliberately *not* an input, for two reasons:
+
+    * the coverage guard below would otherwise be fed by the very dict it is
+      checking — a faction `DEMOS` has forgotten would also be missing from the
+      board, so the guard would fail on a missing task rather than on the
+      missing praxis it is actually about;
+    * it makes `_board(..., ERA_2)` the board a dev database under that era
+      would really have, which is the only way to exercise the skip path a
+      `DEMOS` key the era dropped has to take (#2710).
     """
     for slug in era.factions:
         existing = (
@@ -56,8 +63,7 @@ async def _board(
         if existing is None:
             db_session.add(Faction(slug=slug, status=FactionStatus.visible))
     await db_session.flush()
-    slugs = set(DEMOS) | set(fixture_faction_slugs(era)) | set(real_faction_slugs(era))
-    for slug in slugs:
+    for slug in set(real_faction_slugs(era)) | set(fixture_faction_slugs(era)):
         db_session.add(Task(
             title=f"Board task ({slug})",
             description="fixture",
@@ -265,3 +271,43 @@ async def test_every_joinable_faction_has_a_praxis_in_the_submitted_feed(
             f"no submitted praxis renders for {slug!r}, so that faction's "
             f"praxis card archetype cannot be seen on a seeded dev DB (#2895)"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_demos_faction_the_era_dropped_is_skipped_not_crashed(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    capsys,
+):
+    """#2710's crash class, exercised rather than guarded against twice.
+
+    `DEMOS` names factions; an era decides which of them exist. Era 2 carries
+    neither `coven` nor `ua`, and the seed's answer to that is already written
+    — no task on the board for that slug, so the loop prints a skip and moves
+    on. Nothing new is needed for the `coven` entry #2895 adds; what is needed
+    is a test that the existing path really is the one it takes, because the
+    last time a fixture named a faction an era had dropped it was a `KeyError`
+    on a fresh dev database, not a skipped line.
+
+    The board here is Era 2's own, so the `DEMOS` keys it dropped genuinely
+    have nothing to point at. The era is passed explicitly; `CURRENT_ERA` is
+    untouched.
+    """
+    dropped = [slug for slug in DEMOS if slug not in ERA_2.factions]
+    assert dropped, "ERA_2 carries every DEMOS faction — this proves nothing"
+
+    await _board(db_session, character, ERA_2)
+    await seed(db_session, ERA_2)
+
+    printed = capsys.readouterr().out
+    for slug in dropped:
+        assert f"! {slug}: no task on the board" in printed
+
+    # The factions Era 2 *does* carry still reach the feed, so the skip is a
+    # skip and not a bail-out part-way through the loop.
+    for slug in real_faction_slugs(ERA_2):
+        visible = await list_praxes(
+            db_session, status=PraxisStatus.submitted, faction=[slug]
+        )
+        assert visible, f"{slug!r} renders nothing under its own era"

--- a/backend/tests/integration/test_seed_demo_praxes.py
+++ b/backend/tests/integration/test_seed_demo_praxes.py
@@ -19,6 +19,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import real_faction_slugs
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.era import Era
@@ -41,10 +42,12 @@ async def _board(
 ) -> None:
     """Every era faction plus one task per faction `seed()` needs.
 
-    Covers both the per-faction `DEMOS` slugs and the score-fixture slugs
-    (`fixture_faction_slugs`, which `seed()` also drives) — for Era 1 the
-    latter is already a subset of the former, but the union keeps this board
-    correct if that ever stops being true.
+    Covers the per-faction `DEMOS` slugs, the score-fixture slugs
+    (`fixture_faction_slugs`, which `seed()` also drives) and every joinable
+    faction the era declares. The last one is not redundant with the first: it
+    is what stops the coverage guard below being fed by the very dict it is
+    checking, so a faction `DEMOS` has forgotten still gets a task on the board
+    and the guard fails on the missing *praxis* rather than on a missing task.
     """
     for slug in era.factions:
         existing = (
@@ -53,7 +56,8 @@ async def _board(
         if existing is None:
             db_session.add(Faction(slug=slug, status=FactionStatus.visible))
     await db_session.flush()
-    for slug in set(DEMOS) | set(fixture_faction_slugs(era)):
+    slugs = set(DEMOS) | set(fixture_faction_slugs(era)) | set(real_faction_slugs(era))
+    for slug in slugs:
         db_session.add(Task(
             title=f"Board task ({slug})",
             description="fixture",
@@ -205,3 +209,59 @@ async def test_assert_no_corrupt_submitted_raises_on_a_violation(
     repaired = await _repair_corrupt_submitted(db_session)
     assert repaired == 1
     await _assert_no_corrupt_submitted(db_session)  # no longer raises
+
+
+def test_demos_covers_every_joinable_faction_the_live_era_declares():
+    """The seed's own stated promise, as arithmetic (#2895).
+
+    `DEMOS` exists so "every per-faction praxis card archetype has something to
+    render" — its own comment. Coven fell out of that silently: #2710 de-pinned
+    the collab fixture from `coven` to `fixture_faction_slugs(era)[2]`, which
+    for Era 1 is `wow`, a faction `DEMOS` already covered. Nothing crashed, and
+    nothing read as six-versus-seven anywhere a reader would look.
+
+    Derived on both sides, never a literal list and never a count: the ceiling
+    is whatever the live era declares joinable, which is `real_faction_slugs`
+    (ADR-0087 — `na` and `albescent` are structural sentinels, never fixture
+    skins), and it moves when the era does. Needs no database on purpose, so
+    the day a future era adds a faction the seed does not cover, this fails
+    rather than the gap being noticed months later in dev.
+    """
+    missing = [slug for slug in real_faction_slugs(CURRENT_ERA) if slug not in DEMOS]
+    assert not missing, (
+        f"{CURRENT_ERA.config_key} declares {missing} joinable and DEMOS has no "
+        f"entry for them, so their praxis card archetype has nothing to render "
+        f"on a seeded dev database (#2895). Add an entry per slug — and a demo "
+        f"player to author it, appended to the END of PLAYERS."
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_joinable_faction_has_a_praxis_in_the_submitted_feed(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """The behavioural half of the same guard, at the real read path.
+
+    `list_praxes(status=submitted)` is what the `/praxis` feed and the author
+    profile both call, and `faction=[slug]` is the facet those surfaces send —
+    a praxis has no faction of its own, it inherits the linked task's. So this
+    asks the production question ("open the Coven filter; is anything there?")
+    rather than counting rows the script believes it wrote.
+
+    Distinct from the pure check above rather than redundant with it: that one
+    proves the dict is complete, this one proves a complete dict still reaches
+    the feed. #2846's defect passed the first and failed the second.
+    """
+    await _board(db_session, character)
+    await seed(db_session, CURRENT_ERA)
+
+    for slug in real_faction_slugs(CURRENT_ERA):
+        visible = await list_praxes(
+            db_session, status=PraxisStatus.submitted, faction=[slug]
+        )
+        assert visible, (
+            f"no submitted praxis renders for {slug!r}, so that faction's "
+            f"praxis card archetype cannot be seen on a seeded dev DB (#2895)"
+        )


### PR DESCRIPTION
Closes #2895

Cozy Coven had nothing to render on a seeded dev database. `DEMOS` covered six
of Era 1's seven joinable factions, and its own comment says what it is for —
"one praxis per faction so every per-faction praxis card archetype has something
to render."

## The seam

Two, and they answer different halves of the question:

- **`services.praxis.list_praxes(status=submitted, faction=[slug])`** — the read
  path the `/praxis` feed and the author profile share, asked through the facet
  those surfaces actually send. A praxis has no faction of its own; it inherits
  the linked task's, which is why the facet is the right question and counting
  rows the script believes it wrote is not. This is the seam #2846 established.
- **`DEMOS` vs `real_faction_slugs(CURRENT_ERA)`** — a pure assertion, no
  database, which fails the moment an era declares a faction the seed does not
  cover.

Both are derived from the live era. Never a literal list of slugs, never a
number.

## Red first

`test_demos_covers_every_joinable_faction_the_live_era_declares` and
`test_every_joinable_faction_has_a_praxis_in_the_submitted_feed` were written
and run before the fix. Both failed, naming the defect:

```
AssertionError: era_1 declares ['coven'] joinable and DEMOS has no entry for them...
AssertionError: no submitted praxis renders for 'coven'...
```

The nine tests that already existed in the two files named on the issue passed
throughout — the defect was invisible to all of them.

## What changed

- `DEMOS` gains a `coven` entry, shaped like its six siblings: author username,
  title, body, `PraxisType.solo`, a star list. It goes through the same creation
  site as the rest, so it carries `submitted_at` on **both** the `Praxis` and its
  `PraxisMember` — the sealed invariant `_assert_no_corrupt_submitted` guards,
  and the bug #2846 just fixed.
- `PLAYERS` gains its author, `demo_hazel` ("Hazel", `coven`), **appended to the
  end**. The `DEMOS` loop and the metatask fixture both take the first *n*
  non-author players as voters, so an insertion would silently rewrite the
  existing fixtures' tallies. Verified: every pre-existing demo row still gets
  its 3 votes and the duel/collab/metatask fixtures are untouched.
- `_board` in the test module now derives the board from the **era**
  (`real_faction_slugs | fixture_faction_slugs`) instead of from `DEMOS`. That
  stops the coverage guard being fed by the very dict it checks, and it makes
  `_board(..., ERA_2)` the board an Era 2 dev database would really have.

Seeding under Era 1 now prints seven:

```
  + ua: 'Mapped the unmarked stair' by Quill (3 votes)
  + everymen: 'Hit the bench. Then hit it again' by Sol Brennan (3 votes)
  + wow: 'Threw a stranger a parade' by Marigold (3 votes)
  + coven: 'Left a tin on every landing' by Hazel (3 votes)
  + snide: 'Flyposted the quiet block' by Riot (3 votes)
  + ephemerists: 'Traced a myth to its road' by Vesper (3 votes)
  + singularity: 'Logged the signal at 0300' by UNIT-7 (3 votes)
  ...
Done. 7 demo praxis(es) created.
```

## Era-2 safety

Era 2 carries no Coven. **No second guard was added** — the per-faction loop's
existing answer is correct: an era that does not carry `coven` puts no coven task
on the board, so the loop prints `! coven: no task on the board — skipped` and
moves on, and `get_or_create_players` already drops `demo_hazel`'s preference
back to `era.starting_faction_slug`. That path is now *tested* rather than
assumed, because the last fixture to name a faction an era had dropped raised
`KeyError` on a fresh dev database (#2710):
`test_a_demos_faction_the_era_dropped_is_skipped_not_crashed` drives
`seed(session, ERA_2)` against an Era 2 board, asserts the skip line for every
`DEMOS` key Era 2 dropped, and asserts the three factions Era 2 *does* carry
still reach the feed — so the skip is a skip, not a bail-out mid-loop.

## Why this was a regression, not a deliberate six

Coven was covered until #2710, by the collab fixture, which was pinned to it
(`COLLAB_TASK_FACTION_SLUG = "coven"`). #2710 correctly de-pinned that to
`fixture_faction_slugs(era)[2]` — `wow` for Era 1, a faction `DEMOS` already
covered — and Coven went to zero without anything failing. The de-pinning stands;
only the coverage is restored.

On #2846's "all nine factions": that criterion rested on a false premise and
could not have been met. `real_faction_slugs` excludes `na` and `albescent` as
structural sentinels (ADR-0087), so the ceiling is the era's joinable factions.
No code quotes that "nine", so nothing needed editing — it is simply not
propagated here. The "nine factions" claims elsewhere in the repo are about UI
skins, are correct, and are untouched.

## Tests

Dedicated database `wz2895_test` (parallel agents share `worldzero_test`).

**Before**, on `origin/main` @ `91a698eb`:

```
TEST_DATABASE_URL=postgresql+asyncpg://.../wz2895_test \
  pytest tests/integration/test_seed_demo_praxes.py \
         tests/integration/test_fixtures_follow_the_era.py
9 passed
```

**After**, same command:

```
12 passed
```

Full suite, as CI runs it:

```
TEST_DATABASE_URL=postgresql+asyncpg://.../wz2895_test \
  pytest --cov=. --cov-report=term
1816 passed — TOTAL coverage 95% (floor 92%)
```

`ruff` on both touched files is unchanged against the shrink-only allowlist
(`scripts/seed_demo_praxes.py::E501` still 10, `::I001` still 1; the test module
is clean). No migration. No route, `response_model` or Pydantic schema touched,
so `api-schema` has nothing to regenerate; no frontend files touched.

## What to eyeball

Visual QA is outstanding — I have no browser and did not run the dev stack.
On a freshly seeded dev DB (`alembic upgrade head`, then
`scripts/seed_demo_praxes.py`):

1. **The Coven praxis card in the `/praxis` feed** — "[demo] Left a tin on every
   landing" by Hazel. This is the whole point of the issue: Cozy Coven's card
   archetype, the one with the two-stop gradient CTA band, rendering with real
   votes instead of not existing. Check the pink marker-sticker skin, the
   `Caveat` face, and the moon-phase vote plate.
2. **The same card on its author's profile** — Hazel's profile grid. Same row,
   the other surface `list_praxes` feeds; a missing `submitted_at` would hide it
   from exactly these two places and nowhere else.
3. **Filter the feed to Coven** — one result, not zero. That is the facet the new
   guard asserts through.
4. **The other six are unchanged** — same authors, same three votes each, and the
   duel / collab / metatask fixtures score the same as before. `demo_hazel` was
   appended, not inserted, precisely so this holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
