### PR TITLE
Delete the dead WOW seal-copy exclusion in selectDuelTask

### DIFF
--- a/frontend/e2e/duel.helpers.ts
+++ b/frontend/e2e/duel.helpers.ts
@@ -25,10 +25,11 @@ import type { Scenario } from '../src/utils/e2eScenario'
  * clicked button below, so a missing or unreachable control fails the test
  * instead of passing silently.
  *
- * The one faction this suite must steer around (`wow` rewrites the seal copy)
- * and the reason a faction-skinned task is picked at all are documented on
+ * Why a faction-skinned task is picked at all is documented on
  * `selectDuelTask`; the seeder that creates that task is
- * `seed.py::ensure_duel_fixture_task`.
+ * `seed.py::ensure_duel_fixture_task`. This suite steers around no faction's
+ * copy — #1909 deleted the last per-faction seal override, so every skin, WOW
+ * included, renders the shared `useDuelSealCopy` (#2999).
  *
  * Prereqs: backend (seeded dev DB at head) + frontend, via frontend/e2e/run-e2e.sh.
  */

--- a/frontend/src/utils/__tests__/duelScenario.test.ts
+++ b/frontend/src/utils/__tests__/duelScenario.test.ts
@@ -3,9 +3,10 @@
  *
  * `selectDuelTask` has been wrong twice and both times the failure surfaced as
  * something else: once as a missing task with nothing in it about eras (#2710,
- * it pinned a faction slug the era no longer carried), and once as a seal
- * dialog whose copy did not match (`wow` overrides it). It is three predicates
- * and it decides which three archetypes the whole duel suite drives.
+ * it pinned a faction slug the era no longer carried), and once as an
+ * exclusion that steered every fixture away from WOW for a seal-copy override
+ * #1909 had already deleted (#2999). It selects on properties, never a slug
+ * (#2710): at or below the duel level, and belonging to some faction.
  */
 import { describe, it, expect } from 'vitest'
 import { aTask } from '../../test/fixtures'
@@ -22,7 +23,6 @@ describe('selectDuelTask', () => {
       selectDuelTask([
         faction({ id: 1, level_required: DUEL_LEVEL + 1 }),
         faction({ id: 2, primary_faction_slug: 'na' }),
-        faction({ id: 3, primary_faction_slug: 'wow' }),
         wanted,
       ]),
     ).toBe(wanted)
@@ -34,8 +34,12 @@ describe('selectDuelTask', () => {
     expect(() => selectDuelTask([faction({ primary_faction_slug: 'na' })])).toThrow(/seed\.py/)
   })
 
-  it('skips the one faction that rewrites the seal copy the specs assert on', () => {
-    expect(() => selectDuelTask([faction({ primary_faction_slug: 'wow' })])).toThrow(/seed\.py/)
+  it('selects a WOW-skinned task like any other faction (#2999)', () => {
+    // WOW no longer overrides the duel-seal copy — #1909 deleted the last
+    // per-faction override, so WOW takes `useDuelSealCopy` like every other
+    // skin and is not an exclusion here.
+    const wanted = faction({ primary_faction_slug: 'wow' })
+    expect(selectDuelTask([wanted])).toBe(wanted)
   })
 
   it('skips a task above the duel level, which the challenger cannot attempt', () => {

--- a/frontend/src/utils/duelScenario.ts
+++ b/frontend/src/utils/duelScenario.ts
@@ -40,23 +40,16 @@ export const DUEL_LEVEL = 2
 const CROSS_FACTION_SLUG = 'na'
 
 /**
- * The one faction that overrides the duel-seal copy the specs assert on
- * ("Take the Field", `praxis.json` `duelSeal.wow`). Every other skin takes the
- * heading and confirm label from the shared `useDuelSealCopy`, so this is the
- * single slug a duel fixture must steer around — a property of the copy
- * catalog, and the only faction this module names for its own sake.
- */
-const SEAL_COPY_OVERRIDING_SLUG = 'wow'
-
-/**
  * The first task a duel-level challenger may attempt that drives a REAL
  * faction skin.
  *
  * Selects on properties, never on a slug (#2710): at or below the duel level,
- * so the challenger can sign up; belonging to some faction, so the composer,
- * the seal dialog and the duel rail each dispatch to a real archetype rather
- * than the Default fall-through; and not the one faction that rewrites the
- * seal copy the specs assert on.
+ * so the challenger can sign up, and belonging to some faction, so the
+ * composer, the seal dialog and the duel rail each dispatch to a real
+ * archetype rather than the Default fall-through. Every faction's seal
+ * dialog — WOW included — takes its heading and confirm label from the
+ * shared `useDuelSealCopy` (#1909 deleted the last per-faction override), so
+ * there is no faction this selector needs to steer around for copy reasons.
  *
  * The task itself is dev-seeded — `seed.py::ensure_duel_fixture_task`. Era 1
  * declares no tasks (#1398), so without that seeder this matches nothing and
@@ -67,8 +60,7 @@ export function selectDuelTask(tasks: readonly TaskOut[]): TaskOut {
     (candidate) =>
       candidate.level_required <= DUEL_LEVEL &&
       candidate.primary_faction_slug !== '' &&
-      candidate.primary_faction_slug !== CROSS_FACTION_SLUG &&
-      candidate.primary_faction_slug !== SEAL_COPY_OVERRIDING_SLUG,
+      candidate.primary_faction_slug !== CROSS_FACTION_SLUG,
   )
   if (!task) {
     throw new Error(


### PR DESCRIPTION
## Summary

`selectDuelTask` (`frontend/src/utils/duelScenario.ts`) excluded every WOW task because WOW "overrides the duel-seal copy." #1909 deleted the last faction-scoped `duelSeal.wow.*` keys on 2026-08-16 (`frontend/src/locales/en/praxis.json` carries only the six shared `duelSeal` keys, none faction-scoped), so the exclusion filtered on a premise that is no longer true — every skin, WOW included, takes its seal heading and confirm label from the shared `useDuelSealCopy`.

**Seam under test:** `selectDuelTask`'s candidate-filtering predicate in `frontend/src/utils/duelScenario.ts` — a pure function, no DOM/browser involved.

## The four sites (per #2999's collaborator comment)

1. **`SEAL_COPY_OVERRIDING_SLUG` and its docblock** — deleted. The `selectDuelTask` function docblock (which also argued for the dead exclusion) is rewritten to state the true, current selection rule and note that #1909 removed the last per-faction seal-copy override.
2. **Its clause in `selectDuelTask`** — deleted; the function now filters on level and "belongs to some faction" (the two properties that are still true), never on a slug.
3. **`duelScenario.test.ts:7`** (file-level docblock) — rewritten. It repeated the dead premise and mis-stated the predicate count (claimed three predicates while the `describe` block below already ran four cases). Replaced with prose that matches the current code and doesn't invite the same drift.
4. **`duelScenario.test.ts:38`** — inverted, not deleted. `expect(() => selectDuelTask([faction({ primary_faction_slug: 'wow' })])).toThrow(/seed\.py/)` becomes an assertion that a WOW-only board **is** now a usable duel fixture (`selectDuelTask` returns the WOW task). This guards the fix instead of leaving a hole where the wrong rule used to be.

**`:25`** — the WOW row planted in the "takes the first faction-skinned task" test (there only to be stepped over) is removed. Keeping it would have made that test assert the old (now false) behavior — after the fix, a WOW candidate ahead of `wanted` in level/faction order would itself be selected, breaking the test's intent. The fact that WOW is now selectable is proven directly and deliberately by the (inverted) dedicated case instead.

## Untouched, on purpose

- `CROSS_FACTION_SLUG = 'na'` and its exclusion clause — a different, still-true exclusion (na is the FK target for cross-faction tasks; onboarding and collaboration fixture tasks wear it and render Default archetypes). Unrelated to copy.
- `duelSeal.wow.*` keys are **not** re-added. #1909 was a deliberate 133-string cull; `catalog.test.ts`'s stay-deleted registry still holds those nine names and still passes.

## Verification

- `npx tsc --noEmit` — 0 errors.
- `npm run typecheck:design-sync` — 0 errors (no contract change, expected clean).
- `npm run lint` — clean.
- `npx vitest run src/utils/__tests__/duelScenario.test.ts` — 5/5 passing.
- `npx vitest run` (full suite) — 505/509 files passed; the 4 failures (`e2eLintScope`, `factionInkRule`, `inlineAnimationRule`, `rawColourRule`) are ESLint-rule tests unrelated to this change, and pass individually — they only time out under full-suite parallel load.
- `npm run build` — succeeds (the `INEFFECTIVE_DYNAMIC_IMPORT` note is a pre-existing, unrelated `FactionSigil` warning).
- `npm run budget` — pre-existing JS WARN (not FAIL), unrelated to this change: `duelScenario.ts` is an e2e/test-scenario helper, not part of any bundled route chunk, so this diff cannot have moved the number.
- No route/schema/Pydantic change — `api-schema` CI step not applicable.

## What to eyeball

Not applicable — this is a pure logic change to a test-scenario helper with no rendered UI, so there is nothing to visually QA. The real-world consumer of this fix is the **E2E duel suite** (`e2e/duel.spec.ts`, `e2e/duel-zzz-resolved.spec.ts`), which calls `seedDuelChallenge` → `selectDuelTask` against a real seeded DB; that suite is the check that a WOW-skinned fixture task is now actually pickable when the seeded board offers one.

Closes #2999