### PR TITLE
Agent docs: the machine is Linux now, and python3 is a mise shim

### DIFF
--- a/.claude/agents/frontend-feature.md
+++ b/.claude/agents/frontend-feature.md
@@ -18,18 +18,20 @@ If a change needs real styling/design decisions beyond "reuse existing component
 
 - Edit and create under `frontend/src/` — pages, components, api clients, hooks, context, routes.
 - Run `npm` commands via Bash. In a fresh worktree `frontend/node_modules` does not
-  exist. Either run `npm ci`, or junction it from the main checkout. Note `mklink` is a
-  **cmd.exe builtin and is NOT on PATH** in Bash or PowerShell, so it needs the call
-  through `cmd`:
-  - Bash: `cmd //c mklink /J "$(pwd)/frontend/node_modules" "<absolute Windows path to main>\frontend\node_modules"`
-  - PowerShell: `New-Item -ItemType Junction -Path .\frontend\node_modules -Target <absolute path to main>\frontend\node_modules`
+  exist. This machine is **Linux** — either run `npm ci`, or symlink it from the main
+  checkout with an **absolute** target:
 
-  A junction pointing at the wrong target leaves the `tsc` binary absent, and
+      ln -s /home/pixie/Projects/WorldZeroPlayground/frontend/node_modules "$(pwd)/frontend/node_modules"
+
+  A link pointing at the wrong target leaves the `tsc` binary absent, and
   `tsc --noEmit | grep -c error` then reports a **false** 0-error pass. Confirm
   `tsc --version` actually runs before believing a green typecheck.
 
+  Remove the link before you finish, with `rm frontend/node_modules` — never `rm -r`,
+  which follows the link and empties the main checkout's copy.
+
   Backend and e2e test-environment notes: `docs/spec/SPEC-testing.md` (it does NOT
-  cover node_modules or the junction — that guidance is here).
+  cover node_modules or the symlink — that guidance is here).
 - **A helper script — a test runner, a one-off probe — belongs in your own worktree, never in the session scratchpad.** Your worktree is yours; the scratchpad is the one directory parallel agents share, so a generic name like `run_tests.py` gets clobbered and you run another agent's script against the wrong worktree, silently and green. Second-best, if a file genuinely must live in the scratchpad: prefix it with the issue number.
 - Do NOT edit `frontend/src/index.css`, `frontend/src/utils/factions.ts`, or any `*.css` — those belong to `frontend-style`. Do NOT edit outside `frontend/`.
 

--- a/.claude/skills/builder-bot/SKILL.md
+++ b/.claude/skills/builder-bot/SKILL.md
@@ -353,13 +353,20 @@ auto-starting another batch.
 1. Commit + push INCREMENTALLY. A concurrent `/git-reaper` sweep has twice emptied a live
    worktree — uncommitted work in one is not safe. `grep` each file on disk after editing to
    confirm the write landed. Never batch into one final commit.
-2. node_modules: the worktree lacks it. `mklink` is a **cmd.exe builtin and is NOT on
-   PATH** in Bash or PowerShell — it needs the call through `cmd`, or use `npm ci`:
-   Bash: `cmd //c mklink /J "$(pwd)/frontend/node_modules" "<ABSOLUTE Windows path to main>\frontend\node_modules"`
-   or `npm ci`. A WRONG relative depth silently makes the tsc binary absent, so `tsc | grep -c`
-   reports a FALSE 0-error pass — verify `tsc --version` actually runs. `Cannot find module
-   'node:fs'/'node:url'` is a known stale-junction false alarm (PR #675), not a real error.
-   Remove the junction before finishing — `git worktree remove` follows it and wipes main's node_modules.
+2. node_modules: the worktree lacks it. This machine is **Linux** — symlink it:
+   `ln -s /home/pixie/Projects/WorldZeroPlayground/frontend/node_modules "$(pwd)/frontend/node_modules"`
+   (absolute target, always — a WRONG relative depth silently makes the tsc binary absent, so
+   `tsc | grep -c` reports a FALSE 0-error pass; verify `tsc --version` actually runs). `npm ci`
+   also works and is slower. `Cannot find module 'node:fs'/'node:url'` is a known stale-link
+   false alarm (PR #675), not a real error.
+   **Remove the symlink before finishing** — `rm frontend/node_modules` (never `rm -r`, which
+   would follow it into main's copy). `git worktree remove` also follows a link and wipes
+   main's node_modules.
+2b. `python3` on this machine is a **mise shim that rewrites PATH**, which makes `gh` resolve
+   to a broken bootstrap shim at `~/.local/bin/gh` that HANGS FOREVER. Any repo script that
+   shells out to `gh` (`scripts/gh_issue_comments.py`, the merge-guard hook) must be run as
+   **`/usr/bin/python3`**, not `python3`/`python`. For backend work use the venv python at
+   `/home/pixie/Projects/WorldZeroPlayground/backend/.venv/bin/python` — worktrees carry no venv.
 3. CI: **any written list of jobs ROTS — read `.github/workflows/test.yml`.** It is the only
    authoritative list of jobs and steps, and it changes. `grep -E '^  [a-z-]+:$|- name:' .github/workflows/test.yml`
    prints them, and that output is the ONLY list to act on. Run every step it names,

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist/
 !/.claude/skills/
 !/.claude/settings.json
 !/.claude/launch.json
-frontend/node_modules/
+frontend/node_modules
 frontend/dist/
 frontend/.env.local
 frontend/playwright/.auth/


### PR DESCRIPTION
Part of #3006. Two agent-facing notes assumed Windows, and one new hazard
appeared with the OS move. Fixed in flight because tonight's `/builder-bot`
batch could not dispatch a frontend agent without them.

## What changed

**`.claude/skills/builder-bot/SKILL.md`** (hazards block, pasted verbatim into
every subagent prompt) and **`.claude/agents/frontend-feature.md`**:

- `node_modules` in a worktree: `cmd //c mklink /J` → `ln -s` with an absolute
  target. The false-green warning is kept, because a wrong target still hides
  the `tsc` binary and `tsc --noEmit | grep -c error` then reports a **false**
  0-error pass.
- The teardown warning is sharpened rather than dropped: `rm -r` follows a
  symlink into the main checkout's `node_modules` the same way
  `git worktree remove` followed a junction. `rm frontend/node_modules`, never
  `rm -r`.

**New hazard 2b**, in the hazards block only:

`python3` on this machine is a mise shim (`~/.local/share/mise/shims/python3`
→ `/usr/bin/mise`) that re-execs and **rewrites `PATH`**, putting
`~/.local/bin` first. `~/.local/bin/gh` is a mise *bootstrap* script that
hangs forever — even `gh --version`. So any repo Python script that shells out
to `gh` hangs when run as `python3`, while the same `gh` command typed at a
Bash prompt works, because the login shell's profile puts the real binary
first.

Two confirmed casualties tonight:

- `scripts/gh_issue_comments.py` — the issue-reading wrapper every batch skill
  depends on. Hung at 120s.
- `scripts/hooks/guard_pr_merge.py` — invoked as bare `python` by
  `.claude/settings.json`. It denies when it cannot answer, by design, so it
  denied **every** merge tonight.

The fix in this PR is documentation only: tell agents to use `/usr/bin/python3`
for those scripts. **The settings.json half is deliberately not in this PR** —
see #3006 for why, and for the machine-level fix that would let the docs stay
silent about this entirely.

## Verification

Docs only, no code. Verified by running the wrapper both ways:

    python3   scripts/gh_issue_comments.py 2990   # hangs, exit 124 at 120s
    /usr/bin/python3 scripts/gh_issue_comments.py 2990   # prints the issue

and the merge guard both ways, where the system interpreter reaches the guard's
real logic instead of timing out on `gh repo view`.

Not covered: `.claude/skills/git-reaper/SKILL.md` and
`docs/agents/running-locally.md` are still Windows-flavoured. They are itemised
in #3006 rather than swept here, because neither was in tonight's path and a
blind sweep of the git-reaper junction hazard risks deleting a warning that is
still real on Linux in symlink form.

## What to eyeball

Nothing rendered. Worth a human check that the `ln -s` line's hardcoded
`/home/pixie/Projects/WorldZeroPlayground` matches where you actually keep the
main checkout — #3006 flags deriving it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)