### PR TITLE
The two edit-only slots take a dress from the archetype that mounts them (#2956)

### DIFF
--- a/frontend/src/pages/characterPaths/__tests__/editCharacterSlotsDress.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/editCharacterSlotsDress.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * THE SEAM: the dress an archetype hands the two edit-only slots (#2956).
+ *
+ * `editCharacterSlots.tsx` designs `FactionRow` and `DeleteCharacter` once for
+ * all eight edit archetypes, and its contract is that an archetype MOUNTS them
+ * — *"where each one sits on the page is the dress and belongs to the
+ * archetype"*. Until now it also painted them, in module-level inline styles
+ * naming app-global neutrals measured on the na page's washed ground, and it
+ * exposed no way in. So the paint decided the placement: six of the seven
+ * lanes #2537 landed worked around it, in four different ways (Coven and UA
+ * moved the slot off their own sheet at 4.06:1 and 4.15:1; S.N.I.D.E. and
+ * Singularity repointed global tokens on a wrapper root they own). That is the
+ * contract backwards.
+ *
+ * Two claims here, and the second is the one that makes the seam safe to land
+ * before any dress uses it:
+ *
+ *   1. a mount that supplies a dress GETS it — the props spread last, over the
+ *      defaults, so the archetype wins;
+ *   2. a mount that supplies NOTHING renders exactly what it rendered before.
+ *      That is the whole safety argument for a shared file with ten mounts: a
+ *      default that drifts here quietly repaints ten surfaces, and `na` and
+ *      Albescent have no dress to notice with. Asserted the way
+ *      `__tests__/composerErrorBannerGround.test.tsx` asserts it — bare render
+ *      against `undefined`-everywhere render, then the literal tokens.
+ *
+ * The confirm branch is behind local state and this harness has no DOM, so the
+ * three styles only a click reaches are pinned as SOURCE instead: their spread
+ * order, and the fact that the filled DELETE key has no seam over it at all.
+ * That last one is a ruling rather than an omission (2026-08-27, ADR-0061) —
+ * `--color-danger` / `--color-on-danger` is a ground and its ink, and a prop
+ * generous enough to carry an ink is generous enough to repaint that pair.
+ *
+ * `renderToStaticMarkup` only — no jsdom, effects never run.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { ReactElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+
+import '../../../i18n'
+import { stripComments } from '../../../test/sourceScan'
+import { DeleteCharacter, FactionRow } from '../editCharacterSlots'
+
+/** Comments stripped: the file's own header names every token it draws. */
+const SOURCE = stripComments(
+  readFileSync(fileURLToPath(new URL('../editCharacterSlots.tsx', import.meta.url)), 'utf8'),
+)
+
+const render = (node: ReactElement): string =>
+  renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>)
+
+const noop = () => {}
+
+describe('the faction row takes a dress, and defaults to today', () => {
+  it('keeps today’s rendering for a mount that supplies none', () => {
+    const bare = render(<FactionRow slug="wow" />)
+    expect(bare).toBe(
+      render(
+        <FactionRow
+          slug="wow"
+          style={undefined}
+          labelStyle={undefined}
+          rowStyle={undefined}
+          chevronStyle={undefined}
+          helpStyle={undefined}
+        />,
+      ),
+    )
+    // The literal defaults, so a "byte identical" seam cannot drift by being
+    // re-tokenised. These are the six globals `wowEditCharacterContrast` and
+    // `singularityEditCharacterTail` measure and repoint from the outside.
+    expect(bare).toContain('color:var(--color-text-secondary)')
+    expect(bare).toContain('background:var(--color-bg-surface-alt)')
+    expect(bare).toContain('border:1px solid var(--color-border-strong)')
+    expect(bare).toContain('color:var(--color-text-tertiary)')
+    // And the wrapper still carries no style attribute of its own.
+    expect(bare.startsWith('<div><span style=')).toBe(true)
+  })
+
+  it('lets the archetype repaint the plate, which is the ground-dependent half', () => {
+    // WoW's case, and the one measurement gap the seam exists to let a dress
+    // close: the default well reads 1.06:1 on the charter sheet and its
+    // hairline 1.41/1.56, under 1.4.11's 3:1 for a graphical boundary.
+    const dressed = render(
+      <FactionRow
+        slug="wow"
+        rowStyle={{
+          background: 'var(--faction-wow-card-bg)',
+          border: '1px solid var(--faction-wow-card-edge)',
+        }}
+      />,
+    )
+    expect(dressed).toContain('background:var(--faction-wow-card-bg)')
+    expect(dressed).toContain('border:1px solid var(--faction-wow-card-edge)')
+    expect(dressed).not.toContain('var(--color-bg-surface-alt)')
+    expect(dressed).not.toContain('var(--color-border-strong)')
+  })
+
+  it('lets it repaint every text tier, because they are three tiers and not one', () => {
+    // Singularity's case, and the shape of it: the label, the NAME on the plate
+    // (which travels with the plate, in `rowStyle`), the chevron and the help
+    // are four sites over three tiers. That is why this is a small named set
+    // rather than one `slotStyle` — the seam has to be able to send them to
+    // different places, which `SLOT_INK`'s six-token repoint already does.
+    const dressed = render(
+      <FactionRow
+        slug="singularity"
+        labelStyle={{ color: 'var(--faction-singularity-term-ink)' }}
+        rowStyle={{ color: 'var(--faction-singularity-term-ink)' }}
+        chevronStyle={{ color: 'var(--faction-singularity-term-dim)' }}
+        helpStyle={{ color: 'var(--faction-singularity-term-dim)' }}
+      />,
+    )
+    expect(dressed).toContain('color:var(--faction-singularity-term-ink)')
+    expect(dressed).toContain('color:var(--faction-singularity-term-dim)')
+    expect(dressed).not.toContain('var(--color-text-secondary)')
+    expect(dressed).not.toContain('var(--color-text-tertiary)')
+  })
+
+  it('and the wrapper takes the surrounding spacing, which is placement', () => {
+    expect(render(<FactionRow slug="coven" style={{ marginTop: 'var(--space-lg)' }} />)).toContain(
+      '<div style="margin-top:var(--space-lg)">',
+    )
+  })
+
+  it('still sends an unaffiliated life to the DIRECTORY, not to /factions/na', () => {
+    // Behaviour, not chrome. `na` is seeded hidden, so `/factions/na` renders
+    // "Faction not found" for the one population the branch exists to serve.
+    expect(render(<FactionRow slug={null} />)).toContain('href="/factions"')
+    expect(render(<FactionRow slug="na" />)).toContain('href="/factions"')
+    expect(render(<FactionRow slug="coven" />)).toContain('href="/factions/coven"')
+  })
+})
+
+describe('the destructive slot takes an ink, and defaults to the faction’s', () => {
+  it('keeps today’s rendering for a mount that supplies none', () => {
+    const bare = render(<DeleteCharacter slug="coven" deleting={false} onDelete={noop} />)
+    expect(bare).toBe(
+      render(
+        <DeleteCharacter
+          slug="coven"
+          deleting={false}
+          onDelete={noop}
+          alarm={undefined}
+          buttonStyle={undefined}
+          panelStyle={undefined}
+          promptStyle={undefined}
+          cancelStyle={undefined}
+        />,
+      ),
+    )
+    expect(bare).toContain('border:1px solid var(--faction-coven-card-alarm)')
+    expect(bare).toContain('color:var(--faction-coven-card-alarm)')
+  })
+
+  it('still reads the alarm off the character’s own faction when none is given', () => {
+    // The `na` default, which is the one every unaffiliated life gets.
+    expect(render(<DeleteCharacter slug={null} deleting={false} onDelete={noop} />)).toContain(
+      'var(--faction-default-card-alarm)',
+    )
+  })
+
+  it('takes the ink an archetype re-measured on its own sheet', () => {
+    // S.N.I.D.E.'s case: `-card-alarm` is 1.24:1 on the wall and `-wall-alarm`
+    // is 5.13:1, which it had to reach by repointing a token on a wrapper root
+    // because this control took no ink.
+    const dressed = render(
+      <DeleteCharacter
+        slug="snide"
+        deleting={false}
+        onDelete={noop}
+        alarm="var(--faction-snide-wall-alarm)"
+      />,
+    )
+    expect(dressed).toContain('var(--faction-snide-wall-alarm)')
+    expect(dressed).not.toContain('var(--faction-snide-card-alarm)')
+  })
+
+  it('lets the outline keep its own geometry and face', () => {
+    expect(
+      render(
+        <DeleteCharacter
+          slug="ua"
+          deleting={false}
+          onDelete={noop}
+          buttonStyle={{ borderRadius: 0 }}
+        />,
+      ),
+    ).toContain('border-radius:0')
+  })
+})
+
+describe('the confirm branch, which no click can reach without a DOM', () => {
+  it('spreads each supplied style LAST, so the archetype wins', () => {
+    for (const pair of [
+      '...confirmPanel',
+      '...panelStyle',
+      '...confirmPrompt, ...promptStyle',
+      '...confirmCancel, ...cancelStyle',
+    ]) {
+      expect(SOURCE, `the confirm branch no longer carries ${pair}`).toContain(pair)
+    }
+    // Order matters and a `toContain` on two names in one object literal is the
+    // only place it can be read: default first, prop second.
+    expect(SOURCE.indexOf('...confirmPanel')).toBeLessThan(SOURCE.indexOf('...panelStyle'))
+  })
+
+  it('leaves the filled DELETE key with no seam over it (ADR-0061)', () => {
+    // A ground and its ink rather than type on a wash. The 2026-08-27 ruling is
+    // explicit, and this is the assertion that a later "just one more prop"
+    // has to argue with.
+    expect(SOURCE).toContain('style={confirmDelete}')
+    expect(SOURCE).toContain("background: 'var(--color-danger)'")
+    expect(SOURCE).toContain("color: 'var(--color-on-danger)'")
+    expect(SOURCE).not.toContain('...confirmDelete')
+  })
+
+  it('takes the alarm from the faction unless one is handed in', () => {
+    expect(SOURCE).toContain(
+      "suppliedAlarm ?? factionCssVar(slug ?? UNAFFILIATED_FACTION_SLUG, 'card-alarm')",
+    )
+  })
+})

--- a/frontend/src/pages/characterPaths/editCharacterSlots.tsx
+++ b/frontend/src/pages/characterPaths/editCharacterSlots.tsx
@@ -50,11 +50,51 @@
  * pair is a ground and its ink, not type on the wash, so the wash never reaches
  * it.
  *
- * ponytail: the alarm ink is measured on the na page's washed ground only,
- * because that is the only ground an edit archetype draws on today. A faction
- * archetype that lands this slot on its own SHEET must re-measure its
+ * ## THE DRESS SEAM: an archetype supplies ink; it still does not re-draw (#2956)
+ *
+ * The paint below was measured on the na page's washed ground, which was the
+ * only ground an edit archetype drew on when this file was written. #2537 made
+ * it eight, and six of the seven new lanes worked around the missing seam in
+ * four different ways: two MOVED the slot off their own sheet because the
+ * shared neutrals would not clear there (Coven's faction-row ink 4.06:1 on the
+ * washed ward sheet in dark; UA's 4.15:1, `--color-bg-surface-alt` being a 6%
+ * white wash that composites over the leaf to rgb(91,66,49)), and two repointed
+ * global tokens on a wrapper root they own (S.N.I.D.E. sending `-card-alarm` to
+ * `-wall-alarm`, 1.24:1 to 5.13:1; Singularity sending SIX globals onto
+ * `-term-*`). That inverts this file's own contract — placement is the dress's
+ * decision, and it was being made by the slot's paint.
+ *
+ * So both slots take optional style props, in the shape `ErrorBanner` and the
+ * neighbouring `PortraitPicker` already ship: spread LAST over the defaults, so
+ * a mount that passes nothing renders byte-identically to what it rendered
+ * before. The seam commits no archetype to anything; it only removes the
+ * constraint. Whether a given dress uses it is that dress's own PR with that
+ * dress's own measurement. `__tests__/editCharacterSlotsDress.test.tsx` is the
+ * guard for both halves.
+ *
+ * WHY PROPS RATHER THAN THE `--label-ink` SEAM. `PortraitPicker` states the
+ * split: a TIER a frame root already dresses reads the seam and mints nothing,
+ * a GROUND-DEPENDENT ink takes a prop. That rule was checked here and it does
+ * not reach. `--label-ink` is `var(--color-text-tertiary)` at root, so the
+ * label, the row's ink and the confirm prompt — all `--color-text-secondary` —
+ * are one tier off it and would MOVE on every ground including na's; and the
+ * one line that does match at root (the help) resolves to something else under
+ * the three roots that repoint the seam (Ephemerists to `-plate-quiet`,
+ * S.N.I.D.E. to `--control-off-ink`, Singularity to `-term-dim`). Reading the
+ * seam here would repaint dresses in a change whose whole contract is that
+ * nothing moves. Those are re-dress decisions, and they belong to the dresses.
+ *
+ * WHAT THE SEAM DOES NOT REACH, on purpose: the confirm's filled key. Its
+ * `--color-danger` / `--color-on-danger` is a ground and its ink rather than
+ * type on a wash (2026-08-27 ruling, ADR-0061), so it takes no prop — a prop
+ * generous enough to carry an ink is generous enough to repaint that pair.
+ *
+ * ponytail: the alarm ink is measured on the na page's washed ground only. A
+ * faction archetype that lands this slot on its own SHEET must re-measure its
  * `-card-alarm` against that sheet in its own PR — the upgrade path is a row in
- * `factionContrast.test.ts`, not a change here.
+ * `factionContrast.test.ts` plus, since #2956, handing the re-measured ink in
+ * through {@link DeleteCharacterProps.alarm} rather than repointing a global on
+ * a wrapper root. The DEFAULT stays `factionCssVar(slug, 'card-alarm')`.
  */
 import { useState, type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
@@ -70,26 +110,71 @@ export function factionDetailHref(slug: string | null | undefined): string {
   return slug && slug !== UNAFFILIATED_FACTION_SLUG ? `/factions/${slug}` : '/factions'
 }
 
+export interface FactionRowProps {
+  slug: string | null | undefined
+  /** Wrapper override, for a surface that owns the surrounding spacing. */
+  style?: CSSProperties
+  /** The label tier above the row. */
+  labelStyle?: CSSProperties
+  /**
+   * The row's own PLATE — its well, its hairline and the ink on it. This is the
+   * ground-dependent half and the one the fan-out kept tripping over: the
+   * default well is `--color-bg-surface-alt`, which reads 1.06:1 on the WoW
+   * charter sheet and composites to rgb(91,66,49) over UA's leaf in dark.
+   */
+  rowStyle?: CSSProperties
+  /** The disclosure chevron, which is the row's quiet tier rather than its ink. */
+  chevronStyle?: CSSProperties
+  /** The help line under the row. */
+  helpStyle?: CSSProperties
+}
+
 /** The calling a character already has — read-only, and a way back to it. */
-export function FactionRow({ slug }: { slug: string | null | undefined }) {
+export function FactionRow({
+  slug,
+  style,
+  labelStyle,
+  rowStyle,
+  chevronStyle,
+  helpStyle,
+}: FactionRowProps) {
   const { t } = useTranslation('forms')
   return (
-    <div>
-      <span style={label}>{t('editCharacter.factionLabel')}</span>
-      <Link to={factionDetailHref(slug)} className="content-text" style={row}>
+    <div style={style}>
+      <span style={{ ...label, ...labelStyle }}>{t('editCharacter.factionLabel')}</span>
+      <Link to={factionDetailHref(slug)} className="content-text" style={{ ...row, ...rowStyle }}>
         <span>{slug ? factionName(slug) : t('editCharacter.unaffiliated')}</span>
-        <span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>
+        <span aria-hidden style={{ ...chevron, ...chevronStyle }}>›</span>
       </Link>
-      <p className="content-text" style={help}>{t('editCharacter.factionHelp')}</p>
+      <p className="content-text" style={{ ...help, ...helpStyle }}>{t('editCharacter.factionHelp')}</p>
     </div>
   )
 }
 
-interface DeleteCharacterProps {
+export interface DeleteCharacterProps {
   /** The EDITED character's faction, which is what paints the alarm ink. */
   slug: string | null | undefined
   deleting: boolean
   onDelete: () => void | Promise<void>
+  /**
+   * The destructive ink — the outline's hairline and label, and the confirm
+   * panel's frame. Defaults to this character's `-card-alarm`, which is what
+   * every mount rendered before the seam existed; an archetype whose own sheet
+   * that alarm does not clear passes the one it re-measured instead of
+   * repointing `--faction-{key}-card-alarm` on a wrapper root.
+   */
+  alarm?: string
+  /** The outline button's geometry and face. Its INK is {@link alarm}. */
+  buttonStyle?: CSSProperties
+  /** The confirm panel's ground. Transparent by default — a well is a dress. */
+  panelStyle?: CSSProperties
+  /** The confirm question's ink. */
+  promptStyle?: CSSProperties
+  /**
+   * The confirm's CANCEL key — a well, a hairline and an ink, all three of them
+   * ground-dependent. The DELETE key beside it takes no prop: see the header.
+   */
+  cancelStyle?: CSSProperties
 }
 
 /**
@@ -98,17 +183,26 @@ interface DeleteCharacterProps {
  * route and no other slot can answer it, so lifting it into
  * `useEditCharacter` would give eight archetypes a field they all ignore.
  */
-export function DeleteCharacter({ slug, deleting, onDelete }: DeleteCharacterProps) {
+export function DeleteCharacter({
+  slug,
+  deleting,
+  onDelete,
+  alarm: suppliedAlarm,
+  buttonStyle,
+  panelStyle,
+  promptStyle,
+  cancelStyle,
+}: DeleteCharacterProps) {
   const { t } = useTranslation(['forms', 'common'])
   const [confirming, setConfirming] = useState(false)
-  const alarm = factionCssVar(slug ?? UNAFFILIATED_FACTION_SLUG, 'card-alarm')
+  const alarm = suppliedAlarm ?? factionCssVar(slug ?? UNAFFILIATED_FACTION_SLUG, 'card-alarm')
 
   if (!confirming) {
     return (
       <button
         type="button"
         onClick={() => setConfirming(true)}
-        style={{ ...outlineBtn, border: `1px solid ${alarm}`, color: alarm }}
+        style={{ ...outlineBtn, border: `1px solid ${alarm}`, color: alarm, ...buttonStyle }}
       >
         {t('editCharacter.delete')}
       </button>
@@ -116,12 +210,16 @@ export function DeleteCharacter({ slug, deleting, onDelete }: DeleteCharacterPro
   }
 
   return (
-    <div style={{ ...confirmPanel, border: `1px solid ${alarm}` }}>
-      <span className="content-text" style={confirmPrompt}>
+    <div style={{ ...confirmPanel, border: `1px solid ${alarm}`, ...panelStyle }}>
+      <span className="content-text" style={{ ...confirmPrompt, ...promptStyle }}>
         {t('editCharacter.deleteConfirm')}
       </span>
       <div style={{ display: 'flex', gap: 'var(--space-md)' }}>
-        <button type="button" onClick={() => setConfirming(false)} style={confirmCancel}>
+        <button
+          type="button"
+          onClick={() => setConfirming(false)}
+          style={{ ...confirmCancel, ...cancelStyle }}
+        >
           {t('common:actions.cancel')}
         </button>
         <button type="button" onClick={onDelete} disabled={deleting} style={confirmDelete}>
@@ -143,6 +241,9 @@ const row: CSSProperties = {
   background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border-strong)',
   borderRadius: 8, padding: 'var(--space-md)', textDecoration: 'none',
   fontFamily: 'var(--font-body)', color: 'var(--color-text-secondary)',
+}
+const chevron: CSSProperties = {
+  color: 'var(--color-text-tertiary)',
 }
 const help: CSSProperties = {
   fontFamily: 'var(--font-body)', lineHeight: 1.6,
@@ -166,6 +267,11 @@ const confirmCancel: CSSProperties = {
   border: '1px solid var(--color-border-strong)', borderRadius: 8, padding: 'var(--space-md)',
   fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)', color: 'var(--color-text-primary)',
 }
+/**
+ * The one paint in this file with NO seam over it, and that is the decision
+ * (2026-08-27, ADR-0061). A ground and its ink, not type on a wash — no dress
+ * reaches past it, which is why `DeleteCharacter` exposes no key for it.
+ */
 const confirmDelete: CSSProperties = {
   flex: 1, cursor: 'pointer', background: 'var(--color-danger)', border: 'none',
   borderRadius: 8, padding: 'var(--space-md)', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',


### PR DESCRIPTION
Closes #2956

## The seam

**The dress an archetype hands the two edit-only slots.** `editCharacterSlots.tsx` designs `FactionRow` and `DeleteCharacter` once for all eight edit archetypes, and its own contract says an archetype *mounts* them — *"where each one sits on the page is the dress and belongs to the archetype"*. But it painted them in module-level inline styles naming app-global neutrals measured on the `na` page's washed ground, and it exposed no way in. So the paint decided the placement, which is the contract backwards: of the seven lanes #2537 landed, two moved the slot off their own sheet because the shared neutrals would not clear (Coven 4.06:1, UA 4.15:1) and two repointed global tokens on a wrapper root they own (S.N.I.D.E., Singularity's six-token `SLOT_INK`).

This adds the seam. It changes no dress.

## What changed

`frontend/src/pages/characterPaths/editCharacterSlots.tsx` — optional style props, in the shape `ErrorBanner` and the neighbouring `PortraitPicker` already ship: **spread last over the defaults**, defaults untouched.

- `FactionRow`: `style` (wrapper spacing), `labelStyle`, `rowStyle` (the plate — well, hairline and the name on it), `chevronStyle`, `helpStyle`.
- `DeleteCharacter`: `alarm` (the destructive ink, defaulting to `factionCssVar(slug, 'card-alarm')` exactly as before), `buttonStyle`, `panelStyle`, `promptStyle`, `cancelStyle`.

Four sites over three tiers on the row, so it is a small named set rather than one `slotStyle` — Singularity's existing repoint already sends them to three different places.

**The confirm's filled DELETE key gets no prop.** `--color-danger` / `--color-on-danger` is a ground and its ink rather than type on a wash (2026-08-27 ruling, ADR-0061), and a prop generous enough to carry an ink is generous enough to repaint that pair. That is asserted, not just commented.

## The guard

`frontend/src/pages/characterPaths/__tests__/editCharacterSlotsDress.test.tsx`, copying `composerErrorBannerGround.test.tsx`'s shape — 12 arms, `renderToStaticMarkup` only.

Written at the seam and run red first: **7 of the 12 fail against the pre-seam file**, restored from git and run. The 5 that pass on both sides are the byte-identity and routing arms, which is what they are for — a bare render is compared against an `undefined`-everywhere render *and* against the literal token strings (`background:var(--color-bg-surface-alt)`, `border:1px solid var(--color-border-strong)`, `color:var(--color-text-secondary)`, `color:var(--color-text-tertiary)`, `var(--faction-coven-card-alarm)`, `var(--faction-default-card-alarm)` for an unaffiliated life), so a "byte identical" default cannot drift by being quietly re-tokenised across ten mounts. `factionDetailHref`'s `na` -> `/factions` directory routing is pinned at the markup level too (`href="/factions"` for both `null` and `"na"`).

The three styles only a click reaches are behind local state and this harness has no DOM, so their spread order is pinned as source instead.

## What I deliberately did NOT do

- **No archetype's dress changed.** S.N.I.D.E. and Singularity keep their wrapper-root repoints; their guards (`singularityEditCharacterTail.test.tsx` pins all six) stay green untouched. Using the seam is each dress's own PR with its own measurement, as the issue says.
- **The WoW gap is left open.** `--color-bg-surface-alt` at 1.06:1 on `--faction-wow-card-bg` and its hairline at 1.41/1.56 are still unguarded and unfixed on `main`. The seam is now what WoW needs to fix it without touching the shared file, but fixing it is a dress change and this PR's whole claim is that no dress moved.
- **The eslint glob is not widened.** The seam comes first.
- Nothing was weakened. `wowEditCharacterContrast`'s four source assertions against `editCharacterSlots.tsx` all still hold by construction, including the literal `factionCssVar(slug ?? UNAFFILIATED_FACTION_SLUG, 'card-alarm')`.

## One finding worth recording: the `--label-ink` half does not apply here

The brief carried `PortraitPicker`'s rule — a *tier* a frame root already dresses reads the seam and mints nothing, a *ground-dependent* ink takes a prop — and suggested the neutral tiers here are `--label-ink`-class. I checked it and it does not reach, so I did not do that half:

- `--label-ink` is `var(--color-text-tertiary)` at root (`01-base-tokens.css:189`). The label, the row's ink and the confirm prompt are all `--color-text-secondary` — **one tier off it**. Reading the seam would move them on every ground, `na` included.
- The one site that does match at root — the help line — resolves to something else entirely under the three roots that repoint the seam (Ephemerists -> `-plate-quiet`, S.N.I.D.E. -> `--control-off-ink`, Singularity -> `-term-dim`). Reading it there would repaint three dresses inside a change whose contract is that nothing moves, and would invalidate the `--color-text-tertiary` rows those lanes measured.

Both are written into the file's header so the next reader does not re-derive them. If the owner wants those tiers on the seam, that is a re-dress with its own measurements, not part of a behaviour-preserving refactor.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (507 files, 10,461 passed), `npm run build`, `npm run budget` — all green from `.github/workflows/test.yml`'s `frontend` job. The budget's JS WARN block is pre-existing on `main` (the script's own header at line 203 says so) and exits 0; this diff adds nothing to the initial payload.

**No browser was available, so visual QA is outstanding.**

## What to eyeball

If I did this right there is **nothing visual to see** — and that is itself the claim to check, on the pages where a regression would be silent:

1. **Edit Character on `na`** (light and dark) — the faction row's label, plate, chevron and help, and the delete outline. This is the mount that passes nothing, so it must be pixel-for-pixel what it was.
2. **Albescent's Edit Character** — the other mount that passes nothing.
3. **Delete -> confirm, on `na`** — the bordered panel, the prompt, the Cancel key and the filled Delete key. The confirm branch is the part no test here can render, so it is the one that most wants a human.
4. **Singularity and S.N.I.D.E. Edit Character** — the two lanes with wrapper-root repoints. Their repoints are untouched, so their tails should be unchanged; if either moved, the spread order is wrong.
5. **The faction row's link on an unaffiliated character** — still goes to the `/factions` directory, not `/factions/na`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
