### PR TITLE
One breadcrumb on Propose a Task, and a shared component that can say its trail (#2973)

### DIFF
--- a/.design-sync/previews/Breadcrumb.tsx
+++ b/.design-sync/previews/Breadcrumb.tsx
@@ -2,7 +2,8 @@
 // replacing eighteen hand-rolled trails. It derives the whole trail from the
 // task it hangs off: Tasks → <task title> → Praxis → (Edit). `praxisId` is
 // present on the two praxis surfaces and absent on a task detail; `editing`
-// runs the trail one step further, into the composer.
+// runs the trail one step further, into the composer. A page under Tasks that
+// has no task — Propose a Task — hands a `current` label instead (#2973).
 //
 // The last crumb carries aria-current="page" and is not a link. Long titles are
 // handled by shrinkIndex + flexbox rather than a breakpoint, so the cells below
@@ -40,6 +41,17 @@ export function Composer() {
   return (
     <div style={wrap}>
       <Breadcrumb taskId={412} taskTitle="Walk a mile before breakfast" praxisId={9021} editing />
+    </div>
+  )
+}
+
+/** A page under Tasks that is NOT a task (#2973): `Propose a Task` has no task
+ *  to hang the second crumb on, so it hands its own label instead. Two crumbs,
+ *  one chevron, and the last is where you are. */
+export function CurrentPage() {
+  return (
+    <div style={wrap}>
+      <Breadcrumb current="Propose a Task" />
     </div>
   )
 }

--- a/frontend/src/components/nav/Breadcrumb.tsx
+++ b/frontend/src/components/nav/Breadcrumb.tsx
@@ -19,6 +19,15 @@
  * that already behaved correctly, promoted out of
  * `pages/editPraxis/archetypes/shared.tsx` to a shared home.
  *
+ * AND IT HAS TO BE ABLE TO SAY EVERY TRAIL, or the rules below are unkeepable
+ * (#2973). The trail was built from a `taskId` + `taskTitle`, so `Propose a
+ * Task` — the one page under `Tasks` where no task exists yet — could not be
+ * expressed here at all. Eight propose surfaces each hit that wall separately
+ * and hand-rolled a `<nav>` apiece, drifting back onto the same axes within
+ * weeks: one inside the sheet, two on `--label-ink`, one on a `--faction-*`
+ * token. A rule a caller cannot obey is a rule that gets broken, so
+ * {@link CurrentTrailProps} closes it.
+ *
  * ### Three rules it enforces rather than offers
  *
  * 1. **Every level is a real link except the current page.** "Clicking Tasks
@@ -81,7 +90,8 @@ export function shrinkIndex(crumbs: readonly Crumb[]): number {
   return widest;
 }
 
-interface BreadcrumbProps {
+/** The three surfaces that hang off an existing task. */
+interface TaskTrailProps {
   /** The task all three of these surfaces hang off. */
   taskId: number;
   taskTitle: string;
@@ -89,7 +99,33 @@ interface BreadcrumbProps {
   praxisId?: number | string;
   /** The composer: the trail runs one step past the praxis. */
   editing?: boolean;
+  current?: never;
 }
+
+/**
+ * A PAGE UNDER `Tasks` THAT IS NOT A TASK (#2973).
+ *
+ * `Propose a Task` is one: the task does not exist yet — proposing it is the
+ * point — so there is no id to hang the second crumb on and no title to read.
+ * That is the whole reason eight propose surfaces hand-rolled a `<nav>` apiece
+ * and drifted straight back onto #2102's axes. The trail is `Tasks › <current>`,
+ * two crumbs, and the second is the page you are already on, so it is never a
+ * link and needs no destination.
+ *
+ * A UNION RATHER THAN THREE OPTIONAL PROPS: a caller supplies a task or a
+ * current label, never both and never neither, and `taskTitle` stays required on
+ * the seventeen surfaces that do have a task.
+ */
+interface CurrentTrailProps {
+  /** What this page is called — the last crumb, and the only one after `Tasks`. */
+  current: string;
+  taskId?: never;
+  taskTitle?: never;
+  praxisId?: never;
+  editing?: never;
+}
+
+type BreadcrumbProps = TaskTrailProps | CurrentTrailProps;
 
 /** Nothing in the trail may wrap — a wrapped breadcrumb never truncates. */
 const LIST_STYLE = {
@@ -107,22 +143,20 @@ const CLIPPED = {
   whiteSpace: "nowrap",
 } as const;
 
-export default function Breadcrumb({
-  taskId,
-  taskTitle,
-  praxisId,
-  editing,
-}: BreadcrumbProps) {
+export default function Breadcrumb(props: BreadcrumbProps) {
   const { t } = useTranslation("common");
 
-  const trail: Crumb[] = [
-    { label: t("breadcrumb.tasks"), to: "/tasks" },
-    { label: taskTitle, to: `/tasks/${taskId}` },
-  ];
-  if (praxisId !== undefined) {
-    trail.push({ label: t("breadcrumb.praxis"), to: `/praxis/${praxisId}` });
+  const trail: Crumb[] = [{ label: t("breadcrumb.tasks"), to: "/tasks" }];
+  if (props.current !== undefined) {
+    trail.push({ label: props.current });
+  } else {
+    const { taskId, taskTitle, praxisId, editing } = props;
+    trail.push({ label: taskTitle, to: `/tasks/${taskId}` });
+    if (praxisId !== undefined) {
+      trail.push({ label: t("breadcrumb.praxis"), to: `/praxis/${praxisId}` });
+    }
+    if (editing) trail.push({ label: t("breadcrumb.edit") });
   }
-  if (editing) trail.push({ label: t("breadcrumb.edit") });
   // The page you are on is not a link to itself.
   const crumbs = trail.map((crumb, index) =>
     index === trail.length - 1 ? { label: crumb.label } : crumb,

--- a/frontend/src/components/nav/__tests__/breadcrumb.test.tsx
+++ b/frontend/src/components/nav/__tests__/breadcrumb.test.tsx
@@ -109,3 +109,41 @@ describe("the trail", () => {
     expect(html).toContain("text-overflow:ellipsis");
   });
 });
+
+/**
+ * THE TASK-LESS TRAIL (#2973).
+ *
+ * `Propose a Task` is the one page in this family whose second step is not a
+ * task: no task exists yet — proposing it is the point. Seven archetypes each
+ * hit that wall independently and each hand-rolled a `<nav>` around it, which is
+ * verbatim the drift #2102 deleted. So the component has to be able to say
+ * `Tasks › <where you are>` with no id, and it is held to the same three rules
+ * as the task trail: the root is a real link, the page you are on is not, and it
+ * says so.
+ */
+describe("a trail with no task", () => {
+  it("still leads back to the task bank", () => {
+    const html = draw(<Breadcrumb current="Propose a Task" />);
+    expect(html, "the way back is the whole reason the crumb is there").toContain(
+      'href="/tasks"',
+    );
+    expect(html).toContain("Propose a Task");
+  });
+
+  it("does not link the page you are already on", () => {
+    const html = draw(<Breadcrumb current="Propose a Task" />);
+    expect(html).toContain('aria-current="page"');
+    // Two crumbs, one chevron — and no invented `/tasks/undefined` step.
+    expect(html.match(/›/g)).toHaveLength(1);
+    expect(html).not.toContain("/tasks/");
+  });
+
+  it("is the same chrome as every other trail — one nav, one ink", () => {
+    const html = draw(<Breadcrumb current="Propose a Task" />);
+    expect(html).toMatch(/<nav[^>]+aria-label="[^"]+"/);
+    expect(html, "the site's own tertiary ink, never a --faction-* token").toContain(
+      "color:var(--color-text-tertiary)",
+    );
+    expect(html).not.toContain("--faction-");
+  });
+});

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -61,9 +61,6 @@
     "seconds": "{{seconds}}s ago",
     "minutes": "{{minutes}}m ago"
   },
-  "breadcrumb": {
-    "tasks": "Tasks"
-  },
   "taskMeta": {
     "points_one": "{{points}} point",
     "points_other": "{{points}} points",

--- a/frontend/src/pages/proposeTask/__tests__/proposeTaskBreadcrumb.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/proposeTaskBreadcrumb.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * ONE BREADCRUMB ON PROPOSE A TASK (#2973).
+ *
+ * THE SEAM IS THE MOUNT, not the markup. #2102 collapsed eighteen hand-rolled
+ * crumbs onto `components/nav/Breadcrumb` and stated three rules it "enforces
+ * rather than offers" — one ink, above the sheet, one component at every width.
+ * The propose surfaces then restarted the drift, and not through carelessness:
+ * the shared component took a `taskId` + `taskTitle` and this page has no task
+ * yet, so seven archetypes each hit the same wall and each answered it
+ * differently (inside the sheet / above it; slip ink / `--label-ink` / a
+ * `--faction-*` token). #2973 gave the component a task-less trail so there is
+ * one answer to mount.
+ *
+ * WHAT THIS ASSERTS IS THEREFORE "the trail on this page is the SHARED one",
+ * and the way to say that without a DOM is: exactly one `<nav>` landmark on the
+ * page, drawn in the site's own tertiary ink, carrying the shared component's
+ * own shape. A hand-rolled copy fails on the count, the ink, or both — which is
+ * the drift stated as a failing assertion rather than as a convention.
+ *
+ * The roster is DERIVED from `surfaceMap('proposeTask')`, so a future archetype
+ * inherits this the moment it registers and no PR appends to a second list
+ * (#1162). Nothing here proves a pixel: `renderToStaticMarkup`, no DOM
+ * (SPEC-testing.md). Visual QA is outstanding and stated on the PR.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so copy keys resolve to English text.
+import '../../../i18n'
+import { archetypeFor, EVERY_SLUG, proposeTaskState } from './proposeTaskState'
+import type { ProposeTaskState } from '../useProposeTask'
+
+/** The archetype the dispatcher would pick for `slug`, rendered. */
+function renderFor(slug: string, overrides: Partial<ProposeTaskState> = {}): string {
+  const Archetype = archetypeFor(slug)
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Archetype state={proposeTaskState({ factionSlug: slug, ...overrides })} />
+    </MemoryRouter>,
+  )
+}
+
+/** The opening tag of every `<nav>` the page drew. */
+const navTags = (html: string): string[] => html.match(/<nav[^>]*>/g) ?? []
+
+describe.each(EVERY_SLUG)('propose task — the trail back (%s)', (slug) => {
+  it('draws exactly ONE trail, so no archetype hand-rolls a second', () => {
+    expect(navTags(renderFor(slug))).toHaveLength(1)
+  })
+
+  it('leads back to the task bank, and the propose page is not a link to itself', () => {
+    const html = renderFor(slug)
+    expect(html, 'Cancel is not a way back — a link is').toContain('href="/tasks"')
+    expect(html).toContain('aria-current="page"')
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Propose a Task')
+  })
+
+  it('is neutral site chrome — the site\'s tertiary ink, no faction token', () => {
+    // Rule 1 of #2102, and the axis UA's crumb drifted off: the trail took the
+    // leaf's own quiet ink, which is a `--faction-*` token on a control that is
+    // measured on the app's own ground.
+    const [nav] = navTags(renderFor(slug))
+    expect(nav).toContain('color:var(--color-text-tertiary)')
+    expect(nav).not.toContain('--faction-')
+    expect(nav).not.toContain('--label-ink')
+  })
+
+  it('sits ABOVE the sheet, never inside it', () => {
+    // Rule 2, and the axis Coven's crumb drifted off — its docblock argued for
+    // the inside placement explicitly. Without a DOM, "outside the sheet" is
+    // read off the order of the markup: every archetype wraps its sheet in the
+    // page's one `<form>`, so a crumb drawn before that tag is a crumb the sheet
+    // does not contain.
+    const html = renderFor(slug)
+    const nav = html.indexOf('<nav')
+    const form = html.indexOf('<form')
+    expect(nav).toBeGreaterThanOrEqual(0)
+    expect(form, 'the form is the sheet boundary this reads against').toBeGreaterThan(0)
+    expect(nav).toBeLessThan(form)
+  })
+})

--- a/frontend/src/pages/proposeTask/__tests__/proposeTaskBreadcrumb.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/proposeTaskBreadcrumb.test.tsx
@@ -17,6 +17,13 @@
  * own shape. A hand-rolled copy fails on the count, the ink, or both — which is
  * the drift stated as a failing assertion rather than as a convention.
  *
+ * IT IS A THIRD FAMILY, NOT A THIRD COPY. `pages/__tests__/
+ * breadcrumbAcrossSurfaces.test.tsx` walks the same claim over `taskDetail` and
+ * `praxisDetail`, whose trails end in a task and are keyed off ids and a title.
+ * This page's trail has neither, and its roster and state fixture already live
+ * here beside the other propose suites — so it is the propose family's row of
+ * the same consistency guard, kept where its fixture is.
+ *
  * The roster is DERIVED from `surfaceMap('proposeTask')`, so a future archetype
  * inherits this the moment it registers and no PR appends to a second list
  * (#1162). Nothing here proves a pixel: `renderToStaticMarkup`, no DOM

--- a/frontend/src/pages/proposeTask/__tests__/uaProposeTaskContrast.test.ts
+++ b/frontend/src/pages/proposeTask/__tests__/uaProposeTaskContrast.test.ts
@@ -13,24 +13,26 @@
  * second name for one measurement, which that file spends a paragraph warning
  * against.
  *
- * What is left is the delta, and it is three rows:
+ * What is left is the delta, and it is two rows:
  *
- *  1. THE TRAIL, which stands on the SITE's page rather than on the leaf. The na
- *     kit draws it in the app's own tertiary ink; this kit draws it in its own
- *     quiet tier, and the tier arm's whole point is that a faction ink on a
- *     ground it was not measured against is where this goes wrong. The route
- *     declares no faction backdrop — `useFactionBackdrop` has exactly one caller
- *     and it is `CharacterProfile` — so the ground is `--color-bg-page` under
- *     the neutral spectrum wash, the same composite the na kit's own tails are
- *     measured on.
+ * THE TRAIL WAS THE THIRD AND IS GONE (#2973). It measured this kit's quiet tier
+ * on the SITE's washed page, because the archetype drew the crumb in
+ * `--faction-ua-card-body` — a faction ink on a ground it was never priced
+ * against, which is the tier arm's whole subject. The archetype now mounts
+ * `components/nav/Breadcrumb`, so the ink is the app's own tertiary and the
+ * pairing is already measured, on this exact composite and in both themes, by
+ * `characterPaths/__tests__/createCharacterContrast.test.ts`. Keeping a row here
+ * would be the second name for one measurement this file's second paragraph
+ * warns against. If the crumb ever takes a faction ink again, that is a new
+ * pairing and this is where it comes back.
  *
- *  2. THE PREVIEW'S CREDIT LINE. A bonus is a credit and the kit has a name for
+ *  1. THE PREVIEW'S CREDIT LINE. A bonus is a credit and the kit has a name for
  *     that rung, so the strip reads `--faction-ua-card-credit` where the na kit
  *     reads the global `--color-success`. That is a new pairing: the panel
  *     carries this family's ink / prose / muted / accent rows already and has
  *     never carried its credit.
  *
- *  3. THE LEVEL ROW, which is the load-bearing one — it measures the control
+ *  2. THE LEVEL ROW, which is the load-bearing one — it measures the control
  *     this archetype did NOT mount. `FilterLevelNodes` is site chrome standing
  *     on `--color-bg-surface`, a TRANSLUCENT token in both cascades, so on this
  *     leaf it takes the warm stock underneath rather than the app's own. The
@@ -40,8 +42,8 @@
  *     in the kit's inks, and if the shared control ever clears this ground the
  *     redraw is dead weight — which is what the failing row below would say.
  *
- * THE WASH IS READ FROM THE STYLESHEET, NOT TRANSCRIBED, for the reason the
- * sibling file records: repaint a stop and this file measures the new one.
+ * THE LEAF'S WASH IS READ FROM THE STYLESHEET, NOT TRANSCRIBED, for the reason
+ * the sibling file records: repaint a stop and this file measures the new one.
  */
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -69,30 +71,6 @@ function resolve(token: string, theme: Theme): Rgba {
   return parsed!
 }
 
-/**
- * The spectrum wash's stops for one theme, read out of the rule that paints
- * them. Light is the bare `.na-backdrop` block; dark is the
- * `[data-theme="dark"]` override, which repaints every stop. Each stop is its
- * own corner-anchored radial, so they do not stack — every one is composited
- * alone and all of them must clear.
- */
-function washStops(theme: Theme): string[] {
-  const marker = theme === 'dark' ? '[data-theme="dark"] .na-backdrop {' : '\n.na-backdrop {'
-  const start = INDEX_CSS.indexOf(marker)
-  expect(start, `the ${theme} .na-backdrop rule exists`).toBeGreaterThan(-1)
-  const block = INDEX_CSS.slice(start, INDEX_CSS.indexOf('}', start))
-  const stops = [...block.matchAll(/rgba\([^)]*\)/g)].map(([whole]) => whole)
-  expect(stops.length, `the ${theme} wash still paints its stops`).toBe(5)
-  return stops
-}
-
-/** The page stock with one wash stop over it — the ground the trail stands on. */
-function pageUnderWash(theme: Theme, stop: string): Rgba {
-  const wash = parseColor(stop)
-  expect(wash, `${stop} parses`).not.toBeNull()
-  return compositeOver(wash!, resolve('--color-bg-page', theme))
-}
-
 /** The sheet under the ornament layer — what a mark on the leaf really sits on. */
 function washedLeaf(theme: Theme): Rgba {
   const alpha = Number(resolveVar('--faction-ua-card-lotus-opacity', theme, THEMES))
@@ -102,25 +80,6 @@ function washedLeaf(theme: Theme): Rgba {
     resolve('--faction-ua-card-bg', theme),
   )
 }
-
-describe('the trail above the leaf carries the kit ink on the SITE ground', () => {
-  const TRAIL_INKS: Array<{ what: string; token: string }> = [
-    { what: 'the Tasks crumb', token: '--faction-ua-card-body' },
-    { what: 'the current page', token: '--faction-ua-card-text' },
-  ]
-  for (const theme of BOTH_THEMES) {
-    for (const { what, token } of TRAIL_INKS) {
-      it(`${what} — ${theme}`, () => {
-        for (const stop of washStops(theme)) {
-          const ratio = contrastRatio(resolve(token, theme), pageUnderWash(theme, stop))
-          expect(ratio, `${token} over ${stop} is ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(
-            AA_NORMAL,
-          )
-        }
-      })
-    }
-  }
-})
 
 describe("the preview's bonus line reads the kit's own credit rung", () => {
   it.each(BOTH_THEMES)('%s', (theme) => {

--- a/frontend/src/pages/proposeTask/archetypes/CovenProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/CovenProposeTask.tsx
@@ -122,8 +122,8 @@
  * `proposalNotes.test.tsx` still owns that seam.
  */
 import type { CSSProperties } from 'react'
-import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { CovenSigil } from '../../../components/sigil/CovenSigil'
 import { useGameConfig } from '../../../hooks/useGameConfig'
@@ -414,28 +414,24 @@ export default function CovenProposeTask({ state }: { state: ProposeTaskState })
   ]
 
   return (
-    <ComposerPage sizes={sizes} style={{ fontFamily: CHROME, color: INK }}>
+    <ComposerPage
+      sizes={sizes}
+      style={{ fontFamily: CHROME, color: INK }}
+      /* THE CRUMB LEFT THE SHEET (#2973). It rode inside, in the slip's own
+         label ink, on the argument that the slot above sits on the app's
+         `--color-bg-page` and no Coven ink is measured there. That is true of
+         Coven ink and beside the point: a breadcrumb is not Coven's, it is
+         neutral site chrome measured on exactly that ground, and #2102 rule 2
+         says so in terms. The trail a player follows between a Coven task and a
+         Singularity one may not move house on the way. */
+      breadcrumb={<Breadcrumb current={t('proposeTask.pageTitle')} />}
+    >
       {/* A REAL `<form>`, not a bare button with an onClick: it is what makes
           Enter commit from a text field, and what gives the browser's own
           required-field behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
         <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
-          {/* The crumb rides INSIDE the sheet rather than in `ComposerPage`'s
-              breadcrumb slot. That slot sits above the sheet on the app's own
-              `--color-bg-page`, which is a ground no Coven ink is measured on —
-              the finding `CovenEditCharacter` made from the other direction when
-              it moved its tail OFF the slip to reach the register its neutral
-              slots were priced in. Here the type is the faction's, so the sheet
-              is the ground that is already answered. */}
-          <nav style={{ fontFamily: CHROME, fontSize: 'var(--text-lg)', letterSpacing: '0.1em', color: LABEL }}>
-            <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>
-              {t('breadcrumb.tasks')}
-            </Link>
-            {' › '}
-            <span style={{ color: INK }}>{t('proposeTask.pageTitle')}</span>
-          </nav>
-
           <h1
             style={{
               fontFamily: DISPLAY,

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
-import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import Breadcrumb from "../../../components/nav/Breadcrumb";
 import PageTitle from "../../../components/ui/PageTitle";
 import FilterLevelNodes from "../../../components/ui/FilterLevelNodes";
 import { Chip } from "../../../components/ui/ChipRow";
@@ -26,12 +26,6 @@ import {
 } from "../useProposeTask";
 
 const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
-
-const breadcrumbStyle: CSSProperties = {
-  fontSize: "var(--text-md)",
-  letterSpacing: "0.1em",
-  color: "var(--color-text-tertiary)",
-};
 
 const descriptionTextareaStyle: CSSProperties = {
   width: "100%",
@@ -234,19 +228,10 @@ export default function DefaultProposeTask({
 
   return (
     <div className="py-8">
-      {/* Breadcrumb */}
-      <nav
-        className="font-body mb-4"
-        style={breadcrumbStyle}
-      >
-        <Link to="/tasks" style={{ color: "inherit", textDecoration: "none" }}>
-          {t("breadcrumb.tasks")}
-        </Link>
-        {" › "}
-        <span style={{ color: "var(--color-text-primary)" }}>
-          {t("proposeTask.pageTitle")}
-        </span>
-      </nav>
+      {/* The site's one trail (#2102), first child of the page root. This was
+          the original hand-rolled hold-out — the shared component could not
+          say a trail with no task until #2973 gave it one. */}
+      <Breadcrumb current={t("proposeTask.pageTitle")} />
 
       <PageTitle title={t("proposeTask.pageTitle")} />
       <div aria-hidden="true" style={titleRuleStyle} />

--- a/frontend/src/pages/proposeTask/archetypes/EphemeristsProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/EphemeristsProposeTask.tsx
@@ -90,8 +90,8 @@
  * grid (SPEC-faction-ui-profile §1a).
  */
 import type { CSSProperties } from 'react'
-import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { useGameConfig } from '../../../hooks/useGameConfig'
 import {
@@ -353,19 +353,11 @@ export default function EphemeristsProposeTask({ state }: { state: ProposeTaskSt
     ['--label-ink' as string]: QUIET,
   } as CSSProperties
 
-  // The trail, in the plate's own voice. The site's shared `Breadcrumb` cannot
-  // serve it — its trail is keyed to a task id and this page has no task — so
-  // the na kit's two-crumb nav is redrawn here rather than a component reached
-  // for that would need a record to exist first.
-  const breadcrumb = (
-    <nav style={{ fontFamily: READING, fontSize: 'var(--text-lg)', color: QUIET }}>
-      <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>
-        {t('breadcrumb.tasks')}
-      </Link>
-      {' › '}
-      <span style={{ color: INK }}>{t('proposeTask.pageTitle')}</span>
-    </nav>
-  )
+  // The trail, in the SITE's voice rather than the plate's (#2973). It was
+  // redrawn here because the shared component was keyed to a task id and this
+  // page has no task; it now takes a `current` label, so the reason is gone and
+  // the copy goes with it.
+  const breadcrumb = <Breadcrumb current={t('proposeTask.pageTitle')} />
 
   if (success) {
     return (

--- a/frontend/src/pages/proposeTask/archetypes/EverymenProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/EverymenProposeTask.tsx
@@ -98,19 +98,18 @@
  * `factions.json`, which is what every other Everymen surface puts there under
  * ADR-0057.
  *
- * ONE na-KIT ELEMENT IS NOT DRAWN: its hand-rolled `Tasks › Propose a Task`
- * breadcrumb. #2102 collapsed eighteen hand-rolled crumbs onto ONE shared
- * component precisely so a faction surface would stop drawing its own, and the
- * shared `components/nav/Breadcrumb` cannot express this trail — it takes a
- * `taskId` and a `taskTitle` and builds `Tasks › <task>` from them, and no task
- * exists yet. A nineteenth copy inside a faction archetype is the thing that
- * issue deleted, and it would have to be inked either in the site's neutral
- * tiers (which `local/no-global-ink-on-faction-surface` forbids here, correctly)
- * or in this kit's paper inks on the app's own ground, which nothing measures.
- * So the way back is the footer's Cancel, which is `navigate(-1)`. Both
- * character plates this dress derives from draw no crumb either. Flagged on the
- * PR: giving this page a task-less trail is a change to the SHARED component,
- * not something an archetype may decide on its own.
+ * THE TRAIL IS THE SITE'S, AND IT ARRIVED LATE ON PURPOSE (#2973). This dress
+ * shipped without one: #2102 collapsed eighteen hand-rolled crumbs onto ONE
+ * shared component precisely so a faction surface would stop drawing its own,
+ * and that component could not express this trail — it took a `taskId` and a
+ * `taskTitle` and built `Tasks › <task>`, and no task exists yet. A nineteenth
+ * copy inside a faction archetype was the thing that issue deleted, so this file
+ * drew none and flagged it: giving the page a task-less trail is a change to the
+ * SHARED component, not an archetype's call. Six sibling archetypes hand-rolled
+ * one anyway and drifted onto three different inks and two placements, which is
+ * how the issue got filed. The component takes a `current` label now, so the
+ * page has a real way back rather than only the footer's Cancel — and it is the
+ * same crumb, in the same place, as every other propose surface.
  *
  * ## Presentation only
  *
@@ -120,6 +119,7 @@
  */
 import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { useGameConfig } from '../../../hooks/useGameConfig'
 import {
@@ -447,7 +447,12 @@ export default function EverymenProposeTask({ state }: { state: ProposeTaskState
   ]
 
   return (
-    <ComposerPage sizes={sizes} style={rootStyle}>
+    <ComposerPage
+      sizes={sizes}
+      style={rootStyle}
+      /* The way back, and this page's first (#2973) — see the header. */
+      breadcrumb={<Breadcrumb current={t('proposeTask.pageTitle')} />}
+    >
       {/* The docket, above the sheet: the pick the sheet below is dressed by.
           That placement is the na kit's own — the chips live outside its framed
           card, because the pick is what the card wears and cannot live inside

--- a/frontend/src/pages/proposeTask/archetypes/SingularityProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SingularityProposeTask.tsx
@@ -81,7 +81,8 @@
  *   and the create page has none, so the derivation would delete a navigation
  *   affordance. It keeps the site's neutral ink because it is site chrome
  *   standing on the site's own ground OUTSIDE the sheet (#2102), which is also
- *   the only ground it has ever been measured on.
+ *   the only ground it has ever been measured on — and since #2973 it is that
+ *   shared component rather than this file's restatement of it.
  * - **No `PageTitle`.** Its per-letter spectrum bars are the na kit's identity
  *   (ADR-0066); the heading here is the terminal's prompt line, as on the create
  *   plate.
@@ -97,8 +98,8 @@
  * keep sweeping it with the rest of the roster.
  */
 import type { CSSProperties, ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import SingularityLamps from '../../../components/factionMarks/SingularityLamps'
 import { useGameConfig } from '../../../hooks/useGameConfig'
@@ -474,46 +475,23 @@ export default function SingularityProposeTask({ state }: { state: ProposeTaskSt
   }
 
   return (
-    <ComposerPage sizes={sizes} style={pageStyle}>
-      {/* Site chrome, above the sheet and on the site's own ground — NEUTRAL by
-          rule (#2102), which is why it does not take the terminal's ink: a
-          phosphor cut for a near-black chassis has nothing to do with the app's
-          own page.
+    <ComposerPage
+      sizes={sizes}
+      style={pageStyle}
+      /* Site chrome, above the sheet and on the site's own ground — NEUTRAL by
+         rule (#2102), which is why it does not take the terminal's ink: a
+         phosphor cut for a near-black chassis has nothing to do with the app's
+         own page.
 
-          THE INK COMES FROM `components/nav/Breadcrumb`, NOT FROM THE na KIT'S
-          HAND-ROLLED COPY, and the difference is the one thing the tier arm of
-          `no-raw-style-values` would not let through. The site's one breadcrumb
-          paints the trail `--label-ink` and gives the current crumb `inherit`
-          plus weight; `DefaultProposeTask` predates it and reaches the global
-          `--color-text-*` family directly, which is banned on a
-          faction-dispatched surface and correctly so. `--label-ink` is unset to
-          `--color-text-tertiary` on this ground — nothing here repoints it, the
-          one Singularity repoint being fenced to `[data-composer-body]` — so
-          this renders the na kit's own value while reading the seam rather than
-          painting over it.
-
-          The shared component itself cannot be mounted: its trail is built from
-          a `taskId` / `taskTitle`, and no task exists yet on this page. */}
-      <nav
-        className="font-body"
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: '0 auto',
-          padding: 'var(--space-lg) var(--space-lg) 0',
-          fontSize: 'var(--text-md)',
-          letterSpacing: '0.1em',
-          color: 'var(--label-ink)',
-        }}
-      >
-        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>
-          {t('breadcrumb.tasks')}
-        </Link>
-        {' › '}
-        <span aria-current="page" style={{ color: 'inherit', fontWeight: 700 }}>
-          {t('proposeTask.pageTitle')}
-        </span>
-      </nav>
-
+         IT IS NOW THE COMPONENT AND NOT A COPY OF IT (#2973). The shape here was
+         already `components/nav/Breadcrumb`'s, restated because that component
+         built its trail from a `taskId` / `taskTitle` and no task exists yet on
+         this page; it takes a `current` label now, so the copy has nothing left
+         to justify it. The one visible change is the ink: the component paints
+         `--color-text-tertiary` outright rather than reading `--label-ink`,
+         which on this ground is unset to exactly that value. */
+      breadcrumb={<Breadcrumb current={t('proposeTask.pageTitle')} />}
+    >
       {/* A REAL `<form>`, not a bare button with an onClick: it is what makes
           Enter commit from a text field, and `handleSubmit` calls
           `preventDefault()` itself. */}

--- a/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
@@ -48,13 +48,16 @@
  *    the wall — it is the one block that has to read as a separate object, and
  *    every ink it prints is already measured on that stock (below).
  *
- * ## The breadcrumb is hand-drawn, and that is not a slip
+ * ## The breadcrumb is the site's, and it was hand-drawn only because it had to be
  *
- * `components/nav/Breadcrumb` is the site's one trail (#2102) and it may not
- * serve here: it takes a `taskId` and a `taskTitle`, and on this page the task
- * does not exist yet. The na kit hand-rolls the same two crumbs for the same
- * reason, off the same `forms:breadcrumb.tasks` key. Ours is the same trail in
- * this skin's face — it sits ABOVE the sheet, which is rule 2 of that file.
+ * `components/nav/Breadcrumb` is the site's one trail (#2102) and it could not
+ * serve here: it took a `taskId` and a `taskTitle`, and on this page the task
+ * does not exist yet. The na kit hand-rolled the same two crumbs for the same
+ * reason, and so did five more archetypes — which is how #2102's drift restarted
+ * on the axes it had just deleted. #2973 gave the component a `current` label
+ * and every one of those copies came out, this one included. It is not in this
+ * skin's face any more, because a breadcrumb is not the skin's: it is neutral
+ * chrome standing above the sheet on the app's own ground.
  *
  * ## Colour, and the two families this faction keeps apart
  *
@@ -95,8 +98,8 @@
  * is what decides whether the tick exists at all.
  */
 import { type CSSProperties } from 'react'
-import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { useGameConfig } from '../../../hooks/useGameConfig'
 import {
@@ -343,31 +346,14 @@ export default function SnideProposeTask({ state }: { state: ProposeTaskState })
   }
 
   return (
-    <ComposerPage sizes={sizes} style={{ fontFamily: BODY_FACE, color: INK }}>
-      {/* The trail, above the sheet (#2102 rule 2). Hand-drawn for the reason in
-          this file's header: the shared component needs a task that does not
-          exist yet. */}
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: '0 auto',
-          padding: 'var(--space-lg) var(--space-lg) 0',
-        }}
-      >
-        <nav
-          aria-label={t('common:breadcrumb.label')}
-          style={{ fontFamily: BODY_FACE, fontSize: 'var(--text-lg)', letterSpacing: '0.06em', color: MUTED }}
-        >
-          <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'underline' }}>
-            {t('breadcrumb.tasks')}
-          </Link>
-          {' › '}
-          <span aria-current="page" style={{ color: INK }}>
-            {t('proposeTask.pageTitle')}
-          </span>
-        </nav>
-      </div>
-
+    <ComposerPage
+      sizes={sizes}
+      style={{ fontFamily: BODY_FACE, color: INK }}
+      /* The trail, above the sheet (#2102 rule 2) and in the site's own hand
+         since #2973 — see this file's header. The slot draws the column the
+         hand-rolled wrapper used to. */
+      breadcrumb={<Breadcrumb current={t('proposeTask.pageTitle')} />}
+    >
       {/* A REAL `<form>`, not a bare button with an onClick: it is what makes
           Enter commit from a text field. `handleSubmit` calls `preventDefault()`
           itself. */}

--- a/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
@@ -53,8 +53,10 @@
  * `components/nav/Breadcrumb` is the site's one trail (#2102) and it could not
  * serve here: it took a `taskId` and a `taskTitle`, and on this page the task
  * does not exist yet. The na kit hand-rolled the same two crumbs for the same
- * reason, and so did five more archetypes — which is how #2102's drift restarted
- * on the axes it had just deleted. #2973 gave the component a `current` label
+ * reason — off `forms:breadcrumb.tasks`, a key that existed only to serve those
+ * copies and is deleted with them — and so did five more archetypes, which is
+ * how #2102's drift restarted on the axes it had just deleted, three inks and
+ * two placements in seven files. #2973 gave the component a `current` label
  * and every one of those copies came out, this one included. It is not in this
  * skin's face any more, because a breadcrumb is not the skin's: it is neutral
  * chrome standing above the sheet on the app's own ground.

--- a/frontend/src/pages/proposeTask/archetypes/UaProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/UaProposeTask.tsx
@@ -92,8 +92,8 @@
  * shared ring (#2266).
  */
 import type { CSSProperties } from 'react'
-import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { useGameConfig } from '../../../hooks/useGameConfig'
 import {
@@ -337,27 +337,17 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
   }
 
   return (
-    <ComposerPage sizes={sizes} style={pageStyle}>
-      {/* The trail the na kit draws, kept rather than dropped — a reskin may not
-          cost a page its way back — in the leaf's own quiet ink. */}
-      <nav
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: '0 auto',
-          padding: 'var(--space-lg) var(--space-lg) 0',
-          fontFamily: UA_TEXT,
-          fontSize: 'var(--text-lg)',
-          letterSpacing: '0.1em',
-          color: BODY,
-        }}
-      >
-        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>
-          {t('breadcrumb.tasks')}
-        </Link>
-        {' › '}
-        <span style={{ color: INK }}>{t('proposeTask.pageTitle')}</span>
-      </nav>
-
+    <ComposerPage
+      sizes={sizes}
+      style={pageStyle}
+      /* The trail the na kit draws, kept rather than dropped — a reskin may not
+         cost a page its way back — but NOT in the leaf's quiet ink any more
+         (#2973). That was a `--faction-*` token on a control #2102 rule 1 holds
+         to the site's own tertiary, and the ground it stands on is the app's
+         page rather than this skin's, so the leaf ink was never measured where
+         the crumb is read. */
+      breadcrumb={<Breadcrumb current={t('proposeTask.pageTitle')} />}
+    >
       {/* A REAL `<form>`: it is what makes Enter commit from a text field, and
           `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>

--- a/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
@@ -44,7 +44,7 @@
  *
  * ## Copy — none of its own
  *
- * Every string is an existing `forms:proposeTask.*` / `forms:breadcrumb.*` /
+ * Every string is an existing `forms:proposeTask.*` / `common:breadcrumb.*` /
  * `common:filters.*` key, unchanged and un-reordered. WOW's knightly vocabulary
  * is NOT reintroduced; ADR-0065 §3 deleted `editPraxis.wow.*` outright and the
  * faction carries identity in dress alone. The fields are placeholder-only, as

--- a/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
@@ -55,16 +55,14 @@
  *
  * It sits OUTSIDE the sheet, on the site's own ground, and *"a breadcrumb is
  * neutral SITE CHROME, not part of the faction surface"* (`components/nav/
- * Breadcrumb`). So the trail below takes that component's own shape and its own
- * ink tier rather than the charter's: an `<ol>`, `›` separators, the current
- * page marked by weight and `aria-current` instead of a second colour, and
- * `--label-ink` — whose root value is the app's tertiary tier on the app's own
- * ground, which is the one pairing a crumb is ever measured on. The na kit's
- * inline crumb tinted its last item with `--color-text-primary`; that is a
- * global ink inside a faction-dispatched surface, which `local/no-global-ink-on-
- * faction-surface` refuses, and weight says the same thing without the token.
- * `components/nav/Breadcrumb` itself is task-scoped (`taskId` / `taskTitle`) and
- * no task exists yet on this page — see the `ponytail:` note at the call site.
+ * Breadcrumb`). This file used to restate that component's shape — an `<ol>`,
+ * `›` separators, the current page marked by weight and `aria-current` instead
+ * of a second colour — because the component was task-scoped (`taskId` /
+ * `taskTitle`) and no task exists yet on this page. #2973 took the `ponytail:`
+ * upgrade path that note named and gave it a `current` label, so the restatement
+ * is gone and the component is mounted. The one difference the swap makes is
+ * that the ink is `--color-text-tertiary` outright rather than `--label-ink`,
+ * which is unset to that value on this ground.
  *
  * ## Two WOW rules that are load-bearing, not taste (§3)
  *
@@ -111,8 +109,8 @@
  * file — an archetype only ever draws the happy path or its success screen.
  */
 import type { CSSProperties } from 'react'
-import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import Breadcrumb from '../../../components/nav/Breadcrumb'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { BalloonBunch, Bunting, Zig } from '../../../components/factionMarks/wowOrnament'
 import { WowSpark } from '../../../components/factionMarks/wowMobile'
@@ -337,41 +335,11 @@ export default function WowProposeTask({ state }: { state: ProposeTaskState }) {
     color: INK,
   }
 
-  /* THE BREADCRUMB STAYS NEUTRAL SITE CHROME, and it is the site's own crumb
-     rather than this skin's: the trail reads `--label-ink`, whose root value is
-     the app's tertiary tier, and the page you are on is distinguished by weight
-     and `aria-current`, never by a second colour. That is exactly what
-     `components/nav/Breadcrumb` does, down to the `<ol>` and the `›`.
-
-     ponytail: it is restated here rather than mounted because that component is
-     task-scoped (`taskId` / `taskTitle`) and no task exists yet on this page.
-     The upgrade path is generalising it onto a `crumbs` prop, which is a change
-     to a component seventeen surfaces mount and is not this lane's to make. */
-  const breadcrumb = (
-    <nav
-      aria-label={t('common:breadcrumb.label')}
-      className="font-body"
-      style={{
-        fontSize: 'var(--text-md)',
-        letterSpacing: '0.1em',
-        color: 'var(--label-ink)',
-      }}
-    >
-      <ol style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
-        <li>
-          <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>
-            {t('common:breadcrumb.tasks')}
-          </Link>
-        </li>
-        <li style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
-          <span aria-hidden="true">&rsaquo;</span>
-          <span aria-current="page" style={{ color: 'inherit', fontWeight: 700 }}>
-            {t('proposeTask.pageTitle')}
-          </span>
-        </li>
-      </ol>
-    </nav>
-  )
+  /* THE BREADCRUMB IS NEUTRAL SITE CHROME, and since #2973 it is the site's own
+     component rather than this file's copy of it — the `ponytail:` note that
+     stood here named exactly that upgrade. Both stages mount it: the success
+     stage is still a page under `Tasks` and still needs a way back. */
+  const breadcrumb = <Breadcrumb current={t('proposeTask.pageTitle')} />
 
   /** The sheet's head: ✦, the page's own words, a wavy rule, one bunch. */
   const head = (heading: string) => (


### PR DESCRIPTION
Closes #2973

`components/nav/Breadcrumb` states three rules it "enforces rather than offers",
and it could not express the one trail the propose page needs: it built
`Tasks › <task>` from a `taskId` + `taskTitle`, and on a propose page no task
exists yet. So seven archetypes each hit that wall independently and each
answered it differently — which is verbatim the drift #2102 deleted. A rule a
caller cannot obey is a rule that gets broken.

## The seam

**The mount, not the markup.** The defect is not "these seven navs look
different", it is "the shared component cannot serve this page", so the fix is
one prop on the component and the test is *"the trail on this page is the shared
one"* asserted over the whole roster.

The loop went red on the real defect first: `proposeTaskBreadcrumb.test.tsx`
walks `surfaceMap('proposeTask')` and asserts, per slug, exactly ONE `<nav>`, a
real `/tasks` link, `aria-current` on the page you are on, the site's tertiary
ink with no `--faction-*` and no `--label-ink`, and the crumb drawn before the
`<form>` that wraps the sheet. Sixteen of thirty-six failed on `origin/main`'s
behaviour before a line of the fix existed — including all four rows for
Everymen, which had no crumb at all.

## What changed

**The component.** `BreadcrumbProps` is now a union: the task trail as it was,
or `{ current: string }` for a page under `Tasks` that is not a task. A union
rather than three optional props, so `taskTitle` stays required on the seventeen
surfaces that do have a task and nobody can pass a task id with no title.

**Eight surfaces repointed, seven `<nav>`s deleted.** The issue title says
eight hand-rolled crumbs; there are seven — its own table agrees, Everymen
correctly refused. `AlbescentProposeTask` is a pass-through wrapper of the
Default and needed nothing; `proposeTaskDispatch.test.tsx` still asserts the two
render byte-identically.

- **Coven** — the crumb comes out of the sheet. Its docblock argued the slot
  above sits on `--color-bg-page`, a ground no Coven ink is measured on. True,
  and beside the point: a breadcrumb is not Coven's, and that ground is exactly
  the one it *is* measured on (#2102 rule 2).
- **UA** — was drawing the trail in `--faction-ua-card-body`, the clause rule 1
  bans in terms.
- **WoW** — took the `ponytail:` upgrade path its own note named.
- **Singularity, S.N.I.D.E., Ephemerists, na** — restatements with nothing left
  to justify them.
- **Everymen** — gains a crumb for the first time. Its way back was the footer's
  Cancel; it has a real `Tasks` link now.

**`forms:breadcrumb.tasks` deleted.** It existed only to serve the hand-rolled
copies; the shared component reads `common:breadcrumb.tasks`.

**One contrast row retired.** `uaProposeTaskContrast.test.ts` measured this
kit's quiet tier on the site's washed page *because* the crumb took a faction
ink there. The ink is the app's own tertiary now, and that pairing is already
measured on this exact composite in both themes and all five wash stops by
`characterPaths/__tests__/createCharacterContrast.test.ts` — keeping a row would
be the second name for one measurement that file's own header warns against.
The docblock says where it comes back if a crumb ever takes a faction ink again.

**Preview kit** gains the task-less cell.

## Two things checked rather than assumed

- **`local/no-global-ink-on-faction-surface` is path-scoped** to
  `src/**/archetypes/**`, `src/**/mobileArchetypes/**` and
  `src/components/factionMarks/**` (`FACTION_DISPATCHED_PATHS`), so
  `components/nav/Breadcrumb` is out of scope and mounting it inside an
  archetype does not import the ban. `npm run lint` is clean.
- **`DefaultProposeTask`'s allowlist entry cannot shrink yet.** Deleting the
  crumb removed two `--color-text-*` uses; **nine remain**, so the line stays.
  Its trailing `# 10` is not touched — `.eslint-legacy-faction-ink.txt`'s own
  header says that number is unenforced seed-day trivia that "would rot on the
  first unrelated edit", and it already had (the file read 11 before this PR).
  The ratchet is untouched and nothing was added to the list.

## Verification

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` ·
`npm test` (506 files, 10,449 passed) · `npm run build` · `npm run budget` — all
run locally, all green. The budget prints its standing JS WARNING (149.6 KB vs
the 130.9 KB warn line, fail at 175.8) and exits 0; that overshoot predates this
PR and nothing here touches an initial-load chunk.

**Visual QA is outstanding** — I have no browser and no dev stack. The harness
is `renderToStaticMarkup` with no DOM (SPEC-testing.md), so nothing here proves
a pixel.

## What to eyeball

Desktop and phone widths, light and dark, at `/propose-task` with each chip
picked — the page reskins live on the chip, so all of this is one page.

Repointed, and the crumb should read identically on every one of them — same
place, same ink, same chevron:

1. **Unaffiliated (na kit)** — the only one whose crumb was already the site's
   ink; check the gap above `Propose a Task`'s spectrum-underlined heading did
   not change.
2. **Cozy Coven** — the biggest move: the crumb left the sheet and now sits above
   the slip, on the app's page. Check it reads on `--color-bg-page` in both
   themes and that the slip's top edge did not gain a hole where the crumb was.
3. **Unwavering Artisans** — was the leaf's quiet ink, now the site's tertiary
   over the neutral spectrum wash.
4. **Warriors of Whimsy** — and its **success screen**, which is the one surface
   that draws a crumb in both stages.
5. **Singularity** — near-black chassis; the crumb must stay off the phosphor.
6. **S.N.I.D.E.** — its crumb used to be underlined in the press's face; it is
   the site's chrome now.
7. **The Ephemerists** — check the crumb sits clear of the plate's masthead.
8. **Everymen** — a crumb that has never been on this page before. Check it
   lines up with the docket row of faction chips below it, which sits in the
   same column.

Left alone, and worth a glance for collateral:

9. **Albescent** — pass-through of the na kit; should be pixel-identical to (1).
10. **Any task detail and any praxis detail**, plus **the praxis composer** —
    they share the component whose props changed and are the seventeen call
    sites the union protects. `Tasks › <title>` and
    `Tasks › <title> › Praxis › Edit` should be untouched, including the
    long-title shrink on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
