### PR TITLE
The latest Era row chooses the live ruleset, and a mod picks it from the admin page (#827)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ identity + era-as-ruleset in ADR-0041 / ADR-0042.
 
 | Need... | Go to |
 |---|---|
-| Active rule values (signup cap, vote budget, level thresholds, resets) | `backend/eras/era_1.py` (live `ERA_1`; `CURRENT_ERA` resolves here) |
+| Active rule values (signup cap, vote budget, level thresholds, resets) | `backend/eras/era_1.py` (`ERA_1`; which era is live is the latest DB `Era` row — ADR-0091) |
 | Factions, tasks, level ranks/unlocks + taunt structure for the live era | `backend/eras/era_1.py` |
 | Taunt & rank/unlock **wording** (ADR-0031: backend emits keys) | `frontend/src/locales/en/{taunts,progression}.json` |
 | Faction **name/description** wording (ADR-0038: backend emits slug) | `frontend/src/locales/en/factions.json` (`names.<slug>`, `descriptions.<slug>`) |
@@ -54,7 +54,14 @@ Read only what your task needs.
 
 ## Config architecture
 - `game_config.py` = dataclass shape. `eras/era_N.py` = values. `CURRENT_ERA` = active era.
-- DB `Era.config_key` records which era was active; it does not own rules.
+- **The latest DB `Era` row's `config_key` chooses which era is active** (ADR-0091).
+  It owns no rule *value* — those stay in `eras/` — but it decides which set is
+  live, and a mod sets it from the admin page. `CURRENT_ERA` is still the one
+  lever; the hand on it moved off a code edit.
+- `CURRENT_ERA` is a stable **object identity**, refreshed in place. Never
+  reassign `game_config.CURRENT_ERA` — a default argument binds at `def` time,
+  so that moves one name and leaves 157 call sites on the old era. The only
+  rebinding site is `services.era.rebind_live_era`, and a test keeps it at one.
 - Services take `era: EraConfig = CURRENT_ERA`. Never import `CURRENT_ERA`
   inside a service body.
 - Never hardcode a value that lives in `EraConfig`. Read `era.*`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,8 @@ Read only what your task needs.
   lever; the hand on it moved off a code edit.
 - `CURRENT_ERA` is a stable **object identity**, refreshed in place. Never
   reassign `game_config.CURRENT_ERA` — a default argument binds at `def` time,
-  so that moves one name and leaves 157 call sites on the old era. The only
-  rebinding site is `services.era.rebind_live_era`, and a test keeps it at one.
+  so that moves one name and leaves every call site on the old era. The only
+  module that rebinds it is `services/era.py`, and a test keeps it there.
 - Services take `era: EraConfig = CURRENT_ERA`. Never import `CURRENT_ERA`
   inside a service body.
 - Never hardcode a value that lives in `EraConfig`. Read `era.*`.

--- a/backend/db.py
+++ b/backend/db.py
@@ -27,6 +27,15 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
     Services call ``session.flush()`` only — the router's dependency owns the
     single per-request commit. If the handler raises, the transaction rolls back
     and the exception propagates unchanged.
+
+    **One deliberate exception**, and it is the era rollover:
+    ``services.era.commit_and_bind_live_era`` commits inside the service,
+    because the process-wide live-era binding has to land *after* the write is
+    durable and this dependency's commit runs after the handler has already
+    returned (ADR-0091, #827). The commit below then finds nothing left to
+    write. Do not read it as a precedent — anything else that wants its own
+    commit needs the same "a non-transactional side effect must follow it"
+    argument.
     """
     async with AsyncSessionLocal() as session:
         try:

--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -8,10 +8,23 @@ Steps:
   2. Rename all ERA_N references to match (e.g. ERA_2, ERA_2_FACTIONS, etc.)
   3. Fill in every section marked with TODO
   4. Update backend/game_config.py:
-       - Add: from eras.era_N import ERA_N
-       - Add the key to _ERA_ATTRIBUTE_BY_CONFIG_KEY ("era_N": "ERA_N") -- this
-         is the registry every era-aware tool walks, step 7 included
-       - Change: CURRENT_ERA = ERA_N
+       - Add an `if name in ("ERA_N", "ERA_N_FACTIONS"):` branch to `__getattr__`,
+         copying the ERA_2 one. The lazy import is what keeps eras/ out of a
+         circular import with game_config; never import the era file at module
+         scope here.
+       - APPEND the key to _ERA_ATTRIBUTE_BY_CONFIG_KEY ("era_N": "ERA_N") --
+         this is the registry every era-aware tool walks, step 7 included, and
+         its order is the order the admin era selector offers. Append, never
+         insert.
+       - Do NOT assign CURRENT_ERA. Which era is LIVE is a database fact now
+         (ADR-0091, #827): the latest `Era` row's config_key chooses it, and
+         `services.era.rebind_live_era` binds it at start-up. Reassigning the
+         name would move nothing anyway -- `era: EraConfig = CURRENT_ERA`
+         defaults bind at def time, so the process would end up half-flipped.
+         A mod opens the new era from the admin page (Admin > Era), or an
+         operator runs `python scripts/era_reset.py USERNAME --yes` from a
+         shell. Adding the era file makes it *offerable*; it does not make it
+         live, and nothing about this step touches production's ruleset.
   5. Run: python seed.py --env dev
   6. Run tests: pytest tests/unit/test_era_config.py
   7. Write this era's rules module (#2709). It is not optional:

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -245,6 +245,16 @@ class ErrorCode(str, enum.Enum):
     #: is no sign-in. The player starts one.
     returning_player_consent_expired = "RETURNING_PLAYER_CONSENT_EXPIRED"
 
+    # -- Era rollover (#827, ADR-0091) --------------------------------------
+    #: A rollover naming a ``config_key`` no era file registers. Coded despite
+    #: ``routers/admin.py`` being an otherwise-uncoded staff surface, for the
+    #: same reason as :attr:`character_departed_not_restorable`: this raise is
+    #: new and the uncoded-raise allowlist only shrinks. It is also the one
+    #: refusal standing between a typo and an ``Era`` row that names no
+    #: ruleset — a row whose rules the process cannot resolve, on the most
+    #: destructive operation in the system.
+    era_config_unknown = "ERA_CONFIG_UNKNOWN"
+
 
 #: The keys of a coded ``detail`` body. Named so the frontend contract is
 #: greppable from Python and no raise site spells them as bare literals.

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -254,6 +254,14 @@ class ErrorCode(str, enum.Enum):
     #: ruleset — a row whose rules the process cannot resolve, on the most
     #: destructive operation in the system.
     era_config_unknown = "ERA_CONFIG_UNKNOWN"
+    #: A rollover naming the era that is already live. Refused because opening
+    #: an era is an append, not an assignment: re-opening the live one wipes
+    #: every score, level, vote budget and faction, freezes every duel and
+    #: retires the board, to arrive at the ruleset the game was already on.
+    #: Distinct from :attr:`era_config_unknown` — the key is perfectly valid,
+    #: the *target* is. 409 rather than 422 because nothing about the request is
+    #: malformed; it is the state of the world that refuses it.
+    era_already_live = "ERA_ALREADY_LIVE"
 
 
 #: The keys of a coded ``detail`` body. Named so the frontend contract is

--- a/backend/faction_slugs.py
+++ b/backend/faction_slugs.py
@@ -150,7 +150,7 @@ def real_faction_slugs(era) -> list[str]:
     lists is a faction a player could actually be in.
 
     The predicate had spelled itself out twice before it got a home (#2708):
-    ``seed.DUEL_FIXTURE_TASK_FACTION_SLUG`` and
+    ``seed.duel_fixture_task_faction_slug`` and
     ``scripts.seed_demo_praxes.fixture_faction_slugs``, both of which left a note
     naming this module as its place — beside :func:`faction_filter_slugs`, the
     leaf every layer may import — the day a third site asked. The integration

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -1,10 +1,18 @@
 """
 Single source of truth for all game rules.
 
-Services import EraConfig instances from this file. The database stores
-config_key to record which ruleset was active during each era, but never
-owns the rules themselves. Changing CURRENT_ERA is the one lever that
-switches all live game mechanics.
+Services import EraConfig instances from this file, which owns the *rules*. The
+database owns the **choice**: the latest ``Era`` row's ``config_key`` names which
+of these rulesets is live, and ``services.era.rebind_live_era`` resolves it at
+start-up and again the moment a rollover writes a new row (ADR-0091, #827).
+
+That reverses the older invariant this docstring used to state — "the database
+never owns the rules; changing CURRENT_ERA is the one lever". A mod now ends an
+era from the admin console instead of an owner editing this file and deploying.
+CURRENT_ERA is still the one lever; the hand on it moved.
+
+See "The live era binding" at the foot of this file for why CURRENT_ERA is a
+stable object identity rather than a name that gets reassigned.
 """
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -512,24 +520,26 @@ def __getattr__(name: str):
     one.
     """
     if name == "CURRENT_ERA":
-        # The ONE line a rollover moves. Deliberately its own branch: resolving
-        # ERA_1 must not also (re)bind CURRENT_ERA, or the flip is undone by a
-        # side effect. `services.activity_feed` calls `era_config_for_key` on a
-        # stored row's key to label a PAST era, and with the two folded together
-        # the first such call after the flip would rebind CURRENT_ERA to Era 1
-        # for the life of the process — while every module that imported it at
-        # start-up kept the new one. Found rehearsing the flip in #2708.
-        from eras.era_1 import ERA_1 as _era_1
-        globals()["CURRENT_ERA"] = _era_1
-        return _era_1
+        # Deliberately its own branch: resolving ERA_1 must not also (re)bind
+        # CURRENT_ERA, or a flip is undone by a side effect.
+        # `services.activity_feed` calls `era_config_for_key` on a stored row's
+        # key to label a PAST era, and with the two folded together the first
+        # such call after a flip would put the process back on Era 1's rules for
+        # the life of it — while every module that imported CURRENT_ERA at
+        # start-up kept the new one. Found rehearsing the flip in #2708, and
+        # still the reason these are two branches now that #827 makes the
+        # rebinding deliberate.
+        live = _new_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
+        globals()["CURRENT_ERA"] = live
+        return live
     if name in ("ERA_1", "ERA_1_FACTIONS"):
         from eras.era_1 import ERA_1 as _era_1
         globals()["ERA_1"] = _era_1
         globals()["ERA_1_FACTIONS"] = _era_1.factions
         return globals()[name]
     if name in ("ERA_2", "ERA_2_FACTIONS"):
-        # Era 2 (Metamorphosis) is authored, not activated: CURRENT_ERA stays
-        # Era 1 above.
+        # Resolving Era 2's config does not make Era 2 live. Only the database
+        # decides that, through `bind_live_era` below (ADR-0091).
         from eras.era_2 import ERA_2 as _era_2
         globals()["ERA_2"] = _era_2
         globals()["ERA_2_FACTIONS"] = _era_2.factions
@@ -546,10 +556,28 @@ def __getattr__(name: str):
 # the config_key off an era file means importing every era file at module load,
 # which is exactly the eager import the __getattr__ above exists to avoid. The
 # duplication is one string per era, and a unit test asserts the two agree.
+#
+# Insertion order is authoring order, which is era order — the admin selector
+# lists the eras in it, so a new era is appended, never inserted (#827).
 _ERA_ATTRIBUTE_BY_CONFIG_KEY: dict[str, str] = {
     "era_1": "ERA_1",
     "era_2": "ERA_2",
 }
+
+#: The era the process compiles against, and the ONLY thing the live binding
+#: falls back to: a fresh database has no ``Era`` row at all, and startup must
+#: not crash on that (ADR-0091). It is not "the live era" — the database is.
+COMPILE_TIME_ERA_CONFIG_KEY = "era_1"
+
+
+def registered_era_config_keys() -> tuple[str, ...]:
+    """Every ``config_key`` an ``Era`` row may name, in era order.
+
+    The admin era selector's option list, and the validation behind it: a
+    ``config_key`` outside this tuple names no ruleset, so no row may be written
+    with it.
+    """
+    return tuple(_ERA_ATTRIBUTE_BY_CONFIG_KEY)
 
 
 def era_config_for_key(config_key: str) -> EraConfig | None:
@@ -563,3 +591,65 @@ def era_config_for_key(config_key: str) -> EraConfig | None:
     if attribute_name is None:
         return None
     return globals().get(attribute_name) or __getattr__(attribute_name)
+
+
+# ---------------------------------------------------------------------------
+# The live era binding (ADR-0091, #827)
+# ---------------------------------------------------------------------------
+#
+# ``CURRENT_ERA`` is a **stable object identity**, not a name that gets
+# reassigned, and this is the whole trick — so it is worth the paragraph.
+#
+# 157 sites under ``backend/`` are written ``era: EraConfig = CURRENT_ERA``. A
+# default argument is evaluated once, when the ``def`` executes, so each of
+# those functions holds the *object* for the life of the process. Four more read
+# ``CURRENT_ERA`` as a module global inside a function body — which is the
+# *importing* module's global, not this one's. Assigning
+# ``game_config.CURRENT_ERA = other`` moves neither: it rebinds one name in one
+# module while every holder keeps what it captured. A process flipped that way
+# is half-flipped, which is worse than either era.
+#
+# So the flip refreshes the fields of the one instance every holder already
+# points at. All 157 call sites stay untouched and become correct at once — and
+# the alternative, threading ``era=`` through 157 signatures where an omitted
+# argument silently serves the compile-time era, is the refactor the #827 ruling
+# declined for exactly that reason.
+#
+# Writing through a frozen dataclass is the same move ``__post_init__`` already
+# makes above. The wall exists to stop *callers* mutating a config, not to stop
+# this module owning one.
+
+
+def _new_live_era(source: EraConfig) -> EraConfig:
+    """A distinct ``EraConfig`` carrying ``source``'s fields.
+
+    Distinct is the point. ``bind_live_era`` refreshes this object in place, so
+    if the live era *were* ``ERA_1`` the first flip would overwrite the era
+    file's own config and Era 1 would stop existing in the process.
+
+    ``object.__new__`` skips ``__init__`` and ``__post_init__`` deliberately:
+    the fields being copied have already been through them, and perk inheritance
+    (#1871) is not idempotent.
+    """
+    live = object.__new__(EraConfig)
+    live.__dict__.update(source.__dict__)
+    return live
+
+
+def bind_live_era(era: EraConfig) -> EraConfig:
+    """Point the live ruleset at ``era``. THE one lever (ADR-0091).
+
+    Call it through :func:`services.era.rebind_live_era`, which is the only
+    thing that knows *which* era the database says is live;
+    ``tests/unit/test_live_era_binding.py`` keeps that to one caller.
+
+    Returns the live instance — the same object every time, by design.
+    """
+    live = globals().get("CURRENT_ERA") or __getattr__("CURRENT_ERA")
+    if era is live:
+        # Already live. Guarded because the refresh below clears the dict it is
+        # about to read from, so aliasing would empty the live era instead.
+        return live
+    live.__dict__.clear()
+    live.__dict__.update(era.__dict__)
+    return live

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -644,12 +644,35 @@ def bind_live_era(era: EraConfig) -> EraConfig:
     ``tests/unit/test_live_era_binding.py`` keeps that to one caller.
 
     Returns the live instance — the same object every time, by design.
+
+    **Per-key overwrite, never empty-then-fill.** The refresh below must not be
+    ``clear()`` followed by ``update()``: between those two statements the live
+    era would be an ``EraConfig`` with no attributes at all, and every one of the
+    157 default arguments points at that object. FastAPI runs sync dependencies
+    and sync route handlers in a threadpool and the GIL is released between
+    bytecodes, so a worker thread can read the object mid-refresh and raise
+    ``AttributeError`` on a field that exists — an inexplicable failure under
+    load, during the one operation this whole mechanism exists to enable.
+
+    ``update()`` alone is also sufficient, which is why the clear was pure cost:
+    ``EraConfig`` is a frozen dataclass with a fixed field list and no
+    ``__slots__``, both sides of every call are fully-constructed era configs,
+    and all 43 declared fields are present on each — so there is never a stale
+    key for a clear to remove. The prune below keeps that defensiveness for an
+    era config that somehow carries an extra attribute, without the empty state.
+
+    A concurrent reader therefore sees either the closing era's value or the
+    opening era's for any given field, never a missing one. That is exactly the
+    "a request in flight can straddle the change" the #827 ruling accepted, and
+    nothing worse.
     """
     live = globals().get("CURRENT_ERA") or __getattr__("CURRENT_ERA")
     if era is live:
-        # Already live. Guarded because the refresh below clears the dict it is
-        # about to read from, so aliasing would empty the live era instead.
+        # Already live, so there is nothing to copy. A cheap no-op rather than a
+        # correctness guard: the per-key overwrite below is harmless when source
+        # and target alias, since every write would set a key to its own value.
         return live
-    live.__dict__.clear()
     live.__dict__.update(era.__dict__)
+    for stale in set(live.__dict__) - set(era.__dict__):
+        del live.__dict__[stale]
     return live

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -354,11 +354,14 @@ class EraConfig:
     # era names must be a slug that era actually configures, since it is an FK
     # onto a Faction row — and, since ADR-0087, that slug can only be `na`.
     #
-    # Read from the era being *opened*: apply_era_reset takes `era: EraConfig =
-    # CURRENT_ERA` and scripts/era_reset.py leaves that default in place, the
-    # rollover procedure being "point CURRENT_ERA at the next era, then run the
-    # script". So this is the incoming era's answer to where the outgoing era's
+    # Read from the era being *opened*. Both doors pass it explicitly:
+    # `services.admin_service.roll_into_era` hands `apply_era_reset` the config a
+    # mod picked, and `scripts/era_reset.py` hands it the one the live `Era` row
+    # names. So this is the incoming era's answer to where the outgoing era's
     # players land — consistent with reset_score/reset_level/reset_faction.
+    # (Before #827 the procedure was "point CURRENT_ERA at the next era, then run
+    # the script", and the default argument was what carried it. The database
+    # chooses now; the default is only the fallback for callers that pass none.)
     reset_faction_slug: str = UNAFFILIATED_FACTION_SLUG
 
     # Metatask-per-praxis cap (defaulted so bare EraConfig constructions stay valid).
@@ -600,9 +603,12 @@ def era_config_for_key(config_key: str) -> EraConfig | None:
 # ``CURRENT_ERA`` is a **stable object identity**, not a name that gets
 # reassigned, and this is the whole trick — so it is worth the paragraph.
 #
-# 157 sites under ``backend/`` are written ``era: EraConfig = CURRENT_ERA``. A
-# default argument is evaluated once, when the ``def`` executes, so each of
-# those functions holds the *object* for the life of the process. Four more read
+# Every service that takes a ruleset is written ``era: EraConfig = CURRENT_ERA``
+# — 114 sites under ``backend/`` at the time of writing, countable with
+# ``grep -rn --include='*.py' "era: EraConfig = CURRENT_ERA" backend/``, and the
+# number is expected to drift. A default argument is evaluated once, when the
+# ``def`` executes, so each of those functions holds the *object* for the life
+# of the process. Four more read
 # ``CURRENT_ERA`` as a module global inside a function body — which is the
 # *importing* module's global, not this one's. Assigning
 # ``game_config.CURRENT_ERA = other`` moves neither: it rebinds one name in one
@@ -610,10 +616,10 @@ def era_config_for_key(config_key: str) -> EraConfig | None:
 # is half-flipped, which is worse than either era.
 #
 # So the flip refreshes the fields of the one instance every holder already
-# points at. All 157 call sites stay untouched and become correct at once — and
-# the alternative, threading ``era=`` through 157 signatures where an omitted
-# argument silently serves the compile-time era, is the refactor the #827 ruling
-# declined for exactly that reason.
+# points at. Every one of those call sites stays untouched and becomes correct
+# at once — and the alternative, threading ``era=`` through all of them where an
+# omitted argument silently serves the compile-time era, is the refactor the
+# #827 ruling declined for exactly that reason.
 #
 # Writing through a frozen dataclass is the same move ``__post_init__`` already
 # makes above. The wall exists to stop *callers* mutating a config, not to stop
@@ -647,8 +653,8 @@ def bind_live_era(era: EraConfig) -> EraConfig:
 
     **Per-key overwrite, never empty-then-fill.** The refresh below must not be
     ``clear()`` followed by ``update()``: between those two statements the live
-    era would be an ``EraConfig`` with no attributes at all, and every one of the
-    157 default arguments points at that object. FastAPI runs sync dependencies
+    era would be an ``EraConfig`` with no attributes at all, and every one of
+    those default arguments points at that object. FastAPI runs sync dependencies
     and sync route handlers in a threadpool and the GIL is released between
     bytecodes, so a worker thread can read the object mid-refresh and raise
     ``AttributeError`` on a field that exists — an inexplicable failure under

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -604,11 +604,11 @@ def era_config_for_key(config_key: str) -> EraConfig | None:
 # reassigned, and this is the whole trick — so it is worth the paragraph.
 #
 # Every service that takes a ruleset is written ``era: EraConfig = CURRENT_ERA``
-# — 114 sites under ``backend/`` at the time of writing, countable with
-# ``grep -rn --include='*.py' "era: EraConfig = CURRENT_ERA" backend/``, and the
-# number is expected to drift. A default argument is evaluated once, when the
-# ``def`` executes, so each of those functions holds the *object* for the life
-# of the process. Four more read
+# — more than a hundred signatures under ``backend/``, 108 of them in shipped
+# code at the time of writing (ADR-0091 carries the grep and the caveat that the
+# number drifts). A default argument is evaluated once, when the ``def``
+# executes, so each of those functions holds the *object* for the life of the
+# process. Four more read
 # ``CURRENT_ERA`` as a module global inside a function body — which is the
 # *importing* module's global, not this one's. Assigning
 # ``game_config.CURRENT_ERA = other`` moves neither: it rebinds one name in one

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,10 +10,11 @@ from sqlalchemy.exc import IntegrityError
 from starlette.middleware.sessions import SessionMiddleware
 
 from config import settings
-from db import engine
+from db import engine, get_session_factory
 from routers import activity_feed, admin, auth, characters, duel, factions, game_config, leaderboard, praxes, relationships, tasks, votes
 from routers import comments, contact, me, terms
 from schemas.system import HealthOut
+from services.era import rebind_live_era
 from services.praxis_room import (
     PRAXIS_ROOM_APP,
     PRAXIS_ROOM_SERVER,
@@ -40,6 +41,15 @@ async def lifespan(app: FastAPI):
     # instance may run (ADR-0073). Claim that right before serving anything;
     # a second instance raises here and the deploy fails loudly.
     single_instance_lock = await acquire_single_instance_lock(engine)
+
+    # Which era's rules this process plays by is a database fact (ADR-0091).
+    # Read it once the instance lock is held, because the lock is what makes a
+    # process-wide live era sound in the first place: exactly one worker runs
+    # (ADR-0073), so there is nothing to drift out of step with. Never raises —
+    # a fresh database has no Era row yet and start-up must survive that.
+    async with get_session_factory()() as session:
+        await rebind_live_era(session)
+
     try:
         # The room server's task group has to outlive every socket it serves,
         # which means it belongs to the app's lifespan, not to a request.

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,15 +42,21 @@ async def lifespan(app: FastAPI):
     # a second instance raises here and the deploy fails loudly.
     single_instance_lock = await acquire_single_instance_lock(engine)
 
-    # Which era's rules this process plays by is a database fact (ADR-0091).
-    # Read it once the instance lock is held, because the lock is what makes a
-    # process-wide live era sound in the first place: exactly one worker runs
-    # (ADR-0073), so there is nothing to drift out of step with. Never raises —
-    # a fresh database has no Era row yet and start-up must survive that.
-    async with get_session_factory()() as session:
-        await rebind_live_era(session)
-
     try:
+        # Which era's rules this process plays by is a database fact (ADR-0091).
+        # Read it once the instance lock is held, because the lock is what makes
+        # a process-wide live era sound in the first place: exactly one worker
+        # runs (ADR-0073), so there is nothing to drift out of step with.
+        #
+        # Inside the try, because the lock is already held: a *row* it cannot
+        # resolve is survivable — no Era row on a fresh install, or a key no era
+        # file registers, both fall back to the compile-time era and log — but
+        # the query itself can still fail, and a database that is down at boot
+        # must not leave the single-instance advisory lock held by a process
+        # that then dies. The finally below is what releases it.
+        async with get_session_factory()() as session:
+            await rebind_live_era(session)
+
         # The room server's task group has to outlive every socket it serves,
         # which means it belongs to the app's lifespan, not to a request.
         async with PRAXIS_ROOM_SERVER:

--- a/backend/models/era.py
+++ b/backend/models/era.py
@@ -18,7 +18,20 @@ class Era(Base):
     #: written by a newer version). That is the whole reason ``seed.py`` and
     #: ``routers/admin.py`` keep writing it. Not a dead field; do not sweep it.
     name: Mapped[str] = mapped_column(String, nullable=False)
-    #: Identity, not prose: the link to the EraConfig that governed this era.
+    #: Identity, not prose: the link to the EraConfig that governs this era.
+    #:
+    #: On the LATEST row this column is also the **choice** — it is what says
+    #: which ruleset the process plays by, resolved at start-up and again the
+    #: moment a rollover appends a row (ADR-0091, #827). That reverses what this
+    #: comment used to say, which was that the column "does not own the rules":
+    #: it still owns no *value* — every rule lives in ``eras/era_N.py`` — but it
+    #: decides which set of them is live, and an admin writes it. On every older
+    #: row it is history, exactly as before.
+    #:
+    #: So a key here that no era file registers is not a cosmetic problem: the
+    #: process cannot resolve the rules that row records and falls back, loudly,
+    #: to the compile-time era (``services.era.rebind_live_era``). The rollover
+    #: route validates against the registry before writing, for that reason.
     config_key: Mapped[str] = mapped_column(String, nullable=False)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7632,7 +7632,7 @@
     },
     "/admin/eras": {
       "get": {
-        "description": "Admin-only: the eras a rollover may target, and which one is live.\n\nNo session: which rulesets exist is a code fact, and which is live is the\nbinding this process is already holding (ADR-0091).",
+        "description": "Admin-only: the eras a rollover may target, and which one is live.\n\nWhich rulesets exist is a code fact; which one is **live** is a database one\n— the latest ``Era`` row (ADR-0091), which is also what ``PUT /eras/live``\nrefuses against. Reading it from the process binding instead would let the\nselector offer an era the ``PUT`` then rejects, in the one state where the\ntwo can disagree.",
         "operationId": "admin_list_eras_admin_eras_get",
         "parameters": [
           {
@@ -7691,7 +7691,7 @@
     },
     "/admin/eras/live": {
       "put": {
-        "description": "Admin-only: end the live era and open the one named. **No undo.**\n\nEveryone's score, level, vote budget and faction reset per the incoming\nera's flags; every unresolved duel freezes into a permanent result (#824);\nthe whole board retires; and the process starts playing by the new rules\nbefore this response is written.\n\n``PUT`` rather than ``POST`` because the resource is \"the live era\" and this\nsets it. It is emphatically **not** idempotent all the same — opening an era\nis an append, so a second call opens a second one. The confirmation that\nstops that is the mod's, on the admin page; the equivalent gate on\n``scripts/era_reset.py`` is its ``--yes``.\n\nThis route restores an entry point #1667 deleted, deliberately and on the\nother side of the argument that deleted it: ``PUT /admin/era/reset`` went\nbecause it was unreachable from any UI and re-instantiated the same era, so\na destructive rollover sat behind any admin session for no gain. It comes\nback because #827 gives it the two things it lacked — a target to choose,\nand a mod control that chooses it.",
+        "description": "Admin-only: end the live era and open the one named. **No undo.**\n\nEveryone's score, level, vote budget and faction reset per the incoming\nera's flags; every unresolved duel freezes into a permanent result (#824);\nthe whole board retires; and the process starts playing by the new rules\nbefore this response is written.\n\n``PUT`` rather than ``POST`` because the resource is \"the live era\" and this\nsets it — and unlike the append it wraps, the call itself settles: repeating\nit with the key that is now live is refused with **409\n``ERA_ALREADY_LIVE``** rather than opening a second era, and two calls that\noverlap are serialized by an advisory lock, so the second one sees the first\none's row and refuses on it. What is still not idempotent is rolling on:\nnaming a *different* era opens another one every time, and the only thing\nbetween a mod and that is the confirmation on the admin page — the\nequivalent gate on ``scripts/era_reset.py`` is its ``--yes``.\n\nThis route restores an entry point #1667 deleted, deliberately and on the\nother side of the argument that deleted it: ``PUT /admin/era/reset`` went\nbecause it was unreachable from any UI and re-instantiated the same era, so\na destructive rollover sat behind any admin session for no gain. It comes\nback because #827 gives it the two things it lacked — a target to choose,\nand a mod control that chooses it.",
         "operationId": "admin_roll_into_era_admin_eras_live_put",
         "parameters": [
           {

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2339,6 +2339,73 @@
         "title": "EraAnnouncementPayload",
         "type": "object"
       },
+      "EraOption": {
+        "description": "One row in the admin era selector.\n\n``config_key`` is the identity a mod picks and ``Era.config_key`` stores;\n``name`` is the era's player-visible name, read off the config rather than\noff any row, because an era that has never run has no row to read.",
+        "properties": {
+          "config_key": {
+            "title": "Config Key",
+            "type": "string"
+          },
+          "is_live": {
+            "title": "Is Live",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "config_key",
+          "name",
+          "is_live"
+        ],
+        "title": "EraOption",
+        "type": "object"
+      },
+      "EraRollIn": {
+        "description": "``POST /admin/eras/roll`` — the era to roll the game into.\n\nDeliberately just the key. A rollover has no options: the resets it performs\nare the *incoming* era's flags (ADR-0042), so anything else this body could\ncarry would be a second place to state a rule the era file already owns.",
+        "properties": {
+          "config_key": {
+            "title": "Config Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "config_key"
+        ],
+        "title": "EraRollIn",
+        "type": "object"
+      },
+      "EraRollOut": {
+        "description": "What the rollover did, read back rather than echoed.",
+        "properties": {
+          "characters_reset": {
+            "title": "Characters Reset",
+            "type": "integer"
+          },
+          "config_key": {
+            "title": "Config Key",
+            "type": "string"
+          },
+          "era_id": {
+            "title": "Era Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "era_id",
+          "config_key",
+          "name",
+          "characters_reset"
+        ],
+        "title": "EraRollOut",
+        "type": "object"
+      },
       "FactionChoiceRequest": {
         "properties": {
           "faction_slug": {
@@ -7558,6 +7625,130 @@
           }
         ],
         "summary": "Admin Moderate Comment",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/admin/eras": {
+      "get": {
+        "description": "Admin-only: the eras a rollover may target, and which one is live.\n\nNo session: which rulesets exist is a code fact, and which is live is the\nbinding this process is already holding (ADR-0091).",
+        "operationId": "admin_list_eras_admin_eras_get",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "access_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Access Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EraOption"
+                  },
+                  "title": "Response Admin List Eras Admin Eras Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin List Eras",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/admin/eras/live": {
+      "put": {
+        "description": "Admin-only: end the live era and open the one named. **No undo.**\n\nEveryone's score, level, vote budget and faction reset per the incoming\nera's flags; every unresolved duel freezes into a permanent result (#824);\nthe whole board retires; and the process starts playing by the new rules\nbefore this response is written.\n\n``PUT`` rather than ``POST`` because the resource is \"the live era\" and this\nsets it. It is emphatically **not** idempotent all the same — opening an era\nis an append, so a second call opens a second one. The confirmation that\nstops that is the mod's, on the admin page; the equivalent gate on\n``scripts/era_reset.py`` is its ``--yes``.\n\nThis route restores an entry point #1667 deleted, deliberately and on the\nother side of the argument that deleted it: ``PUT /admin/era/reset`` went\nbecause it was unreachable from any UI and re-instantiated the same era, so\na destructive rollover sat behind any admin session for no gain. It comes\nback because #827 gives it the two things it lacked — a target to choose,\nand a mod control that chooses it.",
+        "operationId": "admin_roll_into_era_admin_eras_live_put",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "access_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Access Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EraRollIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EraRollOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Roll Into Era",
         "tags": [
           "admin"
         ]

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2364,7 +2364,7 @@
         "type": "object"
       },
       "EraRollIn": {
-        "description": "``POST /admin/eras/roll`` — the era to roll the game into.\n\nDeliberately just the key. A rollover has no options: the resets it performs\nare the *incoming* era's flags (ADR-0042), so anything else this body could\ncarry would be a second place to state a rule the era file already owns.",
+        "description": "``PUT /admin/eras/live`` — the era to roll the game into.\n\nDeliberately just the key. A rollover has no options: the resets it performs\nare the *incoming* era's flags (ADR-0042), so anything else this body could\ncarry would be a second place to state a rule the era file already owns.",
         "properties": {
           "config_key": {
             "title": "Config Key",

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -26,6 +26,9 @@ from schemas.admin import (
     CharacterStatsOut,
     CharacterSummary,
     CliTokenResponse,
+    EraOption,
+    EraRollIn,
+    EraRollOut,
     FlaggedCommentOut,
     FlaggedPraxisOut,
     ModerationAction,
@@ -56,6 +59,8 @@ from services.admin_service import (
     list_characters,
     list_contact_messages,
     list_pending_tasks_with_proposer,
+    list_registered_eras,
+    roll_into_era,
     set_character_stats,
     suspend_account,
     update_task_status,
@@ -423,3 +428,49 @@ async def admin_import_tasks_csv(
         created_titles=outcome.created_titles,
         warnings=outcome.warnings,
     )
+
+
+# ---------------------------------------------------------------------------
+# Era rollover (#827, ADR-0091)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/eras", response_model=list[EraOption])
+async def admin_list_eras(
+    _: Account = Depends(require_admin),
+) -> list[EraOption]:
+    """Admin-only: the eras a rollover may target, and which one is live.
+
+    No session: which rulesets exist is a code fact, and which is live is the
+    binding this process is already holding (ADR-0091).
+    """
+    return list_registered_eras()
+
+
+@router.put("/eras/live", response_model=EraRollOut)
+async def admin_roll_into_era(
+    data: EraRollIn,
+    admin: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+) -> EraRollOut:
+    """Admin-only: end the live era and open the one named. **No undo.**
+
+    Everyone's score, level, vote budget and faction reset per the incoming
+    era's flags; every unresolved duel freezes into a permanent result (#824);
+    the whole board retires; and the process starts playing by the new rules
+    before this response is written.
+
+    ``PUT`` rather than ``POST`` because the resource is "the live era" and this
+    sets it. It is emphatically **not** idempotent all the same — opening an era
+    is an append, so a second call opens a second one. The confirmation that
+    stops that is the mod's, on the admin page; the equivalent gate on
+    ``scripts/era_reset.py`` is its ``--yes``.
+
+    This route restores an entry point #1667 deleted, deliberately and on the
+    other side of the argument that deleted it: ``PUT /admin/era/reset`` went
+    because it was unreachable from any UI and re-instantiated the same era, so
+    a destructive rollover sat behind any admin session for no gain. It comes
+    back because #827 gives it the two things it lacked — a target to choose,
+    and a mod control that chooses it.
+    """
+    return await roll_into_era(data.config_key, admin, session)

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -438,13 +438,17 @@ async def admin_import_tasks_csv(
 @router.get("/eras", response_model=list[EraOption])
 async def admin_list_eras(
     _: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
 ) -> list[EraOption]:
     """Admin-only: the eras a rollover may target, and which one is live.
 
-    No session: which rulesets exist is a code fact, and which is live is the
-    binding this process is already holding (ADR-0091).
+    Which rulesets exist is a code fact; which one is **live** is a database one
+    — the latest ``Era`` row (ADR-0091), which is also what ``PUT /eras/live``
+    refuses against. Reading it from the process binding instead would let the
+    selector offer an era the ``PUT`` then rejects, in the one state where the
+    two can disagree.
     """
-    return list_registered_eras()
+    return await list_registered_eras(session)
 
 
 @router.put("/eras/live", response_model=EraRollOut)
@@ -461,10 +465,14 @@ async def admin_roll_into_era(
     before this response is written.
 
     ``PUT`` rather than ``POST`` because the resource is "the live era" and this
-    sets it. It is emphatically **not** idempotent all the same — opening an era
-    is an append, so a second call opens a second one. The confirmation that
-    stops that is the mod's, on the admin page; the equivalent gate on
-    ``scripts/era_reset.py`` is its ``--yes``.
+    sets it — and unlike the append it wraps, the call itself settles: repeating
+    it with the key that is now live is refused with **409
+    ``ERA_ALREADY_LIVE``** rather than opening a second era, and two calls that
+    overlap are serialized by an advisory lock, so the second one sees the first
+    one's row and refuses on it. What is still not idempotent is rolling on:
+    naming a *different* era opens another one every time, and the only thing
+    between a mod and that is the confirmation on the admin page — the
+    equivalent gate on ``scripts/era_reset.py`` is its ``--yes``.
 
     This route restores an entry point #1667 deleted, deliberately and on the
     other side of the argument that deleted it: ``PUT /admin/era/reset`` went

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -223,7 +223,7 @@ class EraOption(WireModel):
 
 
 class EraRollIn(WireModel):
-    """``POST /admin/eras/roll`` — the era to roll the game into.
+    """``PUT /admin/eras/live`` — the era to roll the game into.
 
     Deliberately just the key. A rollover has no options: the resets it performs
     are the *incoming* era's flags (ADR-0042), so anything else this body could

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -202,3 +202,41 @@ class BanActionOut(WireModel):
 
 class CliTokenResponse(WireModel):
     access_token: str
+
+
+# ---------------------------------------------------------------------------
+# Era rollover (#827, ADR-0091)
+# ---------------------------------------------------------------------------
+
+
+class EraOption(WireModel):
+    """One row in the admin era selector.
+
+    ``config_key`` is the identity a mod picks and ``Era.config_key`` stores;
+    ``name`` is the era's player-visible name, read off the config rather than
+    off any row, because an era that has never run has no row to read.
+    """
+
+    config_key: str
+    name: str
+    is_live: bool
+
+
+class EraRollIn(WireModel):
+    """``POST /admin/eras/roll`` — the era to roll the game into.
+
+    Deliberately just the key. A rollover has no options: the resets it performs
+    are the *incoming* era's flags (ADR-0042), so anything else this body could
+    carry would be a second place to state a rule the era file already owns.
+    """
+
+    config_key: str
+
+
+class EraRollOut(WireModel):
+    """What the rollover did, read back rather than echoed."""
+
+    era_id: int
+    config_key: str
+    name: str
+    characters_reset: int

--- a/backend/scripts/era_reset.py
+++ b/backend/scripts/era_reset.py
@@ -24,9 +24,16 @@ route did. Re-runnability here means "the plan-only run changes nothing", not
 the rollover's audit trail: a not-null FK recording *who* opened the era. This
 script refuses a username whose account is not an admin, which is the one thing
 ``PUT /admin/era/reset`` guaranteed that a shell prompt otherwise would not.
-That route was this operation's only entry point and is being deleted (#1667) —
+That route was this operation's only entry point and was deleted in #1667 —
 unreachable from the UI, and a destructive rollover behind any authenticated
 admin session is a blast radius nothing was using.
+
+**This is no longer the primary door (#827, ADR-0091).** ``PUT /admin/eras/live``
+and the admin page's era selector are, because a mod can reach them and they can
+*choose* which era to open — the two things #1667's route lacked. This script
+re-opens whichever era the database already says is live, which is what it always
+did back when the compile-time era and the live era were the same thing. It stays
+for the shell: a rollover when the site is down, or when nobody can sign in.
 """
 
 import argparse
@@ -51,7 +58,11 @@ from models.character import Character  # noqa: E402
 from models.era import Era  # noqa: E402
 from script_utils import add_env_argument, get_settings  # noqa: E402
 from services.admin_service import list_active_characters  # noqa: E402
-from services.era import apply_era_reset, get_current_era_row_safe  # noqa: E402
+from services.era import (  # noqa: E402
+    apply_era_reset,
+    get_current_era_row_safe,
+    rebind_live_era,
+)
 
 
 def print_plan(current_era_row: Era, character_count: int) -> None:
@@ -100,6 +111,14 @@ async def reset_era(session: AsyncSession, username: str, confirmed: bool) -> in
     if current_era_row is None:
         print("ERROR: no era row for the current config - run seed.py before a rollover.")
         return 1
+
+    # Point CURRENT_ERA at whatever the DATABASE says is live before printing a
+    # plan about it (ADR-0091, #827). Without this the script would re-open the
+    # *compile-time* era, so running it after a mod has rolled the game forward
+    # from the admin page would silently roll it back. This one call is why
+    # `print_plan` and the row built below need no edit: the live era is one
+    # object refreshed in place, not a name each of them re-reads.
+    await rebind_live_era(session)
 
     characters = await list_active_characters(session)
     print_plan(current_era_row, len(characters))

--- a/backend/scripts/era_reset.py
+++ b/backend/scripts/era_reset.py
@@ -75,6 +75,7 @@ from services.era import (  # noqa: E402
     apply_era_reset,
     commit_and_bind_live_era,
     get_current_era_row_safe,
+    lock_era_rollover,
 )
 
 
@@ -126,6 +127,19 @@ async def reset_era(session: AsyncSession, username: str, confirmed: bool) -> in
             f"opened the era. Run elevate_admin.py first, or name an admin."
         )
         return 1
+
+    # The same lock `PUT /admin/eras/live` takes, and taken here for the same
+    # reason it is taken there: everything from the read below to the commit has
+    # to be one decision. The two doors are not each other's hypothetical — a
+    # mod confirming on the admin page while an operator runs this in a shell is
+    # exactly the outage-shaped moment this script exists for. Without it both
+    # read the same live row, both open an era, and the process is left bound to
+    # whichever finished last rather than to the latest row.
+    #
+    # Before the read, so the row below is already the locked-in answer and
+    # needs no second look. Held until this transaction ends, which on every
+    # refusal path is the rollback the session context manager performs.
+    await lock_era_rollover(session)
 
     current_era_row = await get_current_era_row_safe(session)
     if current_era_row is None:

--- a/backend/scripts/era_reset.py
+++ b/backend/scripts/era_reset.py
@@ -31,9 +31,22 @@ admin session is a blast radius nothing was using.
 **This is no longer the primary door (#827, ADR-0091).** ``PUT /admin/eras/live``
 and the admin page's era selector are, because a mod can reach them and they can
 *choose* which era to open — the two things #1667's route lacked. This script
-re-opens whichever era the database already says is live, which is what it always
-did back when the compile-time era and the live era were the same thing. It stays
-for the shell: a rollover when the site is down, or when nobody can sign in.
+re-opens whichever era **the database** says is live, which is what it always did
+back when the compile-time era and the live era were the same thing. It stays for
+the shell: a rollover when the site is down, or when nobody can sign in.
+
+It cannot choose a *different* era; that is the admin page's job. So if the live
+row names a ``config_key`` no era file registers, this script **refuses** rather
+than falling back to the compile-time era: "re-open the live era" and "roll the
+game back to Era 1" are not the same operation, and an operator reaching for a
+shell in an outage is owed the difference.
+
+**The route refuses what this script does, and that asymmetry is deliberate.**
+``PUT /admin/eras/live`` rejects the era that is already live (``ERA_ALREADY_LIVE``)
+because from the admin page it is a mis-click: a full destructive reset that lands
+on the ruleset the game was already on. From here it is the *only* thing on offer
+and it is the operation asked for by name — a new season under the same rules —
+behind ``--yes`` typed by someone with shell access to production.
 """
 
 import argparse
@@ -53,34 +66,41 @@ from sqlalchemy.ext.asyncio import (  # noqa: E402
 )
 
 from dependencies import account_has_admin_role  # noqa: E402
-from game_config import CURRENT_ERA  # noqa: E402
+from game_config import EraConfig, era_config_for_key  # noqa: E402
 from models.character import Character  # noqa: E402
 from models.era import Era  # noqa: E402
 from script_utils import add_env_argument, get_settings  # noqa: E402
 from services.admin_service import list_active_characters  # noqa: E402
 from services.era import (  # noqa: E402
     apply_era_reset,
+    commit_and_bind_live_era,
     get_current_era_row_safe,
-    rebind_live_era,
 )
 
 
-def print_plan(current_era_row: Era, character_count: int) -> None:
-    """Everything an operator needs before an irreversible decision."""
+def print_plan(
+    current_era_row: Era, opening: EraConfig, character_count: int
+) -> None:
+    """Everything an operator needs before an irreversible decision.
+
+    ``opening`` is passed rather than read off ``CURRENT_ERA`` so this prints
+    the era the row names even when nothing has bound it yet — the plan-only run
+    changes nothing, and that includes the process's live era.
+    """
     print(
         f"Closing     : era id={current_era_row.id} "
         f"config_key={current_era_row.config_key!r} (opened {current_era_row.started_at})"
     )
-    print(f"Opening     : {CURRENT_ERA.name!r} config_key={CURRENT_ERA.config_key!r}")
+    print(f"Opening     : {opening.name!r} config_key={opening.config_key!r}")
     print(f"Characters  : {character_count} active (banned characters are skipped)")
     # Read off the era, never restated here: the flags ARE the reset (ADR-0042).
     print(
         "Resets      : "
-        f"score={CURRENT_ERA.reset_score}, "
-        f"all_time_score={CURRENT_ERA.reset_all_time_score}, "
-        f"level={CURRENT_ERA.reset_level}, "
-        f"vote_budget={CURRENT_ERA.reset_vote_budget}, "
-        f"faction={CURRENT_ERA.reset_faction}"
+        f"score={opening.reset_score}, "
+        f"all_time_score={opening.reset_all_time_score}, "
+        f"level={opening.reset_level}, "
+        f"vote_budget={opening.reset_vote_budget}, "
+        f"faction={opening.reset_faction}"
     )
     print("Also        : every unresolved duel is frozen, and the board is retired")
 
@@ -112,29 +132,47 @@ async def reset_era(session: AsyncSession, username: str, confirmed: bool) -> in
         print("ERROR: no era row for the current config - run seed.py before a rollover.")
         return 1
 
-    # Point CURRENT_ERA at whatever the DATABASE says is live before printing a
-    # plan about it (ADR-0091, #827). Without this the script would re-open the
-    # *compile-time* era, so running it after a mod has rolled the game forward
-    # from the admin page would silently roll it back. This one call is why
-    # `print_plan` and the row built below need no edit: the live era is one
-    # object refreshed in place, not a name each of them re-reads.
-    await rebind_live_era(session)
+    # The era to re-open is whatever the DATABASE says is live (ADR-0091, #827),
+    # never the compile-time one — running this after a mod has rolled the game
+    # forward from the admin page must not silently roll it back.
+    #
+    # Refuse, rather than fall back, when that key resolves to nothing.
+    # `services.era.rebind_live_era` falls back to the compile-time era on this
+    # state because start-up has to survive it; a rollover does not. Falling
+    # back here would turn "re-open the live era" into "roll the game back to
+    # Era 1" without saying so, on the one operation with no undo.
+    opening = era_config_for_key(current_era_row.config_key)
+    if opening is None:
+        print(
+            f"ERROR: the live Era row (id={current_era_row.id}) names config_key "
+            f"{current_era_row.config_key!r}, which no era file registers.\n"
+            f"       This script re-opens the LIVE era, and it cannot resolve "
+            f"which one that is. Nothing was changed.\n"
+            f"       Restore the era file, or roll into a registered era from "
+            f"the admin page."
+        )
+        return 1
 
     characters = await list_active_characters(session)
-    print_plan(current_era_row, len(characters))
+    print_plan(current_era_row, opening, len(characters))
 
     if not confirmed:
+        # Nothing above bound anything: the live era of THIS process is exactly
+        # what it was when the script started, so the line below is true.
         print("\nNothing was changed. Re-run with --yes to perform the rollover.")
         return 1
 
     new_era_row = Era(
-        name=CURRENT_ERA.name,
-        config_key=CURRENT_ERA.config_key,
+        name=opening.name,
+        config_key=opening.config_key,
         started_by=operator.account_id,
     )
     session.add(new_era_row)
     await session.flush()
-    await apply_era_reset(characters, new_era_row, session)
+    await apply_era_reset(characters, new_era_row, session, era=opening)
+    # Commits, then binds — the same order the route takes, and the reason this
+    # process ends up on exactly what it just wrote.
+    await commit_and_bind_live_era(session, opening)
     print(f"\nEra {new_era_row.id} is open; {len(characters)} character(s) reset.")
     return 0
 
@@ -149,9 +187,11 @@ async def run(username: str, env: str, confirmed: bool) -> int:
     async_session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with async_session() as session:
+            # `reset_era` owns its own commit on the success path, because the
+            # live-era binding has to land after it (`commit_and_bind_live_era`).
+            # Every refusal returns without committing and the session context
+            # rolls back.
             exit_code = await reset_era(session, username, confirmed)
-            if exit_code == 0:
-                await session.commit()
     finally:
         await engine.dispose()
     return exit_code

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -31,7 +31,7 @@ from faction_slugs import (
     UNAFFILIATED_FACTION_SLUG,
     real_faction_slugs,
 )
-from game_config import CURRENT_ERA, era_config_for_key
+from game_config import CURRENT_ERA, EraConfig, era_config_for_key
 from script_utils import add_env_argument, get_settings
 from models.account import Account, AuthProvider, OAuthProvider
 from models.character import Character
@@ -331,7 +331,20 @@ DUEL_FIXTURE_TASK_DESCRIPTION = (
 # faction_slugs.py in #2708, when the integration fixtures became its third
 # caller — the day this comment and `scripts/seed_demo_praxes.py` were both
 # waiting for.
-DUEL_FIXTURE_TASK_FACTION_SLUG = real_faction_slugs(CURRENT_ERA)[0]
+#
+# A FUNCTION, not a module constant, since #827: a constant here is read when
+# `seed` is imported, which is before `seed()` resolves the live era from the
+# database (ADR-0091). After a mod rolls the game forward from the admin page,
+# that frozen value is the *previous* era's slug — and the `Faction` row for it
+# still exists, because rows retire and never delete, so the guard below waves
+# it through and the fixture task lands in a faction the live era does not
+# carry. That is #2710's symptom again, reached by a different route. Reading it
+# at call time is what keeps the paragraph above true.
+def duel_fixture_task_faction_slug(era: EraConfig = CURRENT_ERA) -> str:
+    """The first real faction of the era in hand."""
+    return real_faction_slugs(era)[0]
+
+
 DUEL_FIXTURE_TASK_POINT_VALUE = 10
 
 
@@ -365,10 +378,9 @@ async def ensure_duel_fixture_task(session, created_by_id: int) -> bool:
     if existing is not None:
         return False
 
+    slug = duel_fixture_task_faction_slug()
     faction = (
-        await session.execute(
-            select(Faction).where(Faction.slug == DUEL_FIXTURE_TASK_FACTION_SLUG)
-        )
+        await session.execute(select(Faction).where(Faction.slug == slug))
     ).scalar_one_or_none()
     if faction is None:
         return False
@@ -381,7 +393,7 @@ async def ensure_duel_fixture_task(session, created_by_id: int) -> bool:
         status=TaskStatus.active,
         task_type=TaskType.standard,
         created_by=created_by_id,
-        primary_faction_slug=DUEL_FIXTURE_TASK_FACTION_SLUG,
+        primary_faction_slug=slug,
     ))
     await session.flush()
     return True
@@ -479,7 +491,7 @@ async def seed_dev_demo(session, created_by_id: int) -> None:
     # database, which is exactly the case where this top-up matters.
     if await ensure_duel_fixture_task(session, created_by_id):
         print(
-            f"  >Duel e2e fixture task (1 {DUEL_FIXTURE_TASK_FACTION_SLUG} task "
+            f"  >Duel e2e fixture task (1 {duel_fixture_task_faction_slug()} task "
             f"at the duel level)"
         )
     await session.commit()

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -31,7 +31,7 @@ from faction_slugs import (
     UNAFFILIATED_FACTION_SLUG,
     real_faction_slugs,
 )
-from game_config import CURRENT_ERA
+from game_config import CURRENT_ERA, era_config_for_key
 from script_utils import add_env_argument, get_settings
 from models.account import Account, AuthProvider, OAuthProvider
 from models.character import Character
@@ -494,28 +494,46 @@ async def seed_dev_demo(session, created_by_id: int) -> None:
 # ---------------------------------------------------------------------------
 
 async def stale_era_warning(session, era) -> str | None:
-    """What to tell the operator when the configured era has no Era row yet.
+    """What to tell the operator when the live ``Era`` row names no ruleset.
 
-    The seeder does not open an era for an unseen ``config_key`` — the rollover
-    does, because it is what stamps ``Era.started_by``. So a deploy that flips
-    ``CURRENT_ERA`` forward leaves the app running the new rules against the old
-    row, and since #2705 it does that *quietly*: the live era is the latest row
-    whatever its key, which is what keeps the rollover runnable instead of
-    500ing every character-stats read. This is where the noise went. ``start.sh``
-    runs the seeder on every deploy, so it lands in front of the one person who
-    can act on it.
+    Rewritten by #827/ADR-0091, and the *advice* is inverted. This used to warn
+    that the configured era had no row yet — "``CURRENT_ERA`` is era_2 but the
+    live row is era_1, run ``era_reset.py``" — because a rollover was an owner's
+    code edit and a deploy could legitimately arrive ahead of it. Under the live
+    binding that state cannot occur: the row **chooses**, so the row and the live
+    era agree by construction and warning about the compile-time era would be
+    telling an operator to undo a mod's rollover.
 
-    Returns None when the live row already matches; the caller prints.
+    What is left is the one state that is still genuinely wrong: a row naming a
+    ``config_key`` no era file registers. Then the process cannot resolve the
+    rules that row records and is falling back to the compile-time era — the
+    game is not playing by the era the database says it is in. ``start.sh`` runs
+    the seeder on every deploy, so this lands in front of the one person who can
+    put the era file back.
+
+    ``era`` is the era actually bound, which is what makes the message say what
+    the game is *doing* rather than only what it failed to do.
+
+    Returns None when the live row resolves; the caller prints.
     """
     live = (
         await session.execute(select(Era).order_by(Era.id.desc()).limit(1))
     ).scalar_one_or_none()
-    if live is not None and live.config_key == era.config_key:
+    if live is None:
+        return (
+            "\nWARNING: no Era row exists, so the game is running on the "
+            f"compile-time era {era.config_key}.\n         Phase 2 opens the "
+            "first row; if you see this after a successful seed, something "
+            "rolled it back."
+        )
+    if era_config_for_key(live.config_key) is not None:
         return None
-    live_key = live.config_key if live is not None else "absent"
     return (
-        f"\nWARNING: {era.config_key} is configured but the live Era row is "
-        f"{live_key}.\n         Run scripts/era_reset.py to open it."
+        f"\nWARNING: the live Era row (id={live.id}) names config_key "
+        f"{live.config_key!r}, which no era file\n         registers. The game "
+        f"has fallen back to {era.config_key} and is NOT playing by the rules "
+        "that row\n         records. Restore the era file, or roll into a "
+        "registered era from the admin page."
     )
 
 
@@ -524,13 +542,11 @@ async def stale_era_warning(session, era) -> str | None:
 # ---------------------------------------------------------------------------
 
 async def seed(env: str, yes: bool) -> None:
-    era = CURRENT_ERA
     settings = get_settings(env)
     db_host = settings.DATABASE_URL.split("@")[-1]
 
     print(f"Environment : {env}")
     print(f"Database    : {db_host}")
-    print(f"Era         : {era.name} ({era.config_key})\n")
 
     if env == "prod" and not yes:
         print("WARNING: You are about to seed a PRODUCTION database.")
@@ -544,6 +560,21 @@ async def seed(env: str, yes: bool) -> None:
     async_session = async_sessionmaker(engine, expire_on_commit=False)
 
     async with async_session() as session:
+        # The era the DATABASE says is live, not the compile-time one
+        # (ADR-0091, #827). Load-bearing: ``start.sh`` runs this seeder on every
+        # deploy, and Phase 1 below is a two-way mirror — it marks the era's
+        # roster ``visible`` and every other slug ``retired``. Seeding the
+        # compile-time era after a mod has rolled the game into a later one
+        # would silently un-do the roster half of their rollover on the next
+        # deploy, with the ``Era`` row still correctly naming the new era.
+        #
+        # Imported here rather than at module scope because ``services.era``
+        # imports this module for ``ONBOARDING_TASK_TITLE``; by the time this
+        # line runs, ``seed`` is fully loaded and there is no cycle to break.
+        from services.era import rebind_live_era
+
+        era = await rebind_live_era(session)
+        print(f"Era         : {era.name} ({era.config_key})\n")
 
         # Check what's already present
         pixie_result = await session.execute(

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -46,6 +46,7 @@ from services.era import (
     get_current_era_row,
     get_current_era_row_safe,
     get_or_create_stats,
+    lock_era_rollover,
 )
 from services.scoring import compute_vote_budget, compute_votes_available
 
@@ -514,34 +515,39 @@ async def admin_edit_task(
 # ---------------------------------------------------------------------------
 
 
-def list_registered_eras(era: EraConfig = CURRENT_ERA) -> list[EraOption]:
+async def list_registered_eras(
+    session: AsyncSession, era: EraConfig = CURRENT_ERA
+) -> list[EraOption]:
     """Every era a mod may roll into, in era order.
 
-    Read off the registry, never off ``Era`` rows: an era that has never run has
-    no row, and it is precisely the ones that have never run that a mod wants to
-    pick. ``is_live`` compares against the era in hand — the live binding — so
-    the selector marks where the game actually is, not where the newest era file
-    is.
+    *Which eras exist* is read off the registry, never off ``Era`` rows: an era
+    that has never run has no row, and it is precisely the ones that have never
+    run that a mod wants to pick.
+
+    *Which one is live* is read off the latest ``Era`` row — the same source
+    :func:`roll_into_era`'s refusal reads, and that agreement is the point. The
+    selector used to answer from the process binding instead, which is the same
+    fact only while the two agree. They can come apart: a row naming a
+    ``config_key`` no era file registers leaves the process on the compile-time
+    fallback (``rebind_live_era`` logs it loudly), and in that state the selector
+    would have offered an era the ``PUT`` then refused with
+    ``ERA_ALREADY_LIVE``. A list whose disabled row disagrees with the server is
+    worse than no list.
+
+    ``era`` — the process binding — is the fallback for the one case the row
+    cannot answer: a fresh database with no ``Era`` row at all, where nothing has
+    run and the compile-time era is genuinely what the game is playing by.
     """
+    live_row = await get_current_era_row_safe(session)
+    live_key = era.config_key if live_row is None else live_row.config_key
     return [
         EraOption(
             config_key=config_key,
             name=era_config_for_key(config_key).name,
-            is_live=config_key == era.config_key,
+            is_live=config_key == live_key,
         )
         for config_key in registered_era_config_keys()
     ]
-
-
-#: Serializes the rollover against itself. A transaction-scoped Postgres
-#: advisory lock, not a row lock: ``SELECT ... FOR UPDATE`` on the latest ``Era``
-#: row locks nothing on a database that has none, and under READ COMMITTED the
-#: waiter's locked row is re-checked but its ``ORDER BY id DESC LIMIT 1`` is
-#: not re-planned, so it would still be holding the *old* latest row after the
-#: winner inserted a new one — and would decide against it. Reads as the issue
-#: number in ``pg_locks``, the same convention as
-#: ``services.praxis_room._SINGLE_INSTANCE_LOCK_KEY``.
-_ERA_ROLLOVER_LOCK_KEY = 17400827
 
 
 async def roll_into_era(
@@ -578,14 +584,10 @@ async def roll_into_era(
             f"Unknown era: {config_key}.",
         )
 
-    # Take the lock BEFORE reading the live row, so the check below and the
-    # insert that follows it are one indivisible decision. Two mods confirming
-    # the same rollover within a second of each other is exactly the shape this
-    # exists for: without it both read the same live row, both pass the refusal,
-    # and the game takes two destructive resets.
-    await session.execute(
-        select(func.pg_advisory_xact_lock(_ERA_ROLLOVER_LOCK_KEY))
-    )
+    # Before the read below, so the read, the refusal it feeds and the insert
+    # that follows are one indivisible decision — against a second mod and
+    # against `scripts/era_reset.py`, which takes the same lock.
+    await lock_era_rollover(session)
 
     live_row = await get_current_era_row_safe(session)
     if live_row is not None and live_row.config_key == era_config.config_key:

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -33,8 +33,20 @@ from schemas.admin import (
     FlagOut,
     OverviewStats,
 )
+# ``seed`` imports models, game_config and config, never a service, so the
+# roster mirror is reachable from here without a cycle — the same reason
+# ``services.era`` already imports it (for ``ONBOARDING_TASK_TITLE``). The
+# mirror stays in ``seed`` because the seeder is what runs it on every deploy;
+# the rollover is the second caller, not the owner.
+from seed import upsert_era_factions
 from services.duel import forfeit_settled_duels_for_character
-from services.era import apply_era_reset, get_current_era_row, get_or_create_stats
+from services.era import (
+    apply_era_reset,
+    commit_and_bind_live_era,
+    get_current_era_row,
+    get_current_era_row_safe,
+    get_or_create_stats,
+)
 from services.scoring import compute_vote_budget, compute_votes_available
 
 
@@ -521,6 +533,17 @@ def list_registered_eras(era: EraConfig = CURRENT_ERA) -> list[EraOption]:
     ]
 
 
+#: Serializes the rollover against itself. A transaction-scoped Postgres
+#: advisory lock, not a row lock: ``SELECT ... FOR UPDATE`` on the latest ``Era``
+#: row locks nothing on a database that has none, and under READ COMMITTED the
+#: waiter's locked row is re-checked but its ``ORDER BY id DESC LIMIT 1`` is
+#: not re-planned, so it would still be holding the *old* latest row after the
+#: winner inserted a new one — and would decide against it. Reads as the issue
+#: number in ``pg_locks``, the same convention as
+#: ``services.praxis_room._SINGLE_INSTANCE_LOCK_KEY``.
+_ERA_ROLLOVER_LOCK_KEY = 17400827
+
+
 async def roll_into_era(
     config_key: str, operator: Account, session: AsyncSession
 ) -> EraRollOut:
@@ -529,14 +552,23 @@ async def roll_into_era(
 
     Everything it does, it does through the pieces that already own it: the
     ``Era`` row is the append-only record of which ruleset governs from now
-    (ADR-0042), ``apply_era_reset`` performs the resets the **incoming** era's
-    flags declare, freezes every unresolved duel into a permanent result (#824)
-    and retires the board, and ``rebind_live_era`` — which ``apply_era_reset``
-    calls — points the process at the new rules.
+    (ADR-0042), ``seed.upsert_era_factions`` re-mirrors the roster,
+    ``apply_era_reset`` performs the resets the **incoming** era's flags declare,
+    freezes every unresolved duel into a permanent result (#824) and retires the
+    board, and ``commit_and_bind_live_era`` makes the write durable and *then*
+    points the process at the new rules.
 
     ``operator`` lands in ``Era.started_by``, the not-null audit trail recording
     who opened the era. The route's ``require_admin`` is what fills it, which is
     the guarantee ``scripts/era_reset.py`` has to re-derive by hand.
+
+    **Two refusals, and both matter more here than a validation usually does.**
+    An unregistered key would write a row whose rules nothing can resolve. The
+    era that is *already* live would be a second full destructive reset for no
+    change of ruleset — every score, level, budget and faction wiped, every duel
+    frozen, the board retired, to arrive where the game already was. Until now
+    the only thing stopping it was a ``disabled`` option in the admin page's
+    select, which is not a control.
     """
     era_config = era_config_for_key(config_key)
     if era_config is None:
@@ -544,6 +576,23 @@ async def roll_into_era(
             422,
             ErrorCode.era_config_unknown,
             f"Unknown era: {config_key}.",
+        )
+
+    # Take the lock BEFORE reading the live row, so the check below and the
+    # insert that follows it are one indivisible decision. Two mods confirming
+    # the same rollover within a second of each other is exactly the shape this
+    # exists for: without it both read the same live row, both pass the refusal,
+    # and the game takes two destructive resets.
+    await session.execute(
+        select(func.pg_advisory_xact_lock(_ERA_ROLLOVER_LOCK_KEY))
+    )
+
+    live_row = await get_current_era_row_safe(session)
+    if live_row is not None and live_row.config_key == era_config.config_key:
+        raise_coded(
+            409,
+            ErrorCode.era_already_live,
+            f"{era_config.name} is already the live era.",
         )
 
     characters = await list_active_characters(session)
@@ -556,7 +605,22 @@ async def roll_into_era(
     )
     session.add(new_era_row)
     await session.flush()
+
+    # The roster is half the rollover, and it used to wait for the next deploy.
+    # `Faction` is a two-way display mirror of the live era (ADR-0087): the
+    # incoming era's slugs go `visible`, everything else `retired`. Skipping it
+    # left join tiles offering factions the new era does not carry, and — for an
+    # era that adds a slug — no `Faction` row for the FK a join would write.
+    # Before the reset, because `apply_era_reset` seats every character in
+    # `era.reset_faction_slug`, which is an FK onto this table.
+    await upsert_era_factions(session, era_config)
+
     await apply_era_reset(characters, new_era_row, session, era=era_config)
+
+    # Durable first, live second. See `commit_and_bind_live_era` for why that
+    # order is the whole point.
+    await commit_and_bind_live_era(session, era_config)
+
     return EraRollOut(
         era_id=new_era_row.id,
         config_key=era_config.config_key,

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -5,10 +5,16 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import ErrorCode, raise_coded
-from game_config import CURRENT_ERA, EraConfig
+from game_config import (
+    CURRENT_ERA,
+    EraConfig,
+    era_config_for_key,
+    registered_era_config_keys,
+)
 from models.account import Account, AccountStatus
 from models.character import Character, CharacterStatus
 from models.character_stats import CharacterStats
+from models.era import Era
 from models.roles import AccountRole, Role
 from models.contact import ContactMessage
 from models.flag import Flag, normalize_flag_reason
@@ -22,11 +28,13 @@ from schemas.admin import (
     CharacterBrief,
     CharacterStatsPatch,
     CharacterSummary,
+    EraOption,
+    EraRollOut,
     FlagOut,
     OverviewStats,
 )
 from services.duel import forfeit_settled_duels_for_character
-from services.era import get_current_era_row, get_or_create_stats
+from services.era import apply_era_reset, get_current_era_row, get_or_create_stats
 from services.scoring import compute_vote_budget, compute_votes_available
 
 
@@ -487,3 +495,71 @@ async def admin_edit_task(
     await session.flush()
     await session.refresh(task)
     return task
+
+
+# ---------------------------------------------------------------------------
+# Era rollover — the control that ends an era (#827, ADR-0091)
+# ---------------------------------------------------------------------------
+
+
+def list_registered_eras(era: EraConfig = CURRENT_ERA) -> list[EraOption]:
+    """Every era a mod may roll into, in era order.
+
+    Read off the registry, never off ``Era`` rows: an era that has never run has
+    no row, and it is precisely the ones that have never run that a mod wants to
+    pick. ``is_live`` compares against the era in hand — the live binding — so
+    the selector marks where the game actually is, not where the newest era file
+    is.
+    """
+    return [
+        EraOption(
+            config_key=config_key,
+            name=era_config_for_key(config_key).name,
+            is_live=config_key == era.config_key,
+        )
+        for config_key in registered_era_config_keys()
+    ]
+
+
+async def roll_into_era(
+    config_key: str, operator: Account, session: AsyncSession
+) -> EraRollOut:
+    """End the live era and open ``config_key``. The most destructive operation
+    in the system, and there is no undo.
+
+    Everything it does, it does through the pieces that already own it: the
+    ``Era`` row is the append-only record of which ruleset governs from now
+    (ADR-0042), ``apply_era_reset`` performs the resets the **incoming** era's
+    flags declare, freezes every unresolved duel into a permanent result (#824)
+    and retires the board, and ``rebind_live_era`` — which ``apply_era_reset``
+    calls — points the process at the new rules.
+
+    ``operator`` lands in ``Era.started_by``, the not-null audit trail recording
+    who opened the era. The route's ``require_admin`` is what fills it, which is
+    the guarantee ``scripts/era_reset.py`` has to re-derive by hand.
+    """
+    era_config = era_config_for_key(config_key)
+    if era_config is None:
+        raise_coded(
+            422,
+            ErrorCode.era_config_unknown,
+            f"Unknown era: {config_key}.",
+        )
+
+    characters = await list_active_characters(session)
+    new_era_row = Era(
+        # Written, not read on the happy path — the historical fallback for a
+        # row whose config file is later deleted. See models/era.py.
+        name=era_config.name,
+        config_key=era_config.config_key,
+        started_by=operator.id,
+    )
+    session.add(new_era_row)
+    await session.flush()
+    await apply_era_reset(characters, new_era_row, session, era=era_config)
+    return EraRollOut(
+        era_id=new_era_row.id,
+        config_key=era_config.config_key,
+        name=era_config.name,
+        characters_reset=len(characters),
+    )

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -33,12 +33,21 @@ logger = logging.getLogger(__name__)
 async def rebind_live_era(session: AsyncSession) -> EraConfig:
     """Resolve the live ruleset from the latest ``Era`` row and bind it.
 
-    The **only** caller of :func:`game_config.bind_live_era` in the shipped
-    backend (ADR-0091); ``tests/unit/test_live_era_binding.py`` keeps it that
-    way. Two moments call this one, and there is no third:
+    One of the two functions in the shipped backend that reach
+    :func:`game_config.bind_live_era` — the other is
+    :func:`commit_and_bind_live_era` below, and
+    ``tests/unit/test_live_era_binding.py`` keeps it to those two, both here.
+    This one is for the callers that have no era in hand and must ask the
+    database which it is:
 
     * process start-up, from the app's lifespan, and
-    * :func:`apply_era_reset`, the instant a rollover appends the new row.
+    * ``seed.py``, which ``start.sh`` runs on every deploy and whose faction
+      mirror must reflect the era the database says is live, not the one the
+      process compiled against.
+
+    A rollover does **not** come through here. It already holds the era it just
+    wrote, and it must not bind until that write is durable — see
+    :func:`commit_and_bind_live_era`.
 
     Total by construction — it binds *something* on every path, because a
     start-up that raises here takes the whole app down over a row that a fresh
@@ -52,34 +61,69 @@ async def rebind_live_era(session: AsyncSession) -> EraConfig:
     * **A row naming a ``config_key`` no era file claims.** A deleted era file,
       or a row written by a newer version of the app and then rolled back. Same
       fallback, louder — this one is a deployment mistake, not a fresh install.
+
+    The database call itself can still raise; "total" is about the *row*, not
+    about the connection.
     """
     era_row = await get_current_era_row_safe(session)
-    if era_row is None:
-        logger.info(
-            "No Era row yet — the live ruleset falls back to the compile-time "
-            "era %r. Expected on a fresh database, before the first seed.",
-            COMPILE_TIME_ERA_CONFIG_KEY,
-        )
-        return bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
-
-    era_config = era_config_for_key(era_row.config_key)
-    if era_config is None:
-        logger.warning(
-            "Era row id=%s names config_key %r, which no era file registers — "
-            "the live ruleset falls back to the compile-time era %r. The game is "
-            "NOT playing by the rules that row records.",
-            era_row.id,
-            era_row.config_key,
-            COMPILE_TIME_ERA_CONFIG_KEY,
-        )
-        return bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
-
-    logger.info(
-        "Live ruleset bound to %r from Era row id=%s.",
-        era_config.config_key,
-        era_row.id,
+    era_config = (
+        None if era_row is None else era_config_for_key(era_row.config_key)
     )
+    if era_config is None:
+        if era_row is None:
+            logger.info(
+                "No Era row yet — the live ruleset falls back to the "
+                "compile-time era %r. Expected on a fresh database, before the "
+                "first seed.",
+                COMPILE_TIME_ERA_CONFIG_KEY,
+            )
+        else:
+            logger.warning(
+                "Era row id=%s names config_key %r, which no era file registers "
+                "— the live ruleset falls back to the compile-time era %r. The "
+                "game is NOT playing by the rules that row records.",
+                era_row.id,
+                era_row.config_key,
+                COMPILE_TIME_ERA_CONFIG_KEY,
+            )
+        era_config = era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY)
+    else:
+        logger.info(
+            "Live ruleset bound to %r from Era row id=%s.",
+            era_config.config_key,
+            era_row.id,
+        )
     return bind_live_era(era_config)
+
+
+async def commit_and_bind_live_era(
+    session: AsyncSession, era: EraConfig
+) -> EraConfig:
+    """Commit the rollover, then point the process at the era it just wrote.
+
+    **The order is the point.** The live era is a process-wide object; the row
+    that justifies it is a database fact. Binding first and committing second
+    means a failed commit — a serialization failure, a dropped connection, a
+    constraint the rollover tripped on the way out — rolls the database back to
+    the closing era while the process goes on playing by the opening one's
+    rules, with nothing to notice and no request able to put it back. Committing
+    first means the worst case is a durable rollover the process has not
+    noticed yet, which the next restart fixes.
+
+    This is the one place a service owns its own commit, against the repo's
+    "services flush, the router's ``get_db`` commits" rule
+    (``SPEC-backend-architecture.md``). It is deliberate and it is narrow: the
+    router cannot own this boundary without also owning *which* era to bind,
+    which is the rollover's decision, and ``get_db``'s commit lands after the
+    handler has already returned — too late for the handler to bind behind it.
+    ``get_db`` still commits afterwards; that second commit has nothing left to
+    write.
+
+    ``era`` is the config the caller already resolved, so there is no re-query
+    and no chance of binding something other than what was written.
+    """
+    await session.commit()
+    return bind_live_era(era)
 
 
 async def get_current_era_row(session: AsyncSession) -> Era:
@@ -476,12 +520,14 @@ async def apply_era_reset(
 
     await session.flush()
 
-    # The rules change here, not at the next deploy. ``new_era_row`` is now the
-    # latest row, so this resolves to the era just opened (ADR-0091, #827).
+    # Deliberately does NOT move the live era. This function only flushes, so
+    # the rows above are not durable yet, and binding a process-wide object to
+    # a transaction that may still roll back is how the process and the database
+    # end up disagreeing about which era the game is in. The caller binds, after
+    # its commit, through :func:`commit_and_bind_live_era` (ADR-0091, #827).
     #
     # Accepted with the ruling: a request already in flight straddles the change
     # — it began under the closing era's rules and finishes under the opening
     # one's. The hand-flip this replaces had the same effect, arriving via a
     # deploy that restarted the process. If it ever matters, the answer is
     # draining or rebinding behind the rollover's own lock.
-    await rebind_live_era(session)

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -110,9 +110,9 @@ async def commit_and_bind_live_era(
     first means the worst case is a durable rollover the process has not
     noticed yet, which the next restart fixes.
 
-    This is the one place a service owns its own commit, against the repo's
-    "services flush, the router's ``get_db`` commits" rule
-    (``SPEC-backend-architecture.md``). It is deliberate and it is narrow: the
+    This is the one place a service owns its own commit, against the rule
+    ``db.get_db`` states — services flush, the router's dependency owns the
+    single per-request commit. It is deliberate and it is narrow: the
     router cannot own this boundary without also owning *which* era to bind,
     which is the rollover's decision, and ``get_db``'s commit lands after the
     handler has already returned — too late for the handler to bind behind it.

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -1,10 +1,17 @@
+import logging
 from datetime import datetime, timezone
 
 from fastapi import HTTPException
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from game_config import CURRENT_ERA, EraConfig
+from game_config import (
+    COMPILE_TIME_ERA_CONFIG_KEY,
+    CURRENT_ERA,
+    EraConfig,
+    bind_live_era,
+    era_config_for_key,
+)
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
@@ -19,6 +26,60 @@ from seed import ONBOARDING_TASK_TITLE
 from services.duel_outcome import duel_winner
 from services.scoring import sole_tie_taker_id
 from services.vote_tally import get_tally, tally_votes
+
+logger = logging.getLogger(__name__)
+
+
+async def rebind_live_era(session: AsyncSession) -> EraConfig:
+    """Resolve the live ruleset from the latest ``Era`` row and bind it.
+
+    The **only** caller of :func:`game_config.bind_live_era` in the shipped
+    backend (ADR-0091); ``tests/unit/test_live_era_binding.py`` keeps it that
+    way. Two moments call this one, and there is no third:
+
+    * process start-up, from the app's lifespan, and
+    * :func:`apply_era_reset`, the instant a rollover appends the new row.
+
+    Total by construction — it binds *something* on every path, because a
+    start-up that raises here takes the whole app down over a row that a fresh
+    install has not written yet:
+
+    * **No ``Era`` row at all.** A fresh database. ``bootstrap_admin`` writes the
+      first row only on an un-bootstrapped database, so start-up can legitimately
+      find nothing. Fall back to the compile-time era and say so; do not invent
+      a row, because ``Era.started_by`` is a not-null audit trail with nobody to
+      put in it.
+    * **A row naming a ``config_key`` no era file claims.** A deleted era file,
+      or a row written by a newer version of the app and then rolled back. Same
+      fallback, louder — this one is a deployment mistake, not a fresh install.
+    """
+    era_row = await get_current_era_row_safe(session)
+    if era_row is None:
+        logger.info(
+            "No Era row yet — the live ruleset falls back to the compile-time "
+            "era %r. Expected on a fresh database, before the first seed.",
+            COMPILE_TIME_ERA_CONFIG_KEY,
+        )
+        return bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
+
+    era_config = era_config_for_key(era_row.config_key)
+    if era_config is None:
+        logger.warning(
+            "Era row id=%s names config_key %r, which no era file registers — "
+            "the live ruleset falls back to the compile-time era %r. The game is "
+            "NOT playing by the rules that row records.",
+            era_row.id,
+            era_row.config_key,
+            COMPILE_TIME_ERA_CONFIG_KEY,
+        )
+        return bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
+
+    logger.info(
+        "Live ruleset bound to %r from Era row id=%s.",
+        era_config.config_key,
+        era_row.id,
+    )
+    return bind_live_era(era_config)
 
 
 async def get_current_era_row(session: AsyncSession) -> Era:
@@ -414,3 +475,13 @@ async def apply_era_reset(
             character.faction_slug = era.reset_faction_slug
 
     await session.flush()
+
+    # The rules change here, not at the next deploy. ``new_era_row`` is now the
+    # latest row, so this resolves to the era just opened (ADR-0091, #827).
+    #
+    # Accepted with the ruling: a request already in flight straddles the change
+    # — it began under the closing era's rules and finishes under the opening
+    # one's. The hand-flip this replaces had the same effect, arriving via a
+    # deploy that restarted the process. If it ever matters, the answer is
+    # draining or rebinding behind the rollover's own lock.
+    await rebind_live_era(session)

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import HTTPException
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import (
@@ -28,6 +28,37 @@ from services.scoring import sole_tie_taker_id
 from services.vote_tally import get_tally, tally_votes
 
 logger = logging.getLogger(__name__)
+
+
+#: Serializes the rollover against itself, across **both** doors — the admin
+#: route and ``scripts/era_reset.py``. Lives here rather than in
+#: ``services.admin_service`` because the script must take the same lock and
+#: importing it from the admin service would drag the whole admin surface into a
+#: CLI. Reads as the issue number in ``pg_locks``, the same convention as
+#: ``services.praxis_room._SINGLE_INSTANCE_LOCK_KEY``.
+_ERA_ROLLOVER_LOCK_KEY = 17400827
+
+
+async def lock_era_rollover(session: AsyncSession) -> None:
+    """Take the rollover lock. Held until the caller's transaction ends.
+
+    Call it **before** reading the live ``Era`` row, so that read, the decision
+    made on it and the insert that follows are one indivisible operation. Two
+    rollovers overlapping is not hypothetical: two mods confirming within a
+    second of each other, or — the case the route alone could not cover — an
+    operator running ``era_reset.py`` while a mod is confirming on the admin
+    page. Without this, both read the same live row, both pass their refusals,
+    the game takes two destructive resets, and the process is left bound to
+    whichever finished last rather than to the latest row.
+
+    A transaction-scoped advisory lock, not ``SELECT ... FOR UPDATE`` on the
+    latest row. The row lock locks nothing on a database that has none, and
+    under READ COMMITTED a waiter's locked row is re-checked but its
+    ``ORDER BY id DESC LIMIT 1`` is not re-planned — so after the winner
+    inserts a new latest row the waiter is still holding the old one, and would
+    decide against it.
+    """
+    await session.execute(select(func.pg_advisory_xact_lock(_ERA_ROLLOVER_LOCK_KEY)))
 
 
 async def rebind_live_era(session: AsyncSession) -> EraConfig:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,5 +22,10 @@ def restore_live_era():
     yield
     live = game_config.CURRENT_ERA
     if live.__dict__ != before:
-        live.__dict__.clear()
+        # Per-key, matching ``game_config.bind_live_era``. Nothing reads the live
+        # era between tests, so a clear-then-fill would be safe here — but this is
+        # the shape a reader will copy, and in the shipped path an empty window is
+        # an AttributeError in a threadpool worker.
         live.__dict__.update(before)
+        for stale in set(live.__dict__) - set(before):
+            del live.__dict__[stale]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,20 +12,15 @@ def restore_live_era():
     test that rolls into Era 2 would otherwise hand Era 2 to every test after it
     in the same session, in file order, silently.
 
-    Snapshots the ``__dict__`` rather than the name because the name never
-    moves; see ``game_config.bind_live_era``. ``game_config`` imports no
-    settings, so this stays honest to the "no env vars" note above.
+    Snapshots the *object* rather than the name because the name never moves;
+    see ``game_config.bind_live_era``. The snapshot is a detached copy made the
+    same way the live instance itself is, so restoring is one call to the real
+    lever rather than a second hand-rolled refresh that could drift from it.
+    ``game_config`` imports no settings, so this stays honest to the "no env
+    vars" note above.
     """
     import game_config
 
-    before = dict(game_config.CURRENT_ERA.__dict__)
+    before = game_config._new_live_era(game_config.CURRENT_ERA)
     yield
-    live = game_config.CURRENT_ERA
-    if live.__dict__ != before:
-        # Per-key, matching ``game_config.bind_live_era``. Nothing reads the live
-        # era between tests, so a clear-then-fill would be safe here — but this is
-        # the shape a reader will copy, and in the shipped path an empty window is
-        # an AttributeError in a threadpool worker.
-        live.__dict__.update(before)
-        for stale in set(live.__dict__) - set(before):
-            del live.__dict__[stale]
+    game_config.bind_live_era(before)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,10 +7,11 @@ import pytest
 def restore_live_era():
     """Put the live era back after every test (ADR-0091, #827).
 
-    ``services.era.apply_era_reset`` rebinds the live ruleset in place, which is
-    the whole point of it — but the live era is one process-wide object, so a
-    test that rolls into Era 2 would otherwise hand Era 2 to every test after it
-    in the same session, in file order, silently.
+    A rollover rebinds the live ruleset in place (``services.era.
+    commit_and_bind_live_era``), which is the whole point of it — but the live
+    era is one process-wide object, so a test that rolls into Era 2 would
+    otherwise hand Era 2 to every test after it in the same session, in file
+    order, silently.
 
     Snapshots the *object* rather than the name because the name never moves;
     see ``game_config.bind_live_era``. The snapshot is a detached copy made the

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,2 +1,26 @@
 # Unit test conftest — no DB or app imports here so env vars are not required.
 # Integration fixtures live in tests/integration/conftest.py
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_live_era():
+    """Put the live era back after every test (ADR-0091, #827).
+
+    ``services.era.apply_era_reset`` rebinds the live ruleset in place, which is
+    the whole point of it — but the live era is one process-wide object, so a
+    test that rolls into Era 2 would otherwise hand Era 2 to every test after it
+    in the same session, in file order, silently.
+
+    Snapshots the ``__dict__`` rather than the name because the name never
+    moves; see ``game_config.bind_live_era``. ``game_config`` imports no
+    settings, so this stays honest to the "no env vars" note above.
+    """
+    import game_config
+
+    before = dict(game_config.CURRENT_ERA.__dict__)
+    yield
+    live = game_config.CURRENT_ERA
+    if live.__dict__ != before:
+        live.__dict__.clear()
+        live.__dict__.update(before)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -237,7 +237,12 @@ async def some_faction(db_session: AsyncSession) -> Faction:
     from seed import upsert_era_factions
 
     configs = [era_config_for_key(key) for key in _ERA_ATTRIBUTE_BY_CONFIG_KEY]
-    for config in [c for c in configs if c is not None and c is not CURRENT_ERA]:
+    # By ``config_key``, not identity: ``CURRENT_ERA`` is a distinct instance
+    # refreshed in place rather than one of these objects (ADR-0091), so ``is
+    # not`` would run the live era's pass twice and stop meaning "the non-live
+    # ones first".
+    live_key = CURRENT_ERA.config_key
+    for config in [c for c in configs if c is not None and c.config_key != live_key]:
         await upsert_era_factions(db_session, config)
     await upsert_era_factions(db_session, CURRENT_ERA)
     await db_session.commit()

--- a/backend/tests/integration/test_admin_era_rollover.py
+++ b/backend/tests/integration/test_admin_era_rollover.py
@@ -10,6 +10,7 @@ performs the reset with the **incoming** era's flags.
 each of these, so a rollover here cannot leak into the rest of the session.
 """
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +21,8 @@ from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
+from models.faction import Faction, FactionStatus
+from seed import HIDDEN_FACTION_SLUGS
 from tests.integration.factories import make_admin
 
 # ---------------------------------------------------------------------------
@@ -84,6 +87,146 @@ async def test_rolling_into_an_unregistered_era_changes_nothing(
     assert game_config.CURRENT_ERA.config_key == before
     rows = (await db_session.execute(select(Era))).scalars().all()
     assert [row.id for row in rows] == [era.id]
+
+
+async def test_rolling_into_the_era_that_is_already_live_is_refused(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+):
+    """Re-opening the live era is a full destructive reset that lands where the
+    game already was: every score, level, budget and faction wiped, every duel
+    frozen, the board retired, for no change of ruleset.
+
+    Before this refusal the only thing preventing it was a ``disabled`` option
+    in the admin page's ``<select>``, which is not a control (#3013 review).
+    """
+    await make_admin(db_session, account)
+    live_key = game_config.CURRENT_ERA.config_key
+    assert era.config_key == live_key, "the fixture row is the live era"
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": live_key}, headers=auth_headers
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "ERA_ALREADY_LIVE"
+    # Nothing happened: no second row, and the live era has not moved.
+    rows = (await db_session.execute(select(Era))).scalars().all()
+    assert [row.id for row in rows] == [era.id]
+    assert game_config.CURRENT_ERA.config_key == live_key
+
+
+async def test_the_refusal_reads_the_row_not_the_process(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+):
+    """Which era is live is a database fact (ADR-0091), so the refusal has to be
+    one too. A process whose binding has drifted from the latest row — the state
+    ``rebind_live_era`` logs and falls back on — must not be able to open a
+    second row for the era that row already names.
+    """
+    await make_admin(db_session, account)
+    # The row says era_2; the process is still on era_1. `restore_live_era`
+    # (tests/conftest.py) puts the binding back after this test either way.
+    db_session.add(
+        Era(name="whatever", config_key="era_2", started_by=account.id)
+    )
+    await db_session.commit()
+    assert game_config.CURRENT_ERA.config_key == "era_1"
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "ERA_ALREADY_LIVE"
+
+
+async def test_two_overlapping_rollovers_open_exactly_one_era(
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    character: Character,
+    some_faction: Faction,
+):
+    """The lock, at the seam it guards.
+
+    Two mods confirming within a second of each other is the shape: without the
+    advisory lock both read the same live row, both pass the refusal above, and
+    the game takes two destructive resets. Driven through the service rather
+    than the route because the two calls must share this test's connection —
+    the suite runs every test inside one transaction, so a genuinely concurrent
+    second connection could not see the fixture rows at all. What is being
+    pinned is that the *decision* is re-made after the first rollover lands, not
+    that Postgres blocks (which is Postgres's job, and is what the lock buys
+    once the two are on separate connections).
+    """
+    from services.admin_service import roll_into_era
+
+    await make_admin(db_session, account)
+
+    first = await roll_into_era("era_2", account, db_session)
+    assert first.config_key == "era_2"
+
+    with pytest.raises(HTTPException) as caught:
+        await roll_into_era("era_2", account, db_session)
+    assert caught.value.status_code == 409
+    assert caught.value.detail["code"] == "ERA_ALREADY_LIVE"
+
+    rows = (await db_session.execute(select(Era).order_by(Era.id))).scalars().all()
+    assert [row.config_key for row in rows] == [era.config_key, "era_2"]
+
+
+async def test_the_rollover_re_mirrors_the_faction_roster(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+    some_faction: Faction,
+):
+    """``Faction`` is a two-way display mirror of the live era (ADR-0087), and
+    it used to wait for the next deploy — so between a mod's rollover and the
+    next push the join tiles offered factions the new era does not carry, and an
+    era that *adds* a slug had no row for the FK a join would write.
+
+    Read off the two configs rather than restated: which slugs Era 2 drops is
+    the era files' business, not this test's.
+    """
+    await make_admin(db_session, account)
+    era_1 = era_config_for_key("era_1")
+    era_2 = era_config_for_key("era_2")
+    dropped = set(era_1.factions) - set(era_2.factions)
+    assert dropped, "this test needs an incoming era that drops at least one slug"
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+
+    rows = {
+        row.slug: row.status
+        for row in (await db_session.execute(select(Faction))).scalars()
+    }
+    for slug in dropped:
+        # Retired, never deleted: `character.faction_slug` is an FK and a closed
+        # era's characters are the history it points at.
+        assert rows[slug] is FactionStatus.retired, slug
+    for slug in era_2.factions:
+        assert slug in rows, slug
+        # A system row stays hidden; the roster's real factions go visible.
+        assert rows[slug] in (FactionStatus.visible, FactionStatus.hidden), slug
+    for slug in set(era_2.factions) - HIDDEN_FACTION_SLUGS:
+        assert rows[slug] is FactionStatus.visible, slug
 
 
 async def test_rolling_into_era_2_moves_the_live_ruleset(

--- a/backend/tests/integration/test_admin_era_rollover.py
+++ b/backend/tests/integration/test_admin_era_rollover.py
@@ -1,0 +1,254 @@
+"""The mod control that ends an era — ADR-0091, issue #827.
+
+Seam under test: the two ``/admin/eras`` routes and the thing they exist to
+move, which is the process's live ruleset. The unit tests in
+``tests/unit/test_live_era_binding.py`` pin the binding mechanism; these pin that
+an authenticated mod's HTTP request actually reaches it, writes the row, and
+performs the reset with the **incoming** era's flags.
+
+``tests/conftest.py``'s autouse ``restore_live_era`` puts the live era back after
+each of these, so a rollover here cannot leak into the rest of the session.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import game_config
+from game_config import era_config_for_key
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from tests.integration.factories import make_admin
+
+# ---------------------------------------------------------------------------
+# GET /admin/eras — the selector's option list
+# ---------------------------------------------------------------------------
+
+
+async def test_listing_eras_requires_admin(client: AsyncClient, auth_headers: dict):
+    resp = await client.get("/admin/eras", headers=auth_headers)
+    assert resp.status_code == 403
+
+
+async def test_rolling_requires_admin(client: AsyncClient, auth_headers: dict):
+    """The gate matters more here than anywhere else on the console: there is no
+    undo, and ``Era.started_by`` records whoever got through."""
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+    assert resp.status_code == 403
+
+
+async def test_lists_every_registered_era_and_marks_the_live_one(
+    client: AsyncClient, db_session: AsyncSession, account: Account, auth_headers: dict
+):
+    await make_admin(db_session, account)
+
+    resp = await client.get("/admin/eras", headers=auth_headers)
+
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [row["config_key"] for row in rows] == ["era_1", "era_2"]
+    assert [row["name"] for row in rows] == [
+        era_config_for_key("era_1").name,
+        era_config_for_key("era_2").name,
+    ]
+    live = [row["config_key"] for row in rows if row["is_live"]]
+    assert live == [game_config.CURRENT_ERA.config_key]
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/eras/live — the rollover
+# ---------------------------------------------------------------------------
+
+
+async def test_rolling_into_an_unregistered_era_changes_nothing(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+):
+    """A typo must not become an ``Era`` row whose rules nothing can resolve."""
+    await make_admin(db_session, account)
+    before = game_config.CURRENT_ERA.config_key
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_99"}, headers=auth_headers
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "ERA_CONFIG_UNKNOWN"
+    assert game_config.CURRENT_ERA.config_key == before
+    rows = (await db_session.execute(select(Era))).scalars().all()
+    assert [row.id for row in rows] == [era.id]
+
+
+async def test_rolling_into_era_2_moves_the_live_ruleset(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+):
+    """THE feature. After the request the process plays by Era 2's rules —
+    including at the 157 sites that hold ``CURRENT_ERA`` as a default argument
+    bound at import time, which is what ``max_task_signups`` stands in for here.
+    """
+    await make_admin(db_session, account)
+    era_2 = era_config_for_key("era_2")
+    assert game_config.CURRENT_ERA.config_key == "era_1"
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config_key"] == "era_2"
+    assert body["name"] == era_2.name
+    assert body["characters_reset"] >= 1
+
+    assert game_config.CURRENT_ERA.config_key == "era_2"
+    assert game_config.CURRENT_ERA.name == era_2.name
+    assert game_config.CURRENT_ERA.max_task_signups == era_2.max_task_signups
+    assert set(game_config.CURRENT_ERA.factions) == set(era_2.factions)
+
+    # ...and the era files themselves are untouched by the flip.
+    assert era_config_for_key("era_1").config_key == "era_1"
+    assert era_config_for_key("era_2") is era_2
+
+
+async def test_the_rollover_appends_a_row_stamped_with_the_operator(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+):
+    """Append-only, and ``started_by`` is the audit trail ``require_admin`` fills."""
+    await make_admin(db_session, account)
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+
+    assert resp.status_code == 200
+    rows = (await db_session.execute(select(Era).order_by(Era.id))).scalars().all()
+    assert len(rows) == 2
+    assert rows[0].id == era.id, "the closing era's row stays as history"
+    new_row = rows[1]
+    assert new_row.id == resp.json()["era_id"]
+    assert new_row.config_key == "era_2"
+    assert new_row.name == era_config_for_key("era_2").name
+    assert new_row.started_by == account.id
+
+
+async def test_the_reset_applies_the_incoming_era_s_flags(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+):
+    """The resets are the *opening* era's decision, not the closing one's
+    (ADR-0042). Read off the config rather than restated here.
+    """
+    await make_admin(db_session, account)
+    era_2 = era_config_for_key("era_2")
+    stats = (
+        await db_session.execute(
+            select(CharacterStats).where(CharacterStats.character_id == character.id)
+        )
+    ).scalar_one()
+    stats.score = 500
+    stats.level = 4
+    await db_session.commit()
+
+    resp = await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+
+    new_stats = (
+        await db_session.execute(
+            select(CharacterStats)
+            .where(CharacterStats.character_id == character.id)
+            .order_by(CharacterStats.era_id.desc())
+            .limit(1)
+        )
+    ).scalar_one()
+    assert new_stats.era_id == resp.json()["era_id"]
+    assert new_stats.score == (0 if era_2.reset_score else 500)
+    assert new_stats.level == (0 if era_2.reset_level else 4)
+
+    await db_session.refresh(character)
+    if era_2.reset_faction:
+        assert character.faction_slug == era_2.reset_faction_slug
+
+
+async def test_the_selector_reports_the_new_era_as_live_afterwards(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+    character: Character,
+):
+    """What the admin page re-fetches once the confirm returns."""
+    await make_admin(db_session, account)
+
+    await client.put(
+        "/admin/eras/live", json={"config_key": "era_2"}, headers=auth_headers
+    )
+    resp = await client.get("/admin/eras", headers=auth_headers)
+
+    assert resp.status_code == 200
+    live = [row["config_key"] for row in resp.json() if row["is_live"]]
+    assert live == ["era_2"]
+
+
+# ---------------------------------------------------------------------------
+# The resolver's own edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "config_key, expected",
+    [("era_2", "era_2"), ("era_99", "era_1")],
+)
+async def test_rebind_reads_the_latest_row_and_falls_back_on_an_unknown_key(
+    db_session: AsyncSession, account: Account, era: Era, config_key: str, expected: str
+):
+    """The row is written directly, past the route's validation, because the
+    unregistered-key branch is exactly the state the route refuses to create —
+    a config file deleted under a row that already names it."""
+    from services.era import rebind_live_era
+
+    db_session.add(Era(name="whatever", config_key=config_key, started_by=account.id))
+    await db_session.flush()
+
+    bound = await rebind_live_era(db_session)
+
+    assert bound.config_key == expected
+    assert game_config.CURRENT_ERA.config_key == expected
+
+
+async def test_rebind_on_a_database_with_no_era_row_does_not_raise(
+    db_session: AsyncSession,
+):
+    """A fresh install. ``bootstrap_admin`` writes the first row only on an
+    un-bootstrapped database, so start-up can legitimately find nothing — and
+    start-up must survive it rather than taking the app down."""
+    from services.era import rebind_live_era
+
+    assert (await db_session.execute(select(Era))).scalar_one_or_none() is None
+
+    bound = await rebind_live_era(db_session)
+
+    assert bound.config_key == game_config.COMPILE_TIME_ERA_CONFIG_KEY

--- a/backend/tests/integration/test_admin_era_rollover.py
+++ b/backend/tests/integration/test_admin_era_rollover.py
@@ -45,8 +45,13 @@ async def test_rolling_requires_admin(client: AsyncClient, auth_headers: dict):
 
 
 async def test_lists_every_registered_era_and_marks_the_live_one(
-    client: AsyncClient, db_session: AsyncSession, account: Account, auth_headers: dict
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
 ):
+    """Every registered era in era order, with the ``Era`` row's one marked."""
     await make_admin(db_session, account)
 
     resp = await client.get("/admin/eras", headers=auth_headers)
@@ -59,6 +64,52 @@ async def test_lists_every_registered_era_and_marks_the_live_one(
         era_config_for_key("era_2").name,
     ]
     live = [row["config_key"] for row in rows if row["is_live"]]
+    assert live == [era.config_key]
+
+
+async def test_the_selector_marks_live_from_the_row_not_the_process(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    era: Era,
+):
+    """The selector and the ``PUT``'s refusal must answer from the same source.
+
+    They can disagree — a row naming a ``config_key`` no era file registers
+    leaves the process on the compile-time fallback, and ``rebind_live_era``
+    logs exactly that. Reading ``is_live`` off the binding in that state would
+    have the selector offer an era the ``PUT`` then refuses with
+    ``ERA_ALREADY_LIVE``: a list whose disabled row disagrees with the server.
+
+    This is the same drift ``test_the_refusal_reads_the_row_not_the_process``
+    constructs, seen from the other end. ``restore_live_era``
+    (``tests/conftest.py``) puts the binding back afterwards.
+    """
+    await make_admin(db_session, account)
+    db_session.add(Era(name="whatever", config_key="era_2", started_by=account.id))
+    await db_session.commit()
+    assert game_config.CURRENT_ERA.config_key == "era_1", "the process has not moved"
+
+    resp = await client.get("/admin/eras", headers=auth_headers)
+
+    assert resp.status_code == 200
+    live = [row["config_key"] for row in resp.json() if row["is_live"]]
+    assert live == ["era_2"]
+
+
+async def test_the_selector_falls_back_to_the_process_with_no_era_row(
+    client: AsyncClient, db_session: AsyncSession, account: Account, auth_headers: dict
+):
+    """A fresh database. Nothing has run, so the compile-time era is genuinely
+    what the game would play by, and it is the one thing the row cannot say."""
+    await make_admin(db_session, account)
+    assert (await db_session.execute(select(Era))).scalar_one_or_none() is None
+
+    resp = await client.get("/admin/eras", headers=auth_headers)
+
+    assert resp.status_code == 200
+    live = [row["config_key"] for row in resp.json() if row["is_live"]]
     assert live == [game_config.CURRENT_ERA.config_key]
 
 

--- a/backend/tests/integration/test_era_reset_script.py
+++ b/backend/tests/integration/test_era_reset_script.py
@@ -6,9 +6,10 @@ new here is the only thing standing between an operator and it — a script that
 runs on invocation rather than on ``--yes`` is a different, much worse tool than
 the route it replaces, which at least required an admin session.
 
-So these tests assert the *refusals*: no ``--yes``, no admin, no such character —
-each leaves the database exactly as it found it. Plus the one positive case,
-that a confirmed run writes the same rows ``PUT /admin/era/reset`` did.
+So these tests assert the *refusals*: no ``--yes``, no admin, no such character,
+no era file for the key the live row names — each leaves the database exactly as
+it found it. Plus the positive cases: a confirmed run writes the same rows
+``PUT /admin/era/reset`` did, and leaves the process bound to what it wrote.
 """
 import pytest
 from sqlalchemy import func, select
@@ -21,7 +22,7 @@ from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction
 from scripts.era_reset import reset_era
-from services.era import get_closing_era_id, get_current_era_row_safe
+from services.era import get_current_era_row_safe
 from tests.integration.factories import make_admin
 
 
@@ -111,29 +112,64 @@ async def test_an_unknown_operator_is_refused(
 
 
 @pytest.mark.asyncio
-async def test_a_rollover_into_a_new_config_key_opens_it_and_closes_the_old(
+async def test_a_live_row_naming_no_era_file_is_refused(
     db_session: AsyncSession,
     account: Account,
     character: Character,
     era: Era,
     some_faction: Faction,
 ):
-    """The rollover CURRENT_ERA exists for: the live row carries the *old* key (#2705).
+    """A key nothing registers stops the script rather than steering it (#3013).
 
-    Every other test here rolls Era N into Era N — the ``era`` fixture builds its
-    row from ``CURRENT_ERA.config_key``, so the keys always matched and the bug
-    hid. Re-keying the seeded row to the era it succeeded is the same shape as
-    flipping ``CURRENT_ERA`` forward, without re-binding the constant in two
-    modules: what matters is that the live row's key is not the configured one.
+    This test used to assert the opposite, and it was right to at the time: under
+    the pre-#827 procedure the live row legitimately carried the *previous* era's
+    key during the window between an owner's code flip and the hand rollover, and
+    rolling forward into the compile-time era was the whole job (#2705).
+
+    ADR-0091 abolishes that window — the row **chooses** the ruleset, so the row
+    and the live era agree by construction, and this script re-opens whatever the
+    row names. The one state left is a row whose ``config_key`` no era file
+    registers: a deleted era file, or a row from a newer build. The resolver
+    ``services.era.rebind_live_era`` falls back to the compile-time era there
+    because start-up must survive it. A rollover must not: falling back would
+    turn "re-open the live era" into "roll the game back to Era 1", silently, on
+    the operation with no undo.
     """
     await make_admin(db_session, account, commit=False)
     era.config_key = "era_0_previous"
     await db_session.commit()
+    eras_before = await _era_count(db_session)
 
-    # No 500 in the deploy window: the live era is the latest row, whatever key
-    # it carries. This is the read every character-stats path makes.
+    # The live era is still the latest row, whatever key it carries — the read
+    # every character-stats path makes, and it must not 500 (#2705).
     live = await get_current_era_row_safe(db_session)
     assert live is not None and live.id == era.id
+
+    exit_code = await reset_era(db_session, character.username, confirmed=True)
+
+    assert exit_code == 1
+    assert await _era_count(db_session) == eras_before
+    still_live = await get_current_era_row_safe(db_session)
+    assert still_live is not None and still_live.id == era.id
+
+
+@pytest.mark.asyncio
+async def test_a_confirmed_run_ends_bound_to_what_it_wrote(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    some_faction: Faction,
+):
+    """The script's half of ADR-0091's binding rule.
+
+    It re-opens the era the live row names, so the process must end on exactly
+    that — bound after the commit, not before it, through the same
+    ``commit_and_bind_live_era`` the route uses.
+    """
+    import game_config
+
+    await make_admin(db_session, account, commit=False)
 
     exit_code = await reset_era(db_session, character.username, confirmed=True)
 
@@ -141,17 +177,4 @@ async def test_a_rollover_into_a_new_config_key_opens_it_and_closes_the_old(
     new_era = (
         await db_session.execute(select(Era).order_by(Era.id.desc()).limit(1))
     ).scalar_one()
-    assert new_era.id != era.id
-    assert new_era.config_key == CURRENT_ERA.config_key
-    assert await get_closing_era_id(new_era, db_session) == era.id
-
-    # apply_era_reset ran against the era it opened.
-    stats = (
-        await db_session.execute(
-            select(CharacterStats).where(
-                CharacterStats.character_id == character.id,
-                CharacterStats.era_id == new_era.id,
-            )
-        )
-    ).scalar_one()
-    assert stats.era_id == new_era.id
+    assert game_config.CURRENT_ERA.config_key == new_era.config_key

--- a/backend/tests/integration/test_fixtures_follow_the_era.py
+++ b/backend/tests/integration/test_fixtures_follow_the_era.py
@@ -62,7 +62,11 @@ ALL_ERAS = [
 #: An era that is *not* the live one, for the flip rehearsal below. Skipped
 #: rather than failed if only one era is configured: the day Era 2 becomes
 #: CURRENT_ERA, this file must keep passing without being edited.
-OTHER_ERAS = [era for era in ALL_ERAS if era is not CURRENT_ERA]
+#:
+#: Compared by ``config_key``, not by identity. ``CURRENT_ERA`` is now a distinct
+#: instance refreshed in place rather than one of these objects (ADR-0091), so
+#: ``is not`` would call the live era "other" and rehearse a flip to itself.
+OTHER_ERAS = [era for era in ALL_ERAS if era.config_key != CURRENT_ERA.config_key]
 
 
 def test_every_configured_era_has_a_real_faction_to_give():

--- a/backend/tests/integration/test_seed_stale_era_warning.py
+++ b/backend/tests/integration/test_seed_stale_era_warning.py
@@ -1,59 +1,92 @@
-"""The seeder's deploy-window warning about a configured era with no row (#2705).
+"""The seeder's warning about a live ``Era`` row that names no ruleset (#2705, #827).
 
 Seam under test: ``seed.stale_era_warning`` — the string the summary block prints
 at the end of every deploy, because ``start.sh`` runs the seeder there.
 
-It is the only loud thing left in the rollover window. Resolving the live era
-stopped filtering on ``config_key`` so that ``scripts/era_reset.py`` can run at
-all (``services.era.get_current_era_row_safe``), which means a deployed-but-not-
-rolled-over app now serves the new rules against the old row instead of 500ing.
-Silence there is the trade; this warning is what pays for it.
-"""
-from dataclasses import replace
+**The advice this file pins was inverted by ADR-0091.** It used to warn that the
+*configured* era had no row — "era_2 is configured but the live row is era_1, run
+``era_reset.py``" — which was the deploy window between an owner flipping
+``CURRENT_ERA`` in code and running the rollover by hand. The row now **chooses**
+the ruleset (#827), so that window does not exist: the row and the live era agree
+by construction, and warning about the compile-time era would be telling an
+operator to undo a mod's rollover.
 
+What is left is the one state still genuinely wrong, and it is worse than the old
+one: a row naming a ``config_key`` no era file registers. The process cannot
+resolve the rules that row records, falls back to the compile-time era, and the
+game is quietly not in the era the database says it is in. That silence is what
+this warning pays for.
+"""
 import pytest
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from game_config import _ERA_ATTRIBUTE_BY_CONFIG_KEY, CURRENT_ERA
+from game_config import CURRENT_ERA, era_config_for_key
 from models.character_stats import CharacterStats
 from models.era import Era
 from seed import stale_era_warning
 
-#: Any era key the build knows that is **not** the live one, since the live one
-#: is what the ``era`` fixture writes the row for. Derived, never named (#2708):
-#: naming ``era_2`` here made the test vacuous the moment ``era_2`` went live,
-#: because the warning fires on "configured key != live row key" and nothing else.
-UNOPENED_ERA_KEY = next(
-    key for key in _ERA_ATTRIBUTE_BY_CONFIG_KEY if key != CURRENT_ERA.config_key
-)
+#: A key no era file registers. Named as a literal rather than derived, because
+#: unlike #2708's case there is nothing to derive it from: every *registered* key
+#: is now a legitimate live era, so the only way to reach this branch is a key
+#: that is not one.
+UNREGISTERED_ERA_KEY = "era_from_the_future"
 
 
 @pytest.mark.asyncio
-async def test_no_warning_when_the_live_row_is_the_configured_era(
+async def test_no_warning_when_the_live_row_resolves(
     db_session: AsyncSession,
     era: Era,
 ):
+    """The normal case, and now also the case after any rollover: the row names
+    a registered era, so there is nothing to say."""
     assert await stale_era_warning(db_session, CURRENT_ERA) is None
 
 
 @pytest.mark.asyncio
-async def test_a_configured_era_with_no_row_names_both_keys_and_the_script(
+async def test_no_warning_when_the_row_names_a_registered_era_that_is_not_the_first(
     db_session: AsyncSession,
     era: Era,
+    account,
 ):
-    """The state a deploy that flips CURRENT_ERA forward leaves behind."""
-    unopened_era = replace(CURRENT_ERA, config_key=UNOPENED_ERA_KEY)
+    """A rolled-over deployment must deploy quietly. Under the old rule this row
+    was exactly what triggered the warning."""
+    other_key = next(
+        key
+        for key in ("era_1", "era_2")
+        if key != CURRENT_ERA.config_key
+    )
+    db_session.add(
+        Era(
+            name=era_config_for_key(other_key).name,
+            config_key=other_key,
+            started_by=account.id,
+        )
+    )
+    await db_session.commit()
 
-    warning = await stale_era_warning(db_session, unopened_era)
+    assert await stale_era_warning(db_session, era_config_for_key(other_key)) is None
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_row_names_the_key_and_says_what_is_running(
+    db_session: AsyncSession,
+    era: Era,
+    account,
+):
+    """A deleted era file under a row that already names it. The operator needs
+    both halves: which key went missing, and which rules the game fell back to."""
+    db_session.add(
+        Era(name="Whatever", config_key=UNREGISTERED_ERA_KEY, started_by=account.id)
+    )
+    await db_session.commit()
+
+    warning = await stale_era_warning(db_session, CURRENT_ERA)
 
     assert warning is not None
-    assert (
-        f"{UNOPENED_ERA_KEY} is configured but the live Era row is "
-        f"{CURRENT_ERA.config_key}."
-        in warning
-    )
-    assert "Run scripts/era_reset.py to open it." in warning
+    assert UNREGISTERED_ERA_KEY in warning
+    assert "no era file" in warning
+    assert f"fallen back to {CURRENT_ERA.config_key}" in warning
 
 
 @pytest.mark.asyncio
@@ -69,4 +102,4 @@ async def test_an_empty_era_table_warns_rather_than_crashing_the_seed(
     warning = await stale_era_warning(db_session, CURRENT_ERA)
 
     assert warning is not None
-    assert "the live Era row is absent" in warning
+    assert "no Era row exists" in warning

--- a/backend/tests/integration/test_seed_task_sync.py
+++ b/backend/tests/integration/test_seed_task_sync.py
@@ -33,9 +33,9 @@ from models.era import Era
 from models.faction import Faction
 from models.task import Task, TaskStatus, TaskType
 from seed import (
-    DUEL_FIXTURE_TASK_FACTION_SLUG,
     DUEL_FIXTURE_TASK_TITLE,
     ONBOARDING_TASK_TITLE,
+    duel_fixture_task_faction_slug,
     ensure_duel_fixture_task,
     ensure_onboarding_task,
     sync_era_tasks,
@@ -205,8 +205,9 @@ async def test_duel_fixture_slug_is_a_real_faction_of_the_live_era():
     This is the property that makes the no-op guard a backstop rather than the
     thing deciding whether the duel suite has a task at all (#2710).
     """
-    assert DUEL_FIXTURE_TASK_FACTION_SLUG in CURRENT_ERA.factions
-    assert DUEL_FIXTURE_TASK_FACTION_SLUG not in (
+    slug = duel_fixture_task_faction_slug()
+    assert slug in CURRENT_ERA.factions
+    assert slug not in (
         UNAFFILIATED_FACTION_SLUG,
         ALBESCENT_FACTION_SLUG,
     )
@@ -235,7 +236,7 @@ async def test_duel_fixture_task_is_reachable_at_the_duel_level(
     assert len(rows) == 1
     task = rows[0]
     # The two properties pickUaDuelTask filters on.
-    assert task.primary_faction_slug == DUEL_FIXTURE_TASK_FACTION_SLUG
+    assert task.primary_faction_slug == duel_fixture_task_faction_slug()
     assert task.level_required <= CURRENT_ERA.duel_level_required
     # ...and the two that make it pickable at all.
     assert task.status == TaskStatus.active
@@ -265,7 +266,9 @@ async def test_duel_fixture_task_skipped_when_the_era_lacks_the_faction(
     itself holds an FK to that row — so "the faction is absent" is only
     expressible from the seeder's side.
     """
-    monkeypatch.setattr("seed.DUEL_FIXTURE_TASK_FACTION_SLUG", "no_such_faction")
+    monkeypatch.setattr(
+        "seed.duel_fixture_task_faction_slug", lambda *_, **__: "no_such_faction"
+    )
 
     created = await ensure_duel_fixture_task(db_session, character.id)
     assert created is False

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -70,7 +70,7 @@ from __future__ import annotations
 
 #: The headline number. Asserted against the sum of the entries below, so it
 #: cannot drift into being a separate claim about the code.
-RUFF_FINDING_TOTAL = 636
+RUFF_FINDING_TOTAL = 635
 
 #: ``<path relative to backend/>::<rule code>`` -> how many that file is still
 #: allowed. Sorted by path; keep it sorted so diffs stay readable.
@@ -257,7 +257,6 @@ RUFF_ALLOWLIST: dict[str, int] = {
     "tests/unit/test_character_capabilities.py::E501": 5,
     "tests/unit/test_character_capabilities.py::I001": 1,
     "tests/unit/test_era_config.py::E501": 12,
-    "tests/unit/test_era_config.py::I001": 1,
     "tests/unit/test_era_reset.py::E501": 1,
     "tests/unit/test_era_reset.py::F401": 1,
     "tests/unit/test_errors.py::E501": 3,

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -4,11 +4,12 @@ import pytest
 
 from faction_slugs import ALBESCENT_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
 from game_config import (
+    _ERA_ATTRIBUTE_BY_CONFIG_KEY,
+    COMPILE_TIME_ERA_CONFIG_KEY,
     CURRENT_ERA,
     ERA_1,
     ERA_2,
     EraConfig,
-    _ERA_ATTRIBUTE_BY_CONFIG_KEY,
     era_config_for_key,
 )
 
@@ -227,9 +228,21 @@ def test_era1_level_profiles_use_slug_keys():
 
 
 def test_era_2_is_authored_not_activated():
+    """Which era is live is a database question now (ADR-0091, #827).
+
+    This used to assert ``CURRENT_ERA is ERA_1``. Under the live binding that
+    identity is deliberately false — ``CURRENT_ERA`` is a distinct instance
+    refreshed in place, so that a flip reaches the 157 ``= CURRENT_ERA``
+    defaults. What "not activated" means here is the code half of it: Era 2 is
+    not what a process with no ``Era`` row falls back to, and merely resolving
+    its config does not make it live.
+    """
     assert ERA_2.name == "Metamorphosis"
     assert ERA_2.config_key == "era_2"
-    assert CURRENT_ERA is ERA_1, "Metamorphosis is authored, not activated"
+    assert COMPILE_TIME_ERA_CONFIG_KEY == "era_1"
+    assert CURRENT_ERA == ERA_1, "Metamorphosis is authored, not activated"
+    assert era_config_for_key("era_2") is ERA_2
+    assert CURRENT_ERA.config_key == "era_1"
 
 
 def test_era_2_roster_is_five_factions_and_no_ua():
@@ -335,24 +348,25 @@ def test_resolving_a_past_era_does_not_rebind_the_live_one():
     that imported ``CURRENT_ERA`` at start-up kept the new era's. A half-flipped
     process is worse than either era.
 
-    Asserted through a stand-in flip rather than by flipping anything: the
-    module attribute is rebound here, exactly as a rollover edit would, and the
-    lookup must leave it alone.
+    Flipped through the real lever now (#827): the rollover is an operation the
+    mods run, not an edit an owner deploys, so the flip under test is the one
+    ``services.era.rebind_live_era`` performs. ``tests/unit/test_live_era_binding.py``
+    holds the rest of that seam; this one stays here because the hazard belongs
+    to ``era_config_for_key``, which lives in this file's subject.
     """
-    import game_config
+    from game_config import CURRENT_ERA as live
+    from game_config import bind_live_era
 
-    live = game_config.CURRENT_ERA
     other = next(
         era_config_for_key(key)
         for key in _ERA_ATTRIBUTE_BY_CONFIG_KEY
-        if era_config_for_key(key) is not live
+        if era_config_for_key(key).config_key != live.config_key
     )
-    game_config.CURRENT_ERA = other
-    try:
-        era_config_for_key(live.config_key)
-        assert game_config.CURRENT_ERA is other
-    finally:
-        game_config.CURRENT_ERA = live
+    bind_live_era(other)
+    era_config_for_key("era_1")
+    assert live.config_key == other.config_key, (
+        "resolving a past era for display moved the live one"
+    )
 
 
 def test_registry_returns_none_for_an_unknown_key():

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -4,8 +4,8 @@ Seam under test: ``game_config.CURRENT_ERA`` as an *object identity* rather than
 a name, and ``game_config.bind_live_era`` as the one lever that moves it.
 
 Why the identity and not the name. Every service that takes a ruleset is written
-``era: EraConfig = CURRENT_ERA`` — 114 sites under ``backend/`` when this was
-written, and the number drifts. A default argument is evaluated once, when the
+with the live era as a default argument — more than a hundred signatures under
+``backend/``, and the number drifts. A default argument is evaluated once, when the
 ``def`` executes — so the function holds the **object**, not the name, for the
 life of the process. Four more sites read ``CURRENT_ERA`` as a module global
 inside a function body, which is the importing module's global, not
@@ -282,9 +282,11 @@ def test_only_services_era_rebinds_the_live_era():
     """"Exactly one site rebinds it, and a guard keeps it at one" (#827 ruling).
 
     ``bind_live_era`` is the primitive and ``services/era.py`` is the only
-    shipped module allowed to call it, because that module is where "which era
-    is live" is decided — ``rebind_live_era`` for the callers that must ask the
-    database, ``commit_and_bind_live_era`` for the rollover, which already holds
+    module outside ``tests/`` allowed to call it — ``scripts/`` included, since
+    ``scripts/era_reset.py`` rolls production over — because that module is
+    where "which era is live" is decided — ``rebind_live_era`` for the callers
+    that must ask the database, ``commit_and_bind_live_era`` for the rollover,
+    which already holds
     the era it wrote and must not bind until the write is durable. A caller
     anywhere else is how a process ends up half-flipped, or ahead of its own
     database.
@@ -297,7 +299,14 @@ def test_only_services_era_rebinds_the_live_era():
     callers = set()
     for path in BACKEND_ROOT.rglob("*.py"):
         relative = path.relative_to(BACKEND_ROOT).as_posix()
-        if relative.startswith((".venv/", "tests/", "scripts/")):
+        # `scripts/` is IN scope. It used to be skipped as tooling, but
+        # `scripts/era_reset.py` is a real door onto the live era — it performs
+        # rollovers against production — so exempting it exempted exactly the
+        # file most able to get this wrong. It passes because it goes through
+        # `commit_and_bind_live_era` like the route does, which is the property
+        # worth pinning. `tests/` stays out: this file itself flips the live era
+        # on purpose, and so must anything testing a rollover.
+        if relative.startswith((".venv/", "tests/")):
             continue
         if call.search(path.read_text(encoding="utf-8")):
             callers.add(relative)

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -95,10 +95,75 @@ def test_resolving_a_past_era_does_not_move_the_live_one(flip_to_era_2):
 
 
 def test_binding_the_live_era_to_itself_is_a_no_op():
-    """The refresh clears and refills one ``__dict__``; aliasing would empty it."""
+    """Source and target aliasing must leave the live era intact."""
     bind_live_era(CURRENT_ERA)
     assert CURRENT_ERA.config_key == COMPILE_TIME_ERA_CONFIG_KEY
     assert CURRENT_ERA.factions
+
+
+# ---------------------------------------------------------------------------
+# The refresh is a per-key overwrite, never empty-then-fill
+# ---------------------------------------------------------------------------
+#
+# ``bind_live_era`` must not ``clear()`` the live ``__dict__`` and then refill
+# it. Between those two statements the live era is an ``EraConfig`` with no
+# attributes, and all 157 default arguments point at that object — so a reader
+# that touches it in the window gets ``AttributeError`` on a field that exists.
+# FastAPI runs sync dependencies and sync handlers in a threadpool and the GIL
+# is released between bytecodes, so that reader is a real one.
+#
+# The race itself is not worth chasing in a test. What IS assertable is the
+# property that makes the race impossible: the live object carries a complete
+# field set at every point a caller could observe it, and a bind only ever
+# overwrites keys in place.
+
+
+def test_a_bind_leaves_the_complete_field_set(flip_to_era_2):
+    era_2 = era_config_for_key("era_2")
+    assert set(CURRENT_ERA.__dict__) == set(era_2.__dict__)
+    assert {field.name for field in dataclasses.fields(EraConfig)} <= set(
+        CURRENT_ERA.__dict__
+    )
+
+
+def test_a_bind_never_reduces_the_key_count():
+    """The empty window would show up here as a bind that shrank the object."""
+    before = set(CURRENT_ERA.__dict__)
+    for key in registered_era_config_keys():
+        bind_live_era(era_config_for_key(key))
+        assert set(CURRENT_ERA.__dict__) == before, key
+    bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
+
+
+def test_the_refresh_overwrites_keys_rather_than_emptying_the_object():
+    """Watches the live ``__dict__`` itself while a real flip runs.
+
+    A ``clear()`` shows up as a ``__delitem__`` on the mapping every holder is
+    pointing at; a per-key overwrite never deletes anything. Asserted by swapping
+    in a dict subclass that records deletions, which is the closest a
+    single-threaded test can get to standing where the threadpool reader stands.
+    """
+    deletions = []
+
+    class WatchedDict(dict):
+        def __delitem__(self, key):
+            deletions.append(key)
+            super().__delitem__(key)
+
+        def clear(self):
+            deletions.append("<clear>")
+            super().clear()
+
+    live = CURRENT_ERA
+    original = live.__dict__
+    object.__setattr__(live, "__dict__", WatchedDict(original))
+    try:
+        bind_live_era(era_config_for_key("era_2"))
+        assert live.config_key == "era_2", "the flip still has to happen"
+        assert deletions == [], f"the refresh removed keys: {deletions}"
+        assert set(live.__dict__) == set(original)
+    finally:
+        object.__setattr__(live, "__dict__", dict(original))
 
 
 def test_the_live_era_is_still_a_real_era_config():

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 import pytest
 
-import game_config
 from game_config import (
     COMPILE_TIME_ERA_CONFIG_KEY,
     CURRENT_ERA,

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -190,6 +190,88 @@ def test_the_compile_time_fallback_is_a_registered_key():
 
 
 # ---------------------------------------------------------------------------
+# The bind lands AFTER the commit, never before
+# ---------------------------------------------------------------------------
+#
+# Seam: ``services.era.commit_and_bind_live_era``, the one function that makes a
+# rollover durable and then moves the process onto it. The defect it exists for
+# is ordering, not behaviour, so the test stands where the ordering is decided
+# and needs no database: a session stub that fails its commit is the failure
+# mode, and the live era is the thing that must not have moved.
+
+
+class _RecordingSession:
+    """The two things ``commit_and_bind_live_era`` may do to a session."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+        self.commits = 0
+        self.live_era_at_commit: str | None = None
+
+    async def commit(self) -> None:
+        self.commits += 1
+        # Read the live era from inside the commit: if the bind had already
+        # happened, this would show the incoming era.
+        self.live_era_at_commit = CURRENT_ERA.config_key
+        if self.fail:
+            raise RuntimeError("commit failed")
+
+
+async def test_a_failed_commit_leaves_the_live_era_where_it_was():
+    """THE defect this seam exists for (#3013 review, finding 1).
+
+    A rollover whose commit fails rolls the database back to the closing era. If
+    the process had already bound the opening one, it would go on playing by
+    rules no ``Era`` row records, with nothing to notice and no request able to
+    put it back.
+    """
+    from services.era import commit_and_bind_live_era
+
+    before = CURRENT_ERA.config_key
+    session = _RecordingSession(fail=True)
+
+    with pytest.raises(RuntimeError):
+        await commit_and_bind_live_era(session, era_config_for_key("era_2"))
+
+    assert CURRENT_ERA.config_key == before
+    assert _service_reading_the_default() == before
+
+
+async def test_the_bind_happens_after_a_successful_commit():
+    """The happy path, asserted as an *order* rather than an outcome."""
+    from services.era import commit_and_bind_live_era
+
+    session = _RecordingSession()
+    try:
+        bound = await commit_and_bind_live_era(session, era_config_for_key("era_2"))
+
+        assert session.commits == 1
+        assert session.live_era_at_commit == COMPILE_TIME_ERA_CONFIG_KEY, (
+            "the live era moved before the write was durable"
+        )
+        assert bound.config_key == "era_2"
+        assert CURRENT_ERA.config_key == "era_2"
+        assert _service_reading_the_default() == "era_2"
+    finally:
+        bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
+
+
+async def test_apply_era_reset_does_not_bind_anything_itself():
+    """It only flushes, so there is nothing durable for a bind to stand on.
+
+    Greps rather than calls: exercising ``apply_era_reset`` needs a database,
+    and what is being pinned is that the rebind was *moved out* of it and not
+    quietly moved back.
+    """
+    source = (BACKEND_ROOT / "services" / "era.py").read_text(encoding="utf-8")
+    body = source[source.index("async def apply_era_reset("):]
+    assert "bind_live_era(" not in body, (
+        "apply_era_reset must not move the live era — it has not committed yet. "
+        "The caller binds through commit_and_bind_live_era."
+    )
+
+
+# ---------------------------------------------------------------------------
 # The guard the ruling asked for: exactly one site rebinds the live era
 # ---------------------------------------------------------------------------
 
@@ -197,10 +279,13 @@ def test_the_compile_time_fallback_is_a_registered_key():
 def test_only_services_era_rebinds_the_live_era():
     """"Exactly one site rebinds it, and a guard keeps it at one" (#827 ruling).
 
-    ``bind_live_era`` is the primitive; ``services.era.rebind_live_era`` is the
-    only thing in the shipped backend allowed to call it, because that is the
-    one function that decides *which* era the database says is live. A second
-    caller is how a process ends up half-flipped.
+    ``bind_live_era`` is the primitive and ``services/era.py`` is the only
+    shipped module allowed to call it, because that module is where "which era
+    is live" is decided — ``rebind_live_era`` for the callers that must ask the
+    database, ``commit_and_bind_live_era`` for the rollover, which already holds
+    the era it wrote and must not bind until the write is durable. A caller
+    anywhere else is how a process ends up half-flipped, or ahead of its own
+    database.
     """
     # \b so `rebind_live_era(` — the resolver, which every legitimate caller
     # goes through and which main.py's lifespan calls — is not counted as a call

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -1,0 +1,151 @@
+"""The live-era binding — ADR-0091, issue #827.
+
+Seam under test: ``game_config.CURRENT_ERA`` as an *object identity* rather than
+a name, and ``game_config.bind_live_era`` as the one lever that moves it.
+
+Why the identity and not the name. 157 sites under ``backend/`` are written
+``era: EraConfig = CURRENT_ERA``. A default argument is evaluated once, when the
+``def`` executes — so the function holds the **object**, not the name, for the
+life of the process. Four more sites read ``CURRENT_ERA`` as a module global
+inside a function body, which is the importing module's global, not
+``game_config``'s. Neither shape can be moved by assigning to
+``game_config.CURRENT_ERA``: that rebinds one name in one module and every
+holder keeps what it captured.
+
+So the live era is one stable ``EraConfig`` instance whose *fields* are
+refreshed in place. Every holder — default argument, module global, closure —
+sees the new ruleset at once, and no call site changes. These tests are what
+makes that claim checkable rather than asserted.
+"""
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+import game_config
+from game_config import (
+    COMPILE_TIME_ERA_CONFIG_KEY,
+    CURRENT_ERA,
+    EraConfig,
+    bind_live_era,
+    era_config_for_key,
+    registered_era_config_keys,
+)
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+# A default argument bound at import time, exactly as the 157 real ones are.
+# Module level on purpose: binding it inside a test would evaluate the default
+# *after* a flip and prove nothing.
+def _service_reading_the_default(era: EraConfig = CURRENT_ERA) -> str:
+    return era.config_key
+
+
+@pytest.fixture
+def flip_to_era_2():
+    """Point the live era at Era 2 for one test, then put it back."""
+    bind_live_era(era_config_for_key("era_2"))
+    yield
+    bind_live_era(era_config_for_key(COMPILE_TIME_ERA_CONFIG_KEY))
+
+
+def test_a_flip_reaches_a_default_argument_bound_at_import(flip_to_era_2):
+    """THE defect. A name rebind cannot do this; an in-place refresh can."""
+    assert _service_reading_the_default() == "era_2"
+
+
+def test_the_default_is_back_on_era_1_outside_the_flip():
+    assert _service_reading_the_default() == COMPILE_TIME_ERA_CONFIG_KEY
+
+
+def test_a_flip_carries_the_whole_ruleset_not_just_the_key(flip_to_era_2):
+    """Fields, not identity. Era 2 has a different roster and different modifiers."""
+    era_2 = era_config_for_key("era_2")
+    assert CURRENT_ERA.name == era_2.name
+    assert set(CURRENT_ERA.factions) == set(era_2.factions)
+    assert CURRENT_ERA.level_thresholds == era_2.level_thresholds
+    assert CURRENT_ERA == era_2
+
+
+def test_the_live_era_is_never_the_era_file_s_own_config():
+    """``bind_live_era`` refreshes CURRENT_ERA in place. If CURRENT_ERA *were*
+    ``ERA_1``, the first flip would overwrite the era file's config with Era 2's
+    fields and Era 1 would cease to exist in the process."""
+    for key in registered_era_config_keys():
+        assert CURRENT_ERA is not era_config_for_key(key)
+
+
+def test_a_flip_leaves_the_era_files_untouched(flip_to_era_2):
+    assert era_config_for_key("era_1").config_key == "era_1"
+    assert era_config_for_key("era_1").name != era_config_for_key("era_2").name
+
+
+def test_resolving_a_past_era_does_not_move_the_live_one(flip_to_era_2):
+    """#2708's hazard, re-pinned against the deliberate rebind (#827).
+
+    ``services.activity_feed`` resolves a stored row's ``config_key`` to label a
+    *past* era. Under the old shape that lookup rebound CURRENT_ERA as a side
+    effect and undid the flip. Making the rebind deliberate must not fold the
+    two paths back together.
+    """
+    era_config_for_key("era_1")
+    assert CURRENT_ERA.config_key == "era_2"
+    assert _service_reading_the_default() == "era_2"
+
+
+def test_binding_the_live_era_to_itself_is_a_no_op():
+    """The refresh clears and refills one ``__dict__``; aliasing would empty it."""
+    bind_live_era(CURRENT_ERA)
+    assert CURRENT_ERA.config_key == COMPILE_TIME_ERA_CONFIG_KEY
+    assert CURRENT_ERA.factions
+
+
+def test_the_live_era_is_still_a_real_era_config():
+    """It has to survive everything an ``EraConfig`` is put through — the type
+    annotation on 157 parameters, and ``dataclasses.replace`` in the tests that
+    build variant rulesets."""
+    assert isinstance(CURRENT_ERA, EraConfig)
+    assert dataclasses.is_dataclass(CURRENT_ERA)
+    variant = dataclasses.replace(CURRENT_ERA, max_task_signups=99)
+    assert variant.max_task_signups == 99
+    assert CURRENT_ERA.max_task_signups != 99
+
+
+def test_registered_era_config_keys_is_ordered_and_resolvable():
+    """The selector's option list. Order is authoring order, which is era order."""
+    keys = registered_era_config_keys()
+    assert keys == ("era_1", "era_2")
+    for key in keys:
+        assert era_config_for_key(key).config_key == key
+
+
+def test_the_compile_time_fallback_is_a_registered_key():
+    assert COMPILE_TIME_ERA_CONFIG_KEY in registered_era_config_keys()
+
+
+# ---------------------------------------------------------------------------
+# The guard the ruling asked for: exactly one site rebinds the live era
+# ---------------------------------------------------------------------------
+
+
+def test_only_services_era_rebinds_the_live_era():
+    """"Exactly one site rebinds it, and a guard keeps it at one" (#827 ruling).
+
+    ``bind_live_era`` is the primitive; ``services.era.rebind_live_era`` is the
+    only thing in the shipped backend allowed to call it, because that is the
+    one function that decides *which* era the database says is live. A second
+    caller is how a process ends up half-flipped.
+    """
+    allowed = {"game_config.py", "services/era.py"}
+    callers = set()
+    for path in BACKEND_ROOT.rglob("*.py"):
+        relative = path.relative_to(BACKEND_ROOT).as_posix()
+        if relative.startswith((".venv/", "tests/", "scripts/")):
+            continue
+        if "bind_live_era(" in path.read_text(encoding="utf-8"):
+            callers.add(relative)
+    assert callers == allowed, (
+        "A new site rebinds the live era. Route it through "
+        "services.era.rebind_live_era instead — see ADR-0091."
+    )

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -3,8 +3,9 @@
 Seam under test: ``game_config.CURRENT_ERA`` as an *object identity* rather than
 a name, and ``game_config.bind_live_era`` as the one lever that moves it.
 
-Why the identity and not the name. 157 sites under ``backend/`` are written
-``era: EraConfig = CURRENT_ERA``. A default argument is evaluated once, when the
+Why the identity and not the name. Every service that takes a ruleset is written
+``era: EraConfig = CURRENT_ERA`` — 114 sites under ``backend/`` when this was
+written, and the number drifts. A default argument is evaluated once, when the
 ``def`` executes — so the function holds the **object**, not the name, for the
 life of the process. Four more sites read ``CURRENT_ERA`` as a module global
 inside a function body, which is the importing module's global, not
@@ -35,7 +36,7 @@ from game_config import (
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
 
-# A default argument bound at import time, exactly as the 157 real ones are.
+# A default argument bound at import time, exactly as the real ones are.
 # Module level on purpose: binding it inside a test would evaluate the default
 # *after* a flip and prove nothing.
 def _service_reading_the_default(era: EraConfig = CURRENT_ERA) -> str:
@@ -107,7 +108,8 @@ def test_binding_the_live_era_to_itself_is_a_no_op():
 #
 # ``bind_live_era`` must not ``clear()`` the live ``__dict__`` and then refill
 # it. Between those two statements the live era is an ``EraConfig`` with no
-# attributes, and all 157 default arguments point at that object — so a reader
+# attributes, and every one of those default arguments points at that object —
+# so a reader
 # that touches it in the window gets ``AttributeError`` on a field that exists.
 # FastAPI runs sync dependencies and sync handlers in a threadpool and the GIL
 # is released between bytecodes, so that reader is a real one.
@@ -168,8 +170,8 @@ def test_the_refresh_overwrites_keys_rather_than_emptying_the_object():
 
 def test_the_live_era_is_still_a_real_era_config():
     """It has to survive everything an ``EraConfig`` is put through — the type
-    annotation on 157 parameters, and ``dataclasses.replace`` in the tests that
-    build variant rulesets."""
+    annotation on every one of those parameters, and ``dataclasses.replace`` in
+    the tests that build variant rulesets."""
     assert isinstance(CURRENT_ERA, EraConfig)
     assert dataclasses.is_dataclass(CURRENT_ERA)
     variant = dataclasses.replace(CURRENT_ERA, max_task_signups=99)

--- a/backend/tests/unit/test_live_era_binding.py
+++ b/backend/tests/unit/test_live_era_binding.py
@@ -18,6 +18,7 @@ sees the new ruleset at once, and no call site changes. These tests are what
 makes that claim checkable rather than asserted.
 """
 import dataclasses
+import re
 from pathlib import Path
 
 import pytest
@@ -136,13 +137,17 @@ def test_only_services_era_rebinds_the_live_era():
     one function that decides *which* era the database says is live. A second
     caller is how a process ends up half-flipped.
     """
+    # \b so `rebind_live_era(` — the resolver, which every legitimate caller
+    # goes through and which main.py's lifespan calls — is not counted as a call
+    # to the primitive it wraps.
+    call = re.compile(r"\bbind_live_era\(")
     allowed = {"game_config.py", "services/era.py"}
     callers = set()
     for path in BACKEND_ROOT.rglob("*.py"):
         relative = path.relative_to(BACKEND_ROOT).as_posix()
         if relative.startswith((".venv/", "tests/", "scripts/")):
             continue
-        if "bind_live_era(" in path.read_text(encoding="utf-8"):
+        if call.search(path.read_text(encoding="utf-8")):
             callers.add(relative)
     assert callers == allowed, (
         "A new site rebinds the live era. Route it through "

--- a/docs/adr/0042-era-as-ruleset-config-owns-rules-db-owns-history.md
+++ b/docs/adr/0042-era-as-ruleset-config-owns-rules-db-owns-history.md
@@ -1,6 +1,6 @@
 # ADR-0042 — Era-as-ruleset: `game_config` owns the rules, the DB owns only history
 
-**Status:** Amended by ADR-0087
+**Status:** Amended by ADR-0087, ADR-0091
 **Date:** 2026-07-17
 
 **Relates to:** CLAUDE.md "Config architecture", `backend/game_config.py`, `backend/eras/`
@@ -19,6 +19,18 @@ those two slugs carry structural roles (neutral, and endgame) that are fixed acr
 Nothing else here moves. "Config owns the rules, the DB owns history" is reinforced by
 ADR-0087, not weakened: the reason the two fields are pinned is that they were never really
 *rules*, they were the names of structural slugs.
+
+**Partly amended 2026-09-02 by [ADR-0091](0091-the-latest-era-row-chooses-the-live-ruleset.md)** — the
+clause "the `Era` **DB table stores history only**", and the sentence "Flipping
+`CURRENT_ERA = ERA_2` is the one lever". The latest `Era` row's `config_key` now **chooses**
+which ruleset is live, resolved at start-up and again the moment a rollover appends a row, so
+that a mod can end an era from the admin console instead of an owner editing a file and
+deploying.
+
+The first half of this record is untouched and is the reason the amendment is narrow: the row
+still stores no rule. Every value stays in `game_config.py` + `eras/era_N.py`, services still
+take `era: EraConfig` and still never import `CURRENT_ERA` in the body, and `CURRENT_ERA` is
+still the one lever — what moved is the hand on it.
 
 ## Context
 

--- a/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
+++ b/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
@@ -80,9 +80,23 @@ in one module while every holder keeps what it captured. A process flipped that 
 either era, and is the same failure mode #2708 found from the other direction.
 
 So the live era is one `EraConfig` instance, distinct from every era file's own config,
-whose `__dict__` is replaced when the era changes. Every holder — default argument, module
-global, closure — sees the new ruleset at once, and the "157 call sites untouched and
-correct" the ruling asked for is actually true rather than merely stated.
+whose fields are overwritten **per key** when the era changes. Every holder — default
+argument, module global, closure — sees the new ruleset at once, and the "157 call sites
+untouched and correct" the ruling asked for is actually true rather than merely stated.
+
+Per key, and never `clear()`-then-refill. That distinction is the whole safety of the
+mechanism, so it is a decision and not an implementation detail: an empty-then-fill refresh
+leaves the live era with **no attributes** between two statements, and every one of the 157
+holders points at that object. FastAPI runs sync dependencies and sync route handlers in a
+threadpool and the GIL is released between bytecodes, so a worker thread can read the object
+mid-refresh and raise `AttributeError` on a field that exists — under load, during the one
+operation this mechanism exists to enable. Overwriting key by key means a concurrent reader
+sees the closing era's value or the opening era's for any given field, never a missing one,
+which is exactly the straddling this record already accepts under *Consequences* and nothing
+worse. A clear also buys nothing: `EraConfig` is a frozen dataclass with a fixed field list
+and no `__slots__`, and both sides of every call carry all 43 declared fields, so there is
+never a stale key to remove. `bind_live_era` prunes unexpected extras after the update
+instead, which keeps that defensiveness without the empty state.
 
 Consequences taken knowingly:
 
@@ -90,9 +104,9 @@ Consequences taken knowingly:
   Correct on the merits — `CURRENT_ERA` means "the live binding", not "era 1" — but it
   broke one assertion, in `test_era_2_is_authored_not_activated`, which is updated in the
   same commit.
-- **The live instance must never *be* an era file's config.** `bind_live_era` clears and
-  refills the object it is given custody of; doing that to `ERA_1` would destroy Era 1 in
-  the process. Pinned by a test.
+- **The live instance must never *be* an era file's config.** `bind_live_era` overwrites
+  the fields of the object it is given custody of; doing that to `ERA_1` would leave Era 1
+  carrying Era 2's rules for the life of the process. Pinned by a test.
 - **Writing through a frozen dataclass** is the same move `EraConfig.__post_init__`
   already makes. The frozen wall stops *callers* mutating a config; it is not a claim that
   the module cannot own one instance.

--- a/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
+++ b/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
@@ -43,11 +43,13 @@ selection.
 
 ### The measurement that settled the shape
 
-`era: EraConfig = CURRENT_ERA` appears **114** times under `backend/`
-(`grep -rn --include='*.py' "era: EraConfig = CURRENT_ERA" backend/`; the number drifts,
-the shape does not). The rejected alternative — a request-scoped
-`Depends(get_current_era)` with `era=` threaded down explicitly — makes every one of them
-a silent trap until it is stripped: a caller
+`era: EraConfig = CURRENT_ERA` is the default on **more than a hundred** function
+signatures under `backend/` — 108 in shipped code and 4 more in the test suite, as of this
+writing. `grep -rn --include='*.py' "era: EraConfig = CURRENT_ERA" backend/` finds them,
+along with a handful of prose lines (this one included) that only quote the pattern; the
+count drifts, the order of magnitude is what the argument rests on. The rejected
+alternative — a request-scoped `Depends(get_current_era)` with `era=` threaded down
+explicitly — makes every one of them a silent trap until it is stripped: a caller
 that omits `era=` quietly serves the compile-time era, and nothing fails. It buys
 correctness under a scale-out that ADR-0073 forbids, at the cost of the largest refactor
 on the board.

--- a/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
+++ b/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
@@ -43,9 +43,11 @@ selection.
 
 ### The measurement that settled the shape
 
-`era: EraConfig = CURRENT_ERA` appears **157** times under `backend/`. The rejected
-alternative — a request-scoped `Depends(get_current_era)` with `era=` threaded down
-explicitly — makes every one of those 157 a silent trap until it is stripped: a caller
+`era: EraConfig = CURRENT_ERA` appears **114** times under `backend/`
+(`grep -rn --include='*.py' "era: EraConfig = CURRENT_ERA" backend/`; the number drifts,
+the shape does not). The rejected alternative — a request-scoped
+`Depends(get_current_era)` with `era=` threaded down explicitly — makes every one of them
+a silent trap until it is stripped: a caller
 that omits `era=` quietly serves the compile-time era, and nothing fails. It buys
 correctness under a scale-out that ADR-0073 forbids, at the cost of the largest refactor
 on the board.
@@ -57,20 +59,28 @@ on the board.
 Resolved through the existing `era_config_for_key`. Bound at exactly two moments, and
 there is no third:
 
-- **process start-up**, from the app's lifespan, after the single-instance lock is held;
-- **the end of `apply_era_reset`**, the instant a rollover appends the new row.
+- **process start-up**, from the app's lifespan, after the single-instance lock is held —
+  and from `seed.py`, which `start.sh` runs on every deploy and whose faction mirror has
+  to reflect the era the database says is live. Both ask the database which era that is,
+  through `services.era.rebind_live_era`.
+- **immediately after a rollover's commit**, through
+  `services.era.commit_and_bind_live_era`, which takes the era config the rollover
+  already holds. Not before the commit and not inside `apply_era_reset`: that function
+  only flushes, and binding a process-wide object to a transaction that may still roll
+  back is how the process and the database end up disagreeing about which era the game is
+  in.
 
-`services.era.rebind_live_era` is the only function that performs it, and
-`tests/unit/test_live_era_binding.py` fails if a second site calls the primitive.
+`services/era.py` is the only module that reaches the primitive, and
+`tests/unit/test_live_era_binding.py` fails if a site outside it calls `bind_live_era`.
 
-Services keep taking `era: EraConfig`. Not one of the 157 call sites changes.
+Services keep taking `era: EraConfig`. Not one of those call sites changes.
 
 ### 2. `CURRENT_ERA` is a stable object identity whose fields are refreshed in place
 
 This is the part that is easy to get wrong, and the ruling's own phrasing — "rebind the
 name" — does not survive contact with Python.
 
-A default argument is evaluated **once, when the `def` executes**. Every one of those 157
+A default argument is evaluated **once, when the `def` executes**. Every one of those
 functions therefore holds the *object* `CURRENT_ERA` named at import time, for the life of
 the process. Four further sites read `CURRENT_ERA` as a module global inside a function
 body, which resolves against the *importing* module's globals, not `game_config`'s.
@@ -81,12 +91,12 @@ either era, and is the same failure mode #2708 found from the other direction.
 
 So the live era is one `EraConfig` instance, distinct from every era file's own config,
 whose fields are overwritten **per key** when the era changes. Every holder — default
-argument, module global, closure — sees the new ruleset at once, and the "157 call sites
+argument, module global, closure — sees the new ruleset at once, and the "call sites
 untouched and correct" the ruling asked for is actually true rather than merely stated.
 
 Per key, and never `clear()`-then-refill. That distinction is the whole safety of the
 mechanism, so it is a decision and not an implementation detail: an empty-then-fill refresh
-leaves the live era with **no attributes** between two statements, and every one of the 157
+leaves the live era with **no attributes** between two statements, and every one of those
 holders points at that object. FastAPI runs sync dependencies and sync route handlers in a
 threadpool and the GIL is released between bytecodes, so a worker thread can read the object
 mid-refresh and raise `AttributeError` on a field that exists — under load, during the one
@@ -161,9 +171,16 @@ a constraint the CRDT praxis rooms already pay for rather than adding a new one.
 constraint is ever lifted, this record must be revisited before the second worker starts —
 two workers would drift onto different eras with nothing to notice.
 
-**`scripts/era_reset.py` still works and is now the second-best door.** It rolls into
-whatever the compile-time era is, which is what it always did. The admin control is the one
-that can choose.
+**`scripts/era_reset.py` still works and is now the second-best door.** It re-opens
+whichever era **the latest `Era` row** names — a new season under the same ruleset — which
+is what it always did back when the compile-time era and the live era were the same thing.
+It cannot choose a different one; the admin control is the one that can choose. If that
+row's `config_key` resolves to no era file it refuses outright rather than falling back to
+the compile-time era, because "re-open the live era" and "roll the game back to Era 1" are
+not the same operation. Note the deliberate asymmetry: the route refuses the era that is
+already live (`ERA_ALREADY_LIVE`), because from the admin page that is a mis-click — a full
+destructive reset landing on the ruleset the game was already on — while from a shell,
+behind `--yes`, it is the operation asked for by name.
 
 **One more thing an era file must get right.** A new era is *appended* to
 `_ERA_ATTRIBUTE_BY_CONFIG_KEY`, never inserted: that dict's order is the order the selector

--- a/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
+++ b/docs/adr/0091-the-latest-era-row-chooses-the-live-ruleset.md
@@ -1,0 +1,162 @@
+# ADR-0091 — The latest `Era` row chooses the live ruleset, and `CURRENT_ERA` is an identity, not a name
+
+**Status:** Accepted
+**Date:** 2026-09-02
+
+**Amends:** [ADR-0042](0042-era-as-ruleset-config-owns-rules-db-owns-history.md) — the
+clause "the DB owns only history", *as applied to the choice of ruleset*. The database
+still owns no rule. It now owns **which** ruleset is live: the latest `Era` row's
+`config_key`. Every rule value stays in `backend/eras/`, exactly as before.
+
+**Relates to:** [ADR-0073](0073-a-praxis-is-written-in-a-room-and-the-room-is-not-the-record.md)
+(the single-instance lock this leans on), [ADR-0045](0045-pragmatic-ddd-posture.md)
+(why there is no request-scoped era dependency), #827 (this issue and its ruling),
+#824 (the duel freeze this control fires), #1623 (`era_config_for_key`, the registry
+reused here), #2708 (the side-effect rebinding this must not reintroduce),
+#2711 / PR #2760 (the hand-flip rollover this replaces), #1667 (which deleted the
+admin era route this restores).
+
+## Context
+
+Ending an era was an owner's code edit. `CURRENT_ERA` was a constant pointing at
+`ERA_1`; rolling into Era 2 meant editing `game_config.py`, deploying, and then running
+`scripts/era_reset.py` from a shell. PR #2760 exists to do exactly that by hand.
+
+Mods cannot deploy. So "end the era" — the moment that freezes every duel (#824), retires
+the board, and resets every character — was reachable only by the one person who can push
+to `main`. #827 asks for it as a control on the admin page, which means the active ruleset
+has to resolve at **runtime** from something a mod can change, and the only such thing is
+the database.
+
+That reverses a stated invariant. `CLAUDE.md` said *"Changing `CURRENT_ERA` is the one
+lever"*, `game_config.py`'s docstring said the database *"never owns the rules themselves"*,
+and `models/era.py` said `config_key` was identity-only. Under this record the row still
+owns no rule — but it decides which set of rules is live, which those sentences were
+written to deny.
+
+### What was already built
+
+`era_config_for_key(config_key) -> EraConfig | None` and `_ERA_ATTRIBUTE_BY_CONFIG_KEY`
+have shipped since #1623, and `services.activity_feed` already uses them to label a *past*
+era correctly. The lookup this needs existed; what was missing was ordering and runtime
+selection.
+
+### The measurement that settled the shape
+
+`era: EraConfig = CURRENT_ERA` appears **157** times under `backend/`. The rejected
+alternative — a request-scoped `Depends(get_current_era)` with `era=` threaded down
+explicitly — makes every one of those 157 a silent trap until it is stripped: a caller
+that omits `era=` quietly serves the compile-time era, and nothing fails. It buys
+correctness under a scale-out that ADR-0073 forbids, at the cost of the largest refactor
+on the board.
+
+## Decision
+
+### 1. The latest `Era` row's `config_key` names the live ruleset
+
+Resolved through the existing `era_config_for_key`. Bound at exactly two moments, and
+there is no third:
+
+- **process start-up**, from the app's lifespan, after the single-instance lock is held;
+- **the end of `apply_era_reset`**, the instant a rollover appends the new row.
+
+`services.era.rebind_live_era` is the only function that performs it, and
+`tests/unit/test_live_era_binding.py` fails if a second site calls the primitive.
+
+Services keep taking `era: EraConfig`. Not one of the 157 call sites changes.
+
+### 2. `CURRENT_ERA` is a stable object identity whose fields are refreshed in place
+
+This is the part that is easy to get wrong, and the ruling's own phrasing — "rebind the
+name" — does not survive contact with Python.
+
+A default argument is evaluated **once, when the `def` executes**. Every one of those 157
+functions therefore holds the *object* `CURRENT_ERA` named at import time, for the life of
+the process. Four further sites read `CURRENT_ERA` as a module global inside a function
+body, which resolves against the *importing* module's globals, not `game_config`'s.
+Assigning `game_config.CURRENT_ERA = other` moves neither population: it rebinds one name
+in one module while every holder keeps what it captured. A process flipped that way is
+**half-flipped** — some readers on the new era, most on the old — which is worse than
+either era, and is the same failure mode #2708 found from the other direction.
+
+So the live era is one `EraConfig` instance, distinct from every era file's own config,
+whose `__dict__` is replaced when the era changes. Every holder — default argument, module
+global, closure — sees the new ruleset at once, and the "157 call sites untouched and
+correct" the ruling asked for is actually true rather than merely stated.
+
+Consequences taken knowingly:
+
+- **`CURRENT_ERA is ERA_1` is now false, and `CURRENT_ERA == ERA_1` is the question.**
+  Correct on the merits — `CURRENT_ERA` means "the live binding", not "era 1" — but it
+  broke one assertion, in `test_era_2_is_authored_not_activated`, which is updated in the
+  same commit.
+- **The live instance must never *be* an era file's config.** `bind_live_era` clears and
+  refills the object it is given custody of; doing that to `ERA_1` would destroy Era 1 in
+  the process. Pinned by a test.
+- **Writing through a frozen dataclass** is the same move `EraConfig.__post_init__`
+  already makes. The frozen wall stops *callers* mutating a config; it is not a claim that
+  the module cannot own one instance.
+
+### 3. Resolving a past era still never touches the live one
+
+`game_config.__getattr__` keeps `CURRENT_ERA` and `ERA_N` in separate branches. #2708 found
+that folding them meant `services.activity_feed`'s lookup of a stored row's key — done to
+label a *past* era in the feed — silently put the whole process back on Era 1. Making the
+rebinding deliberate is the same operation pointed the right way, which is exactly why the
+separation has to survive it. Two tests pin it, one either side of a flip.
+
+### 4. A fresh database falls back, loudly, and invents nothing
+
+`bootstrap_admin` writes the first `Era` row only on an un-bootstrapped database, so
+start-up can legitimately find none. `rebind_live_era` then binds
+`COMPILE_TIME_ERA_CONFIG_KEY` and logs it at info. A row naming a `config_key` no era file
+registers — a deleted era file, or a row from a newer version rolled back — falls back the
+same way at warning, saying plainly that the game is not playing by the rules that row
+records.
+
+It does not write a row. `Era.started_by` is a not-null audit trail and a fresh process has
+nobody to put in it.
+
+### 5. The rollover is one admin operation with a target
+
+`GET /admin/eras` lists the registered rulesets in era order and marks the live one.
+`PUT /admin/eras/live` takes a `config_key`, refuses one the registry does not know
+(`ERA_CONFIG_UNKNOWN`, 422), appends the `Era` row, and runs `apply_era_reset` with the
+**incoming** era's flags — which freezes every unresolved duel (#824), retires the board,
+and rebinds the live era.
+
+This restores an entry point #1667 deleted, on the other side of the argument that deleted
+it. `PUT /admin/era/reset` went because it was unreachable from any UI and re-instantiated
+the *same* era: a destructive operation behind any admin session, for no gain. It returns
+because #827 gives it the two things it lacked — a target to choose, and a mod control that
+chooses it.
+
+## Consequences
+
+**The rules change under a live process.** A request in flight when a mod confirms the
+rollover began under the closing era's rules and finishes under the opening one's. Accepted
+with the ruling, and stated here so it is not discovered as a surprise. The hand-flip this
+replaces had the same effect, arriving via a deploy that restarted the process. If it ever
+proves to matter, the answer is draining, or rebinding behind the rollover's own lock — not
+reverting to a request-scoped era.
+
+**A process-wide mutable global is sound here because it is enforced, not assumed.**
+`render.yaml` declares no instance count deliberately and the app takes a Postgres
+session-level advisory lock at boot; a second instance exits loudly (ADR-0073). This spends
+a constraint the CRDT praxis rooms already pay for rather than adding a new one. If that
+constraint is ever lifted, this record must be revisited before the second worker starts —
+two workers would drift onto different eras with nothing to notice.
+
+**`scripts/era_reset.py` still works and is now the second-best door.** It rolls into
+whatever the compile-time era is, which is what it always did. The admin control is the one
+that can choose.
+
+**One more thing an era file must get right.** A new era is *appended* to
+`_ERA_ATTRIBUTE_BY_CONFIG_KEY`, never inserted: that dict's order is the order the selector
+offers, and the offer is an ordering claim about eras.
+
+**Three records had to be corrected, not just added to.** `CLAUDE.md`'s "Config
+architecture" section, `backend/game_config.py`'s module docstring and
+`backend/models/era.py`'s `config_key` comment each asserted the invariant this reverses.
+All three are fixed in the same commit as this record; a rule that lives in four places and
+is corrected in one is worse than a rule that was never written down.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,7 +4,7 @@
      script instead. backend/tests/test_adr_index.py fails if this file
      is out of step with docs/adr/. -->
 
-90 records, of which **83 still state a rule**.
+91 records, of which **84 still state a rule**.
 
 | Status | Meaning |
 |---|---|
@@ -56,7 +56,7 @@
 | [0039](0039-unaffiliated-fill-is-a-gradient-not-a-hue.md) | Unaffiliated's fill is a gradient, not a hue | Accepted | — |
 | [0040](0040-feed-controls-are-neutral-chrome.md) | Feed controls are neutral chrome; faction skinning stops at the card boundary | Accepted | — |
 | [0041](0041-two-layer-identity-account-vs-character.md) | Two-layer identity: Account (private anchor) vs Character (public persona) | Accepted | — |
-| [0042](0042-era-as-ruleset-config-owns-rules-db-owns-history.md) | Era-as-ruleset: `game_config` owns the rules, the DB owns only history | Amended | [ADR-0087](0087-structural-faction-slugs-are-not-era-owned.md) |
+| [0042](0042-era-as-ruleset-config-owns-rules-db-owns-history.md) | Era-as-ruleset: `game_config` owns the rules, the DB owns only history | Amended | [ADR-0087](0087-structural-faction-slugs-are-not-era-owned.md), [ADR-0091](0091-the-latest-era-row-chooses-the-live-ruleset.md) |
 | [0043](0043-vote-budget-is-recomputed-on-read.md) | Vote budget is recomputed on read; only `votes_spent_this_era` is stored | Accepted | — |
 | [0044](0044-characterstats-is-a-per-era-star-schema-split.md) | `CharacterStats` is a per-era star-schema split off `Character` | Accepted | — |
 | [0045](0045-pragmatic-ddd-posture.md) | Pragmatic DDD: implicit aggregates, anemic models, no repository layer, HTTPException in services | Accepted | — |
@@ -105,3 +105,4 @@
 | [0088](0088-albescent-wears-its-own-mark-for-a-revealed-viewer.md) | Albescent wears its own mark for a revealed viewer | Accepted | — |
 | [0089](0089-the-role-map-answers-for-every-slug-and-the-rail-keeps-its-guard.md) | The role map answers for every slug; the rail keeps its own guard | Accepted | — |
 | [0090](0090-a-per-faction-difference-is-classified-before-it-is-designed.md) | A per-faction difference is classified before it is designed: paint, tree, behaviour, or content | Accepted | — |
+| [0091](0091-the-latest-era-row-chooses-the-live-ruleset.md) | The latest `Era` row chooses the live ruleset, and `CURRENT_ERA` is an identity, not a name | Accepted | — |

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -35,6 +35,14 @@ export type FlaggedPraxisOut = components['schemas']['FlaggedPraxisOut']
 
 export type FlaggedCommentOut = components['schemas']['FlaggedCommentOut']
 
+/** One era a rollover may target (#827). `config_key` is the identity a mod
+ *  picks and `Era.config_key` stores; `name` is read off the era config rather
+ *  than off any row, because an era that has never run has no row to read. */
+export type EraOption = components['schemas']['EraOption']
+
+/** What a rollover did, read back off the new era rather than echoed. */
+export type EraRollOut = components['schemas']['EraRollOut']
+
 // ---------------------------------------------------------------------------
 // Read / Inspect
 // ---------------------------------------------------------------------------
@@ -61,6 +69,12 @@ export async function getFlaggedPraxes(): Promise<FlaggedPraxisOut[]> {
 
 export async function getFlaggedComments(): Promise<FlaggedCommentOut[]> {
   const { data } = await apiGet('/admin/comments/flagged')
+  return data
+}
+
+/** Every registered era, in era order, flagged with which one is live (#827). */
+export async function getEras(): Promise<EraOption[]> {
+  const { data } = await apiGet('/admin/eras')
   return data
 }
 
@@ -222,4 +236,18 @@ export async function banCharacter(id: number, banned: boolean): Promise<void> {
     params: { path: { character_id: id } },
     body: { banned },
   })
+}
+
+/**
+ * End the live era and open the one named. **No undo** (#827).
+ *
+ * `PUT` because the resource is "the live era" and this sets it — but it is
+ * emphatically not idempotent: opening an era is an append, so a second call
+ * opens a second one. The caller owns the confirmation that stops that.
+ */
+export async function rollIntoEra(configKey: string): Promise<EraRollOut> {
+  const { data } = await apiPut('/admin/eras/live', {
+    body: { config_key: configKey },
+  })
+  return data
 }

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -280,6 +280,67 @@ export interface paths {
         patch: operations["admin_moderate_comment_admin_comments__comment_id__moderate_patch"];
         trace?: never;
     };
+    "/admin/eras": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Admin List Eras
+         * @description Admin-only: the eras a rollover may target, and which one is live.
+         *
+         *     No session: which rulesets exist is a code fact, and which is live is the
+         *     binding this process is already holding (ADR-0091).
+         */
+        get: operations["admin_list_eras_admin_eras_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/eras/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Admin Roll Into Era
+         * @description Admin-only: end the live era and open the one named. **No undo.**
+         *
+         *     Everyone's score, level, vote budget and faction reset per the incoming
+         *     era's flags; every unresolved duel freezes into a permanent result (#824);
+         *     the whole board retires; and the process starts playing by the new rules
+         *     before this response is written.
+         *
+         *     ``PUT`` rather than ``POST`` because the resource is "the live era" and this
+         *     sets it. It is emphatically **not** idempotent all the same — opening an era
+         *     is an append, so a second call opens a second one. The confirmation that
+         *     stops that is the mod's, on the admin page; the equivalent gate on
+         *     ``scripts/era_reset.py`` is its ``--yes``.
+         *
+         *     This route restores an entry point #1667 deleted, deliberately and on the
+         *     other side of the argument that deleted it: ``PUT /admin/era/reset`` went
+         *     because it was unreachable from any UI and re-instantiated the same era, so
+         *     a destructive rollover sat behind any admin session for no gain. It comes
+         *     back because #827 gives it the two things it lacked — a target to choose,
+         *     and a mod control that chooses it.
+         */
+        put: operations["admin_roll_into_era_admin_eras_live_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/messages": {
         parameters: {
             query?: never;
@@ -2987,6 +3048,48 @@ export interface components {
             /** Era Notes */
             era_notes: string;
         };
+        /**
+         * EraOption
+         * @description One row in the admin era selector.
+         *
+         *     ``config_key`` is the identity a mod picks and ``Era.config_key`` stores;
+         *     ``name`` is the era's player-visible name, read off the config rather than
+         *     off any row, because an era that has never run has no row to read.
+         */
+        EraOption: {
+            /** Config Key */
+            config_key: string;
+            /** Is Live */
+            is_live: boolean;
+            /** Name */
+            name: string;
+        };
+        /**
+         * EraRollIn
+         * @description ``POST /admin/eras/roll`` — the era to roll the game into.
+         *
+         *     Deliberately just the key. A rollover has no options: the resets it performs
+         *     are the *incoming* era's flags (ADR-0042), so anything else this body could
+         *     carry would be a second place to state a rule the era file already owns.
+         */
+        EraRollIn: {
+            /** Config Key */
+            config_key: string;
+        };
+        /**
+         * EraRollOut
+         * @description What the rollover did, read back rather than echoed.
+         */
+        EraRollOut: {
+            /** Characters Reset */
+            characters_reset: number;
+            /** Config Key */
+            config_key: string;
+            /** Era Id */
+            era_id: number;
+            /** Name */
+            name: string;
+        };
         /** FactionChoiceRequest */
         FactionChoiceRequest: {
             /** Faction Slug */
@@ -5490,6 +5593,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CommentOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    admin_list_eras_admin_eras_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                access_token?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EraOption"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    admin_roll_into_era_admin_eras_live_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                access_token?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EraRollIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EraRollOut"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -291,8 +291,11 @@ export interface paths {
          * Admin List Eras
          * @description Admin-only: the eras a rollover may target, and which one is live.
          *
-         *     No session: which rulesets exist is a code fact, and which is live is the
-         *     binding this process is already holding (ADR-0091).
+         *     Which rulesets exist is a code fact; which one is **live** is a database one
+         *     — the latest ``Era`` row (ADR-0091), which is also what ``PUT /eras/live``
+         *     refuses against. Reading it from the process binding instead would let the
+         *     selector offer an era the ``PUT`` then rejects, in the one state where the
+         *     two can disagree.
          */
         get: operations["admin_list_eras_admin_eras_get"];
         put?: never;
@@ -321,10 +324,14 @@ export interface paths {
          *     before this response is written.
          *
          *     ``PUT`` rather than ``POST`` because the resource is "the live era" and this
-         *     sets it. It is emphatically **not** idempotent all the same — opening an era
-         *     is an append, so a second call opens a second one. The confirmation that
-         *     stops that is the mod's, on the admin page; the equivalent gate on
-         *     ``scripts/era_reset.py`` is its ``--yes``.
+         *     sets it — and unlike the append it wraps, the call itself settles: repeating
+         *     it with the key that is now live is refused with **409
+         *     ``ERA_ALREADY_LIVE``** rather than opening a second era, and two calls that
+         *     overlap are serialized by an advisory lock, so the second one sees the first
+         *     one's row and refuses on it. What is still not idempotent is rolling on:
+         *     naming a *different* era opens another one every time, and the only thing
+         *     between a mod and that is the confirmation on the admin page — the
+         *     equivalent gate on ``scripts/era_reset.py`` is its ``--yes``.
          *
          *     This route restores an entry point #1667 deleted, deliberately and on the
          *     other side of the argument that deleted it: ``PUT /admin/era/reset`` went

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -3066,7 +3066,7 @@ export interface components {
         };
         /**
          * EraRollIn
-         * @description ``POST /admin/eras/roll`` — the era to roll the game into.
+         * @description ``PUT /admin/eras/live`` — the era to roll the game into.
          *
          *     Deliberately just the key. A rollover has no options: the resets it performs
          *     are the *incoming* era's flags (ADR-0042), so anything else this body could

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -4,7 +4,8 @@
     "moderation": "Moderation",
     "tasks": "Tasks",
     "accounts": "Accounts",
-    "overview": "Overview"
+    "overview": "Overview",
+    "era": "Era"
   },
   "flagReasons": {
     "spam": "Spam",
@@ -147,6 +148,34 @@
       "empty": "No messages.",
       "archive": "archive",
       "unarchive": "unarchive"
+    }
+  },
+  "era": {
+    "heading": "Roll the game into a new era",
+    "blurb": "An era is the ruleset the game runs on. Rolling ends the live one and opens the next, and everything below happens the moment you confirm it.",
+    "loadError": "Couldn't load eras.",
+    "rollError": "Could not roll the era over.",
+    "selectLabel": "Era to roll into",
+    "liveOption": "{{name}} — live now",
+    "noTarget": "Every era in the register is already live. There is nothing to roll into.",
+    "begin": "roll into a new era",
+    "confirm": {
+      "heading": "Read this before you confirm",
+      "lead": "Rolling into {{name}} will:",
+      "effects": {
+        "characters": "reset every character's score, level, vote budget and faction, by the incoming era's rules",
+        "duels": "freeze every unresolved duel into a permanent result",
+        "board": "retire the whole board"
+      },
+      "noUndo": "There is no undo. Nothing brings back the era you are leaving.",
+      "submit": "confirm — roll into {{name}}",
+      "working": "rolling over, don't leave this page…",
+      "cancel": "cancel, change nothing"
+    },
+    "done": {
+      "heading": "{{name}} is live.",
+      "charactersReset_one": "{{count}} character was reset.",
+      "charactersReset_other": "{{count}} characters were reset."
     }
   }
 }

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -94,6 +94,7 @@
     "OAUTH_STATE_EXPIRED": "That sign-in took too long, so we let it lapse. Pick a way in and you'll go straight through.",
     "ACCOUNT_SUSPENDED": "That account is suspended, so we can't sign you in. Get in touch if you think that's wrong.",
     "ACCOUNT_DELETED": "That account was deleted and can't be signed into.",
-    "RETURNING_PLAYER_CONSENT_EXPIRED": "There's no sign-in waiting on an answer. Pick a way in to start one."
+    "RETURNING_PLAYER_CONSENT_EXPIRED": "There's no sign-in waiting on an answer. Pick a way in to start one.",
+    "ERA_CONFIG_UNKNOWN": "No era by that name. Pick one from the list — nothing was changed."
   }
 }

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -95,6 +95,7 @@
     "ACCOUNT_SUSPENDED": "That account is suspended, so we can't sign you in. Get in touch if you think that's wrong.",
     "ACCOUNT_DELETED": "That account was deleted and can't be signed into.",
     "RETURNING_PLAYER_CONSENT_EXPIRED": "There's no sign-in waiting on an answer. Pick a way in to start one.",
-    "ERA_CONFIG_UNKNOWN": "No era by that name. Pick one from the list — nothing was changed."
+    "ERA_CONFIG_UNKNOWN": "No era by that name. Pick one from the list — nothing was changed.",
+    "ERA_ALREADY_LIVE": "That era is already the live one. Nothing was changed — pick a different era to roll into."
   }
 }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -5,10 +5,13 @@ import ModerationTab from './admin/ModerationTab'
 import TasksTab from './admin/TasksTab'
 import AccountsTab from './admin/AccountsTab'
 import OverviewTab from './admin/OverviewTab'
+import EraTab from './admin/EraTab'
 
-type Tab = 'moderation' | 'tasks' | 'accounts' | 'overview'
+type Tab = 'moderation' | 'tasks' | 'accounts' | 'overview' | 'era'
 
-const TABS: Tab[] = ['moderation', 'tasks', 'accounts', 'overview']
+// Era goes last, and stays last: it is the one tab whose button cannot be
+// undone, so it does not sit next to the ones a mod clicks all day (#827).
+const TABS: Tab[] = ['moderation', 'tasks', 'accounts', 'overview', 'era']
 
 function getInitialTab(): Tab {
   const hash = window.location.hash.replace('#', '')
@@ -63,6 +66,7 @@ export default function Admin() {
       {activeTab === 'tasks' && <TasksTab />}
       {activeTab === 'accounts' && <AccountsTab />}
       {activeTab === 'overview' && <OverviewTab />}
+      {activeTab === 'era' && <EraTab />}
     </div>
   )
 }

--- a/frontend/src/pages/admin/EraTab.tsx
+++ b/frontend/src/pages/admin/EraTab.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getEras, rollIntoEra } from "../../api/admin";
+import type { EraOption, EraRollOut } from "../../api/admin";
+import { extractError } from "../../utils/errors";
+import { defaultEraTarget, selectableEras } from "./eraRollTargets";
+
+/** Explicit, because the label is a sibling rather than a wrapper — one control
+ *  on one tab, so a fixed id cannot collide with a second instance. */
+const TARGET_SELECT_ID = "admin-era-target";
+
+/**
+ * The era rollover control (#827, ADR-0091).
+ *
+ * The destructive tab, and the only irreversible button in the admin page: the
+ * request ends the live era and opens another, resetting every character by the
+ * incoming era's rules. So it is two-step, the second step spells out what it
+ * does in words, and the confirm is really `disabled` while the request is in
+ * flight — a double submit would open two eras, and there is no undo for the
+ * first one, let alone the second.
+ */
+export default function EraTab() {
+  const { t } = useTranslation(["admin", "common"]);
+  const [eras, setEras] = useState<EraOption[] | null>(null);
+  const [target, setTarget] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [rolling, setRolling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [result, setResult] = useState<EraRollOut | null>(null);
+
+  const load = async () => {
+    const rows = await getEras();
+    setEras(rows);
+    setTarget(defaultEraTarget(rows)?.config_key ?? "");
+  };
+
+  useEffect(() => {
+    load().catch((err) => setError(extractError(err, t("era.loadError"))));
+  }, [t]);
+
+  const handleRoll = async () => {
+    setActionError(null);
+    setRolling(true);
+    let outcome: EraRollOut;
+    try {
+      outcome = await rollIntoEra(target);
+    } catch (err) {
+      setActionError(extractError(err, t("era.rollError")));
+      setRolling(false);
+      return;
+    }
+    setResult(outcome);
+    setConfirming(false);
+    setRolling(false);
+    // Re-read rather than patch: `is_live` moved on the server, and the option
+    // a mod is now looking at has to be the one they can still roll into.
+    // A failure here left the rollover itself intact, so it reports as an
+    // action error and keeps the success readout on screen.
+    await load().catch((err) =>
+      setActionError(extractError(err, t("era.loadError"))),
+    );
+  };
+
+  if (error) return <p className="font-body content-text danger-text">{error}</p>;
+  if (!eras)
+    return <div className="font-body text-muted content-text">{t("common:loading")}</div>;
+
+  const targets = selectableEras(eras);
+  const targetEra = eras.find((era) => era.config_key === target) ?? null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="label-heading mb-2">{t("era.heading")}</p>
+        <p className="font-body content-text text-muted">{t("era.blurb")}</p>
+      </div>
+
+      {result && (
+        <div className="card px-4 py-3">
+          <p className="font-display text-lg font-bold">
+            {t("era.done.heading", { name: result.name })}
+          </p>
+          <p className="font-body content-text text-muted">
+            {t("era.done.charactersReset", { count: result.characters_reset })}
+          </p>
+        </div>
+      )}
+
+      {actionError && (
+        <p className="font-body content-text danger-text border-2 danger-edge px-3 py-2">
+          {actionError}
+        </p>
+      )}
+
+      {targets.length === 0 ? (
+        /* One era in the register and it is already live: there is no target,
+           so there is no control. Nothing to disable, nothing to explain. */
+        <p className="font-body content-text text-muted">{t("era.noTarget")}</p>
+      ) : confirming && targetEra ? (
+        <div
+          className="card px-4 py-3 flex flex-col gap-2"
+          style={{ borderColor: "var(--color-danger-edge)" }}
+        >
+          {/* The frame is red; the WORDS are what say this is destructive. A
+              reader who cannot see the border still gets the heading, the list
+              and the no-undo line. */}
+          <p className="label-heading" style={{ color: "var(--color-danger)" }}>
+            {t("era.confirm.heading")}
+          </p>
+          <p className="font-body content-text">
+            {t("era.confirm.lead", { name: targetEra.name })}
+          </p>
+          <ul className="font-body content-text list-disc pl-5">
+            <li>{t("era.confirm.effects.characters")}</li>
+            <li>{t("era.confirm.effects.duels")}</li>
+            <li>{t("era.confirm.effects.board")}</li>
+          </ul>
+          <p className="font-body content-text font-bold">{t("era.confirm.noUndo")}</p>
+          <div className="flex gap-2 flex-wrap">
+            <button
+              onClick={() => void handleRoll()}
+              disabled={rolling}
+              className="btn-primary text-xs"
+            >
+              {rolling
+                ? t("era.confirm.working")
+                : t("era.confirm.submit", { name: targetEra.name })}
+            </button>
+            {/* Hidden rather than disabled while the request is out: cancelling
+                cannot recall a rollover that is already happening. */}
+            {!rolling && (
+              <button
+                onClick={() => setConfirming(false)}
+                className="btn-outline text-xs"
+              >
+                {t("era.confirm.cancel")}
+              </button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 items-start">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor={TARGET_SELECT_ID}
+              className="font-body text-xs text-muted"
+            >
+              {t("era.selectLabel")}
+            </label>
+            <select
+              id={TARGET_SELECT_ID}
+              className="font-body content-text border border-border bg-surface px-2 py-1"
+              value={target}
+              onChange={(event) => setTarget(event.target.value)}
+            >
+              {eras.map((era) => (
+                /* The live era stays in the list, marked and `disabled`. It is
+                   not a control being shown greyed out — it is the register,
+                   and where the game currently sits in it is the fact a mod
+                   needs before picking the next row. What it is NOT is a
+                   target: rolling into the era you are already in is a second
+                   reset for nothing, and there is no undo. */
+                <option
+                  key={era.config_key}
+                  value={era.config_key}
+                  disabled={era.is_live}
+                >
+                  {era.is_live ? t("era.liveOption", { name: era.name }) : era.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            onClick={() => {
+              setActionError(null);
+              setResult(null);
+              setConfirming(true);
+            }}
+            className="btn-outline text-xs"
+            style={{
+              borderColor: "var(--color-danger-ring)",
+              color: "var(--color-danger)",
+            }}
+          >
+            {t("era.begin")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/__tests__/eraRollTargets.test.ts
+++ b/frontend/src/pages/admin/__tests__/eraRollTargets.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #827 — which era the rollover control may be pointed at.
+ *
+ * The whole decision is one filter, and it is worth its own module because
+ * getting it wrong is unrecoverable: a rollover into the LIVE era is a second
+ * reset of every score, level, vote budget and faction, plus a second freeze of
+ * every unresolved duel, for no change at all and with no undo. So the live row
+ * is not a target, and an all-live register has no target rather than a
+ * defaulted one.
+ */
+import { describe, it, expect } from "vitest";
+import type { EraOption } from "../../../api/admin";
+import { defaultEraTarget, selectableEras } from "../eraRollTargets";
+
+const era = (config_key: string, is_live: boolean): EraOption => ({
+  config_key,
+  name: config_key.toUpperCase(),
+  is_live,
+});
+
+const REGISTER: EraOption[] = [era("era_1", true), era("era_2", false)];
+
+describe("selectableEras — the live era is never a rollover target (#827)", () => {
+  it("drops the live era", () => {
+    expect(selectableEras(REGISTER)).toEqual([era("era_2", false)]);
+  });
+
+  it("keeps the backend's era order", () => {
+    const many = [era("era_1", true), era("era_2", false), era("era_3", false)];
+    expect(selectableEras(many).map((e) => e.config_key)).toEqual([
+      "era_2",
+      "era_3",
+    ]);
+  });
+
+  it("yields nothing when every registered era is live", () => {
+    expect(selectableEras([era("era_1", true)])).toEqual([]);
+  });
+
+  it("passes an all-dormant list through untouched", () => {
+    // No live row is not this helper's problem to solve — the backend always
+    // flags one, and inventing a fallback here would hide it if it stopped.
+    const dormant = [era("era_1", false), era("era_2", false)];
+    expect(selectableEras(dormant)).toEqual(dormant);
+  });
+});
+
+describe("defaultEraTarget — where the selector starts (#827)", () => {
+  it("is the first non-live era", () => {
+    expect(defaultEraTarget(REGISTER)).toEqual(era("era_2", false));
+  });
+
+  it("skips the live era even when it leads the list", () => {
+    const many = [era("era_1", true), era("era_2", false), era("era_3", false)];
+    expect(defaultEraTarget(many)?.config_key).toBe("era_2");
+  });
+
+  it("is null when every registered era is live", () => {
+    // The tab reads this as "say so and render no control", which is why null
+    // is a real answer here and not an error to throw.
+    expect(defaultEraTarget([era("era_1", true)])).toBeNull();
+  });
+
+  it("is null for an empty register", () => {
+    expect(defaultEraTarget([])).toBeNull();
+  });
+});

--- a/frontend/src/pages/admin/eraRollTargets.ts
+++ b/frontend/src/pages/admin/eraRollTargets.ts
@@ -1,0 +1,28 @@
+import type { EraOption } from "../../api/admin";
+
+/**
+ * The eras a rollover may actually be pointed at (#827).
+ *
+ * The live era is excluded, not disabled: rolling into the era the game is
+ * already in is a second reset — every score, level, vote budget and faction
+ * cleared again, every unresolved duel frozen again — with nothing gained and
+ * no undo. An option a mod can pick is an option a mod can pick by mistake, so
+ * the live row stays visible as a label and never as a target.
+ *
+ * Order is the backend's (era order), preserved.
+ */
+export function selectableEras(eras: EraOption[]): EraOption[] {
+  return eras.filter((era) => !era.is_live);
+}
+
+/**
+ * The era the selector should start on, or `null` when there is nothing to roll
+ * into.
+ *
+ * `null` is a real answer, not an error: a registry holding exactly one era —
+ * the live one — has no rollover target, and the tab renders that as a sentence
+ * rather than as an empty `<select>` a mod can submit.
+ */
+export function defaultEraTarget(eras: EraOption[]): EraOption | null {
+  return selectableEras(eras)[0] ?? null;
+}


### PR DESCRIPTION
Closes #827

Mods can now end an era from the admin page and choose which era it opens into. The live ruleset resolves from the latest `Era` row, per the owner's 2026-09-01 ruling.

**Visual QA is outstanding.** I have no browser and no dev stack in this environment; everything below was verified through tests, `tsc`, eslint and the build. See "What to eyeball".

**The backend integration tests in this PR are unrun.** There is no Postgres available here — no docker group membership, no local server, and `sudo` needs a password. The 523 backend *unit* tests pass, all 1237 integration tests collect cleanly (so nothing is broken at import), and every frontend CI step passes. CI is the first thing to actually execute `backend/tests/integration/test_admin_era_rollover.py`.

---

## The seam I tested at

`game_config.CURRENT_ERA` as an **object identity** rather than a name, and `services.era.apply_era_reset` as the one operation that moves it.

`backend/tests/unit/test_live_era_binding.py` is the red-first test. Its core case defines, at module scope, a function with `era: EraConfig = CURRENT_ERA` — exactly as the 157 real ones are written — and asserts that after a flip it reports the new era.

## One correction to the ruling, and why it is a correction rather than a re-litigation

The ruling's decision stands untouched: the latest `Era` row chooses the ruleset, bound at start-up and after `apply_era_reset`, services keep taking `era: EraConfig`, 157 call sites unchanged. What does not survive contact with Python is the ruling's *mechanism* — "rebind the name `CURRENT_ERA`":

> Option A leaves every one of them untouched **and correct**.

A default argument is evaluated **once, when the `def` executes**. All 157 functions therefore hold the *object* named at import time, for the life of the process. Four more sites read `CURRENT_ERA` as a module global inside a function body, which resolves against the *importing* module's globals, not `game_config`'s. `game_config.CURRENT_ERA = other` moves neither population — it rebinds one name in one module while every holder keeps what it captured. The process would end up **half-flipped**: a handful of readers on the new era, the overwhelming majority on the old. That is the same failure mode #2708 found, arriving from the other direction.

So `CURRENT_ERA` is now one stable `EraConfig` instance, distinct from every era file's config, whose fields are refreshed in place. Every holder — default argument, module global, closure — sees the new ruleset at once. This is the only mechanism under which the ruling's own promise ("157 call sites untouched and correct") is actually true rather than merely stated, and it makes start-up ordering a non-issue as a bonus: the lifespan can bind after the routers have imported, because they all point at the same object.

Two consequences, both taken deliberately and both documented in ADR-0091:

- `CURRENT_ERA is ERA_1` is now **false**; `CURRENT_ERA == ERA_1` is the question. Correct on the merits — `CURRENT_ERA` means "the live binding", not "era 1" — and it moved three assertions (one unit test, two integration fixtures) that compared eras by identity.
- The live instance must never *be* an era file's config, or the first flip would overwrite `ERA_1` in the process. Pinned by a test.

## The central hazard (#2708) survives, and is re-pinned

`game_config.__getattr__` still keeps `CURRENT_ERA` and `ERA_N` in separate branches. Two tests now cover it — one in `test_live_era_binding.py` that resolves `era_1` while Era 2 is live and asserts both the module attribute and a def-time-bound default are unmoved, and the existing `test_resolving_a_past_era_does_not_rebind_the_live_one`, rewritten to flip through the real lever instead of a stand-in name assignment (that stand-in tested a name nothing reads any more).

## Three regressions this change would otherwise have shipped

None was in the brief; all three were found by tracing what reads `CURRENT_ERA` at runtime, and all three are silent.

1. **`backend/seed.py` runs on every deploy** (`start.sh`) and its Phase 1 is a two-way mirror: it marks the era's roster `visible` and every other slug `retired`. It read the *compile-time* era. So the first deploy after a mod rolled the game into Era 2 would have re-marked Era 1's factions visible and Era 2's retired — silently undoing the roster half of the rollover, with the `Era` row still correctly naming Era 2. It now seeds the live era.
2. **`backend/scripts/era_reset.py`** would have re-opened the compile-time era, i.e. silently rolled the game *back* to Era 1 after a mod rolled it forward. It now resolves the live era first — one call, and `print_plan` and the row it builds needed no edit, because the live era is one object refreshed in place.
3. **`seed.DUEL_FIXTURE_TASK_FACTION_SLUG`** was a module constant, evaluated when `seed` is imported — which is before `seed()` resolves the live era. Its value is `ua`, which Era 2 does not carry. This is #2710's exact symptom reached by a new route, and the comment sitting directly above that line says so ("A slug read off the era cannot go absent, so the guard stays as a backstop rather than as the thing that decides whether the suite has a task at all"). Worse than #2710, in fact: the `Faction` row for `ua` still exists, because rows retire and never delete, so the `faction is None` backstop would wave it through and seat the duel fixture task in a faction the live era does not carry. It is now `duel_fixture_task_faction_slug(era=CURRENT_ERA)`, read at call time. Demonstrated directly: before the flip it returns `ua`, after `bind_live_era(era_2)` it returns `snide`.

A read-only sweep of all 675 `CURRENT_ERA` occurrences under `backend/` found no *other* shipped-code site of either class — no remaining identity comparisons, and no module-level derivations under `services/`, `routers/`, `models/` or `scripts/`. It did find ~30 module-level constants in the **test** suite with the same import-time-freeze shape (`tests/integration/factories.py::DEFAULT_FACTION_SLUG` being the widest). All are latent — the autouse `restore_live_era` fixture contains them and the one file that genuinely flips to Era 2 imports none of them — so they are deliberately **not** in this PR; converting ~30 constants is churn that would bury the change. Flagged separately; a guard test that fails when a new module-level derivation appears is probably the better-value half of that work.

`seed.stale_era_warning` also had its advice inverted. It used to warn "era_2 is configured but the live row is era_1 — run `era_reset.py`", which was the deploy window between an owner's code flip and the hand rollover. That window no longer exists, and the warning would now be telling an operator to undo a mod's rollover. It now fires on the one state still genuinely wrong: a row naming a `config_key` no era file registers, where the process has fallen back and the game is quietly not in the era the database says it is in.

## What is in the PR

**Backend**
- `game_config.py` — `bind_live_era` (the primitive), `_new_live_era`, `registered_era_config_keys()`, `COMPILE_TIME_ERA_CONFIG_KEY`, and the module docstring corrected.
- `services/era.py` — `rebind_live_era(session)`, the **only** caller of the primitive; falls back to the compile-time era with a log line both when there is no `Era` row (fresh database — does not invent one, `Era.started_by` is a not-null audit trail) and when the row names an unregistered key. Called from the app lifespan and from the end of `apply_era_reset`.
- `services/admin_service.py` — `list_registered_eras()`, `roll_into_era()`.
- `routers/admin.py` — `GET /admin/eras`, `PUT /admin/eras/live`. An unregistered key is a coded 422 (`ERA_CONFIG_UNKNOWN`) rather than an uncoded raise, because the uncoded-error allowlist only shrinks.
- `backend/openapi.json` + `frontend/src/api/generated/schema.d.ts` regenerated by `scripts/regen_api_client.py`; `git diff --exit-code` on both is clean.

**The guard the ruling asked for.** `test_only_services_era_rebinds_the_live_era` greps the shipped backend and fails if anything but `game_config.py` and `services/era.py` calls `bind_live_era`. (Word-boundary matched, so `rebind_live_era` — which callers legitimately use — is not counted.)

**Test isolation.** `apply_era_reset` rebinds a process-wide object, so an autouse fixture in `backend/tests/conftest.py` restores the live era after every test. Without it a rollover in one test would hand Era 2 to every test after it in the same session, in file order, silently.

**Docs.** New ADR-0091 (number taken from `ls docs/adr/` at authoring time, not from the issue). It amends ADR-0042's "the DB owns only history" clause — status line updated to `Amended by ADR-0087, ADR-0091` plus an `## Amendment` paragraph, per #2536's vocabulary; no other ADR body rewritten. `docs/adr/README.md` regenerated with `scripts/adr_index.py`. The three records that asserted the reversed invariant are corrected in the same commit: `CLAUDE.md`'s "Config architecture", `game_config.py`'s docstring, `models/era.py`'s `config_key` comment.

**Frontend** — a new Era tab (last in the row, the destructive one), a `<select>` of registered eras, and a two-step confirm that spells out in words what a rollover does. The live era stays in the select as a `disabled`, marked option and is never a target — rolling into the era you are already in is a second reset for nothing. The decision logic is extracted to `eraRollTargets.ts` and unit-tested, matching how `adminTaskRows.ts` is split out of `TasksTab.tsx`.

## Verification actually run

Backend (`backend/.venv/bin/pytest`, dedicated test DB not needed for these):
- `tests/unit` — **523 passed**, including the ruff ratchet, the uncoded-error ratchet, the i18n catalog coverage guard and the ADR index test.
- `tests/integration --collect-only` — 1237 collected, no import errors. **Not executed: no Postgres in this environment.**
- `game_config.py` coverage from unit tests alone: 100%.
- `python scripts/regen_api_client.py` then `git diff --exit-code` — clean (the `api-schema` job).

Frontend, every step named in `.github/workflows/test.yml`:
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 510 files, **10543 passed**, 1 skipped
- `npm run build` — succeeds
- `npm run budget` — `WARN JS 150.1 KB (warn>130.9, fail>175.8)`, exit 0. **Pre-existing**: the baseline is ~149.7 KB, already well past the warn line before this branch. This change adds ~0.4 KB gzip, all of it the new copy landing in the eagerly-imported i18n chunk; `EraTab` itself is behind the already-lazy `Admin` route. 25 KB under the fail ceiling.

## Not touched

PR #2760 and its branch, as instructed.

---

## What to eyeball

I could not open a browser. Everything here is a *visual* or *interaction* claim that tests cannot make:

1. **The Era tab in the tab bar** — it is last, after Overview. Check the underline/active treatment matches its four neighbours, and that `#era` in the URL selects it on reload (the tab bar drives `window.location.hash`).
2. **Step one, the selector.** The live era appears in the `<select>` as a `disabled` option labelled "*{name}* — live now", and the dropdown defaults to the first non-live era. Judgement call worth a second opinion: I kept the live era visible-but-unpickable because the list is the register and where the game sits in it is the fact you need before choosing. If you would rather it were dropped from the select and stated in prose above, that is a one-line change.
3. **Step two, the confirm card.** Red border (`--color-danger-edge`), red heading, three effect bullets, bolded no-undo line. The confirm button is `btn-primary` (strong neutral ink), **not** a red button — `--color-danger` measures 4.40:1 on light, so red-on-white at `text-xs` would be under AA. Please sanity-check that it still *reads* as dangerous enough for an irreversible action, in both light and dark.
4. **Dark mode** on both the confirm card and the select. No `dark ? a : b` ternaries were used; it is all CSS variables, but nobody has looked at it.
5. **In flight.** The confirm button really disables and swaps to the working copy; Cancel is *hidden* rather than disabled while the request is out, since cancelling cannot recall a rollover already happening. Check that the buttons do not jump distractingly when Cancel disappears.
6. **The success readout**, after a real rollover on a scratch database: "{name} is open" plus the pluralised character count, and the selector re-fetches so the new era shows as live and is no longer pickable.
7. **The error path** — send a bad key (or point at a stale build) and confirm the 422 renders the `ERA_CONFIG_UNKNOWN` sentence from `errors.json`, not a raw body.
8. **The one-era case** (`era.noTarget`) is unreachable today with two eras registered, so it is untested by eye. Worth a look if you ever cut back to one.

And the thing worth confirming on a scratch database rather than by eye: **that a rollover actually changes how the game plays in the live process** — roll into Era 2 and then check a surface that reads a rule off the era (the faction roster, a level threshold, the signup cap) *without* restarting the backend. That is the whole point of the change, it is the part the unit tests model rather than prove end-to-end, and it is the one I could not run.
