### PR TITLE
session_factory carries two reasons, and the review that read it found neither (#2866)

### DIFF
--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -2074,10 +2074,16 @@ async def get_activity_feed(
         character_id: The character requesting the feed.
         session: Database session for the pre-fetch phase (friend/foe/task IDs).
         session_factory: Callable that returns an async session context manager.
-            Each concurrent sub-query gets its own session from this factory.
+            One caller: ``_count_sources`` runs the badge ``UNION ALL`` on a
+            session of its own, so a page costs two connections rather than the
+            ~31 that made Updates slow (#1532). It is NOT a fan-out seam —
+            nothing here is gathered, and the row fetches run sequentially on
+            ``session`` above.
             Injected via FastAPI's Depends(get_session_factory); tests override
-            it to reuse the test-transaction session. (ADR-0036: a deliberate
-            test seam, kept even though the router only passes it back down.)
+            it to reuse the test-transaction session. That override is load-
+            bearing in both directions: it is what lets an integration test see
+            uncommitted fixture data, and it is *why* the two passes may never
+            be gathered — one ``AsyncSession`` is not safe under concurrent use.
         feed_filter: One of "all", "friends", "foes", "your_stuff", "global", "requests".
         before_cursor: ISO datetime cursor for pagination (items before this time).
         limit: Max items to return.

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -116,9 +116,13 @@ async def db_session(db_connection):
 class _ReuseSessionContext:
     """Null context manager that yields the shared test session without closing it.
 
-    Used by the test session_factory override so that concurrent sub-query sessions
-    (created by ``asyncio.gather`` in the activity-feed service) reuse the same
-    SAVEPOINT-backed session and therefore see uncommitted fixture data.
+    Used by the test session_factory override so that the activity feed's badge
+    ``UNION ALL`` — the one caller that takes a session from the factory — reuses
+    the same SAVEPOINT-backed session and therefore sees uncommitted fixture data.
+
+    Handing the same session back is also why nothing in that service may be
+    gathered: one ``AsyncSession`` is not safe under concurrent use, so the
+    passes that share this factory run sequentially (#1532, ADR-0036).
     """
 
     def __init__(self, session: AsyncSession) -> None:
@@ -143,9 +147,9 @@ async def client(db_session: AsyncSession):
     Isolation is preserved by the outer test transaction, which rolls back
     unconditionally at the end of the test.
 
-    Also overrides ``get_session_factory`` so concurrent sub-queries (used by
-    the activity-feed service under ``asyncio.gather``) reuse ``db_session``
-    rather than opening new connections that cannot see uncommitted test data.
+    Also overrides ``get_session_factory`` so the activity feed's badge count
+    pass reuses ``db_session`` rather than opening a second connection that
+    cannot see uncommitted test data.
     """
 
     async def _override_get_db():

--- a/docs/adr/0036-feed-sources-are-a-registry-counts-derive-from-the-same-query.md
+++ b/docs/adr/0036-feed-sources-are-a-registry-counts-derive-from-the-same-query.md
@@ -56,6 +56,19 @@ Model each feed type as one **`FeedSource`**, held in a module-level
   > connection. **Nothing above this note changes** — counts still derive from
   > each source's own windowed query, which is what this ADR is actually about.
 
+  > Amended 2026-09-02 (#2866): an architecture review read the bullet without
+  > the note above it and reached the opposite conclusion — that the factory is
+  > a production *fan-out* requirement and the test seam is vestigial. It is
+  > neither. Nothing in the feed is gathered, and both halves of the bullet are
+  > load-bearing at once. **Production:** `_count_sources` runs the badge
+  > `UNION ALL` on a session of its own, which is what holds a page to two
+  > connections. **Tests:** the injected factory hands back the request's own
+  > session — that is how an integration test sees uncommitted fixture data,
+  > and it is *why* the two passes may never be gathered, one `AsyncSession`
+  > not being safe under concurrent use. The seam is exercised, not merely
+  > declared: `test_activity_feed_query_count.py` swaps the factory for a
+  > counting one to assert that connection budget.
+
 ## Consequences
 
 - Pure refactor: the `/activity-feed` payload and pagination are byte-identical


### PR DESCRIPTION
Closes the docstring half of #2866. The ruling half is left open — see the comment on the issue.

## The problem

`get_activity_feed`'s docstring described `session_factory` as:

> (ADR-0036: a deliberate test seam, kept even though the router only passes it back down.)

"kept even though the router only passes it back down" reads as though the parameter would otherwise be unnecessary. #2862's architecture review read that line and concluded the **opposite** — that the factory is a production requirement for concurrent fan-out, and the test seam is vestigial.

Both readings are wrong, in opposite directions, and the docstring is why.

## What the code actually does

Since #1532, **nothing in this service is gathered.** Two comments in the file already say so in as many words ("Deliberately NOT gathered").

| | reality |
|---|---|
| `_run_source_fetch` | sequential, on the request's **own** `session` |
| `session_factory` | exactly one caller — `_count_sources`, running the badge `UNION ALL` on a session of its own |

That second connection is the point: it holds a page to **two** connections instead of the ~31 that made Updates slow against a pool of 15.

And the seam is not vestigial either. The injected factory hands back the request's own session — which is both how an integration test sees uncommitted fixture data, and *why* the two passes may never be gathered (one `AsyncSession` is not safe under concurrent use). `test_activity_feed_query_count.py:231` swaps the factory for a counting one to assert exactly that connection budget, so the seam is **exercised, not merely declared**.

So the parameter carries two load-bearing reasons at once, and the old docstring named neither properly.

## What changed

- **`services/activity_feed.py`** — the docstring now names both reasons and says plainly that it is *not* a fan-out seam.
- **`docs/adr/0036-*.md`** — a **dated amendment note**, not an edited bullet. The file's existing 2026-08-02 amendment was already correct; the review went wrong by reading the bullet *without* it. Per `docs/adr/README.md`, amendments append rather than rewrite, so the original decision stays as recorded.
- **`tests/integration/conftest.py`** — two stale `asyncio.gather` references removed. Same defect, at the surface a test author actually reads.

## Verification

Docstrings and comments only — no behaviour change.

- `pytest tests/unit` — **512 passed** (includes the `test_ruff_clean.py` ratchet gate)
- Full suite was green on this machine before the change: **1816 passed, 94.54% coverage** (gate 92)
- Integration suites not re-run locally afterwards: local Postgres went unreachable when this machine's session lost its `docker` group. CI runs them against its own Postgres, so this PR's checks are the real gate on that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)