### PR TITLE
A profile's two galleries fold, on #2311's primitive generalised (#2958)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -449,6 +449,7 @@
         "sidebarCollapsed": "Whether the side rail is folded away.",
         "sidebarPanels": "The order of the side rail's panels and which are folded. One entry for each account signed in on this browser.",
         "factionSections": "Which galleries on a faction page you left folded. One entry for each account signed in on this browser.",
+        "profileSections": "Which galleries on a character profile you left folded. One entry for each account signed in on this browser.",
         "seenInvites": "Which invitation letters a character has already been shown, so none is announced twice. One entry for each of your characters.",
         "lastSeenLevel": "The last level a character was congratulated on, so the celebration does not repeat. One entry for each of your characters.",
         "onboardingHandoff": "A mark that this tab left for Google or Discord partway through signing up, so you come back where you were."

--- a/frontend/src/pages/characterProfile/__tests__/profileSectionDisclosure.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileSectionDisclosure.test.tsx
@@ -273,12 +273,24 @@ describe('a folded gallery is still worth reading', () => {
       expect(html, slug).not.toContain(
         `id="${sectionBodyId(PROFILE_SECTIONS, 'proposed')}" hidden`,
       )
-      // The praxis cards really left the flow; the task cards did not.
-      const text = html.replace(/<[^>]*>/g, '')
-      expect(text, `${slug} still shows the folded praxis`).not.toContain(
-        PRAXIS[0].task_title,
+      // `hidden` is the rail's idiom and it KEEPS the markup — the gallery
+      // holds its state and its scroll position, and the browser takes it out
+      // of the flow. So the assertion is that the cards are INSIDE the folded
+      // panel rather than absent: the praxis cards fall between the praxis
+      // panel's opening tag and the proposed panel's, and the task cards after.
+      const praxisAt = html.indexOf(`id="${sectionBodyId(PROFILE_SECTIONS, 'praxis')}"`)
+      const proposedAt = html.indexOf(`id="${sectionBodyId(PROFILE_SECTIONS, 'proposed')}"`)
+      const praxisCardAt = html.indexOf(PRAXIS[0].task_title)
+      const taskCardAt = html.indexOf(TASKS[0].title)
+      expect(praxisCardAt, `${slug}: praxis outside the panel it folds`).toBeGreaterThan(
+        praxisAt,
       )
-      expect(text, `${slug} folded the wrong gallery`).toContain(TASKS[0].title)
+      expect(praxisCardAt, `${slug}: praxis outside the panel it folds`).toBeLessThan(
+        proposedAt,
+      )
+      expect(taskCardAt, `${slug}: tasks outside their own panel`).toBeGreaterThan(
+        proposedAt,
+      )
     }
   })
 })

--- a/frontend/src/pages/characterProfile/__tests__/profileSectionDisclosure.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileSectionDisclosure.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * The seam: `FactionProfileBody` × the profile's two long galleries, walked by
+ * SLUG and by FORM FACTOR (#2958).
+ *
+ * WHY THE WALK IS BY SLUG AND NOT BY COMPONENT. Nine slugs reach three
+ * renderers — six kits and WOW's laptop half go through `ProfileSkin`'s
+ * `sectionHeading` seam, na and Albescent go through `DefaultProfileBody`, and
+ * na and WOW each own a phone skin besides. A sweep that greps a heading
+ * component name reaches one of those three and ships whole archetypes with no
+ * disclosure, which is the failure `factionDetail/__tests__/sectionDisclosure`
+ * was written predicting one surface over. `profile.praxisHeading` and
+ * `profile.proposedTasksHeading` are the only thing every rendering has in
+ * common, so the dispatch is driven and every archetype is really rendered.
+ *
+ * THE PHONE IS NOT A UNIFORM ROW, AND THAT IS THE POINT OF SPLITTING THE WALK.
+ * Six kits draw the same two sections at both widths — `ProfileSkin` restacks,
+ * it does not re-author — so their phone rendering folds. The na and WOW phone
+ * skins draw Praxis and Proposed tasks behind a segmented Chronicles / Quests
+ * switch instead: one gallery is on screen at a time and there is no section
+ * heading to hang a control in, so there is nothing to fold and no fold is
+ * asserted. That asymmetry is pinned below rather than left to be rediscovered
+ * as a hole.
+ *
+ * THE HARNESS HAS NO DOM (`renderToStaticMarkup`, node env), so a press cannot
+ * be simulated. What is reachable is the markup and the `aria-*` wiring, plus
+ * the COLLAPSED rendering — the hook reads storage in a lazy `useState`
+ * initializer, which runs during render, so a stubbed `globalThis.localStorage`
+ * is enough. Whether anything visually collapses is an eyeball question.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+
+import '../../../i18n'
+import i18next from 'i18next'
+import type { CharacterOut } from '../../../api/auth'
+import {
+  FACTION_SECTIONS,
+  PROFILE_SECTIONS,
+  sectionBodyId,
+  serializeCollapsedSections,
+} from '../../factionDetail/sectionDisclosure'
+import { aTask, aPraxisCard } from '../../../test/fixtures'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  MOBILE_QUERY: '(max-width: 767px)',
+  formFactorFor: (matches: boolean) => (matches ? 'mobile' : 'desktop'),
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Loaded after the mock, so the archetypes pick it up.
+const FactionProfileBody = (await import('../FactionProfileBody')).default
+type ProfileBodyProps = import('../FactionProfileBody').ProfileBodyProps
+
+/** The seven bespoke bodies, plus `na` and `albescent` on Default. */
+const SLUGS = [
+  'na',
+  'albescent',
+  'coven',
+  'ephemerists',
+  'everymen',
+  'singularity',
+  'snide',
+  'ua',
+  'wow',
+] as const
+
+/** The archetypes whose PHONE skin is `ProfileSkin` restacked — see the head. */
+const FOLDING_ON_A_PHONE = ['coven', 'ephemerists', 'everymen', 'singularity', 'snide', 'ua']
+
+/** The two that swap the sections for a segmented switch on a phone. */
+const SEGMENTED_ON_A_PHONE = ['na', 'albescent', 'wow']
+
+const PRAXIS = [aPraxisCard({ id: 1 }), aPraxisCard({ id: 2 })]
+const TASKS = [aTask({ id: 1 }), aTask({ id: 2 })]
+
+function character(slug: string): CharacterOut {
+  return {
+    id: 7,
+    username: 'reza',
+    display_name: 'Reza',
+    bio: 'A short bio, so the About block really renders.',
+    tagline: '',
+    avatar_url: '',
+    location: '',
+    level: 7,
+    score: 1880,
+    all_time_score: 2400,
+    faction_slug: slug,
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [{ key: 'sock_puppet', name: 'Sock Puppet' }],
+    invitations: [],
+  }
+}
+
+function page(slug: string): string {
+  const props: ProfileBodyProps = {
+    character: character(slug),
+    submissions: PRAXIS,
+    proposedTasks: TASKS,
+    progression: {
+      nextLevel: 8,
+      currentThreshold: 1500,
+      nextThreshold: 2000,
+      pointsIntoLevel: 380,
+      levelSpan: 500,
+      progressPercent: 76,
+    },
+    identityActions: null,
+  }
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FactionProfileBody {...props} />
+    </MemoryRouter>,
+  )
+}
+
+/** `t` is typed to the literal key union; these are looked up from a table. */
+const translate = i18next.t as unknown as (
+  key: string,
+  options?: Record<string, unknown>,
+) => string
+
+/** The visible heading of each section — the string the aria-label names. */
+const HEADING: Record<(typeof PROFILE_SECTIONS.ids)[number], string> = {
+  praxis: translate('common:profile.praxisHeading'),
+  proposed: translate('common:profile.proposedTasksHeading'),
+}
+
+/** The opening tag of the disclosure button that owns `bodyId`, if any. */
+function disclosureTag(html: string, bodyId: string): string | undefined {
+  return html
+    .match(/<button[^>]*>/g)
+    ?.find((tag) => tag.includes(`aria-controls="${bodyId}"`))
+}
+
+beforeEach(() => {
+  mocks.formFactor = 'desktop'
+})
+
+describe('every profile folds both galleries on a laptop', () => {
+  for (const slug of SLUGS) {
+    for (const section of PROFILE_SECTIONS.ids) {
+      it(`${slug} · ${section} — the heading is a disclosure control`, () => {
+        const html = page(slug)
+        const bodyId = sectionBodyId(PROFILE_SECTIONS, section)
+        const tag = disclosureTag(html, bodyId)
+
+        expect(tag, `${slug}'s ${section} heading draws no disclosure button`).toBeDefined()
+        // Open by default.
+        expect(tag).toContain('aria-expanded="true"')
+        // The label names the state the press moves TO, per the sidebar pair.
+        expect(tag).toContain(
+          `aria-label="${translate('common:sidebar.panel.collapse', { panel: HEADING[section] })}"`,
+        )
+        // …and `aria-controls` resolves to something really in the document.
+        expect(html, `${slug}'s ${section} body carries no ${bodyId}`).toContain(
+          `id="${bodyId}"`,
+        )
+      })
+    }
+  }
+
+  it('leaves About and Badges alone', () => {
+    // The faction ruling one surface over (#2311, applied by #2958): a bio and
+    // a row of marks are not what pushes a profile down, and folding a few
+    // paragraphs saves nothing. Only the two long galleries get a control — so
+    // the count of disclosure buttons is exactly two, on every skin.
+    for (const slug of SLUGS) {
+      const html = page(slug)
+      const controls = html.match(/aria-controls="wz-profile-section-[a-z]+"/g) ?? []
+      expect(controls, `${slug} draws ${controls.length} disclosures`).toHaveLength(2)
+      expect(html, `${slug} still draws its About block`).toContain(
+        translate('common:profile.aboutHeading'),
+      )
+      expect(html, `${slug} still draws its badges`).toContain('Sock Puppet')
+    }
+  })
+
+  it('never reaches for the FACTION surface’s panels', () => {
+    // The two surfaces both have a section called `praxis`. A profile naming a
+    // faction body id would mean the wrong `SectionSurface` was passed, and
+    // every assertion above would still pass.
+    for (const slug of SLUGS) {
+      expect(page(slug), `${slug} mounts a faction panel`).not.toContain(
+        FACTION_SECTIONS.bodyIdPrefix,
+      )
+    }
+  })
+})
+
+describe('the phone rendering folds wherever it draws the two sections', () => {
+  beforeEach(() => {
+    mocks.formFactor = 'mobile'
+  })
+
+  for (const slug of FOLDING_ON_A_PHONE) {
+    it(`${slug} — both galleries fold at 375px too`, () => {
+      const html = page(slug)
+      for (const section of PROFILE_SECTIONS.ids) {
+        const bodyId = sectionBodyId(PROFILE_SECTIONS, section)
+        expect(disclosureTag(html, bodyId), `${slug} · ${section}`).toContain(
+          'aria-expanded="true"',
+        )
+        expect(html).toContain(`id="${bodyId}"`)
+      }
+    })
+  }
+
+  for (const slug of SEGMENTED_ON_A_PHONE) {
+    it(`${slug} — a segmented switch instead, so there is nothing to fold`, () => {
+      const html = page(slug)
+      // Both tabs are there and exactly one gallery is on screen, which is the
+      // bounding gesture a fold would otherwise supply. If this skin is ever
+      // redrawn into two stacked sections, this goes red and the fold is owed.
+      const text = html.replace(/<[^>]*>/g, '')
+      expect(text, `${slug} lost its segmented switch`).toContain(
+        translate('common:profile.mobile.tabPraxis'),
+      )
+      expect(text).toContain(translate('common:profile.mobile.tabTasks'))
+      expect(html, `${slug} grew a half-built disclosure`).not.toContain(
+        PROFILE_SECTIONS.bodyIdPrefix,
+      )
+    })
+  }
+})
+
+describe('a folded gallery is still worth reading', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'localStorage')
+  })
+
+  /** Stored under the signed-out (bare) key — the AuthContext default in this
+   *  harness has no user, which is the fallback the ruling keeps on purpose. */
+  function stubStorage(value: string) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: { getItem: () => value, setItem: () => {} },
+    })
+  }
+
+  it('keeps the heading, the count and the control when collapsed', () => {
+    stubStorage(serializeCollapsedSections(PROFILE_SECTIONS.ids, ['praxis', 'proposed']))
+    for (const slug of SLUGS) {
+      const html = page(slug)
+      const text = html.replace(/<[^>]*>/g, '')
+      expect(text, `${slug} lost a heading when folded`).toContain(HEADING.praxis)
+      expect(text).toContain(HEADING.proposed)
+      // The count beside Proposed tasks is the whole reason a folded section
+      // still reads — it lives in the eyebrow, outside the panel.
+      expect(text, `${slug} lost its task count when folded`).toContain(
+        translate('common:profile.proposedTasksTotal', { count: TASKS.length }),
+      )
+      for (const section of PROFILE_SECTIONS.ids) {
+        const tag = disclosureTag(html, sectionBodyId(PROFILE_SECTIONS, section))
+        expect(tag, `${slug} · ${section}`).toContain('aria-expanded="false"')
+        expect(tag).toContain(
+          `aria-label="${translate('common:sidebar.panel.expand', { panel: HEADING[section] })}"`,
+        )
+      }
+    }
+  })
+
+  it('hides the gallery itself, so the page actually gets shorter', () => {
+    stubStorage(serializeCollapsedSections(PROFILE_SECTIONS.ids, ['praxis']))
+    for (const slug of ['na', 'coven']) {
+      const html = page(slug)
+      // React writes a bare `hidden` on the body it folds, and only on that one.
+      expect(html, slug).toContain(`id="${sectionBodyId(PROFILE_SECTIONS, 'praxis')}" hidden`)
+      expect(html, slug).not.toContain(
+        `id="${sectionBodyId(PROFILE_SECTIONS, 'proposed')}" hidden`,
+      )
+      // The praxis cards really left the flow; the task cards did not.
+      const text = html.replace(/<[^>]*>/g, '')
+      expect(text, `${slug} still shows the folded praxis`).not.toContain(
+        PRAXIS[0].task_title,
+      )
+      expect(text, `${slug} folded the wrong gallery`).toContain(TASKS[0].title)
+    }
+  })
+})

--- a/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
@@ -126,7 +126,7 @@ function Watermark() {
 }
 
 /** Section heading — the display face, a braid, then the gloss. */
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)', flexWrap: 'wrap' }}>
       <span

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -46,6 +46,12 @@ import {
 } from '../../../utils/factions'
 import { factionRoleVars } from '../../../utils/factionRoles'
 import { mediaUrl } from '../../../utils/media'
+import {
+  PROFILE_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from '../../factionDetail/sectionDisclosure'
 import type { ProfileBodyProps } from '../FactionProfileBody'
 // The ② About block and the ① tagline slot are shared with every faction kit —
 // see profileSkin.tsx. This is the one profile that does NOT delegate to
@@ -75,8 +81,14 @@ const EYEBROW: CSSProperties = {
   color: 'var(--color-text-tertiary)',
 }
 
-/** Section heading: display-italic title + optional eyebrow + a soft rainbow rule. */
-function SectionHeading({ title, eyebrow }: { title: string; eyebrow?: string }) {
+/**
+ * Section heading: display-italic title + optional eyebrow + a soft rainbow rule.
+ *
+ * `title` is a NODE because the two gallery headings hand it a `SectionToggle`
+ * (#2958) — the disclosure button has to sit inside this `<h2>` to inherit the
+ * face, the size and the ink. About still passes a plain string.
+ */
+function SectionHeading({ title, eyebrow }: { title: ReactNode; eyebrow?: string }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
       <h2
@@ -278,6 +290,11 @@ function DesktopProfile({
   onSignup,
 }: DefaultProfileBodyProps) {
   const { t } = useTranslation('common')
+  // The two long galleries fold; About and Badges do not (#2958). Only this
+  // branch: `MobileProfile` below draws the same two galleries behind a
+  // segmented switch, so one is on screen at a time and there is no section
+  // heading for a control to live in.
+  const sections = useSectionDisclosures(PROFILE_SECTIONS)
   const badges = character.badges ?? []
   const joined = new Date(character.created_at).toLocaleDateString(undefined, {
     month: 'short',
@@ -296,7 +313,10 @@ function DesktopProfile({
             the line could never not say. `common:profile.praxisEyebrow` stays
             in the catalog — it is the right sentence wherever authorship is
             genuinely in question; this mount is simply not one of them. */}
-        <SectionHeading title={t('profile.praxisHeading')} />
+        <SectionHeading
+          title={<SectionToggle section={sections.praxis} label={t('profile.praxisHeading')} />}
+        />
+        <SectionPanel section={sections.praxis}>
         {submissions.length === 0 ? (
           <div
             style={{
@@ -332,14 +352,24 @@ function DesktopProfile({
             ))}
           </div>
         )}
+        </SectionPanel>
       </section>
 
       {/* ── Proposed tasks (kept feature, #419) ── */}
       <section>
+        {/* The count stays in the EYEBROW, outside the panel: a folded section
+            that still says how much is under it is the whole reason folding is
+            worth doing (#2311's ruling). */}
         <SectionHeading
-          title={t('profile.proposedTasksHeading')}
+          title={
+            <SectionToggle
+              section={sections.proposed}
+              label={t('profile.proposedTasksHeading')}
+            />
+          }
           eyebrow={t('profile.proposedTasksTotal', { count: proposedTasks.length })}
         />
+        <SectionPanel section={sections.proposed}>
         {proposedTasks.length === 0 ? (
           <p className="font-body text-muted">{t('profile.proposedTasksEmpty')}</p>
         ) : (
@@ -349,6 +379,7 @@ function DesktopProfile({
             ))}
           </div>
         )}
+        </SectionPanel>
       </section>
     </div>
   )

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -45,7 +45,7 @@ import { BadgeRow, ProfileSkin, SpectrumLaurel, type ProfileDress } from './prof
 /** Level 0 shows a mid-dot rather than a numeral — the codex's own convention. */
 const romanLevel = (value: number): string => (value > 0 ? toRoman(value) : '\u00b7')
 
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div style={{ fontFamily: MARGINALIA, fontStyle: 'italic', fontSize: 'var(--text-lg)', color: QUIET, marginBottom: 'var(--space-xs)' }}>

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -27,7 +27,7 @@ const PAPER = 'var(--everymen-paper)'
 const BEBAS = 'var(--font-accent)' // Bebas Neue
 const MONO = 'var(--font-body)' // Courier Prime
 
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -54,7 +54,7 @@ const PHOSPHOR_GROUND =
 const SCANLINES =
   `repeating-linear-gradient(to bottom, transparent, transparent 2px, ${phosphor(3)} 2px, ${phosphor(3)} 4px)`
 
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       {/* A prompt with no command is not a prompt (#2231). Six kits dress the

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -58,7 +58,7 @@ const IMPACT = 'var(--faction-snide-font-impact)' // Anton
 const TYPE = 'var(--faction-snide-font-type)' // Special Elite
 const MARKER = 'var(--faction-snide-font-marker)' // Permanent Marker
 
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div

--- a/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
@@ -39,7 +39,7 @@ const PANEL = 'var(--faction-ua-panel)'
 const RULE = 'var(--faction-ua-rule)'
 const HAIR = 'var(--faction-ua-hair)'
 
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -104,7 +104,7 @@ const PLATE_BORDER = 'var(--faction-wow-plate-border)'
 const DISPLAY = 'var(--wow-profile-face)'
 const BODY = 'var(--faction-wow-body-font)'
 
-function heading(title: string, eyebrow: string): ReactNode {
+function heading(title: ReactNode, eyebrow: string): ReactNode {
   return (
     <div style={{ marginBottom: 'var(--space-lg)' }}>
       <div

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -39,6 +39,12 @@ import CredentialCard from '../../../components/CredentialCard'
 import PraxisCard from '../../../components/praxisCard/PraxisCard'
 import TaskCard from '../../../components/taskCard/TaskCard'
 import { mediaUrl } from '../../../utils/media'
+import {
+  PROFILE_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from '../../factionDetail/sectionDisclosure'
 import type { ProfileBodyProps } from '../FactionProfileBody'
 
 /** The costume knobs a faction fills in. Everything is a CSS var reference or
@@ -135,8 +141,21 @@ interface ProfileKit {
   formatLevel?: (level: number) => string
 
   /* ── section headings ── */
-  /** Renders a section heading (⑤ praxis, proposed tasks). */
-  sectionHeading: (title: string, eyebrow: string) => ReactNode
+  /**
+   * Renders a section heading (⑤ praxis, proposed tasks, ② About).
+   *
+   * `title` IS A NODE, NOT A STRING, SINCE #2958. Praxis and Proposed tasks
+   * are disclosures now, and the ARIA pattern for one is a `<button>` — which
+   * has to sit INSIDE the kit's own heading element to inherit its face, size,
+   * tracking and ink (`sectionDisclosure`'s whole posture: button semantics
+   * and a marker, never paint). So the shell hands a `SectionToggle` down this
+   * seam where it used to hand a word, and every kit keeps rendering `{title}`
+   * exactly as it did. About still passes a plain string — `ReactNode` covers
+   * both, which is why one type change fixed six skins.
+   *
+   * A kit may therefore not do string work on this parameter.
+   */
+  sectionHeading: (title: ReactNode, eyebrow: string) => ReactNode
 
   /* ── praxis ── */
   /** Empty-state container style. */
@@ -419,6 +438,10 @@ export function ProfileSkin({
 }) {
   const { t } = useTranslation('common')
   const mobile = useFormFactor() === 'mobile'
+  // The two long galleries fold; About and Badges do not (#2958). One call
+  // here is every kit that mounts this shell, at both form factors — the phone
+  // pass restacks the same two sections rather than re-authoring them.
+  const sections = useSectionDisclosures(PROFILE_SECTIONS)
   /** Every quiet ink INSIDE `<header>` — see `ProfileKit.headerMuted`. */
   const headerMuted = kit.headerMuted ?? kit.muted
   const { character, submissions, proposedTasks, progression, identityActions, onSignup } = props
@@ -466,7 +489,11 @@ export function ProfileSkin({
             sentence wherever authorship is genuinely in question, and this
             mount is simply not one of them. An empty eyebrow is how the About
             block below already asks a kit for a bare heading. */}
-        {kit.sectionHeading(t('profile.praxisHeading'), '')}
+        {kit.sectionHeading(
+          <SectionToggle section={sections.praxis} label={t('profile.praxisHeading')} />,
+          '',
+        )}
+        <SectionPanel section={sections.praxis}>
         {submissions.length === 0 ? (
           <div style={kit.emptyStateStyle}>
             <div
@@ -504,11 +531,22 @@ export function ProfileSkin({
             ))}
           </div>
         )}
+        </SectionPanel>
       </section>
 
       {/* ── Proposed tasks (kept feature, #419) ── */}
       <section>
-        {kit.sectionHeading(t('profile.proposedTasksHeading'), t('profile.proposedTasksTotal', { count: proposedTasks.length }))}
+        {/* The count stays in the EYEBROW, outside the panel: a folded section
+            that still says how much is under it is the whole reason folding is
+            worth doing (#2311's ruling, and the faction suite pins it). */}
+        {kit.sectionHeading(
+          <SectionToggle
+            section={sections.proposed}
+            label={t('profile.proposedTasksHeading')}
+          />,
+          t('profile.proposedTasksTotal', { count: proposedTasks.length }),
+        )}
+        <SectionPanel section={sections.proposed}>
         {proposedTasks.length === 0 ? (
           <p style={{ fontFamily: kit.bodyFont ?? kit.eyebrowFont, color: kit.muted }}>
             {t('profile.proposedTasksEmpty')}
@@ -520,6 +558,7 @@ export function ProfileSkin({
             ))}
           </div>
         )}
+        </SectionPanel>
       </section>
     </div>
   )

--- a/frontend/src/pages/factionDetail/__tests__/defaultFactionPlate.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/defaultFactionPlate.test.tsx
@@ -27,7 +27,7 @@ import type { ReactElement } from "react";
 import { describe, it, expect, vi } from "vitest";
 import "../../../i18n";
 import type { FactionDetailState } from "../useFactionDetail";
-import { factionSectionBodyId } from "../sectionDisclosure";
+import { FACTION_SECTIONS, sectionBodyId } from "../sectionDisclosure";
 import { aTask, aPraxisCard } from "../../../test/fixtures";
 
 const mocks = vi.hoisted(() => ({
@@ -96,7 +96,7 @@ describe("the Default faction body draws real plates (#2497)", () => {
   it("keeps the plate OUTSIDE the disclosure, so a fold hides the gallery alone", () => {
     const html = page(DEFAULT_SLUG);
     for (const id of ["tasks", "praxis"] as const) {
-      const bodyAt = html.indexOf(`id="${factionSectionBodyId(id)}"`);
+      const bodyAt = html.indexOf(`id="${sectionBodyId(FACTION_SECTIONS, id)}"`);
       expect(bodyAt, `${id} has no disclosure body`).toBeGreaterThan(-1);
       const plateAt = html.lastIndexOf('class="faction-plate"', bodyAt);
       const kickerAt = html.lastIndexOf("faction-plate-kicker", bodyAt);

--- a/frontend/src/pages/factionDetail/__tests__/sectionDisclosure.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/sectionDisclosure.test.tsx
@@ -41,10 +41,10 @@ import '../../../i18n'
 import i18next from 'i18next'
 import type { FactionDetailState } from '../useFactionDetail'
 import {
-  FACTION_SECTION_IDS,
-  FACTION_SECTION_STORAGE_KEY,
-  factionSectionStorageKey,
-  factionSectionBodyId,
+  FACTION_SECTIONS,
+  PROFILE_SECTIONS,
+  sectionStorageKey,
+  sectionBodyId,
   resolveCollapsedSections,
   serializeCollapsedSections,
   toggleCollapsedSection,
@@ -115,7 +115,7 @@ const translate = i18next.t as unknown as (
 ) => string
 
 /** The visible heading of each section — the string the aria-label names. */
-const HEADING: Record<(typeof FACTION_SECTION_IDS)[number], string> = {
+const HEADING: Record<(typeof FACTION_SECTIONS.ids)[number], string> = {
   tasks: translate('factions:detail.default.tasksHeading', { total: TASKS.length }),
   praxis: translate('factions:detail.default.recentHeading'),
 }
@@ -134,10 +134,10 @@ function textOf(html: string): string {
 
 describe('every faction folds both galleries', () => {
   for (const slug of SLUGS) {
-    for (const section of FACTION_SECTION_IDS) {
+    for (const section of FACTION_SECTIONS.ids) {
       it(`${slug} · ${section} — the heading is a disclosure control`, () => {
         const html = page(slug)
-        const bodyId = factionSectionBodyId(section)
+        const bodyId = sectionBodyId(FACTION_SECTIONS, section)
         const tag = disclosureTag(html, bodyId)
 
         expect(tag, `${slug}'s ${section} heading draws no disclosure button`).toBeDefined()
@@ -191,9 +191,9 @@ describe('the disclosure marker is a hairline on every face', () => {
   }
 
   for (const slug of SLUGS) {
-    for (const section of FACTION_SECTION_IDS) {
+    for (const section of FACTION_SECTIONS.ids) {
       it(`${slug} · ${section} — 1px, butt cap, miter join`, () => {
-        const markup = disclosureMarkup(page(slug), factionSectionBodyId(section))
+        const markup = disclosureMarkup(page(slug), sectionBodyId(FACTION_SECTIONS, section))
         expect(markup, `${slug}'s ${section} disclosure never closes`).toBeDefined()
 
         expect(markup).toContain('stroke-width="1"')
@@ -215,8 +215,8 @@ describe('the disclosure marker is a hairline on every face', () => {
     // disclosure control, however tempting the one-line version looks.
     for (const slug of SLUGS) {
       const html = page(slug)
-      for (const section of FACTION_SECTION_IDS) {
-        const markup = disclosureMarkup(html, factionSectionBodyId(section))
+      for (const section of FACTION_SECTIONS.ids) {
+        const markup = disclosureMarkup(html, sectionBodyId(FACTION_SECTIONS, section))
         expect(markup, `${slug} · ${section}`).toContain('<svg')
         for (const glyph of ['\u203a', '\u276f', '\u3009', '\u00bb']) {
           expect(markup, `${slug} · ${section} draws a glyph marker`).not.toContain(
@@ -243,7 +243,7 @@ describe('a folded section is still worth reading', () => {
   }
 
   it('keeps the heading, the count and the control when collapsed', () => {
-    stubStorage(serializeCollapsedSections(['tasks', 'praxis']))
+    stubStorage(serializeCollapsedSections(FACTION_SECTIONS.ids, ['tasks', 'praxis']))
     for (const slug of SLUGS) {
       const html = page(slug)
       // The count is the whole reason a folded section still reads.
@@ -251,8 +251,8 @@ describe('a folded section is still worth reading', () => {
         HEADING.tasks,
       )
       expect(textOf(html)).toContain(HEADING.praxis)
-      for (const section of FACTION_SECTION_IDS) {
-        const tag = disclosureTag(html, factionSectionBodyId(section))
+      for (const section of FACTION_SECTIONS.ids) {
+        const tag = disclosureTag(html, sectionBodyId(FACTION_SECTIONS, section))
         expect(tag, `${slug} · ${section}`).toContain('aria-expanded="false"')
         expect(tag).toContain(
           `aria-label="${translate('common:sidebar.panel.expand', { panel: HEADING[section] })}"`,
@@ -262,11 +262,11 @@ describe('a folded section is still worth reading', () => {
   })
 
   it('hides the gallery itself, so the page actually gets shorter', () => {
-    stubStorage(serializeCollapsedSections(['tasks']))
+    stubStorage(serializeCollapsedSections(FACTION_SECTIONS.ids, ['tasks']))
     const html = page('albescent')
     // React writes a bare `hidden` on the body it folds, and only on that one.
-    expect(html).toContain(`id="${factionSectionBodyId('tasks')}" hidden`)
-    expect(html).not.toContain(`id="${factionSectionBodyId('praxis')}" hidden`)
+    expect(html).toContain(`id="${sectionBodyId(FACTION_SECTIONS, 'tasks')}" hidden`)
+    expect(html).not.toContain(`id="${sectionBodyId(FACTION_SECTIONS, 'praxis')}" hidden`)
   })
 })
 
@@ -278,38 +278,74 @@ describe('a folded section is still worth reading', () => {
  */
 describe('the fold follows the account, not the browser', () => {
   it('appends the account id to the base key, like the rail does', () => {
-    expect(factionSectionStorageKey(7)).toBe(`${FACTION_SECTION_STORAGE_KEY}:7`)
-    expect(factionSectionStorageKey(8)).not.toBe(factionSectionStorageKey(7))
+    expect(sectionStorageKey(FACTION_SECTIONS.storageKey, 7)).toBe(`${FACTION_SECTIONS.storageKey}:7`)
+    expect(sectionStorageKey(FACTION_SECTIONS.storageKey, 8)).not.toBe(sectionStorageKey(FACTION_SECTIONS.storageKey, 7))
   })
 
   it('falls back to the bare key before the account is known', () => {
     // A faction page renders while `/auth/me` is still in flight, and for a
     // signed-out visitor it never resolves at all.
-    expect(factionSectionStorageKey(null)).toBe(FACTION_SECTION_STORAGE_KEY)
-    expect(factionSectionStorageKey(undefined)).toBe(FACTION_SECTION_STORAGE_KEY)
+    expect(sectionStorageKey(FACTION_SECTIONS.storageKey, null)).toBe(FACTION_SECTIONS.storageKey)
+    expect(sectionStorageKey(FACTION_SECTIONS.storageKey, undefined)).toBe(FACTION_SECTIONS.storageKey)
   })
 
   it('opens everything rather than breaking on junk', () => {
     for (const stored of [null, '', 'not json', '{}', '[1,2]', '["nope"]']) {
-      expect(resolveCollapsedSections(stored)).toEqual([])
+      expect(resolveCollapsedSections(FACTION_SECTIONS.ids, stored)).toEqual([])
     }
   })
 
   it('round-trips a stored fold', () => {
-    expect(resolveCollapsedSections(serializeCollapsedSections(['praxis']))).toEqual([
+    expect(resolveCollapsedSections(FACTION_SECTIONS.ids, serializeCollapsedSections(FACTION_SECTIONS.ids, ['praxis']))).toEqual([
       'praxis',
     ])
   })
 
   it('serializes in a stable order, whatever order they were folded in', () => {
-    expect(serializeCollapsedSections(['praxis', 'tasks'])).toBe(
-      serializeCollapsedSections(['tasks', 'praxis']),
+    expect(serializeCollapsedSections(FACTION_SECTIONS.ids, ['praxis', 'tasks'])).toBe(
+      serializeCollapsedSections(FACTION_SECTIONS.ids, ['tasks', 'praxis']),
     )
   })
 
   it('toggles one section without disturbing the other', () => {
-    expect(toggleCollapsedSection([], 'tasks')).toEqual(['tasks'])
-    expect(toggleCollapsedSection(['tasks'], 'praxis')).toEqual(['tasks', 'praxis'])
-    expect(toggleCollapsedSection(['tasks', 'praxis'], 'tasks')).toEqual(['praxis'])
+    expect(toggleCollapsedSection(FACTION_SECTIONS.ids, [], 'tasks')).toEqual(['tasks'])
+    expect(toggleCollapsedSection(FACTION_SECTIONS.ids, ['tasks'], 'praxis')).toEqual(['tasks', 'praxis'])
+    expect(toggleCollapsedSection(FACTION_SECTIONS.ids, ['tasks', 'praxis'], 'tasks')).toEqual(['praxis'])
+  })
+})
+
+/**
+ * #2958 generalised this primitive so a character profile could reuse it. The
+ * ruling was explicit that the two surfaces get SEPARATE keys — folding Praxis
+ * on a faction page must not fold Praxis on every profile — and both surfaces
+ * happen to have a section called `praxis`, which is exactly the shape that
+ * makes a shared key look harmless and behave otherwise.
+ *
+ * This suite is what a "tidy it into one key" refactor has to argue with.
+ */
+describe('the two surfaces are kept apart', () => {
+  it('remembers each surface under its own key', () => {
+    expect(PROFILE_SECTIONS.storageKey).not.toBe(FACTION_SECTIONS.storageKey)
+    // Nor may one be a prefix of the other: the account id is appended, so a
+    // pair like `wz-faction-sections` / `wz-faction-sections-profile` would
+    // collide for anything that ever walks these keys by prefix.
+    expect(PROFILE_SECTIONS.storageKey.startsWith(FACTION_SECTIONS.storageKey)).toBe(false)
+    expect(FACTION_SECTIONS.storageKey.startsWith(PROFILE_SECTIONS.storageKey)).toBe(false)
+  })
+
+  it('names each panel apart, though both surfaces have a praxis', () => {
+    expect(FACTION_SECTIONS.ids).toContain('praxis')
+    expect(PROFILE_SECTIONS.ids).toContain('praxis')
+    expect(sectionBodyId(PROFILE_SECTIONS, 'praxis')).not.toBe(
+      sectionBodyId(FACTION_SECTIONS, 'praxis'),
+    )
+  })
+
+  it('ignores a blob written by the other surface', () => {
+    // Belt and braces on the ruling: even if the keys were ever shared by
+    // accident, a profile's fold cannot fold a faction's Tasks, because
+    // resolving filters against the ASKING surface's own ids.
+    const profileFold = serializeCollapsedSections(PROFILE_SECTIONS.ids, ['proposed'])
+    expect(resolveCollapsedSections(FACTION_SECTIONS.ids, profileFold)).toEqual([])
   })
 })

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -31,7 +31,12 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -129,7 +134,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   if (!faction) return null;
 

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -8,7 +8,12 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { MobileStickyBar } from "../MobileStickyBar";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
 
@@ -143,7 +148,7 @@ export default function DefaultFactionBody({
     membership,
   } = state;
   const phone = useFormFactor() === "mobile";
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   // Guarded non-null by the dispatcher.
   if (!faction) return null;

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -31,7 +31,12 @@ import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -173,7 +178,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   if (!faction) return null;
 

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -9,7 +9,12 @@ import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -230,7 +235,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   if (!faction) return null;
 

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -10,7 +10,12 @@ import { factionRoleVars } from "../../../utils/factionRoles";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -181,7 +186,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   if (!faction) return null;
 

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -9,7 +9,12 @@ import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -323,7 +328,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   if (!faction) return null;
 

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -16,7 +16,12 @@ import { factionName, factionDescription } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -172,7 +177,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
   const burned = membership.state === "burned";
 
   if (!faction) return null;

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -11,7 +11,12 @@ import { factionRoleVars } from "../../../utils/factionRoles";
 import { computeFactionMultiplier } from "../../../utils/points";
 import type { CharacterOut } from "../../../api/auth";
 import { JoinControl, type JoinControlSkin } from "../../../components/JoinControl";
-import { SectionPanel, SectionToggle, useFactionSections } from "../sectionDisclosure";
+import {
+  FACTION_SECTIONS,
+  SectionPanel,
+  SectionToggle,
+  useSectionDisclosures,
+} from "../sectionDisclosure";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /**
@@ -118,7 +123,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
     onSignup,
     membership,
   } = state;
-  const sections = useFactionSections();
+  const sections = useSectionDisclosures(FACTION_SECTIONS);
 
   // Guarded non-null by the dispatcher.
   if (!faction) return null;

--- a/frontend/src/pages/factionDetail/sectionDisclosure.tsx
+++ b/frontend/src/pages/factionDetail/sectionDisclosure.tsx
@@ -1,36 +1,57 @@
 /**
- * The Tasks / Praxis disclosures on a faction detail page (#2311).
+ * The gallery disclosures — Tasks / Praxis on a faction detail page (#2311),
+ * Praxis / Proposed tasks on a character profile (#2958).
  *
  * A faction with a dozen tasks pushed everything under it off the screen: two
- * unbounded card grids, no way to fold either. This is the ONE primitive all
- * eight archetypes consume — the shape is unified, the components are not, which
- * is the #1911 precedent and what `frontend/CLAUDE.md` requires ("each faction
- * has its own card archetype; don't unify"). Each skin keeps its own heading
- * component, rule ornament and colour and simply passes its heading text
- * through {@link SectionToggle}; this file supplies the button semantics and the
- * marker, never the paint.
+ * unbounded card grids, no way to fold either. A profile with a lot of praxis
+ * does the same thing, which is why the primitive generalised rather than being
+ * copied — a SURFACE now declares its own {@link SectionSurface} (which
+ * galleries, which storage key, which body-id prefix) and everything below is
+ * neutral about who is asking.
  *
- * WHAT IS *NOT* COLLAPSIBLE, and why it is not an oversight. The Charter, The
- * Roll and Members have no disclosure. That is the sidebar's own ruling
- * (2026-08-02, `hooks/useSidebarPanelLayout.ts`) applied one surface over:
- * collapsing is the one gesture that can silently swallow an obligation, so a
- * panel that exists to tell you somebody is waiting on you is not hideable. The
- * Roll is how a player JOINS, and on the gate state it is how they learn why
- * they cannot. The Charter is a few paragraphs — folding it saves nothing.
+ * SEPARATE KEYS, DELIBERATELY. Folding Praxis on a faction page must not fold
+ * Praxis on every character profile: they are different objects that happen to
+ * share a word. One shared key would have been a line shorter and wrong.
+ *
+ * This is the ONE primitive every archetype consumes — the shape is unified, the
+ * components are not, which is the #1911 precedent and what `frontend/CLAUDE.md`
+ * requires ("each faction has its own card archetype; don't unify"). Each skin
+ * keeps its own heading component, rule ornament and colour and simply passes
+ * its heading text through {@link SectionToggle}; this file supplies the button
+ * semantics and the marker, never the paint. On the profile that pass-through is
+ * `ProfileKit.sectionHeading`, which is why six skins got the fold from one edit.
+ *
+ * WHAT IS *NOT* COLLAPSIBLE, and why it is not an oversight. On a faction page:
+ * the Charter, The Roll and Members. On a profile: About and Badges. That is the
+ * sidebar's own ruling (2026-08-02, `hooks/useSidebarPanelLayout.ts`) applied
+ * two surfaces over: collapsing is the one gesture that can silently swallow an
+ * obligation, so a panel that exists to tell you somebody is waiting on you is
+ * not hideable. The Roll is how a player JOINS, and on the gate state it is how
+ * they learn why they cannot. The Charter is a few paragraphs — folding it saves
+ * nothing, and neither About (a bio) nor Badges (a row of marks) is what pushes
+ * a profile down; the two unbounded galleries are.
+ *
+ * WHAT IS NOT COLLAPSIBLE FOR A DIFFERENT REASON: the na and WOW phone skins.
+ * Both draw Praxis and Proposed tasks behind a segmented Chronicles / Quests
+ * switch rather than as two stacked sections, so exactly one gallery is ever on
+ * screen and there is no section heading to hang a control in. A fold on top of
+ * that is a second mechanism answering a question the switch already answers.
+ * Every OTHER phone rendering does fold: `ProfileSkin` draws the same two
+ * sections at both widths.
  *
  * WHY NOT `<details>` / `<summary>`. It was the first thing tried, and it loses
  * on two counts that are not stylistic. (1) `<details>` requires the folded
- * content to be a DOM DESCENDANT of the element carrying the marker, and in all
- * eight skins the heading is a sibling of the gallery inside a bespoke flex
- * column — adopting it means restructuring sixteen call sites' JSX nesting and
- * re-testing eight layouts, against two props here. (2) The issue asks for
+ * content to be a DOM DESCENDANT of the element carrying the marker, and in
+ * every skin the heading is a sibling of the gallery inside a bespoke flex
+ * column — adopting it means restructuring every call site's JSX nesting and
+ * re-testing every layout, against two props here. (2) The issue asks for
  * explicit `aria-expanded` + `aria-controls`, and `<summary>` gives neither: its
  * expanded state is implicit and browser-owned, there is no separately
  * identified region for `aria-controls` to point at, and authoring
  * `aria-expanded` on a `<summary>` is contradicted by the element's own
  * mapping. A `<button>` is what the ARIA disclosure pattern actually is, and it
  * is what the rail already ships. (`<summary>`'s default marker and
- * `display: list-item` would also need CSS resets across eight skins, and CSS
+ * `display: list-item` would also need CSS resets across every skin, and CSS
  * belongs to another agent — a smaller point, but a real one.)
  *
  * THE STORAGE IDIOM IS THE RAIL'S, UNCHANGED: a pure resolver, a lazy
@@ -40,15 +61,16 @@
  * them there would put them in the rail's blob and in its collapsible ruling.
  *
  * WHY THE DECISIONS BELOW ARE EXPORTED WHEN ONLY A TEST IMPORTS THEM. A
- * dead-export audit (#2693) listed `FACTION_SECTION_IDS`,
- * `factionSectionStorageKey`, `factionSectionBodyId`,
- * `resolveCollapsedSections`, `serializeCollapsedSections` and
- * `toggleCollapsedSection` as reachable only from `__tests__`. True, and not a
+ * dead-export audit (#2693) listed the ids constant, the storage-key resolver,
+ * the body-id resolver, `resolveCollapsedSections`,
+ * `serializeCollapsedSections` and `toggleCollapsedSection` as reachable only
+ * from `__tests__` (#2958 renamed the first three; `FACTION_SECTIONS` is now a
+ * real import in `settings/sections/CookiesSection.tsx` besides). True, and not a
  * defect — they are the only seam this harness can reach. `vite.config.ts`
  * declares vitest with no `environment`, so tests run in node: no jsdom, no
  * click events, no `localStorage`, effects never run, and every test is one
- * `renderToStaticMarkup` pass. `useFactionSections` cannot be mounted and
- * toggled here, so what a stored blob is allowed to be, what junk it tolerates,
+ * `renderToStaticMarkup` pass. {@link useSectionDisclosures} cannot be mounted
+ * and toggled here, so what a stored blob is allowed to be, what junk it tolerates,
  * and the `aria-controls` id that must match the panel it names are asserted on
  * these or not at all. Owner ruling 2026-08-28 on #2693: keep them, note why —
  * if the harness ever gains a DOM they become re-examinable, and until then an
@@ -58,33 +80,61 @@ import { useCallback, useState, type CSSProperties, type ReactNode } from "react
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../../auth/AuthContext";
 
-/** The two long galleries, in page order. */
-export const FACTION_SECTION_IDS = ["tasks", "praxis"] as const;
+/**
+ * Everything a surface has to declare to own a set of disclosures. Three
+ * fields, all of them things a second surface has to differ on: WHICH galleries
+ * fold, WHERE the preference is remembered, and what its panels are called.
+ *
+ * The body-id prefix is not derived from the storage key on purpose. It is the
+ * `aria-controls` target — a published, referenced name — and deriving it would
+ * couple a screen reader's reference to a storage key's spelling.
+ */
+export interface SectionSurface<Id extends string = string> {
+  /** The long galleries this surface can fold, in page order. */
+  readonly ids: readonly Id[];
+  /** Base key; the account id is appended, exactly as the rail's is. */
+  readonly storageKey: string;
+  /** Prefixes the id each panel carries — see {@link sectionBodyId}. */
+  readonly bodyIdPrefix: string;
+}
 
-type FactionSectionId = (typeof FACTION_SECTION_IDS)[number];
+/** A faction detail page: its task grid and its recent-praxis grid (#2311). */
+export const FACTION_SECTIONS = {
+  ids: ["tasks", "praxis"],
+  storageKey: "wz-faction-sections",
+  bodyIdPrefix: "wz-faction-section",
+} as const satisfies SectionSurface;
 
-/** Base key; the account id is appended, exactly as the rail's is. */
-export const FACTION_SECTION_STORAGE_KEY = "wz-faction-sections";
+/** A character profile: its praxis gallery and its proposed-task row (#2958). */
+export const PROFILE_SECTIONS = {
+  ids: ["praxis", "proposed"],
+  storageKey: "wz-profile-sections",
+  bodyIdPrefix: "wz-profile-section",
+} as const satisfies SectionSurface;
 
 /**
- * The account's storage key.
+ * The account's storage key, for whichever base key it is handed.
  *
- * Unlike the rail, this surface renders for a signed-out visitor and for the
- * window while `/auth/me` is still in flight, so the bare-key fallback is a
- * state a player really reaches rather than only the DOM-less render. The hook
- * below re-reads when the id arrives, which is why that is harmless.
+ * Unlike the rail, both of these surfaces render for a signed-out visitor and
+ * for the window while `/auth/me` is still in flight, so the bare-key fallback
+ * is a state a player really reaches rather than only the DOM-less render. The
+ * hook below re-reads when the id arrives, which is why that is harmless.
  */
-export function factionSectionStorageKey(
+export function sectionStorageKey(
+  baseKey: string,
   accountId: number | null | undefined,
 ): string {
   return accountId === null || accountId === undefined
-    ? FACTION_SECTION_STORAGE_KEY
-    : `${FACTION_SECTION_STORAGE_KEY}:${accountId}`;
+    ? baseKey
+    : `${baseKey}:${accountId}`;
 }
 
 /** The id a section's body carries and its disclosure points `aria-controls` at. */
-export function factionSectionBodyId(id: FactionSectionId): string {
-  return `wz-faction-section-${id}`;
+export function sectionBodyId<Id extends string>(
+  surface: SectionSurface<Id>,
+  id: Id,
+): string {
+  return `${surface.bodyIdPrefix}-${id}`;
 }
 
 /**
@@ -92,12 +142,15 @@ export function factionSectionBodyId(id: FactionSectionId): string {
  * the repo's DOM-less node env, as `resolveInitialPanelLayout` is.
  *
  * Every failure mode resolves to OPEN: junk, non-JSON, a non-array, or an id
- * this build no longer has. Nothing a stale value can say may leave a player
- * looking at a page whose galleries are gone with no control to bring them back.
+ * this build no longer has — including an id belonging to a DIFFERENT surface,
+ * which is what makes a mistakenly shared key merely inert rather than
+ * confusing. Nothing a stale value can say may leave a player looking at a page
+ * whose galleries are gone with no control to bring them back.
  */
-export function resolveCollapsedSections(
+export function resolveCollapsedSections<Id extends string>(
+  ids: readonly Id[],
   stored: string | null,
-): readonly FactionSectionId[] {
+): readonly Id[] {
   if (!stored) return [];
   let parsed: unknown;
   try {
@@ -108,60 +161,66 @@ export function resolveCollapsedSections(
   if (!Array.isArray(parsed)) return [];
   // Normalized to page order, so the serialized value does not depend on the
   // order the player folded them in.
-  return FACTION_SECTION_IDS.filter((id) => parsed.includes(id));
+  return ids.filter((id) => parsed.includes(id));
 }
 
-export function serializeCollapsedSections(
-  collapsed: readonly FactionSectionId[],
+export function serializeCollapsedSections<Id extends string>(
+  ids: readonly Id[],
+  collapsed: readonly Id[],
 ): string {
-  return JSON.stringify(FACTION_SECTION_IDS.filter((id) => collapsed.includes(id)));
+  return JSON.stringify(ids.filter((id) => collapsed.includes(id)));
 }
 
-export function toggleCollapsedSection(
-  collapsed: readonly FactionSectionId[],
-  id: FactionSectionId,
-): readonly FactionSectionId[] {
+export function toggleCollapsedSection<Id extends string>(
+  ids: readonly Id[],
+  collapsed: readonly Id[],
+  id: Id,
+): readonly Id[] {
   return collapsed.includes(id)
     ? collapsed.filter((entry) => entry !== id)
-    : FACTION_SECTION_IDS.filter((entry) => entry === id || collapsed.includes(entry));
+    : ids.filter((entry) => entry === id || collapsed.includes(entry));
 }
 
 /** One section's disclosure: what the heading needs and what the body needs. */
-interface FactionSection {
+interface SectionDisclosure {
   readonly open: boolean;
   readonly bodyId: string;
   readonly toggle: () => void;
 }
 
-function read(storageKey: string): readonly FactionSectionId[] {
+function read<Id extends string>(
+  surface: SectionSurface<Id>,
+  storageKey: string,
+): readonly Id[] {
   try {
-    return resolveCollapsedSections(localStorage.getItem(storageKey));
+    return resolveCollapsedSections(surface.ids, localStorage.getItem(storageKey));
   } catch {
     return [];
   }
 }
 
 /**
- * The disclosure state for one faction page. Called once per archetype — a page
- * mounts exactly one body, so the two sections need no shared context.
+ * The disclosure state for one page of one surface. Called once per archetype —
+ * a page mounts exactly one body, so its sections need no shared context.
  *
- * ponytail: the preference is per ACCOUNT, not per account × faction. Folding
- * Tasks on one faction page folds it on all of them, which is the rail's own
- * reading of what a fold is — chrome, a standing preference about a KIND of
- * section, not a fact about one faction. If that ever wants to be per faction,
- * the stored value becomes a `Record<slug, FactionSectionId[]>` and the hook
- * takes the slug; nothing at the sixteen call sites changes.
+ * ponytail: the preference is per ACCOUNT × SURFACE, not per account × page.
+ * Folding Tasks on one faction page folds it on all of them, and folding Praxis
+ * on one profile folds it on every profile; that is the rail's own reading of
+ * what a fold is — chrome, a standing preference about a KIND of section, not a
+ * fact about one faction or one player. If that ever wants to be per page, the
+ * stored value becomes a `Record<slug, Id[]>` and the hook takes the slug;
+ * nothing at the call sites changes.
  */
-export function useFactionSections(): Readonly<
-  Record<FactionSectionId, FactionSection>
-> {
+export function useSectionDisclosures<Id extends string>(
+  surface: SectionSurface<Id>,
+): Readonly<Record<Id, SectionDisclosure>> {
   const { user } = useAuth();
-  const storageKey = factionSectionStorageKey(user?.account_id);
+  const storageKey = sectionStorageKey(surface.storageKey, user?.account_id);
 
   const [stored, setStored] = useState<{
     key: string;
-    collapsed: readonly FactionSectionId[];
-  }>(() => ({ key: storageKey, collapsed: read(storageKey) }));
+    collapsed: readonly Id[];
+  }>(() => ({ key: storageKey, collapsed: read(surface, storageKey) }));
 
   // `/auth/me` resolves AFTER the first render, so the initializer above ran
   // against the bare key and the account's own fold has not been read yet.
@@ -169,15 +228,18 @@ export function useFactionSections(): Readonly<
   // answer to "state derived from a prop that changed" — an effect would paint
   // the sections open first and snap them shut afterwards.
   if (stored.key !== storageKey) {
-    setStored({ key: storageKey, collapsed: read(storageKey) });
+    setStored({ key: storageKey, collapsed: read(surface, storageKey) });
   }
 
   const toggle = useCallback(
-    (id: FactionSectionId) => {
+    (id: Id) => {
       setStored((previous) => {
-        const collapsed = toggleCollapsedSection(previous.collapsed, id);
+        const collapsed = toggleCollapsedSection(surface.ids, previous.collapsed, id);
         try {
-          localStorage.setItem(previous.key, serializeCollapsedSections(collapsed));
+          localStorage.setItem(
+            previous.key,
+            serializeCollapsedSections(surface.ids, collapsed),
+          );
         } catch {
           // A browser refusing storage (private mode, quota) must not cost the
           // player the gesture — the fold still holds for this session.
@@ -185,16 +247,23 @@ export function useFactionSections(): Readonly<
         return { key: previous.key, collapsed };
       });
     },
-    [],
+    [surface],
   );
 
-  const section = (id: FactionSectionId): FactionSection => ({
-    open: !stored.collapsed.includes(id),
-    bodyId: factionSectionBodyId(id),
-    toggle: () => toggle(id),
-  });
-
-  return { tasks: section("tasks"), praxis: section("praxis") };
+  // `Object.fromEntries` cannot keep the key union, and the whole value of this
+  // hook at a call site is that `sections.praxis` is a compile error on a
+  // surface with no praxis. The cast is that union being asserted back on, over
+  // an object built from `surface.ids` one line above.
+  return Object.fromEntries(
+    surface.ids.map((id) => [
+      id,
+      {
+        open: !stored.collapsed.includes(id),
+        bodyId: sectionBodyId(surface, id),
+        toggle: () => toggle(id),
+      },
+    ]),
+  ) as Record<Id, SectionDisclosure>;
 }
 
 /**
@@ -219,7 +288,7 @@ export function SectionToggle({
   section,
   label,
 }: {
-  readonly section: FactionSection;
+  readonly section: SectionDisclosure;
   /** The heading's own text — the visible label AND the accessible name. */
   readonly label: string;
 }) {
@@ -271,7 +340,7 @@ export function SectionPanel({
   section,
   children,
 }: {
-  readonly section: FactionSection;
+  readonly section: SectionDisclosure;
   readonly children: ReactNode;
 }) {
   return (

--- a/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
+++ b/frontend/src/pages/settings/__tests__/cookiesSection.test.tsx
@@ -48,7 +48,7 @@ import { MOTION_STORAGE_KEY } from '../../../hooks/useMotion'
 import { SIDEBAR_COLLAPSED_STORAGE_KEY } from '../../../hooks/useSidebarCollapsed'
 import { SIDEBAR_PANEL_LAYOUT_STORAGE_KEY } from '../../../hooks/useSidebarPanelLayout'
 import { THEME_STORAGE_KEY } from '../../../hooks/useTheme'
-import { FACTION_SECTION_STORAGE_KEY } from '../../factionDetail/sectionDisclosure'
+import { FACTION_SECTIONS, PROFILE_SECTIONS } from '../../factionDetail/sectionDisclosure'
 import { ONBOARDING_HANDOFF_KEY } from '../../../utils/onboardingResume'
 import { SETTINGS_SECTIONS } from '../../Settings'
 import { sourceFiles } from '../../../test/sourceScan'
@@ -113,8 +113,8 @@ describe('nothing writes to a browser store without being disclosed', () => {
 })
 
 describe('the inventory is pinned to the keys the app really writes', () => {
-  it('discloses all ten storage entries and the one cookie', () => {
-    expect(names).toHaveLength(11)
+  it('discloses all eleven storage entries and the one cookie', () => {
+    expect(names).toHaveLength(12)
   })
 
   it.each([
@@ -124,7 +124,10 @@ describe('the inventory is pinned to the keys the app really writes', () => {
     ['admin mode', ADMIN_MODE_STORAGE_KEY],
     ['sidebar collapse', SIDEBAR_COLLAPSED_STORAGE_KEY],
     ['sidebar panels', SIDEBAR_PANEL_LAYOUT_STORAGE_KEY],
-    ['faction sections', FACTION_SECTION_STORAGE_KEY],
+    ['faction sections', FACTION_SECTIONS.storageKey],
+    // #2958: one module writes both, so the census above sees one writer and
+    // would stay green with this key undisclosed. Named here on purpose.
+    ['profile sections', PROFILE_SECTIONS.storageKey],
     ['seen invites', SEEN_INVITES_KEY_PREFIX],
     ['last seen level', LAST_SEEN_LEVEL_KEY_PREFIX],
     ['onboarding handoff', ONBOARDING_HANDOFF_KEY],
@@ -132,11 +135,12 @@ describe('the inventory is pinned to the keys the app really writes', () => {
     expect(names).toContain(key)
   })
 
-  it('marks the four families as families, not as single values', () => {
+  it('marks the five families as families, not as single values', () => {
     const families = STORED_ENTRIES.filter((entry) => entry.family).map((entry) => entry.name)
     expect(families).toEqual([
       SIDEBAR_PANEL_LAYOUT_STORAGE_KEY,
-      FACTION_SECTION_STORAGE_KEY,
+      FACTION_SECTIONS.storageKey,
+      PROFILE_SECTIONS.storageKey,
       SEEN_INVITES_KEY_PREFIX,
       LAST_SEEN_LEVEL_KEY_PREFIX,
     ])
@@ -266,7 +270,8 @@ describe('the disclosed list, once opened', () => {
     expect(body).toContain(`${SEEN_INVITES_KEY_PREFIX}[character id]`)
     expect(body).toContain(`${LAST_SEEN_LEVEL_KEY_PREFIX}[character id]`)
     expect(body).toContain(`${SIDEBAR_PANEL_LAYOUT_STORAGE_KEY}[:account id]`)
-    expect(body).toContain(`${FACTION_SECTION_STORAGE_KEY}[:account id]`)
+    expect(body).toContain(`${FACTION_SECTIONS.storageKey}[:account id]`)
+    expect(body).toContain(`${PROFILE_SECTIONS.storageKey}[:account id]`)
   })
 
   it('prints resolved copy beside each key, never a raw catalog path', () => {

--- a/frontend/src/pages/settings/sections/CookiesSection.tsx
+++ b/frontend/src/pages/settings/sections/CookiesSection.tsx
@@ -9,7 +9,7 @@ import { MOTION_STORAGE_KEY } from '../../../hooks/useMotion'
 import { SIDEBAR_COLLAPSED_STORAGE_KEY } from '../../../hooks/useSidebarCollapsed'
 import { SIDEBAR_PANEL_LAYOUT_STORAGE_KEY } from '../../../hooks/useSidebarPanelLayout'
 import { THEME_STORAGE_KEY } from '../../../hooks/useTheme'
-import { FACTION_SECTION_STORAGE_KEY } from '../../factionDetail/sectionDisclosure'
+import { FACTION_SECTIONS, PROFILE_SECTIONS } from '../../factionDetail/sectionDisclosure'
 import { ONBOARDING_HANDOFF_KEY } from '../../../utils/onboardingResume'
 import type { SettingsSectionProps } from '../../Settings'
 import SettingsCard from '../SettingsCard'
@@ -30,7 +30,7 @@ import SettingsSwitch from '../SettingsSwitch'
  *
  * WHY LOCAL STORAGE IS ON A CARD TITLED "COOKIES". It is not a cookie, but it
  * is the same category under ePrivacy and it is *most* of what World Zero
- * actually keeps — one cookie against ten storage entries. A cookies-only card
+ * actually keeps — one cookie against eleven storage entries. A cookies-only card
  * would make the site look like it stores less than it does.
  *
  * ALL THREE SWITCHES RENDER, ALL THREE ARE INERT (owner ruling, 2026-08-17).
@@ -50,7 +50,7 @@ import SettingsSwitch from '../SettingsSwitch'
  * three families whose keys are built at runtime.
  */
 
-/** The four keys the app builds by suffixing an id onto a base. */
+/** The five keys the app builds by suffixing an id onto a base. */
 type KeyFamily = 'account' | 'character'
 
 interface StoredEntry {
@@ -116,9 +116,19 @@ export const STORED_ENTRIES: readonly StoredEntry[] = [
     whereKey: BROWSER_WHERE,
   },
   {
-    name: FACTION_SECTION_STORAGE_KEY,
+    name: FACTION_SECTIONS.storageKey,
     family: 'account',
     purposeKey: 'settings.cookies.entries.factionSections',
+    whereKey: BROWSER_WHERE,
+  },
+  {
+    // ONE writer, TWO keys (#2958). `sectionDisclosure` is the one module that
+    // writes both, so the census below — which finds writers by their
+    // `setItem` call — cannot tell them apart and would keep passing with this
+    // line missing. The second surface has to be disclosed by hand.
+    name: PROFILE_SECTIONS.storageKey,
+    family: 'account',
+    purposeKey: 'settings.cookies.entries.profileSections',
     whereKey: BROWSER_WHERE,
   },
   {


### PR DESCRIPTION
Closes #2958

A character profile stacked Praxis and Proposed tasks as unbounded card galleries with no way to fold either. #2311 built the primitive for exactly this on the faction pages; this generalises it rather than copying it, per the owner ruling of 2026-08-28.

## The seam I tested at

`FactionProfileBody` × the profile's two galleries, walked by **slug × form factor** — the real archetype dispatch, driven off `profile.praxisHeading` / `profile.proposedTasksHeading`, because nine slugs reach three different renderers and a sweep that greps a heading component name reaches one of them and ships the rest with no disclosure. That is the failure `factionDetail/__tests__/sectionDisclosure.test.tsx` was written predicting one surface over.

The loop went red first at that seam: 27 failures across the nine archetypes, and the only three assertions that passed on the red run were the ones asserting what is deliberately *absent* (below).

New file: `frontend/src/pages/characterProfile/__tests__/profileSectionDisclosure.test.tsx` (31 tests).

## What changed

**The primitive generalised** — `pages/factionDetail/sectionDisclosure.tsx`. A surface now declares a `SectionSurface`: which galleries fold, which storage key, which body-id prefix.

| was | now |
|---|---|
| `FACTION_SECTION_IDS` | `FACTION_SECTIONS.ids` / `PROFILE_SECTIONS.ids` |
| `FACTION_SECTION_STORAGE_KEY` | `FACTION_SECTIONS.storageKey` (`wz-faction-sections`) and `PROFILE_SECTIONS.storageKey` (`wz-profile-sections`) |
| `factionSectionStorageKey(accountId)` | `sectionStorageKey(baseKey, accountId)` — appends the id to whichever base key it is handed, bare-key fallback unchanged |
| `factionSectionBodyId(id)` | `sectionBodyId(surface, id)` |
| `useFactionSections()` | `useSectionDisclosures(surface)` |

**Separate keys, and a suite that argues with a future "tidy it into one".** Both surfaces have a section called `praxis`, which is the shape that makes a shared key look harmless. `the two surfaces are kept apart` pins that the keys differ, that neither is a prefix of the other, that the panel ids differ, and that a blob written by one surface resolves to "nothing folded" on the other.

**The profile, in three files.** `profileSkin.tsx`'s `kit.sectionHeading(title, eyebrow)` seam now takes a `ReactNode` title, so the shell hands each kit a `SectionToggle` where it used to hand a word and every kit keeps rendering `{title}` unchanged — one edit covers the six kits plus WOW's laptop half. `DefaultProfileBody`'s laptop branch gets the same pair for na and Albescent. The seven kits' `heading()` signatures widen `string` → `ReactNode` (one token each; `strictFunctionTypes` makes that a real, checked change rather than a silent one). About and Badges get no toggle.

**The cookies/local-storage declaration page** now declares `wz-profile-sections` (`settings.cookies.entries.profileSections`, "Which galleries on a character profile you left folded."). Worth flagging: its census finds writers by their `setItem` **call**, and one module writes both keys — so the census cannot see the second key and would have stayed green with it undisclosed. It is named by hand in `CookiesSection.tsx` and in its test, with a comment saying why.

## Two places I did NOT add a fold, and why

The issue's census expected `DefaultProfileBody` to draw both sections twice, once per form factor. **It does not.** The na phone skin (`MobileProfile`, and therefore Albescent) and the WOW phone skin (the Field Pavilion) both draw Praxis and Proposed tasks behind a **segmented Chronicles / Quests switch** — exactly one gallery is on screen at a time and there is no section heading for a control to live in. `WowProfileBody` draws no proposed-tasks *section* at all; its `WowSectionHead` is used for About and Badges only.

So there is nothing there to fold: the switch already is the bounding gesture, and a fold on top of it is a second mechanism answering a question the first one answers. This is pinned rather than left as a hole — `a segmented switch instead, so there is nothing to fold` asserts both tabs are present and that no half-built disclosure appears, and goes red the day either skin is redrawn into two stacked sections. It is also written into the primitive's docblock. **Every other phone rendering does fold**: `ProfileSkin` restacks the same two sections at 375px, it does not re-author them, so the six kits get the fold at both widths from the one edit.

If you want the phone skins to fold too, that is a redraw of the segmented control and a separate issue.

## Verification

All run locally in this worktree, against `.github/workflows/test.yml`'s `frontend` job:

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **506 files, 10,469 passed, 1 skipped**
- `npm run build` — clean
- `npm run budget` — ok CSS, ok Albescent; JS is the **pre-existing** WARN (#2843's ledger records 155,659 measured against a 134,000 warn line — this branch measures 149.7 KB, below that). Not blocking, and not grown by this change: the profile archetypes are lazy routes.

No new API endpoints consumed. No backend, schema or CSS touched — no `frontend-style` questions arose; the toggle inherits its kit's face, size, tracking and ink by design, and no new style value was authored.

## What to eyeball

**The harness is `renderToStaticMarkup` in node.** There is no DOM, no click, no `localStorage`, and effects never run — so it can assert the markup and the `aria-expanded` / `aria-controls` wiring, and it can assert the *collapsed* rendering (the hook reads storage in a lazy `useState` initializer, so a stubbed `globalThis.localStorage` reaches it). It cannot assert that anything visually collapsed, that the caret rotates, or that the page got shorter. **Visual QA is outstanding.** At **375px** and **1440px**:

1. **Press each toggle on a profile.** Praxis and Proposed tasks fold and unfold; the caret rotates; the page really gets shorter. Nine archetypes — na, Albescent, Coven, Ephemerists, Everymen, Singularity, S.N.I.D.E., UA, WOW.
2. **The toggle wearing its kit's dress.** The button is `font: inherit` inside each skin's own heading, so: S.N.I.D.E.'s acid-on-black plate should still wrap the word *and* the caret cleanly; the Coven's braid rule should still take the leftover width beside it; Singularity's phosphor caps and Ephemerists' deco face should be unchanged. A button that reverted to UA defaults would be obvious.
3. **375px specifically.** The six `ProfileSkin` kits fold at phone width — check the heading row does not wrap awkwardly with the caret on its own line.
4. **375px, na and WOW.** Confirm the segmented Chronicles / Quests switch is untouched and no stray toggle appeared.
5. **Reload persistence.** Fold Praxis, reload — still folded. Sign out and back in as a different account — that account has its own fold.
6. **Cross-surface.** Fold Praxis on a faction page, then open a profile: its Praxis must be **open**. And the reverse.
7. **The settings page.** Cookies and local storage → "Show all 12 entries" lists `wz-profile-sections[:account id]` beside the faction one.
8. **About and Badges** have no toggle on any archetype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
