### PR TITLE
WoW's codicil plate takes the charter's edge, and the suite learns to see it (#2987)

### DIFF
--- a/frontend/src/pages/characterPaths/__tests__/wowEditCharacterContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/wowEditCharacterContrast.test.ts
@@ -40,11 +40,32 @@
  *
  * ## What the numbers say
  *
- * Every one clears AA with room, in both cascades — the cream is a pale warm
- * stock by day and a deep one by night, and all four inks flip with it. So the
- * codicil needed no repaint and no minted token, and that is a result rather
- * than an assumption: `--color-danger`, the ink this slot shipped with before
- * #2788 lifted it, reads 4.40:1 on this same cream and would have missed.
+ * Every INK clears AA with room, in both cascades — the cream is a pale warm
+ * stock by day and a deep one by night, and they all flip with it. That is a
+ * result rather than an assumption: `--color-danger`, the ink this slot shipped
+ * with before #2788 lifted it, reads 4.40:1 on this same cream and would have
+ * missed.
+ *
+ * ## The NON-TEXT rows, and why this file first shipped without them (#2987)
+ *
+ * Four text rows all cleared AA, so the sheet read as guarded and was not. Type
+ * is not the only thing on it: the faction row is a PLATE, and the shared slot's
+ * plate is `--color-bg-surface-alt` behind a `--color-border-strong` hairline —
+ * 1.06:1 of fill and 1.41 / 1.56 of edge on this cream, where 1.4.11 asks 3:1 of
+ * a graphical boundary that carries meaning. A plate edge delimiting a control
+ * region is exactly that, and a text-only suite cannot see it, which is how the
+ * shortfall shipped green.
+ *
+ * So this file now measures the boundary too, and `WowEditCharacter` repaints
+ * both plates on the codicil through #2956's dress seam rather than by editing
+ * the shared file. The measurements live beside {@link PLATE} / {@link EDGE};
+ * the guard that the paint measured here is the paint on screen is
+ * `the plate under both shared controls is the charter's`.
+ *
+ * The gap is NOT WOW-only — every one of the eight edit lanes mounts the same
+ * neutral plate, reading 1.01–1.18 of fill and 1.40–1.72 of edge on its own
+ * ground, Singularity's `-term-*` repoint included. This file fixes and guards
+ * the lane it is named for; the extent is its own issue.
  *
  * ## What it reads out of source, and why
  *
@@ -57,6 +78,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 import {
+  AA_LARGE,
   AA_NORMAL,
   compositeOver,
   contrastRatio,
@@ -80,8 +102,34 @@ const ARCHETYPE = source('../archetypes/WowEditCharacter.tsx')
 
 /** The codicil's stock — the charter's own sheet, reached through the role map. */
 const SHEET = '--faction-wow-card-bg'
-/** The plate `FactionRow` brings with it, laid ON that stock. */
-const ROW_PLATE = '--color-bg-surface-alt'
+/**
+ * THE PLATE UNDER THE ROW, AND THE EDGE THAT IDENTIFIES IT (#2987).
+ *
+ * The shared slot's own plate is `--color-bg-surface-alt` behind a
+ * `--color-border-strong` hairline — an app-neutral pair, and on this cream it
+ * reads 1.06:1 of fill and 1.41:1 of edge. A plate delimiting a control region
+ * is a graphical boundary that carries meaning, so 1.4.11 asks 3:1 of it and
+ * the neutral pair misses by better than half. {@link SHARED_PLATE} below keeps
+ * both readings, because "the default would miss here" is the measurement that
+ * makes this override a fix rather than a preference.
+ *
+ * NO IN-FAMILY STOCK CAN CARRY THAT AS A FILL, and this is the design decision
+ * rather than a shortfall: the chronicle panel is 1.12 / 1.15 against its own
+ * cream, and a well that cleared 3:1 against the sheet would read as a hole
+ * punched in the parchment rather than as a plate laid on it. 1.4.11 does not
+ * ask for it either — what it asks is that the information identifying the
+ * component be 3:1 against ADJACENT colour, and for a plate that is its EDGE.
+ * So the codicil hands the row the charter's own inset plate and cuts it with
+ * the charter's own deep edge, and the edge is measured on both of the colours
+ * it lies between: the sheet outside it and the plate inside it.
+ */
+const PLATE = '--faction-wow-chronicle-panel'
+/** The deep olive-gold the charter letters its labels in — 5.32 / 8.83 on cream. */
+const EDGE = '--faction-wow-accent-deep'
+/** What the shared slot still draws for any mount that passes nothing. */
+const SHARED_PLATE = '--color-bg-surface-alt'
+/** The shared slot's own hairline, the other half of that default. */
+const SHARED_EDGE = '--color-border-strong'
 
 /**
  * Every ink the codicil puts on the sheet, and where it comes from.
@@ -107,7 +155,17 @@ const INKS: Array<{ what: string; token: string; over?: string }> = [
   {
     what: "the faction name on the row's own plate",
     token: '--color-text-secondary',
-    over: ROW_PLATE,
+    over: PLATE,
+  },
+  {
+    what: "the row's disclosure chevron, on that same plate",
+    token: '--color-text-tertiary',
+    over: PLATE,
+  },
+  {
+    what: "the confirm's cancel key, on the plate the codicil gives it",
+    token: '--color-text-primary',
+    over: PLATE,
   },
 ]
 
@@ -122,8 +180,9 @@ function resolve(token: string, theme: Theme): Rgba {
 describe('the codicil is the WOW sheet, and the slots are mounted on it', () => {
   it('the archetype mounts the shared slots rather than redrawing them', () => {
     expect(ARCHETYPE).toContain("from '../editCharacterSlots'")
-    expect(ARCHETYPE).toContain('<FactionRow slug={character.faction_slug} />')
-    expect(ARCHETYPE).toContain('<DeleteCharacter slug={character.faction_slug}')
+    expect(ARCHETYPE).toContain('<FactionRow')
+    expect(ARCHETYPE).toContain('slug={character.faction_slug}')
+    expect(ARCHETYPE).toContain('<DeleteCharacter')
   })
 
   it("the sheet under them is WOW's paper role, which is the token measured below", () => {
@@ -148,8 +207,70 @@ describe('the codicil is the WOW sheet, and the slots are mounted on it', () => 
       "factionCssVar(slug ?? UNAFFILIATED_FACTION_SLUG, 'card-alarm')",
     )
     expect(factionCssVar('wow', 'card-alarm')).toBe('var(--faction-wow-card-alarm)')
-    expect(SLOTS, 'the row still brings its own plate').toContain(`var(${ROW_PLATE})`)
   })
+
+  it('the plate under both shared controls is the charter\'s, handed in through the seam', () => {
+    // The two grounds measured below are the ones on screen only because this
+    // archetype passes them. The shared slot's own default is still the neutral
+    // pair — untouched, because #2956's seam exists precisely so a dress can
+    // repaint without eight archetypes sharing one repaint (`rowStyle` /
+    // `cancelStyle`, both spread LAST over the defaults).
+    expect(SLOTS, 'the shared default is still the neutral plate').toContain(
+      `var(${SHARED_PLATE})`,
+    )
+    expect(SLOTS, '…behind the neutral hairline').toContain(`var(${SHARED_EDGE})`)
+
+    expect(ARCHETYPE).toContain(`const FIELD = 'var(${PLATE})'`)
+    expect(ARCHETYPE).toContain(`const LABEL = 'var(${EDGE})'`)
+    expect(ARCHETYPE, 'the codicil cuts one plate for both controls').toMatch(
+      /const codicilPlate[\s\S]*?background: FIELD[\s\S]*?solid \$\{LABEL\}/,
+    )
+    expect(ARCHETYPE, 'the faction row takes it').toContain('rowStyle={codicilPlate}')
+    expect(ARCHETYPE, 'so does the confirm’s cancel key').toContain('cancelStyle={codicilPlate}')
+  })
+})
+
+describe('the codicil’s plates are identifiable at 3:1 (WCAG 1.4.11)', () => {
+  // 1.4.11 asks 3:1 of the visual information that identifies a component
+  // against ADJACENT colour — not 4.5:1, and not of the fill when an edge
+  // carries the boundary. A plate edge delimiting a control region is exactly
+  // that information, so it is measured on BOTH sides: the sheet it lies on and
+  // the well it encloses. A text-only suite cannot see either, which is how the
+  // neutral pair shipped green here.
+  const BOUNDARIES: Array<{ what: string; token: string }> = [
+    { what: "the faction row's plate edge, and the cancel key's", token: EDGE },
+    { what: 'the delete outline and the confirm panel frame', token: '--faction-wow-card-alarm' },
+  ]
+
+  for (const theme of BOTH_THEMES) {
+    for (const { what, token } of BOUNDARIES) {
+      it(`${what} — against the sheet, ${theme}`, () => {
+        const ratio = contrastRatio(resolve(token, theme), resolve(SHEET, theme))
+        expect(ratio, `${token} on ${SHEET} is ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(
+          AA_LARGE,
+        )
+      })
+    }
+
+    it(`the plate edge against the well it encloses — ${theme}`, () => {
+      const well = compositeOver(resolve(PLATE, theme), resolve(SHEET, theme))
+      const ratio = contrastRatio(resolve(EDGE, theme), well)
+      expect(ratio, `${EDGE} on ${PLATE} is ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(AA_LARGE)
+    })
+
+    it(`the shared neutral pair would miss 3:1 on this sheet — ${theme}`, () => {
+      // Why the override is a fix and not a preference, restated on the ground
+      // that forced it. Same shape as the `--color-danger` reading below: the
+      // paint that WOULD have shipped, measured where it would have shipped.
+      const neutralPlate = compositeOver(resolve(SHARED_PLATE, theme), resolve(SHEET, theme))
+      const fill = contrastRatio(neutralPlate, resolve(SHEET, theme))
+      expect(fill, `the neutral plate reads ${formatRatio(fill)} on the cream`).toBeLessThan(
+        AA_LARGE,
+      )
+      const edge = contrastRatio(compositeOver(resolve(SHARED_EDGE, theme), neutralPlate), neutralPlate)
+      expect(edge, `its hairline reads ${formatRatio(edge)}`).toBeLessThan(AA_LARGE)
+    })
+  }
 })
 
 describe('the codicil clears AA on the charter sheet, both cascades', () => {

--- a/frontend/src/pages/characterPaths/archetypes/WowEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowEditCharacter.tsx
@@ -62,7 +62,25 @@
  *     delete outline + confirm frame / cream      7.57    9.56
  *     faction label + confirm prompt / cream      7.78    8.13
  *     faction help / cream                        7.83    8.72
- *     the row's own plate ink, plate over cream   7.31    6.99
+ *     the row's own plate ink, plate over cream   6.93    7.05
+ *     the row's chevron, on that same plate       6.98    7.57
+ *     the cancel key's ink, on that same plate   15.02   12.69
+ *
+ * ## The NON-TEXT half, which the first pass did not take (#2987)
+ *
+ * All six rows above are TYPE, and a text-only reading cannot see a plate. The
+ * two slots' shared plate is `--color-bg-surface-alt` behind a
+ * `--color-border-strong` hairline, and on this cream that is 1.06:1 of fill
+ * and 1.41 / 1.56 of edge where 1.4.11 asks 3:1 of a boundary that carries
+ * meaning. {@link codicilPlate} is the repaint — the charter's own plate, cut
+ * with the charter's own deep edge, handed through #2956's dress seam:
+ *
+ *     what                                       light   dark
+ *     the codicil plate's edge / cream            5.32    8.83
+ *     the codicil plate's edge / its own well     4.74    7.66
+ *
+ * The FILL is 1.12 / 1.15 and stays there on purpose; the docblock at
+ * {@link codicilPlate} says why an edge and not a well carries this.
  *
  * The charter's own eight pairings are unchanged and are already rows in
  * `utils/__tests__/factionContrast.test.ts`; restating them would be a second
@@ -244,6 +262,34 @@ export default function WowEditCharacter({ state }: { state: EditCharacterState 
       <span style={{ color: spent ? ALARM : MUTED }}>{text}</span>
     </div>
   )
+
+  /* ── THE CODICIL'S PLATE (#2987) ──
+     The two shared slots draw an app-neutral plate: `--color-bg-surface-alt`
+     behind a `--color-border-strong` hairline. On the na page they were
+     measured on, that reads. On this cream it is 1.06:1 of fill and 1.41:1 of
+     edge, and a plate delimiting a control region is a graphical boundary that
+     carries meaning — 1.4.11 asks 3:1 of it, so the pair misses by better than
+     half. The four TEXT rows on this sheet all cleared AA, which is why the
+     shortfall shipped green.
+
+     What clears it is the EDGE, not the fill: 1.4.11 asks 3:1 of the
+     information that identifies the component against adjacent colour, and no
+     in-family stock can be a 3:1 FILL here — the chronicle panel is 1.12 / 1.15
+     on its own cream, and a well that did clear would read as a hole punched in
+     the parchment. So the plate is the charter's own inset {@link FIELD}, cut
+     with {@link LABEL} rather than gilt: the deep olive-gold measured on BOTH
+     chronicle grounds (5.32 / 8.83 on the cream, 4.74 / 7.66 on the plate),
+     where {@link GOLD} is 2.24:1 on the cream and could not carry a boundary
+     any more than it can carry type.
+
+     Handed in through #2956's dress seam. `editCharacterSlots.tsx` is untouched
+     — its defaults still stand for every mount that passes nothing, and
+     `__tests__/wowEditCharacterContrast.test.ts` keeps both readings. */
+  const codicilPlate: CSSProperties = {
+    background: FIELD,
+    border: `1.5px solid ${LABEL}`,
+    borderRadius: RADIUS,
+  }
 
   const sheetStyle = {
     background: SHEET,
@@ -528,8 +574,18 @@ export default function WowEditCharacter({ state }: { state: EditCharacterState 
            the re-measurement that buys. ── */}
       <ComposerSheet sizes={sizes} style={sheetStyle} pageStyle={{ paddingTop: 0 }}>
         <Zig id="amend-codicil" />
-        <FactionRow slug={character.faction_slug} />
-        <DeleteCharacter slug={character.faction_slug} deleting={deleting} onDelete={handleDelete} />
+        <FactionRow slug={character.faction_slug} rowStyle={codicilPlate} />
+        <DeleteCharacter
+          slug={character.faction_slug}
+          deleting={deleting}
+          onDelete={handleDelete}
+          // The confirm's CANCEL key is the codicil's other plate, and it shipped
+          // with the same neutral pair — 1.07:1 of well and 1.41:1 of hairline on
+          // this cream. Same plate, same edge. The DELETE key beside it keeps
+          // `--color-danger` / `--color-on-danger`: a ground and its ink, not
+          // type on a wash (2026-08-27 ruling), and the seam does not reach it.
+          cancelStyle={codicilPlate}
+        />
       </ComposerSheet>
 
       {/* Portrait crop/rotate — locked square (#514). */}


### PR DESCRIPTION
Closes #2987

## The seam this is tested at

`wowEditCharacterContrast.test.ts`, on the **codicil** — WoW's second sheet, where `FactionRow` and `DeleteCharacter` are mounted on `--faction-wow-card-bg` instead of on the na page's washed ground they were designed over. The paint change is made at **#2956's dress seam** (`FactionRow`'s `rowStyle`, `DeleteCharacter`'s `cancelStyle`), from `WowEditCharacter.tsx`. `editCharacterSlots.tsx` is not touched — its defaults still stand for every mount that passes nothing.

The loop went red first at that seam (the guard that the paint measured here is the paint on screen), then green.

## What was wrong

The suite measured four TEXT rows and all four cleared AA, so the sheet read as guarded and was not. The faction row is a **plate**, and the shared slot's plate is `--color-bg-surface-alt` behind a `--color-border-strong` hairline. WCAG 1.4.11 asks 3:1 of a graphical boundary that carries meaning, and a plate edge delimiting a control region is one.

The confirm's **cancel key** is the identical pair two elements away on the same sheet (`--color-bg-surface` + `--color-border-strong`), so it is repainted in the same PR rather than left as a second 1.41 hairline for the next reviewer to find.

## Measured, before and after (light / dark)

| pair | before | after | 1.4.11 asks |
|---|---|---|---|
| faction-row plate edge vs the cream sheet | 1.41 / 1.56 | **5.32 / 8.83** | 3:1 |
| faction-row plate edge vs the well it encloses | 1.41 / 1.61 | **4.74 / 7.66** | 3:1 |
| cancel key's edge (same plate, same edge) | 1.41 / 1.60 | **5.32 / 8.83** | 3:1 |
| delete outline + confirm frame vs the sheet | 7.57 / 9.56 | unchanged | 3:1 |
| plate FILL vs the sheet | 1.06 / 1.16 | 1.12 / 1.15 | see below |

The four existing TEXT rows still pass, re-taken over the new well (the ground moved, so every claim on it had to be):

| ink | before (over the neutral plate) | after (over the charter's plate) |
|---|---|---|
| faction name, `--color-text-secondary` | 7.31 / 6.99 | 6.93 / 7.05 |
| label + confirm prompt, on the cream | 7.78 / 8.13 | unchanged |
| help line, on the cream | 7.83 / 8.72 | unchanged |
| delete/confirm alarm, on the cream | 7.57 / 9.56 | unchanged |
| chevron `--color-text-tertiary` on the plate | *never measured* | **6.98 / 7.57** |
| cancel key's ink on its plate | *never measured* | **15.02 / 12.69** |

## The design decision: the EDGE carries the boundary, not the fill

1.4.11 asks 3:1 of *the information that identifies the component* against adjacent colour. For a plate, that is its edge. **No in-family stock can be a 3:1 fill here** — the chronicle panel is 1.12 / 1.15 against its own cream, and any well that did clear 3:1 against the sheet would read as a hole punched in the parchment rather than a plate laid on it. So the fill stays a fill (and stays measured, and stays documented as deliberate), and the boundary is carried by an edge measured on **both** the colours it lies between.

The edge is `--faction-wow-accent-deep`, the charter's own deep olive-gold, already the ink measured on both chronicle grounds. `--faction-wow-chronicle-gold` could not do it: 2.24:1 on the cream — WoW's gilt frames and rules, and never carries information, exactly as §3 of the archetype's header says of type.

`--color-danger` / `--color-on-danger` on the filled confirm are untouched (2026-08-27 ruling).

## The open question, answered: this is NOT WoW-only

Measured across every lane that mounts these slots, as each one actually paints (Singularity repoints the neutrals to `-term-*` on its wrapper root, so it is measured on the repointed pair):

| lane | ground | plate fill vs ground (light / dark) | hairline vs ground (light / dark) |
|---|---|---|---|
| na / default | page ground | 1.07 / 1.16 | 1.41 / 1.54 |
| Coven | page ground | 1.07 / 1.16 | 1.41 / 1.54 |
| UA | page ground | 1.07 / 1.16 | 1.41 / 1.54 |
| Everymen | `--everymen-paper` | 1.11 / 1.18 | 1.40 / 1.59 |
| Ephemerists | `--faction-ephemerists-plate-bg` | 1.17 / 1.18 | 1.40 / 1.59 |
| S.N.I.D.E. | `--faction-snide-wall` (top of ramp) | 1.01 / 1.12 | 1.41 / 1.47 |
| Singularity | `-term-panel`, repointed pair | 1.07 / 1.04 | 1.52 / 1.72 |
| **WoW (this PR)** | `--faction-wow-card-bg` | 1.12 / 1.15 | **5.32 / 8.83** |

Every lane shares the gap, Singularity's repoint included. **This PR deliberately does not expand into a seven-faction repaint** — each lane's edge has to be chosen and measured on its own stock, which is seven dress decisions with seven measurements. Follow-up issue filed: **#3009**, with the table above and what each lane owes.

## Verification run

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (509 files, 10548 passed), `npm run build`, `npm run budget` — all clean. Budget reports the pre-existing JS **warn** band (149.6 KB, fail line 175.8 KB); this change adds no JS beyond three style properties. Backend untouched, so no `api-schema` regeneration is in play.

**Visual QA is outstanding.** There is no browser in this lane — everything above is computed off the token graph, not observed on screen.

## What to eyeball

1. **WoW edit-character sheet, light** — the codicil (the second sheet, below Save): the faction row is now a parchment plate in a deep olive-gold 1.5px frame instead of a near-invisible grey well. Does it sit with the gilt-framed fields above it, or fight them?
2. **WoW edit-character sheet, dark** — same plate on the deep stock; the edge is 8.83:1 there, which is strong. Check it does not read as a hard black box.
3. **WoW delete confirm, light and dark** — press *Delete*, then look at the two keys side by side: **Cancel** now takes the same parchment plate and deep edge, **Delete** is still the platform's filled red. The weight relationship between them is the thing to judge.
4. **The delete outline before confirming**, both themes — unchanged paint, but it now neighbours a framed plate rather than a flat one.
5. **Phone width**, both themes — the codicil stacks under the charter; check the plate's 1.5px edge and 6px radius do not crowd the sheet's own frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
