### PR TITLE
proposeTask's audit re-scan: the busy CTA invariant seven kits wrote by hand and the Default did not (#2994)

### DIFF
--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/home/pixie/Projects/WorldZeroPlayground/frontend/node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/home/pixie/Projects/WorldZeroPlayground/frontend/node_modules

--- a/frontend/src/pages/characterPaths/__tests__/disabledControlContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/disabledControlContrast.test.ts
@@ -93,6 +93,23 @@ const source = (path: string): string => readFileSync(path, 'utf8')
  * `disabled={!x}` is a control gated on a form's own state — the one that is
  * disabled when the page OPENS. `disabled={deleting}` and friends are transient
  * busy states and are deliberately not swept in here.
+ *
+ * THE BUSY STATE IS OUT OF SCOPE HERE AND IN SCOPE SOMEWHERE — settled by
+ * #2994's audit so the next one does not re-open it. #2486's ruling is about
+ * the disabled PAINT, and a busy control is just as disabled and just as
+ * illegible when it fades; what is out of scope is this FILE, not the class.
+ * Two reasons it stays that way. The `marked === gated` equality below is an
+ * equality on purpose — a file that also dressed its busy control would have
+ * more class lists than gated sites and would fail for wearing the right
+ * thing — and this walk is bound to `characterPaths/archetypes` by directory
+ * and filename, so widening the predicate would still reach only this surface.
+ *
+ * The busy half is therefore asserted per surface, at the rendered control
+ * rather than the source text, over a roster read from the manifest:
+ * `proposeTask/__tests__/submitControlOff.test.tsx` does it for the nine
+ * propose kits, where seven had found `.control-off` privately in #2538 and
+ * the Default still faded. A surface that grows a busy CTA owes a guard of
+ * that shape; it does not belong in this file.
  */
 const gatedControls = (text: string): number => text.match(/disabled=\{!/g)?.length ?? 0
 

--- a/frontend/src/pages/proposeTask/__tests__/submitControlOff.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/submitControlOff.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The propose form's primary action, once it is BUSY (#2994, audit of #2814).
+ *
+ * WHY THIS FILE EXISTS AND `disabledControlContrast` DOES NOT COVER IT.
+ * #2486 ruled that a disabled primary control must DROP its CTA paint for the
+ * measured `--control-off-fill` / `--control-off-ink` pair rather than fade,
+ * because `opacity` composites the whole element — the fill sinks toward the
+ * sheet and the label's ink fades over the faded fill, so the label loses
+ * contrast twice. `characterPaths/__tests__/disabledControlContrast.test.ts`
+ * enforces that, but it sweeps `disabled={!…}` — the control that is disabled
+ * when the page OPENS — and its docblock says busy states are deliberately out
+ * of its scope. It also walks `pages/characterPaths/archetypes` for
+ * `(Create|Edit)Character.tsx`, so it could not reach here whatever it swept.
+ *
+ * NO PROPOSE ARCHETYPE HAS A START-DISABLED CONTROL. All nine gate on
+ * `submitting`, which is the transient class that file excludes. So the
+ * invariant was unenforced on this surface, and seven of the nine kits
+ * discovered `.control-off` privately during #2538 while `DefaultProposeTask`
+ * kept `opacity: submitting ? 0.6 : 1` — the literal spelling #2486 removed —
+ * and `AlbescentProposeTask` inherited it by delegation. That is #2814's thesis
+ * exactly: an invariant hand-written seven times and absent from the Default.
+ *
+ * THE SEAM IS THE RENDERED CONTROL, NOT THE SOURCE TEXT. A source scan would
+ * have to find each kit's file by directory and filename — the coupling that
+ * made the sibling guard unable to see this surface in the first place. Walking
+ * `surfaceMap('proposeTask')` and rendering instead means a tenth kit is swept
+ * the moment it registers, and the Albescent wrapper is measured through what
+ * it actually draws rather than exempted for drawing nothing of its own.
+ *
+ * IT DOES NOT RE-MEASURE THE PAIR. `--control-off-fill` / `--control-off-ink`
+ * and the Singularity's `.sg-control-off` re-point are measured once, in
+ * `disabledControlContrast.test.ts`, and its CSS block says the consuming sites
+ * "should NOT restate the values". This file asserts only that the class is
+ * worn and nothing fades on top of it.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import { archetypeFor, EVERY_SLUG, proposeTaskState } from './proposeTaskState'
+
+/** The kit's page, rendered for one slug in one busy state. */
+function markupFor(slug: string, submitting: boolean): string {
+  const Archetype = archetypeFor(slug)
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Archetype state={proposeTaskState({ factionSlug: slug, submitting })} />
+    </MemoryRouter>,
+  )
+}
+
+/**
+ * The open tags of every `type="submit"` button in `markup`.
+ *
+ * Matched on the tag rather than parsed: these pages carry no `>` inside an
+ * attribute value (React escapes it to `&gt;`), and the two things asserted —
+ * the class list and the `style` declarations — are both attributes of this one
+ * tag. The floor below proves the extraction found something at every slug.
+ */
+const submitTags = (markup: string): string[] =>
+  (markup.match(/<button[^>]*>/g) ?? []).filter((tag) => tag.includes('type="submit"'))
+
+const classesOf = (tag: string): string[] =>
+  /class="([^"]*)"/.exec(tag)?.[1].split(/\s+/).filter(Boolean) ?? []
+
+const styleOf = (tag: string): string => /style="([^"]*)"/.exec(tag)?.[1] ?? ''
+
+describe('the propose sweep reaches every registered kit', () => {
+  it('walks a roster no smaller than the one registered today', () => {
+    // A render scan that renders nothing passes. Nine kits are registered
+    // (albescent, coven, default/na, ephemerists, everymen, singularity, snide,
+    // ua, wow); a floor rather than an equality, so a tenth is swept without
+    // touching this file.
+    expect(EVERY_SLUG.length, 'slugs in surfaceMap("proposeTask")').toBeGreaterThanOrEqual(9)
+  })
+})
+
+describe('a busy propose control drops its paint instead of fading (#2486)', () => {
+  for (const slug of EVERY_SLUG) {
+    it(`${slug} — the submit control exists and is live before submitting`, () => {
+      const tags = submitTags(markupFor(slug, false))
+      // Proves the extraction matches a real call site, and that what the busy
+      // case below measures is the BUSY state and not a control that is always
+      // disabled.
+      expect(tags.length, 'submit controls drawn').toBe(1)
+      expect(tags[0], 'the control is enabled before submitting').not.toContain('disabled=""')
+    })
+
+    it(`${slug} — the busy submit control wears .control-off`, () => {
+      const [tag] = submitTags(markupFor(slug, true))
+      expect(tag, 'a submit control is drawn while busy').toBeDefined()
+      expect(tag, 'the control is disabled while busy').toContain('disabled=""')
+      expect(classesOf(tag!), 'the disabled treatment is the measured one').toContain('control-off')
+    })
+
+    it(`${slug} — the busy submit control declares no opacity`, () => {
+      // The exact defect #2486 removed. `.control-off:disabled` replaces the
+      // fill with `!important`, but nothing stops a fade being composited over
+      // the result, so the class alone is not the whole invariant.
+      expect(styleOf(submitTags(markupFor(slug, true))[0] ?? ''), 'no fade on the CTA').not.toMatch(
+        /(?:^|;)\s*opacity\s*:/,
+      )
+    })
+  }
+})

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -598,12 +598,21 @@ export default function DefaultProposeTask({
               <button
                 type="submit"
                 disabled={submitting}
+                // `.control-off` rather than `opacity: 0.6` (#2486, #2994):
+                // this pill's enabled paint is the spectrum FRAME for `na` — a
+                // gradient with an opaque interior — so a fade folded the ramp,
+                // the paper and the label together and there was never one
+                // colour to measure. The class swaps the whole fill for the
+                // house neutral and hands the label a ratio that is measured
+                // once, in `disabledControlContrast.test.ts`. The seven faction
+                // propose kits reached this answer separately in #2538; this
+                // row is the one they were copied from and it kept the fade.
+                className="control-off"
                 style={{
                   // The selected chip's treatment at CTA size: the faction's
                   // tint, or the spectrum frame for `na` (factionSurfaces.ts).
                   ...submitButtonStyle(factionSlug),
                   cursor: submitting ? "wait" : "pointer",
-                  opacity: submitting ? 0.6 : 1,
                 }}
               >
                 {submitting


### PR DESCRIPTION
Closes #2994

Re-scan of `proposeTask` for #2814, whose clearance expired when #2538 landed nine archetypes on
2026-09-01 against a scan dated 2026-08-28. The dated verdict is posted as a comment on #2814
(#2814's body is not edited).

**This started as an audit and found a real defect.** The issue's lead was that
`disabledControlContrast` cannot reach this surface; that is true, and checking it turned up an
invariant seven kits wrote by hand and the Default did not.

## The seam I tested at

**The rendered `type="submit"` control of each propose archetype, in the `submitting: true`
state, over a roster read from `surfaceMap('proposeTask')`.**

Not the source text. A source scan would have to find each kit by directory and filename, which
is the exact coupling that made the sibling guard blind to this surface in the first place.
Rendering also means the Albescent pass-through is measured through what it *draws* rather than
exempted for drawing nothing of its own — and it is one of the two kits that was wrong.

## The defect

#2486 ruled that a disabled primary control drops its CTA paint for the measured
`--control-off-fill` / `--control-off-ink` pair rather than fading, because `opacity` composites
the whole element: the fill sinks toward the sheet and the label's ink fades over the faded fill,
so the label loses contrast twice. That cannot vary by faction.

Rendered evidence, before the fix — every kit draws exactly one `type="submit"` button and all
nine are `disabled` while busy:

| kit | the busy CTA |
|---|---|
| coven, ephemerists, everymen, singularity, snide, ua, wow | `class="control-off"` (Singularity adds `sg-control-off`, Ephemerists `eph-cta`), no `opacity` |
| **na — `DefaultProposeTask`** | **no class, `cursor:wait;opacity:0.6`** |
| **albescent** | **byte-identical to the above** — pure pass-through |

`na`'s enabled paint is the spectrum *frame* — `linear-gradient(card-bg, card-bg) padding-box,
var(--faction-default-rainbow) border-box` — so the fade folded the ramp, the paper and the label
into one composite with no single ratio to measure. That is #2486's own "cannot be rescued by a
gentler alpha" case, and #2816's shape exactly: seven kits found the answer privately during
#2538's seven-PR fan-out, and the file they were all copied from kept the fade.

## Why neither coverage layer caught it (#2814's two-layer rule)

**Loop layer.** `disabledControlContrast.test.ts` owns this invariant and could not reach here
twice over:

1. `sourceFiles({ dir: ARCHETYPE_DIR, match: /(?:Create|Edit)Character\.tsx$/ })` with
   `ARCHETYPE_DIR` under `pages/characterPaths/` — wrong directory, wrong filename.
2. Its predicate is `disabled={!…}`. **All 58 `disabled=` sites across the nine propose
   archetypes are `disabled={submitting}`**, and no propose archetype spells `opacity: canSubmit`
   — so widening the predicate alone would still have found nothing.

**Per-kit layer.** This surface has exactly one per-kit suite, `uaProposeTaskContrast.test.ts`.
It is UA-only, and its docblock explicitly refuses to restate measurements made elsewhere.

Neither layer, so it is work under the epic's rule rather than a duplicate of a passing loop.

## The scope question, answered

**`.control-off` on a busy control is out of `disabledControlContrast`'s scope, and the reasons
are structural rather than a preference** — so the answer is now in that file's docblock, as the
issue requires:

- its `expect(marked).toBe(gated)` is an **equality**, so a characterPaths file that also dressed
  its busy control would fail *for wearing the right thing*;
- the walk is bound to `characterPaths/archetypes` by directory and filename whatever the
  predicate says.

The docblock now also names where the busy half *is* asserted, so the next audit stops there.

## Changed

- `frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx` — drops
  `opacity: submitting ? 0.6 : 1` for `className="control-off"`. One property out, one class in.
  No new CSS, no new token: `.control-off:disabled` already exists and already carries
  `!important` precisely so it beats these inline skins.
- `frontend/src/pages/proposeTask/__tests__/submitControlOff.test.tsx` — **new**, 28 assertions.
- `frontend/src/pages/characterPaths/__tests__/disabledControlContrast.test.ts` — **docblock
  only**, no assertion changed. (`WowEditCharacter.tsx` and `wowEditCharacterContrast.test.ts`
  are untouched — #2987 owns those tonight.)

## The guard, and its floor

- Roster is `Object.keys(surfaceMap('proposeTask'))` via the existing shared
  `__tests__/proposeTaskState.ts` — **never a typed list** (#2815). A tenth kit is swept on
  registration with no edit here.
- **Floor: 9 slugs**, a `toBeGreaterThanOrEqual`, not an equality — a real number, and the count
  registered today.
- **The extraction is proven against a live call site per slug**: each busy row is paired with an
  enabled row asserting exactly one `type="submit"` control that is *not* disabled. A guard that
  scanned nothing, or that matched a control which is always disabled, fails there.
- **It does not re-measure the pair.** `--control-off-fill` / `--control-off-ink` and the
  Singularity's re-point are measured once in `disabledControlContrast.test.ts`, whose CSS block
  says consuming sites "should NOT restate the values".

Red first: 4 failed / 24 passed, failing on exactly `na` and `albescent`. Green after the
one-line fix.

## What I checked and found sound, so it is not re-opened

- **The loop layer is real and fully derived** — five suites walk `surfaceMap('proposeTask')`:
  `proposeTaskDispatch`, `unaffiliatedOption`, `metataskProposal`, `proposeTaskBreadcrumb`, and
  now `submitControlOff`. `proposalNotes` tests the pure `planProposalSubmission` planner above
  the archetype layer, invariant by construction.
- **No hand-duplicated invariant across kit suites** — there is only one kit suite to duplicate
  *from*. Nothing for the epic's held phase 2 to collapse here.
- **The field set does not diverge.** Rendering all nine with `canProposeMetatask` and an error
  set gives an identical census for every kit — 2 `input`, 2 `textarea`, 20 `button`,
  1 `role="checkbox"`, 8 `role="radio"`, error surfaced. So **#2993's asked-for structure guard
  has nothing to catch as of today.** I did not write it, to avoid contending with that issue.

## Sequencing against #2993

#2993 was not in flight, so this is measured against `origin/main` @ `0d2712a0`. It rebuilds
`DefaultProposeTask.tsx` on the shared chassis and deletes `pages/proposeTask/factionSurfaces.ts`.
**Whoever picks it up should carry `className="control-off"` onto the chassis' CTA, and check
whether its derived structure guard subsumes anything here** — it should not; different
invariant, same roster.

## Adjacent, reported not fixed

A tree-wide grep while establishing that proposeTask was the only propose-side instance found the
same spelling on three sites outside this surface: `components/JoinControl.tsx:270`,
`components/duel/shared.tsx:539`, `pages/CharacterProfile.tsx:328,349`. Not `proposeTask` cells,
not this issue's scope, so they are flagged on #2814 rather than touched.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` (`tsc --noEmit` + e2e project) | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **510 files, 10563 passed, 1 skipped** |
| `npm run build` | ok |
| `npm run budget` | JS **WARN** 149.6 KB (warn >130.9, fail >175.8) — pre-existing; CSS ok, ALB ok |

No backend, route, `response_model` or Pydantic change, so `api-schema` and the backend `test` job
are untouched. No `.github/` change.

The budget WARN is inherited from `main`, not caused here: this diff removes one style property
and adds one class inside `DefaultProposeTask`, which is a code-split archetype chunk and not one
of the 15 blocking assets.

## ⚠️ Visual QA is outstanding

Nothing here proves a pixel. Every assertion is `renderToStaticMarkup` with no DOM
(`SPEC-testing.md`), and I have no browser and no dev stack. The contrast *ratio* of the neutral
pair is measured against the stylesheet in `disabledControlContrast.test.ts`, but nobody has
looked at the propose page mid-submit.

## What to eyeball

1. **The `na` / unaffiliated propose page mid-submit, both themes.** The pill loses the rainbow
   frame entirely for the flat neutral while busy. That is #2486's prescription, but the
   spectrum-frame CTA is the loudest thing on this page when enabled and this is the first time
   it goes quiet — confirm the transition does not read as the button vanishing.
2. **The same page with a real faction picked.** `submitButtonStyle` keeps
   `border: 2px solid <tint>` while `.control-off` replaces the fill, so the busy pill is a
   neutral slab inside a coloured ring. The seven faction kits keep their own geometry the same
   way; confirm it reads as deliberate here too.
3. **That the busy state is still legible as busy.** The label swaps to
   `proposeTask.submit.busy` and `.control-off:disabled` forces `cursor: not-allowed`, which now
   overrides the `cursor: wait` this file still asks for — same as the seven sibling kits, left
   for symmetry rather than churn.
4. **The Albescent target page is still byte-identical to the Default.**
   `proposeTaskDispatch.test.tsx` asserts it and it passes, but it is the invariant most likely to
   be broken by the next change here.
5. **Nothing on `createCharacter` / `editCharacter` moved.** Only a docblock changed in
   `disabledControlContrast.test.ts`; its 42 assertions are unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
