### PR TITLE
na and Albescent read from the composer chassis, and the four defects go with the branch (#2992)

### DIFF
--- a/docs/adr/0065-the-edit-praxis-composer-is-one-shared-layout-every-faction-dresses.md
+++ b/docs/adr/0065-the-edit-praxis-composer-is-one-shared-layout-every-faction-dresses.md
@@ -95,6 +95,23 @@ detail and why this ADR exists for the composer rather than either being an
 amendment. ADR-0065 licenses no further collapse. The next surface needs its
 own record, the same way.
 
+**Amended 2026-09-01 (#2992): the CHASSIS crossed to the character forms, and is
+now the general rule.** The paragraph above is about the mobile-twin collapse —
+"unifying another surface" means retiring another `mobileX` seam — and that
+scoping stands unchanged. It was being read as scoping the composer's shared
+LAYOUT BLOCKS too, and those left this surface without an amendment: #2346 and
+#2351 built Create Character on `ComposerPage` / `ComposerSheet` /
+`ComposerSection` / `ComposerFooter`, and #2537 did the same for Edit Character.
+Seven faction kits shipped that way; only the `na` kit and its Albescent wrapper
+did not, and #2992 brought them in on the owner's ruling that *"all factions read
+from the same chassis"*. So `shared.tsx` is the expected substrate for a
+composer-shaped form on any surface, and a new kit that hand-authors a sheet, a
+section and a footer is the thing that now needs a reason.
+
+What is still not licensed is unchanged and is stated below under *What this ADR
+does not do*: folding the archetypes into a single component with a runtime skin
+table. Mounting shared blocks is not that.
+
 ### 3. The composer carries no faction voice
 
 Copy on this surface goes neutral: one shared block of keys, every archetype

--- a/docs/adr/0090-a-per-faction-difference-is-classified-before-it-is-designed.md
+++ b/docs/adr/0090-a-per-faction-difference-is-classified-before-it-is-designed.md
@@ -81,6 +81,19 @@ A token can repaint anything; it cannot move a node, add a node, or cross a prop
 an archetype file, and nine files stay nine files — `frontend/CLAUDE.md` forbids unifying
 them, and getting smaller by not repeating each other is not the same as merging.
 
+**Amended 2026-09-01 (#2992): the shared chassis is the expected substrate, not the
+exception.** The owner's ruling during `/bug-bot` — *"I do want to, in general, have all
+factions read from the same chassis … The 7 factions which use the chassis all do have
+distinct looks and look very good, while being consistent readable experiences. I want to
+bring NA and Albescent into that"* — settles which half of the sentence above governs.
+Nine files still stay nine files, and each still owns its own tree, dress, ground and
+ornament. What an archetype may **not** do is re-author the sheet, the section and the
+footer its eight siblings already mount out of
+`pages/editPraxis/archetypes/shared.tsx`; a kit that does drifts on information, which is
+what the ruling is about. The forbidden thing is unchanged and is narrower than it reads:
+**one component with a runtime skin table rendering nine trees.** A shared chassis is not
+that. See ADR-0065's scope paragraph, amended the same day and for the same reason.
+
 **3. Behaviour** — a capability or a rule. **Never slug-keyed.** Abilities belong to eras and
 move between factions, so they live in `FactionConfig` in `backend/game_config.py` and are
 read through a service, mirroring ADR-0042. #2660 and #2664 are the live violation history.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -50,7 +50,14 @@
     `resolveRoleReads()` in `test/sourceScan.ts` first — a migrated surface no longer
     writes the token, and a guard matching the spelling silently narrows.
 - Dark mode via the `[data-theme="dark"]` cascade — no `dark ? '#a' : '#b'` ternaries
-- Each faction has its own card archetype; don't unify
+- Each faction has its own card archetype; don't unify. **The boundary (#2992): a
+  shared CHASSIS is not unifying; a runtime SKIN TABLE is.** Nine files stay nine
+  files, and each owns its own tree, dress, ground and ornament — but mounting the
+  blocks its siblings already mount (`ComposerPage`/`Sheet`/`Section`/`Footer` out
+  of `pages/editPraxis/archetypes/shared.tsx`) is how a kit stops re-authoring a
+  sheet, not how it merges. What is forbidden is one component branching on a slug
+  to render nine trees. Owner ruling, quoted in ADR-0090 §Tree and ADR-0065's
+  scope paragraph, both amended the same day.
 - Reuse `.card-meta`, `.card-description` for repeated patterns
 - Hide unusable controls; don't show them disabled
 - Form factor (#494): a new dispatched surface provides a `Default*` mobile skin and dispatches through a parallel `MOBILE_ARCHETYPE_BY_SLUG` on `useFormFactor() === 'mobile'`. The mobile path stacks single-column — never fixed-px inline grids for layout structure. See `docs/spec/SPEC-faction-ui-profile.md` §1a.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -53,11 +53,11 @@
 - Each faction has its own card archetype; don't unify. **The boundary (#2992): a
   shared CHASSIS is not unifying; a runtime SKIN TABLE is.** Nine files stay nine
   files, and each owns its own tree, dress, ground and ornament — but mounting the
-  blocks its siblings already mount (`ComposerPage`/`Sheet`/`Section`/`Footer` out
-  of `pages/editPraxis/archetypes/shared.tsx`) is how a kit stops re-authoring a
-  sheet, not how it merges. What is forbidden is one component branching on a slug
-  to render nine trees. Owner ruling, quoted in ADR-0090 §Tree and ADR-0065's
-  scope paragraph, both amended the same day.
+  layout blocks its siblings already mount is how a kit stops re-authoring a sheet,
+  not how it merges. What is forbidden is one component branching on a slug to
+  render nine trees. Owner ruling, quoted in ADR-0090 §Tree and ADR-0065's scope
+  paragraph, both amended the same day; ADR-0065 names the blocks and where they
+  live.
 - Reuse `.card-meta`, `.card-description` for repeated patterns
 - Hide unusable controls; don't show them disabled
 - Form factor (#494): a new dispatched surface provides a `Default*` mobile skin and dispatches through a parallel `MOBILE_ARCHETYPE_BY_SLUG` on `useFormFactor() === 'mobile'`. The mobile path stacks single-column — never fixed-px inline grids for layout structure. See `docs/spec/SPEC-faction-ui-profile.md` §1a.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1037,19 +1037,25 @@ export default [
   },
   {
     /**
-     * THE TWO ARCHETYPES WHOSE GROUND IS THE APP'S OWN PAGE (#2346, #2537).
+     * THE ONE ARCHETYPE WHOSE GROUND IS THE APP'S OWN PAGE (#2346, #2537, #2992).
      *
-     * A deliberate exemption and NOT a legacy entry — nothing here is going to
-     * migrate, so a shrinking list would be lying about it.
+     * A deliberate exemption and NOT a legacy entry — it is an argument about a
+     * GROUND, so it lives or dies with the ground rather than shrinking on a
+     * schedule.
+     *
+     * IT WAS TWO FILES UNTIL #2992. `DefaultCreateCharacter` moved onto
+     * `ComposerSheet`, where the stock is `--faction-default-card-bg` under the
+     * aurora and the na composer tokens are the measured pair — so its row came
+     * off, and it reads no global tier at all now. The claim below is about the
+     * file that still stands on the page: the `na` EDIT-character kit.
      *
      * The tier arm bans the global `--color-text-*` family on a faction sheet,
      * and its message gives the measurements that justify it: 2.19:1 on
      * S.N.I.D.E., 2.27 on Singularity, 2.01 on the Ephemerists plate. Every one
-     * of those is a FACTION SHEET. `DefaultCreateCharacter` is the `na`
-     * archetype of a page that HAS no sheet: unlike `DefaultEditPraxis`, which
-     * draws on `--faction-default-card-bg`, character creation is bare app page,
-     * so what is behind its type is `--color-bg-page` with the `.na-backdrop`
-     * watercolour over it.
+     * of those is a FACTION SHEET. `DefaultEditCharacter` is the `na` archetype
+     * of a page that HAS no sheet: unlike `DefaultEditPraxis`, which draws on
+     * `--faction-default-card-bg`, this form is bare app page, so what is behind
+     * its type is `--color-bg-page` with the `.na-backdrop` watercolour over it.
      *
      * Measured on that composite in light, the swap the rule would force is the
      * REGRESSION and the neutral is the passing value:
@@ -1070,24 +1076,22 @@ export default [
      * directory names, and one na archetype landed inside it.
      *
      * THE EXEMPTION IS PAIRED, the way `roomPresence.ts`'s is. Its other half is
-     * `src/pages/characterPaths/__tests__/createCharacterContrast.test.ts`, which
-     * resolves these inks over the washed page ground in both themes. Do not
-     * delete that file while this entry exists: "the rule cannot judge this node"
-     * is never "this node needs no judging", and between them they are the whole
-     * guard.
+     * `src/pages/characterPaths/__tests__/createCharacterContrast.test.ts`, whose
+     * `THE WASHED PAGE GROUND` block resolves these inks over the washed page in
+     * both themes. Do not delete that file while this entry exists: "the rule
+     * cannot judge this node" is never "this node needs no judging", and between
+     * them they are the whole guard. (That file's second block measures the na
+     * CREATE kit on the sheet ground it moved to, which is what let this list
+     * lose a row without losing a measurement.)
      *
-     * #2537 ADDED THE SECOND FILE AND SHRANK THE LEGACY LIST BY ONE.
-     * `DefaultEditCharacter` is the same page family — create and edit are one
-     * character, one faction, one form, and the edit half drew on this ground
-     * from `mobileArchetypes/` where it sat on `.eslint-legacy-faction-ink.txt`
-     * with eleven un-argued hits. Folding it into one responsive archetype moved
-     * it under `archetypes/`, so it needed an answer rather than a grandfather
-     * clause: it reads the SAME three neutrals on the SAME washed page ground,
-     * which the paired test above already resolves. A measured exemption for a
+     * #2537 PUT `DefaultEditCharacter` HERE AND SHRANK THE LEGACY LIST BY ONE.
+     * It drew on this ground from `mobileArchetypes/`, where it sat on
+     * `.eslint-legacy-faction-ink.txt` with eleven un-argued hits; folding it
+     * into one responsive archetype moved it under `archetypes/`, so it needed
+     * an answer rather than a grandfather clause. A measured exemption for a
      * measured file, and one fewer line on a ratchet that only shrinks.
      */
     files: [
-      'src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx',
       'src/pages/characterPaths/archetypes/DefaultEditCharacter.tsx',
     ],
     rules: {

--- a/frontend/src/__tests__/albescentSpectraMove.test.tsx
+++ b/frontend/src/__tests__/albescentSpectraMove.test.tsx
@@ -88,10 +88,12 @@ const WEARS_THE_MARKER: Record<string, string> = {
   '../pages/factionDetail/archetypes/AlbescentFactionBody.tsx': 'faction body',
   // the pale sheet's one strip — classed here, since the seal is Albescent's own
   '../components/metataskSeal/skins/AlbescentSeal.tsx': 'metatask seal',
-  // the phone branch's photo ring. The mount was written after #2497's sweep and
-  // so was never in it — an eighteenth inline copy of the conic, and the only
-  // one a stylesheet could not reach; #2531 classed it and this wrapper is what
-  // reaches it. The desktop branch draws no na spectrum at all.
+  // The live credential card's portrait ring, at BOTH widths since #2992. It
+  // used to be the phone branch's 104px photo well — one mount on one form
+  // factor — and that branch retired when the na kit went onto the composer
+  // chassis. The conic now lives in the shared `components/CredentialCard.tsx`,
+  // which #2497's sweep never reached because it censused the `Default*`
+  // archetype files and the card is not one of them.
   '../pages/characterPaths/archetypes/AlbescentCreateCharacter.tsx': 'character creation',
   // The directory tile's one hairline. It moved sides in #2632: the tile used to
   // be bespoke vellum markup with no classed spectrum on it at all, and the

--- a/frontend/src/__tests__/albescentWrapperKinds.test.tsx
+++ b/frontend/src/__tests__/albescentWrapperKinds.test.tsx
@@ -403,7 +403,7 @@ describe('duelSeal — PASS-THROUGH: na draws no spectrum on this dialog', () =>
 
 /* ── The one re-cut ─────────────────────────────────────────────────────── */
 
-describe('createCharacter — RE-CUT: the phone photo ring turns', () => {
+describe('createCharacter — RE-CUT: the credential card’s portrait ring turns', () => {
   const page = (Archetype: typeof DefaultCreateCharacter, width: 'mobile' | 'desktop') =>
     at(width, () =>
       renderToStaticMarkup(
@@ -427,7 +427,7 @@ describe('createCharacter — RE-CUT: the phone photo ring turns', () => {
   it("na's ring wears the class the dresser reaches, not an inline ramp (#2497)", () => {
     const html = page(DefaultCreateCharacter, 'mobile').replace(/\s*([:;,])\s*/g, '$1')
     const ring = /<button[^>]*class="spectrum-dial"[^>]*>/.exec(html)?.[0]
-    expect(ring, 'the phone photo ring is the mount this re-cut reaches').toBeTruthy()
+    expect(ring, "the credential card's portrait ring is the mount this re-cut reaches").toBeTruthy()
     expect(
       ring,
       'an inline background is the one paint a stylesheet cannot reach',

--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -145,13 +145,36 @@ export default function CredentialCard({
             padding: 'var(--space-xs)',
             boxSizing: 'border-box',
             // Unaffiliated wears the spectrum ring (all paths open, ADR-0039);
-            // themed factions keep their accent hoop. Conic ramp is the
-            // round-ring geometry — NOT --faction-default-rainbow (a bar ramp).
-            background: skinned ? 'var(--fc-accent)' : 'var(--faction-default-rainbow-conic)',
+            // themed factions keep their accent hoop. The unaffiliated half is
+            // `.spectrum-dial` below — the conic cut of the na spectrum, said
+            // once in index.css — so only the themed hoop is declared here.
+            background: skinned ? 'var(--fc-accent)' : undefined,
             border: 'none',
             cursor: onAvatarClick ? 'pointer' : 'default',
             boxShadow: '0 4px 14px var(--color-cast-shadow)',
           }
+          /* THE na RING IS CLASSED, NOT INLINED (#2992, the class #2497 minted).
+           * It was the last inline `var(--faction-default-rainbow-conic)` in the
+           * kit: #2497's sweep censused the `Default*` archetype files, and this
+           * card is not one — it is the shared component all nine of them mount,
+           * so no census row looked at it.
+           *
+           * The class is conditional and the ramp always was: this ring only
+           * takes the conic when `skinned` is false, which for Albescent it is —
+           * that slug is registered but deliberately unthemed, `CSS_KEY.albescent
+           * === "default"` (#783). So an Albescent credential takes the rainbow,
+           * and `.alb-moves .spectrum-dial` (two classes, so it wins from
+           * wherever it is written) sets it turning wherever an Albescent wrapper
+           * is the ancestor — the creation preview, the edit preview and the
+           * profile header. `.alb-moves .spectrum-dial > *` lifts the face back
+           * over the rim, so the portrait is not painted over. No new CSS: both
+           * halves already ship, the `::before` behind `motion.ornament.css`'s
+           * `prefers-reduced-motion` gate.
+           *
+           * The FieldDesk life-cards mount this card under `.alb-desk`, not
+           * `.alb-moves`, so that roster's rings stand still — the paint moved,
+           * nothing else. */
+          const ringClass = skinned ? undefined : 'spectrum-dial'
           const inner = (
             <div
               style={{
@@ -184,12 +207,13 @@ export default function CredentialCard({
               onClick={onAvatarClick}
               aria-label={uploadLabel}
               title={uploadLabel}
+              className={ringClass}
               style={ringStyle}
             >
               {inner}
             </button>
           ) : (
-            <div style={ringStyle}>{inner}</div>
+            <div className={ringClass} style={ringStyle}>{inner}</div>
           )
         })()}
       </div>

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -136,8 +136,17 @@ describe('CredentialCard footer sigil — spoken, never printed', () => {
     // Both draw the conic TWICE — the portrait hoop and the mark itself. That
     // the count no longer tells the two apart is the whole point: what differs
     // is the stencil the ramp is poured through, never the ramp.
+    //
+    // THE HOOP SAYS IT BY CLASS SINCE #2992, the mark still by value. That is
+    // #2497's split, not a change of paint: `.spectrum-dial` carries exactly
+    // `--faction-default-rainbow-conic` and nothing else (`spectrumClasses`
+    // asserts that from the stylesheet side), and classing it is what lets
+    // `.alb-moves .spectrum-dial` set an Albescent hoop turning without a copy
+    // of this component existing. The mark keeps its inline ramp on purpose: a
+    // sigil is never part of the wrapper (ADR-0083 §1), so it must NOT turn.
     for (const html of [albescent, unaffiliated]) {
-      expect(html.split('--faction-default-rainbow-conic').length - 1, 'hoop + mark').toBe(2)
+      expect(html.split('--faction-default-rainbow-conic').length - 1, 'the mark, by value').toBe(1)
+      expect(html.split('class="spectrum-dial"').length - 1, 'the hoop, by class').toBe(1)
     }
   })
 })

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -140,10 +140,19 @@ const BESPOKE: Record<string, string[]> = {
   // registration is a WRAPPER rather than a skin (ADR-0027) and a wrapper over
   // the na kit is the na kit. That ruling is intact and #2531 appended the slug
   // anyway: `AlbescentCreateCharacter` is exactly that wrapper — it renders
-  // `DefaultCreateCharacter` whole and re-cuts the one na mark on the page, the
-  // phone's rainbow photo ring, which starts turning. What the empty row could
-  // not say is WHICH of "na draws nothing to grab" and "nobody got to it" was
-  // meant, and it turned out to be neither.
+  // `DefaultCreateCharacter` whole and re-cuts the one na mark on the page,
+  // which starts turning. What the empty row could not say is WHICH of "na
+  // draws nothing to grab" and "nobody got to it" was meant, and it turned out
+  // to be neither.
+  //
+  // WHICH MARK THAT IS MOVED IN #2992, and the row did not. It was the phone
+  // branch's 104px rainbow photo ring — one mount, on one form factor, so the
+  // desktop plate carried no na spectrum and the re-cut reached one width. That
+  // branch retired when the na kit went onto the composer chassis: the delta is
+  // the live credential card's portrait ring now (`components/CredentialCard`,
+  // classed `.spectrum-dial`), it is first in the sheet at BOTH widths, and so
+  // Albescent's ring turns at both. One row still covers both, because the
+  // archetype reads `useFormFactor()` itself.
   createCharacter: ['ephemerists', 'snide', 'wow', 'ua', 'everymen', 'coven', 'singularity', 'albescent'],
   // `factionBody` is what a phone renders too (ADR-0078): faction detail is one
   // responsive component per faction, so this one row covers both widths.

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -425,9 +425,12 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * IT REVERSES ONE LINE OF `surfaceDispatch.test.ts`'s createCharacter note —
    * "Molly's ruling is that it gets no archetype anyway". That ruling was about a
    * SKIN, and it still holds: this is a wrapper over the na kit, which is what
-   * that note says Albescent renders. The dispatch slug here is the pick in
-   * progress, so the ring starts turning as the calling is chosen and stops the
-   * moment it is cleared.
+   * that note says Albescent renders. That note carries the #2992 correction
+   * above as well, so the two say the same thing about which mark is re-cut;
+   * they are the only two prose records of it and they move together.
+   *
+   * The dispatch slug here is the pick in progress, so the ring starts turning
+   * as the calling is chosen and stops the moment it is cleared.
    */
   createCharacter: () => AlbescentCreateCharacter,
 

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -409,12 +409,17 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
 
   /**
    * RE-CUT — the one of the four that changes pixels. na draws a single spectrum
-   * mark on this page, the rainbow ring around the phone branch's photo well,
-   * and this wrapper sets it TURNING: the mount now wears `.spectrum-dial`
+   * mark on this page, the rainbow ring around the live credential card's
+   * portrait, and this wrapper sets it TURNING: the mount wears `.spectrum-dial`
    * (#2497's class, which this file predated) and `.alb-moves` is the dresser it
    * was minted for. No markup added, no colour, no copy, no new keyframe — the
-   * mark is na's already. The desktop branch carries no na spectrum and is
-   * untouched; one row covers both widths because the archetype reads
+   * mark is na's already.
+   *
+   * THE MOUNT MOVED IN #2992. It was the phone branch's 104px photo well, so the
+   * desktop plate carried no na spectrum and this row only reached one width.
+   * That branch retired when the na kit went onto the composer chassis, and the
+   * credential card sits first in the sheet at both widths — so the ring turns at
+   * both now. One row still covers both, because the archetype reads
    * `useFormFactor()` itself.
    *
    * IT REVERSES ONE LINE OF `surfaceDispatch.test.ts`'s createCharacter note —

--- a/frontend/src/locales/README.md
+++ b/frontend/src/locales/README.md
@@ -97,11 +97,18 @@ Create Character and Edit Character are the same form twice, and their copy used
 to disagree on every shared field — `Chosen name` against `Display name`, a
 placeholder in the third person against one in the second. **`forms:character.*`
 is the one block both pages read**, so a reword lands on both at once
-(#2793). It holds the five field words plus the three that were the same
-sentence twice: `portrait` (was `createCharacter.portraitLabel` and
-`editCharacter.portraitHeading`) and the photo-well caption pair
-`addPhoto` / `changePhoto`. `Cancel` went further out still, to
-`common:actions.cancel`, since it is nobody's field.
+(#2793). It holds the five field words plus `portrait`, which was the same
+sentence twice (`createCharacter.portraitLabel` and
+`editCharacter.portraitHeading`), and `changePhoto`, the photo-well caption.
+`Cancel` went further out still, to `common:actions.cancel`, since it is
+nobody's field.
+
+`changePhoto` USED TO BE HALF OF A PAIR. `addPhoto` was the empty-well caption
+beside it, and both wells were phone-only. #2992 put Create Character on the
+composer chassis, which retired its phone branch and with it the only reader
+`addPhoto` ever had — so the key is deleted rather than kept warm. The survivor
+is Edit Character's well, which always has a portrait to change; #2991 is the
+lane that decides whether it keeps one.
 
 Two things about it are decisions rather than tidying, and are worth knowing
 before you reword:

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -14,7 +14,6 @@
     "changePhoto": "Change photo"
   },
   "createCharacter": {
-    "back": "‹ back to your lives",
     "heading": "Who is your character",
     "charsLeft": "{{count}} left",
     "optional": "· optional",
@@ -25,12 +24,7 @@
     "submitBusy": "Stepping out…",
     "startsAt": "starts at Lvl 1 · 0 pts",
     "previewFallbackName": "Wanderer",
-    "mobile": {
-      "title": "New character",
-      "step": "Step 1 of 2 · Identity",
-      "help": "Upload a photo — it becomes your avatar everywhere. Until you answer a calling you play as Unaffiliated, and every path is open to you.",
-      "submit": "Create character"
-    }
+    "help": "Upload a photo — it becomes your avatar everywhere. Until you answer a calling you play as Unaffiliated, and every path is open to you."
   },
   "editCharacter": {
     "notFound": "Character not found.",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -10,7 +10,6 @@
     "locationPlaceholder": "Location (SFO, PDX, YYZ)",
     "handlePlaceholder": "Handle",
     "portrait": "Portrait",
-    "addPhoto": "Add photo",
     "changePhoto": "Change photo"
   },
   "createCharacter": {

--- a/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
@@ -207,28 +207,46 @@ describe('canSubmitName — the shared submit gate', () => {
   })
 })
 
-describe('DefaultCreateCharacter mobile skin', () => {
+/**
+ * THE PHONE BRANCH IS GONE (#2992). `DefaultCreateCharacter` mounts the composer
+ * chassis as one responsive tree, so what used to be checked here — a sticky
+ * `Create character` bar, a 104px photo ring with its own caption, a `Step 1 of
+ * 2` framing — no longer exists at any width, and its copy keys retired with it.
+ *
+ * What is still worth asserting on a PHONE specifically is the half the retired
+ * branch got wrong: the same fields at both widths, the born-unaffiliated
+ * explainer that only the phone used to carry, and the live credential preview
+ * the wide branch used to drop below the fold. The field SET and the exits are
+ * `createCharacterStructure.test.tsx`'s, across all nine kits; these are the na
+ * kit's own three slots.
+ */
+describe('DefaultCreateCharacter on a phone', () => {
   beforeEach(() => { factor.value = 'mobile' })
   afterEach(() => { factor.value = 'desktop' })
 
-  it('renders the name field and a sticky Create action', () => {
+  it('renders the name field, the commit and the born-unaffiliated explainer', () => {
     const { html, text } = render(<DefaultCreateCharacter state={createState({})} />)
     expect(html, 'name input').toContain('value="Molly"')
-    expect(text, 'sticky create').toContain('Create character')
+    // The one commit label, at both widths — the phone's second one went with
+    // the sticky bar.
+    expect(text, 'the commit').toContain('step out')
     expect(text, 'born-unaffiliated explainer').toContain('Unaffiliated')
   })
 
-  // #1149: the ring's accessible name used to fall through to the "+" glyph or,
-  // once a portrait existed, to its alt text. It now matches the caption drawn
-  // right beneath it, in both states.
-  it('names the photo ring with its own caption', () => {
-    const empty = render(<DefaultCreateCharacter state={createState({})} />)
-    expect(empty.html, 'empty ring').toContain('aria-label="Add photo"')
-    expect(empty.text, 'and the caption agrees').toContain('Add photo')
+  it('carries the live credential preview, which the wide branch used to drop', () => {
+    // Defect 2 of #2992, from the side a phone sees it: the phone column had no
+    // preview at all. The card is inside the sheet now, at both widths.
+    const { html, text } = render(<DefaultCreateCharacter state={createState({})} />)
+    expect(text, "the preview shows the name being typed").toContain('Molly')
+    expect(html, 'the portrait ring is the upload affordance').toContain('aria-label="Click to upload a photo"')
+  })
 
-    const picked = render(<DefaultCreateCharacter state={createState({ avatarPreview: 'blob:p-1' })} />)
-    expect(picked.html, 'ring holding a portrait').toContain('aria-label="Change photo"')
-    expect(picked.text, 'and the caption agrees').toContain('Change photo')
+  // #1149: the portrait control names itself rather than falling through to a
+  // glyph or to an alt text. `PortraitPicker` is that control at both widths now.
+  it('names the portrait control, and reports what is chosen', () => {
+    const { text } = render(<DefaultCreateCharacter state={createState({})} />)
+    expect(text, 'the picker button').toContain('Choose a photo')
+    expect(text, 'and the status line beside it').toContain('No photo chosen yet')
   })
 })
 

--- a/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
@@ -208,43 +208,55 @@ describe('canSubmitName — the shared submit gate', () => {
 })
 
 /**
- * THE PHONE BRANCH IS GONE (#2992). `DefaultCreateCharacter` mounts the composer
- * chassis as one responsive tree, so what used to be checked here — a sticky
- * `Create character` bar, a 104px photo ring with its own caption, a `Step 1 of
- * 2` framing — no longer exists at any width, and its copy keys retired with it.
+ * THE na CREATE KIT'S OWN SLOTS, AT BOTH WIDTHS (#2992).
  *
- * What is still worth asserting on a PHONE specifically is the half the retired
- * branch got wrong: the same fields at both widths, the born-unaffiliated
- * explainer that only the phone used to carry, and the live credential preview
- * the wide branch used to drop below the fold. The field SET and the exits are
- * `createCharacterStructure.test.tsx`'s, across all nine kits; these are the na
- * kit's own three slots.
+ * THIS BLOCK USED TO PIN `mobile` AND CALL ITSELF A PHONE TEST, and after #2992
+ * that was a name for a failure mode that no longer exists: the phone branch is
+ * gone — a sticky `Create character` bar, a 104px photo ring with its own
+ * caption, a `Step 1 of 2` framing, all retired with their copy keys — so there
+ * is one tree and pinning one width could only ever assert it twice under two
+ * names. Every case below runs at BOTH widths instead, which is what makes them
+ * able to fail for a width reason again: the two must not diverge.
+ *
+ * WHAT IS HERE AND WHAT IS NEXT DOOR. The field SET and the exit ORDER are
+ * `createCharacterStructure.test.tsx`'s, asked of all nine kits from the
+ * registry. These three are the na kit's own slots — the ones the retired branch
+ * got wrong from the phone's side, and which no registry sweep would name: the
+ * born-unaffiliated explainer only the phone used to carry, and the live
+ * credential preview the WIDE branch used to drop below the fold.
  */
-describe('DefaultCreateCharacter on a phone', () => {
-  beforeEach(() => { factor.value = 'mobile' })
+describe('DefaultCreateCharacter — the na kit’s slots, identical at both widths', () => {
   afterEach(() => { factor.value = 'desktop' })
 
-  it('renders the name field, the commit and the born-unaffiliated explainer', () => {
-    const { html, text } = render(<DefaultCreateCharacter state={createState({})} />)
+  const WIDTHS = ['mobile', 'desktop'] as const
+
+  const at = (width: (typeof WIDTHS)[number]) => {
+    factor.value = width
+    return render(<DefaultCreateCharacter state={createState({})} />)
+  }
+
+  it.each(WIDTHS)('renders the name field, the commit and the explainer — %s', (width) => {
+    const { html, text } = at(width)
     expect(html, 'name input').toContain('value="Molly"')
-    // The one commit label, at both widths — the phone's second one went with
-    // the sticky bar.
+    // ONE commit label at either width — the phone's second one went with the
+    // sticky bar, and `createCharacterStructure` counts the controls.
     expect(text, 'the commit').toContain('step out')
     expect(text, 'born-unaffiliated explainer').toContain('Unaffiliated')
   })
 
-  it('carries the live credential preview, which the wide branch used to drop', () => {
-    // Defect 2 of #2992, from the side a phone sees it: the phone column had no
-    // preview at all. The card is inside the sheet now, at both widths.
-    const { html, text } = render(<DefaultCreateCharacter state={createState({})} />)
-    expect(text, "the preview shows the name being typed").toContain('Molly')
+  it.each(WIDTHS)('carries the live credential preview — %s', (width) => {
+    // Defect 2 of #2992 from both sides: the phone column had no preview at all,
+    // and the wide plate wrapped it below the fold under 634px. The card is
+    // inside the sheet now, first, at both.
+    const { html, text } = at(width)
+    expect(text, 'the preview shows the name being typed').toContain('Molly')
     expect(html, 'the portrait ring is the upload affordance').toContain('aria-label="Click to upload a photo"')
   })
 
   // #1149: the portrait control names itself rather than falling through to a
   // glyph or to an alt text. `PortraitPicker` is that control at both widths now.
-  it('names the portrait control, and reports what is chosen', () => {
-    const { text } = render(<DefaultCreateCharacter state={createState({})} />)
+  it.each(WIDTHS)('names the portrait control, and reports what is chosen — %s', (width) => {
+    const { text } = at(width)
     expect(text, 'the picker button').toContain('Choose a photo')
     expect(text, 'and the status line beside it').toContain('No photo chosen yet')
   })

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterContrast.test.ts
@@ -1,14 +1,25 @@
 /**
- * Character creation's inks, measured on the ground that is actually behind
- * them (#2346, #2347).
+ * The na character forms' inks, measured on the grounds that are actually
+ * behind them (#2346, #2347) — which since #2992 is TWO grounds, not one.
  *
- * THIS FILE IS ONE HALF OF A PAIR. The other is the `eslint.config.js` block
- * exempting `archetypes/DefaultCreateCharacter.tsx` from
+ * ## What moved, and what did not
+ *
+ * `DefaultCreateCharacter` stood on bare app page under the `.na-backdrop` wash
+ * until #2992 put it on `ComposerSheet`. Its ground is now
+ * `--faction-default-card-bg` under the drifting aurora, and its inks moved with
+ * it — so the first block below is no longer about that file. It is about
+ * `DefaultEditCharacter`, which is the na kit's OTHER half and still stands on
+ * the page. The second block is the create page on its new stock.
+ *
+ * THE FIRST BLOCK IS ONE HALF OF A PAIR. The other is the `eslint.config.js`
+ * block exempting `archetypes/DefaultEditCharacter.tsx` from
  * `local/no-global-ink-on-faction-surface`. That rule reads a DIRECTORY NAME and
- * cannot see a ground, so on this one archetype it would force a swap that makes
+ * cannot see a ground, so on that one archetype it would force a swap that makes
  * the page worse; the exemption says so and this file proves it. Deleting either
  * one leaves the other lying — "the rule cannot judge this node" is never "this
- * node needs no judging".
+ * node needs no judging". #2992 took `DefaultCreateCharacter` off that list, and
+ * the row below it deleted is the one this file's second block replaces: no
+ * measurement was dropped, it was re-taken on the ground the type moved to.
  *
  * WHY IT MEASURES THE COMPOSITE. `--color-bg-page` is not what is behind this
  * type. `.na-backdrop` paints that colour and then washes five radial gradients
@@ -67,11 +78,24 @@ const WASH: Record<Theme, string[]> = {
   ],
 }
 
-/** Every ink the na archetype puts straight on the page, and what draws it. */
+/**
+ * Every ink the na EDIT-character archetype puts straight on the page, and what
+ * draws it.
+ *
+ * The three neutral tiers, unchanged since #2537 — `DefaultEditCharacter` reads
+ * all three and is the file the eslint exemption now names alone. The create
+ * half read the same three on this same ground until #2992 moved it to a sheet;
+ * the rows did not change, only which file they are the proof for.
+ */
 const PAGE_INKS: Array<{ what: string; token: string }> = [
-  { what: 'heading, name field and picker name', token: '--color-text-primary' },
-  { what: 'eyebrow labels, back link and cancel', token: '--color-text-secondary' },
-  { what: 'character counters, @handle and the born-unaffiliated help', token: '--color-text-tertiary' },
+  { what: 'heading, name field, the fields and the save bar', token: '--color-text-primary' },
+  // The middle tier is measured even though the archetype reads only the outer
+  // two, and that is not a stale row: the eslint block's own justification table
+  // quotes 6.06 for it, and `--label-ink` — which `PortraitPicker`'s status line
+  // reads on this page — is unset into this family. A number cited in prose that
+  // nothing re-runs is the drift this file exists to stop.
+  { what: 'the middle neutral tier the exemption table cites', token: '--color-text-secondary' },
+  { what: 'character counters, @handle and the faction help', token: '--color-text-tertiary' },
   // NOT `--color-danger`, which is what this page used to draw and which fails
   // here at 3.42:1 in light. See the archetype's own note: the functional red
   // inside a faction frame takes that faction's card alarm (#1302).
@@ -91,7 +115,7 @@ function washedGround(theme: Theme, stop: string): Rgba {
   return compositeOver(parseColor(stop)!, resolve('--color-bg-page', theme))
 }
 
-describe('the na create page clears AA on its washed ground', () => {
+describe('the na EDIT-character page clears AA on its washed ground', () => {
   for (const theme of BOTH_THEMES) {
     for (const { what, token } of PAGE_INKS) {
       it(`${what} — ${theme}`, () => {
@@ -120,9 +144,10 @@ describe('the faction-default TEXT family is not the answer on this ground', () 
   // and the exemption can be reconsidered — which is the outcome worth catching.
   //
   // `--faction-default-composer-faint` WAS THE SECOND MEMBER OF THIS LIST AND IS
-  // NOT ANY MORE (#2485). It never belonged to this page — no `characterPaths`
-  // file reads it; it was here because its 4.49-flat / 3.50-washed gap was the
-  // clearest illustration of the point. #2485 lifted it (its only consumer is
+  // NOT ANY MORE (#2485). It never belonged to this GROUND — it was here because
+  // its 4.49-flat / 3.50-washed gap was the clearest illustration of the point,
+  // and since #2992 it is the create page's quiet rung on the SHEET, which is
+  // the block at the foot of this file. #2485 lifted it (its consumer was
   // `DefaultEditPraxis`, whose sheet is washed by the aurora and where the whole
   // quiet ladder was under AA), and at #5f5b53 it reads 4.79 on this ground, so
   // the row it used to fill would now be asserting something false. The
@@ -155,5 +180,116 @@ describe('keeps the wash list in step with the stylesheet', () => {
       .map((m) => m[0].replace(/\s+/g, ''))
       .slice(0, WASH[theme].length)
     expect(stops).toEqual(WASH[theme])
+  })
+})
+
+/**
+ * THE SHEET GROUND — where the na CREATE page moved to (#2992).
+ *
+ * `DefaultCreateCharacter` mounts `ComposerSheet` now, so its stock is
+ * `--faction-default-card-bg` with the drifting aurora washed under the content
+ * column. That is the same composite `DefaultEditPraxis` stands on, and
+ * `pages/editPraxis/archetypes/__tests__/composerGround.test.ts` OWNS the two
+ * rows both kits share on it — `--faction-default-card-text` (headings, typed
+ * values) and `--faction-default-composer-faint` (labels, counters, @handle,
+ * the calling hint, the born-unaffiliated line and the exits), plus the refusal
+ * of `--faction-default-card-muted`. Restating them here would be a second name
+ * for one measurement, which every file in this family warns against.
+ *
+ * WHAT IS NEW ON THIS PAGE, AND MEASURED NOWHERE ELSE, is the ALARM ink drawn
+ * BARE on that sheet: a character counter that has hit its cap, and
+ * `PortraitPicker`'s error line. `factionContrast.test.ts` carries
+ * `--faction-default-card-alarm` on `--faction-default-card-bg` under
+ * `--color-danger-veil`, which is the error BANNER's ground — a wash of the
+ * ink's own polarity, and a different reading. The composer draws no bare alarm
+ * anywhere, so this page is the first to ask.
+ *
+ * THE AURORA IS MODELLED, NOT TRANSCRIBED. Seven radial stops, each peaking at
+ * its own anchor, desaturated by `--faction-default-aurora-filter` and (in dark)
+ * screen-blended, before `--faction-default-aurora-opacity` lands them on the
+ * sheet. Every number is resolved out of `index.css`, so re-tuning the wash
+ * re-runs the sum instead of leaving this asserting a stock nobody paints. The
+ * model is the same shape `composerGround.test.ts` uses; it is spelled again
+ * here rather than imported because a test file exports nothing, and because
+ * this file has to stand alone as the eslint block's paired proof.
+ */
+
+const AURORA_SHEET = '--faction-default-card-bg'
+
+function number(token: string, theme: Theme): number {
+  const raw = resolveVar(token, theme, THEMES)
+  const value = Number(raw)
+  expect(Number.isFinite(value), `${token} is a number in ${theme}`).toBe(true)
+  return value
+}
+
+/** `saturate()` as `filter` applies it, sRGB, from the SVG colour matrix. */
+function saturate(colour: Rgba, s: number): Rgba {
+  const channel = (r: number, g: number, b: number) =>
+    r * colour.r + g * colour.g + b * colour.b
+  return {
+    r: channel(0.213 + 0.787 * s, 0.715 - 0.715 * s, 0.072 - 0.072 * s),
+    g: channel(0.213 - 0.213 * s, 0.715 + 0.285 * s, 0.072 - 0.072 * s),
+    b: channel(0.213 - 0.213 * s, 0.715 - 0.715 * s, 0.072 + 0.928 * s),
+    a: colour.a,
+  }
+}
+
+/** `mix-blend-mode: screen`, which is how the aurora lifts off the night sheet. */
+function screenOver(top: Rgba, back: Rgba): Rgba {
+  const lift = (x: number, y: number) => 255 - ((255 - x) * (255 - y)) / 255
+  return { r: lift(top.r, back.r), g: lift(top.g, back.g), b: lift(top.b, back.b), a: top.a }
+}
+
+/** The sheet with one aurora stop at its own peak — one ground per stop. */
+function sheetGrounds(theme: Theme): Rgba[] {
+  const sheet = resolve(AURORA_SHEET, theme)
+  const alpha = number('--faction-default-aurora-opacity', theme)
+  const filter = resolveVar('--faction-default-aurora-filter', theme, THEMES)
+  const blend = resolveVar('--faction-default-aurora-blend', theme, THEMES)
+  const aurora = resolveVar('--faction-default-aurora', theme, THEMES)
+  expect(aurora, `the aurora resolves in ${theme}`).not.toBeNull()
+  const amount = /saturate\(([\d.]+)\)/.exec(filter ?? '')
+  expect(amount, `the aurora filter names a saturate() in ${theme}`).not.toBeNull()
+  const stops = [...aurora!.matchAll(/#[0-9a-f]{3,8}|rgba?\([^)]*\)/gi)]
+    .map((match) => parseColor(match[0]))
+    .filter((stop): stop is Rgba => stop !== null)
+  expect(stops.length, `the aurora is a ramp in ${theme}`).toBeGreaterThan(1)
+  return stops.map((stop) => {
+    const filtered = saturate(stop, Number(amount![1]))
+    const painted = blend?.trim() === 'screen' ? screenOver(filtered, sheet) : filtered
+    return compositeOver({ ...painted, a: alpha }, sheet)
+  })
+}
+
+const worstOn = (ink: Rgba, grounds: Rgba[]): number =>
+  Math.min(...grounds.map((ground) => contrastRatio(ink, ground)))
+
+describe('the na create page clears AA on the sheet it moved to (#2992)', () => {
+  it.each(BOTH_THEMES)('the alarm ink, bare on the aurora-washed sheet — %s', (theme) => {
+    const ratio = worstOn(resolve('--faction-default-card-alarm', theme), sheetGrounds(theme))
+    expect(
+      ratio,
+      `--faction-default-card-alarm on the composite is ${formatRatio(ratio)}`,
+    ).toBeGreaterThanOrEqual(AA_NORMAL)
+  })
+
+  // The refusal, and it is the one the page ground already recorded: the neutral
+  // functional red is what a naive fix reaches for, and it misses here too. If
+  // it is ever walked far enough to clear, this row goes red and the archetype
+  // can go back to the platform ink — which is the outcome worth catching.
+  it('and the neutral --color-danger still would not — light', () => {
+    const ratio = worstOn(resolve('--color-danger', 'light'), sheetGrounds('light'))
+    expect(ratio, `--color-danger on the composite is ${formatRatio(ratio)}`).toBeLessThan(AA_NORMAL)
+  })
+
+  // The guard that makes the rows above mean something. If the composite were
+  // ever LIGHTER (in light) than the bare sheet for this ink, measuring it would
+  // be the optimistic reading and the whole block would prove the wrong thing.
+  it.each(BOTH_THEMES)('the wash is the tighter reading, not the flatterer — %s', (theme) => {
+    const ink = resolve('--faction-default-card-alarm', theme)
+    const flat = contrastRatio(ink, resolve(AURORA_SHEET, theme))
+    const washed = worstOn(ink, sheetGrounds(theme))
+    expect(washed, `flat ${formatRatio(flat)} vs washed ${formatRatio(washed)}`).toBeLessThan(flat)
   })
 })

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterContrast.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterContrast.test.ts
@@ -266,6 +266,44 @@ const worstOn = (ink: Rgba, grounds: Rgba[]): number =>
   Math.min(...grounds.map((ground) => contrastRatio(ink, ground)))
 
 describe('the na create page clears AA on the sheet it moved to (#2992)', () => {
+  /**
+   * THE CALLING ROWS, AND WHY THIS ROW IS NOT A RESTATEMENT.
+   *
+   * The picker's faction names are `--faction-default-card-muted` on
+   * `--faction-default-composer-field` — and `composerGround.test.ts` certifies
+   * that same token as the REFUSED, sub-AA rung on the sheet one layer below it.
+   * Two grounds, two answers, six millimetres apart on screen: that is precisely
+   * the pairing a reader of this page will get wrong, and a refusal certified
+   * next door is not a licence to assume the neighbouring ground fails too.
+   *
+   * The field is opaque in both cascades, which is what makes the two grounds
+   * genuinely different rather than one wash apart — asserted below rather than
+   * asserted in prose, because if it ever gained an alpha the aurora would reach
+   * the calling names and this measurement would silently become the optimistic
+   * one.
+   *
+   * It clears comfortably — 6.05:1 by day and 5.23:1 by night, against the
+   * sheet's 3.27–4.30 for the same ink. The gap IS the finding: this token is
+   * not "too quiet for na", it is too quiet for na's WASHED ground, and the
+   * opaque field is where it was always right.
+   *
+   * `factionContrast.test.ts` carries this pairing under the COMPOSER's name
+   * ("na composer field, prose"). It is restated here, against the file's own
+   * rule about second names for one measurement, because the create page is the
+   * only surface that draws this ink beside its own refusal — and a reader who
+   * follows the refusal and repaints the calling rows has broken nothing that
+   * goes red.
+   */
+  it.each(BOTH_THEMES)('the calling names, on the opaque field — %s', (theme) => {
+    const field = resolve('--faction-default-composer-field', theme)
+    expect(field.a, 'the field grounds the calling rows opaquely').toBe(1)
+    const ratio = contrastRatio(resolve('--faction-default-card-muted', theme), field)
+    expect(
+      ratio,
+      `--faction-default-card-muted on --faction-default-composer-field is ${formatRatio(ratio)}`,
+    ).toBeGreaterThanOrEqual(AA_NORMAL)
+  })
+
   it.each(BOTH_THEMES)('the alarm ink, bare on the aurora-washed sheet — %s', (theme) => {
     const ratio = worstOn(resolve('--faction-default-card-alarm', theme), sheetGrounds(theme))
     expect(

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
@@ -61,7 +61,11 @@ const CASES = WIDTHS.flatMap((width) => ARCHETYPES.map((slug) => [slug || 'na', 
  * boxes are the words INSIDE them since #2793, so the expectation and the render
  * come from one string apiece and a reword cannot make this file lie.
  */
-const FIELD_ORDER = ['character.namePlaceholder', 'character.bioPlaceholder', 'character.taglinePlaceholder']
+const FIELD_ORDER = [
+  'character.namePlaceholder',
+  'character.bioPlaceholder',
+  'character.taglinePlaceholder',
+] as const
 
 const forms = i18n.getFixedT(null, 'forms')
 const common = i18n.getFixedT(null, 'common')

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Every character-creation kit offers the same fields, in the same order, with
+ * the same exits — at both widths (#2992).
+ *
+ * ## The seam, and why it is not a source scan
+ *
+ * The rendered markup of every archetype the registry holds. #2992 was filed on
+ * two defects a per-file reading cannot see: the na kit's PHONE branch offered
+ * three of the form's fields where its desktop branch offered five, and its
+ * desktop footer drew `[Create] [Cancel]` — the inverse of the global order
+ * settled in #646 — while its phone branch drew no textual cancel at all. Both
+ * are properties of one tree at one width, so both are invisible to a grep and
+ * to a test that renders one archetype once.
+ *
+ * `createCharacterFields.test.tsx` is the sibling and the split is deliberate:
+ * that file asks whether each field is *reachable* (named, unsuppressed focus
+ * ring, no orphan `<label>`), and this one asks whether the SET and the ORDER
+ * are the same across nine kits. A skin may dress a field; it may not drop one,
+ * add one, or swap the exits round.
+ *
+ * ## The roster is derived, never typed
+ *
+ * `surfaceMap('createCharacter')` plus `''`, which resolves to the na kit the
+ * same way an unregistered slug does. A hand-listed `SITES` array is the exact
+ * failure #2955 is open for, and a typed roster cannot notice a tenth kit
+ * (#2815) — so the tenth kit is covered here the day it registers, with nothing
+ * to append.
+ *
+ * ## What is deliberately not asserted
+ *
+ * Nothing about paint, geometry or ornament. Which face a kit's name field
+ * wears, whether its commit is an inline button or a full-bleed band, whether it
+ * draws a masthead — all of that is the archetype's, and ADR-0090's tree/paint
+ * split is what says so. This file only pins the field set and the exits, which
+ * are the two things `useCreateCharacter` and #646 own rather than any skin.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import i18n from '../../../i18n'
+import { resolveVariant } from '../../../utils/factionDispatch'
+import { surfaceMap } from '../../../factions'
+import type { CreateCharacterState } from '../useCreateCharacter'
+
+const factor = vi.hoisted(() => ({ value: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useFormFactor')>()),
+  useFormFactor: () => factor.value,
+}))
+
+/** Every registered skin, plus the empty slug that lands on the na kit. */
+const ARCHETYPES = [...Object.keys(surfaceMap('createCharacter')), '']
+const WIDTHS = ['desktop', 'mobile'] as const
+const CASES = WIDTHS.flatMap((width) => ARCHETYPES.map((slug) => [slug || 'na', slug, width] as const))
+
+/**
+ * The form's fields, in the order `useCreateCharacter` holds them.
+ *
+ * Read out of the catalogue rather than transcribed: the words that name these
+ * boxes are the words INSIDE them since #2793, so the expectation and the render
+ * come from one string apiece and a reword cannot make this file lie.
+ */
+const FIELD_ORDER = ['character.namePlaceholder', 'character.bioPlaceholder', 'character.taglinePlaceholder']
+
+const forms = i18n.getFixedT(null, 'forms')
+const common = i18n.getFixedT(null, 'common')
+
+function state(overrides: Partial<CreateCharacterState> = {}): CreateCharacterState {
+  return {
+    displayName: 'Molly',
+    setDisplayName: () => {},
+    bio: '',
+    setBio: () => {},
+    tagline: '',
+    setTagline: () => {},
+    factionSlug: '',
+    setFactionSlug: () => {},
+    invited: [],
+    avatarFile: null,
+    avatarPreview: null,
+    avatarSource: null,
+    setAvatarSource: () => {},
+    avatarError: '',
+    setAvatarError: () => {},
+    handleAvatarChange: () => {},
+    handleAvatarConfirm: () => {},
+    error: null,
+    submitting: false,
+    canSubmit: true,
+    handleSubmit: () => {},
+    handle: 'molly',
+    showPicker: true,
+    ...overrides,
+  }
+}
+
+function renderSkin(slug: string, width: 'desktop' | 'mobile'): string {
+  factor.value = width
+  const Archetype = resolveVariant(surfaceMap('createCharacter'), slug)
+  try {
+    return renderToStaticMarkup(
+      <MemoryRouter>
+        <Archetype state={state({ factionSlug: slug, invited: ['ephemerists', 'coven'] })} />
+      </MemoryRouter>,
+    )
+  } finally {
+    factor.value = 'desktop'
+  }
+}
+
+/**
+ * The placeholder of every `<input>`/`<textarea>` a caret can land in, in source
+ * order. File and hidden inputs are skipped: each sits behind a button that
+ * names itself (`PortraitPicker`, #1149) and none of them is a form field.
+ */
+function fieldPlaceholders(html: string): string[] {
+  const found: string[] = []
+  for (const [, attrs] of html.matchAll(/<(?:input|textarea)\b([^>]*)>/g)) {
+    if (/type="(?:file|hidden)"/.test(attrs)) continue
+    found.push(/placeholder="([^"]*)"/.exec(attrs)?.[1] ?? '<unnamed>')
+  }
+  return found
+}
+
+describe('the field set is the same on every kit, at both widths', () => {
+  it('the roster is the registry, not a list kept by hand', () => {
+    // Not a count: the derivation is the point. A tenth kit is covered the day
+    // it registers, and a registry that emptied would fail here rather than
+    // pass every row below by scanning nothing.
+    expect(ARCHETYPES.length).toBeGreaterThan(1)
+  })
+
+  it.each(CASES)('%s on %s: name, bio, tagline — in that order and no others', (_name, slug, width) => {
+    expect(fieldPlaceholders(renderSkin(slug, width))).toEqual(
+      FIELD_ORDER.map((key) => forms(key)),
+    )
+  })
+})
+
+describe('the exits read [Cancel] … [Create] on every kit, at both widths (#646)', () => {
+  const CANCEL = common('actions.cancel')
+
+  /**
+   * The cancel control's own TEXT, not an `aria-label` anywhere on the page.
+   *
+   * The distinction is the defect: the retired na phone column had a back
+   * chevron labelled `Cancel` in its top row, so a page-wide search for the word
+   * found a control at the very top and reported the order correct while the
+   * only visible exit was a glyph the footer never drew.
+   */
+  const cancelAt = (html: string) => html.search(new RegExp(`>\\s*${CANCEL}\\s*<`))
+
+  it.each(CASES)('%s on %s: the leave path is drawn before the commit', (_name, slug, width) => {
+    const html = renderSkin(slug, width)
+    const cancel = cancelAt(html)
+    const submit = html.indexOf('type="submit"')
+    expect(cancel, 'no textual cancel on the page').toBeGreaterThan(-1)
+    expect(submit, 'no submit control on the page').toBeGreaterThan(-1)
+    expect(cancel, '[Cancel] … [Create] is the global order settled in #646').toBeLessThan(submit)
+  })
+
+  it.each(CASES)('%s on %s: exactly one commit control', (_name, slug, width) => {
+    // Two would mean a skin kept a second footer for one width — which is what
+    // the phone branch's sticky bar was.
+    const html = renderSkin(slug, width)
+    expect(html.split('type="submit"').length - 1).toBe(1)
+  })
+})

--- a/frontend/src/pages/characterPaths/__tests__/placeholderInk.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/placeholderInk.test.ts
@@ -26,12 +26,16 @@
  * field outwards and it is composited before anything is measured, which is the
  * mistake #2485 was open for.
  *
- * NOT MEASURED, deliberately: the `.na-backdrop` wash. The na name field is
- * transparent over the washed page, and the wash costs up to a full ratio point
- * (`createCharacterContrast.test.ts` transcribes the stops and owns that
- * measurement). Its row below is held to AAA on the flat page token instead, so
- * the wash has a point of room to spend before AA is at risk — a proxy, stated
- * as one, rather than a second copy of a five-gradient shorthand.
+ * NOT MEASURED, deliberately: the `.na-backdrop` wash. The na EDIT kit's name
+ * field is transparent over the washed page, and the wash costs up to a full
+ * ratio point (`createCharacterContrast.test.ts` transcribes the stops and owns
+ * that measurement). Its two rows below are held to AAA on the flat page token
+ * instead, so the wash has a point of room to spend before AA is at risk — a
+ * proxy, stated as one, rather than a second copy of a five-gradient shorthand.
+ *
+ * The na CREATE kit needs no proxy since #2992: it stands on the composer sheet
+ * and its fields are an OPAQUE box drawn above the aurora, so the ground is
+ * flat and its row takes the plain AA floor.
  */
 import { describe, it, expect } from 'vitest'
 import {
@@ -92,11 +96,17 @@ interface Row {
 }
 
 const FIELDS: Row[] = [
-  // The na kit's name field is transparent over the page, and the phone
-  // column's is the page token itself — both are the washed ground, so both
-  // take the AAA proxy. See the header.
-  { what: 'na, name field on the page', ground: ['--color-bg-page'], ink: '--color-text-primary', floor: AAA_NORMAL },
-  { what: 'na, prose fields', ground: ['--color-bg-surface', '--color-bg-page'], ink: '--color-text-primary', floor: AAA_NORMAL },
+  // THE na CREATE KIT MOVED TO THE COMPOSER SHEET (#2992). Its three fields are
+  // one opaque box on `--faction-default-composer-field`, laid over the sheet
+  // ABOVE the aurora — so this is the ground, flat, with no wash to proxy for,
+  // and it takes the plain AA floor like every faction row below it.
+  { what: 'na create, all three fields', ground: ['--faction-default-composer-field', '--faction-default-card-bg'], ink: '--faction-default-card-text' },
+  // The na EDIT kit still stands on the washed app page, and #2992 did not touch
+  // it (#2991 is that lane). Its name field is transparent over the page and its
+  // prose fields sit on the translucent surface token, so both take the AAA
+  // proxy for the wash this file deliberately does not model. See the header.
+  { what: 'na edit, name field on the page', ground: ['--color-bg-page'], ink: '--color-text-primary', floor: AAA_NORMAL },
+  { what: 'na edit, prose fields', ground: ['--color-bg-surface', '--color-bg-page'], ink: '--color-text-primary', floor: AAA_NORMAL },
   { what: 'coven', ground: ['--faction-coven-ward-page', '--faction-coven-ward-card'], ink: '--faction-coven-slip-ink' },
   { what: 'ephemerists', ground: ['--faction-ephemerists-plate-inner', '--faction-ephemerists-plate-page'], ink: '--faction-ephemerists-plate-ink' },
   { what: 'everymen', ground: ['--faction-everymen-sheet-panel', '--everymen-paper'], ink: '--everymen-paper-text' },

--- a/frontend/src/pages/characterPaths/archetypes/AlbescentCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/AlbescentCreateCharacter.tsx
@@ -5,21 +5,32 @@
  * na kit, slot for slot, word for word — inside one classed div.
  *
  * WHAT IS RE-CUT. na draws exactly one spectrum mark on this page: the rainbow
- * ring around the phone branch's photo well, a padded conic disc with the
+ * ring around the live credential card's portrait, a padded conic disc with the
  * portrait sitting in it. That is the same object `DefaultPointsRing` is, and it
- * now wears the same class (`.spectrum-dial`, #2497 — this mount was written
- * after that sweep and missed it). `.alb-moves` is the dresser that class was
- * minted for, so the ring TURNS here and stands still on every other slug. No
- * markup is added, because there is nothing to add: the mark is na's already and
- * this only sets it moving.
+ * wears the same class (`.spectrum-dial`, #2497). `.alb-moves` is the dresser
+ * that class was minted for, so the ring TURNS here and stands still on every
+ * other slug. No markup is added, because there is nothing to add: the mark is
+ * na's already and this only sets it moving.
  *
- * THE DESKTOP BRANCH IS UNCHANGED, and deliberately so rather than by omission.
- * Its two columns carry no na spectrum at all — the form's chrome is the app's
- * own neutrals (see `DefaultCreateCharacter`'s ink note) and the preview's mark
- * is `FactionSigil`, which for this slug is already the labyrinth and is "never
- * part of the wrapper" (ADR-0083 §1). One row covers both widths because the
- * archetype reads `useFormFactor()` itself; the re-cut simply has nothing to
- * grab on the wide one.
+ * THE MOUNT MOVED IN #2992, AND SO DID THE REACH. It used to be the phone
+ * branch's 104px photo well — one mount, on one form factor, so the desktop
+ * two-column plate carried no na spectrum at all and this wrapper had nothing to
+ * grab on the wide one. That branch retired when `DefaultCreateCharacter` went
+ * onto the composer chassis: there is one responsive tree now, the credential
+ * card is the first thing in the sheet at BOTH widths, and its ring is the
+ * conic. So Albescent's ring turns at both widths here, which is the "the
+ * Albescent layer still has moving colors" half of the ruling that issue carries.
+ *
+ * THE RING IS `CredentialCard`'s, NOT THIS PAGE'S, and that is the non-obvious
+ * half. That card only paints the conic when it is UNSKINNED, and
+ * `isKnownFaction('albescent') === false` — the slug is registered but
+ * deliberately unthemed, `CSS_KEY.albescent === "default"` (#783) — so an
+ * Albescent credential takes the rainbow rather than an accent hoop, and the
+ * dresser reaches it. The card is shared, so the class reaches the edit preview
+ * and the profile header too, wherever an `.alb-moves` wrapper is the ancestor.
+ * The FieldDesk roster mounts it under `.alb-desk`, so those rings stand still.
+ * The calling picker's sigils are a second conic on this screen that must NOT
+ * be classed: a sigil is a MARK, "never part of the wrapper" (ADR-0083 §1).
  *
  * NO NEW CSS AT ALL. `.alb-moves .spectrum-dial` (rest: a containing block) is
  * in index.css and `.alb-moves .spectrum-dial::before` (the turn: a pre-painted

--- a/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
@@ -1,61 +1,101 @@
 /**
  * The Default (na) character-creation archetype — the unaffiliated kit, and the
- * fallback every unregistered slug lands on (#2346).
+ * fallback every unregistered slug lands on (#2346, rebuilt on the chassis in
+ * #2992).
  *
- * ONE RESPONSIVE COMPONENT, no mobile twin. It reads `useFormFactor()` itself,
- * the way `editPraxis` and the profile bodies do, and both branches below — the
- * desktop two-column form and the first-run phone column (#516) — are in this
- * one file. A second mobile path is the thing not to re-create.
+ * ## The chassis is the composer's, not a second one
  *
- * THE DEFAULT IS THE `na` KIT, NOT UA AND NOT THE VIEWER'S FACTION. An empty
- * `factionSlug` means born unaffiliated and renders this, full stop. The
- * precedent is `FactionSelectCard`, whose fallback used to be `UaSelectCard` and
- * so "dressed every unaffiliated and unknown slug in UA's costume" (#796, the
- * third instance of #418/#636). `albescent` reaches here too, and deliberately:
- * it is pickable at creation since #2399, and every Albescent registration is a
- * WRAPPER rather than a skin (ADR-0027), so the na kit is the floor that pattern
- * is built on rather than a gap. How an aurora should wash an `na` ground is
- * #2401, and is a design question.
+ * `ComposerPage` / `ComposerSheet` / `ComposerSection` / `ComposerFooter` out of
+ * `pages/editPraxis/archetypes/shared.tsx` — the same blocks the other eight
+ * create kits already mount. This file used to hand-author a `twoCol` flex
+ * plate plus a separate phone column, and four defects came with that
+ * (#2992): a footer with no `flexWrap` that broke `CREATE & STEP OUT`
+ * mid-phrase, a credential card that wrapped off the fold below 634px, a
+ * hardcoded `1fr 1fr` calling grid that went ragged, and an unclassed conic on
+ * the preview's portrait ring.
  *
- * PRESENTATION ONLY. `useCreateCharacter` is the single source of state for all
- * eight archetypes; nothing here touches the submit path, the payload, the
- * portrait picker or the avatar hook.
+ * **The dress is na's own and is not new.** `DefaultEditPraxis` has shipped this
+ * exact kit on this exact chassis since #1181 — ADR-0065 calls that file *"the
+ * REFERENCE implementation of the layout contract the seven faction skins
+ * inherit"* — so every token below is one that file already reads on this
+ * ground. NO DESIGN WAS DRAWN FOR THIS AND NONE WAS NEEDED, which is the same
+ * finding `CovenCreateCharacter`'s header records for its own kit.
+ *
+ * **This is not a merge.** One file per faction still stands (ADR-0065 §"What
+ * this ADR does not do", `frontend/CLAUDE.md`): what is forbidden is a single
+ * component with a runtime skin table rendering nine trees. This file keeps its
+ * own tree, its own dress, its own ground and its own role map, and stops
+ * re-authoring a sheet, a section and a footer from scratch.
+ *
+ * ## One responsive tree, no phone branch
+ *
+ * `useComposerSizes()` picks the size set and there is one tree at two widths.
+ * The first-run phone column retired with #2992 — with it went the "Step 1 of 2
+ * · Identity" framing, the 104px photo ring, the sticky Create bar, and the
+ * deliberate absence of `bio`/`tagline` on the phone (#516, #1628). na is the
+ * ninth kit offering the same fields at both widths; Coven and the Ephemerists
+ * already deviate this way on purpose and say so in their own headers. Nothing
+ * below is a fixed-px layout grid (SPEC-faction-ui-profile §1a).
+ *
+ * ## The order, and why it is not this file's to choose
+ *
+ * `heading → CredentialCard → name → bio → tagline → portrait → calling picker
+ * → footer` is the order all eight siblings already draw (#2995's census). The
+ * calling picker goes AFTER the portrait section for that reason and no other.
+ * The footer keeps the global `[Cancel] … [Create]` order settled in #646, and
+ * na keeps the INLINE commit button rather than the full-bleed band — that is
+ * the owner ruling on #1828 and the reason `composerBandStyle` is a per-skin
+ * style rather than something `ComposerFooter` does on its own.
+ *
+ * ## PRESENTATION ONLY
+ *
+ * `useCreateCharacter` is the single source of state for all nine archetypes.
+ * Nothing here touches the submit path, the payload, `PortraitPicker` or
+ * `useAvatarPicker`. THE DEFAULT IS THE `na` KIT, NOT UA AND NOT THE VIEWER'S
+ * FACTION: an empty `factionSlug` means born unaffiliated and renders this, full
+ * stop (#796, the third instance of #418/#636). `albescent` reaches here too and
+ * deliberately — it is pickable at creation since #2399, and every Albescent
+ * registration is a WRAPPER rather than a skin (ADR-0027).
  *
  * NO FIELD LABELS, AND THAT IS RULED RATHER THAN MISSING (#2793). This form is
  * placeholder-only: the name, bio and catchphrase boxes carry their own words,
  * shared with Edit Character so the two surfaces speak one vocabulary — around
- * the CHARACTER, with no pronouns, which is what took the second person out of
- * this page's heading too. `namedField()` sets `aria-label` from that same
- * string, because here the visible label WAS the accessible name and deleting
- * it without one is a regression rather than a simplification. The portrait key
- * and the calling grid keep their spans: those head groups of BUTTONS, are
- * section headings rather than field labels, and were explicitly excluded.
- * Where a deleted label was also carrying the gap above its field, the gap
- * moves onto the field.
+ * the CHARACTER, with no pronouns. `namedField()` sets `aria-label` from that
+ * same string, because here the visible label WAS the accessible name. The
+ * portrait key and the calling picker keep their headings: those head groups of
+ * BUTTONS, are section headings rather than field labels, and `ComposerSection`
+ * draws them as a `<span>` when no `htmlFor` is passed — which is the shared
+ * answer, not a local one.
  *
- * THE PHONE BRANCH CARRIES NO PROSE FIELDS, deliberately and unchanged: it is
- * "Step 1 of 2 · Identity" and has never offered `bio`, which mobile players
- * write on the edit screen instead. `tagline` (#1628) follows `bio` for exactly
- * that reason, so the two stay a pair rather than one of them quietly becoming
- * the phone's only first-run prose field.
+ * ## The one motion
  *
- * INKS ARE UNCHANGED FROM WHAT BOTH FILES SHIPPED — the app's own neutral
- * tiers, kept because they are what this page's real ground was measured
- * against. See the constant block below for the numbers and for the lint
- * exemption they justify. Layout is flex/relative single-column on the phone —
- * no fixed-px grid drives the page (SPEC-faction-ui-profile §1a).
+ * `ep-drift` wanders the aurora, and it is a CLASS: the keyframes live in
+ * `index.css` behind the shared `prefers-reduced-motion` guard, and an inline
+ * `animation:` would bypass that guard (#1003). Albescent's delta on this page
+ * is the credential card's portrait ring, which wears `.spectrum-dial` in
+ * `components/CredentialCard.tsx` — see `AlbescentCreateCharacter`.
  */
-import { useRef, type CSSProperties } from 'react'
+import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { factionCssVar, factionName } from '../../../utils/factions'
+import { factionCssVar, factionName, factionSpectrumSheet } from '../../../utils/factions'
 import CredentialCard from '../../../components/CredentialCard'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
 import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
-import { useFormFactor } from '../../../hooks/useFormFactor'
 import PortraitPicker from '../PortraitPicker'
 import { namedField } from '../characterFields'
+import {
+  ComposerFooter,
+  ComposerGround,
+  ComposerPage,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ErrorBanner,
+  composerLabelStyle,
+  useComposerSizes,
+} from '../../editPraxis/archetypes/shared'
 import {
   NAME_MAX,
   BIO_MAX,
@@ -63,72 +103,95 @@ import {
   type CreateCharacterState,
 } from '../useCreateCharacter'
 
-/* The na kit's inks and grounds, named once.
+/* The na kit's inks and grounds, named once — the same set
+ * `DefaultEditPraxis` reads, because this page now stands on the same stock.
  *
- * THE THREE TEXT TIERS ARE THE APP'S OWN NEUTRALS, AND THAT IS MEASURED RATHER
- * THAN INHERITED. `local/no-global-ink-on-faction-surface` bans `--color-text-*`
- * under an `archetypes/` directory, and this file carries the one documented
- * exemption from it (see `eslint.config.js`, and the paired measurement in
- * `__tests__/createCharacterContrast.test.ts` which is the other half of it).
+ * THE APP'S NEUTRAL TIERS ARE GONE, AND SO IS THE LINT EXEMPTION THEY BOUGHT
+ * (#2992). `--color-text-secondary` / `-tertiary` were right here while the page
+ * had no card: type sat on `--color-bg-page` under the `.na-backdrop` wash,
+ * where the neutrals clear AA and the na card family does not. On a
+ * `ComposerSheet` the ground is `--faction-default-card-bg` washed by the
+ * aurora, which is a different measurement with a different answer — the one
+ * `pages/editPraxis/archetypes/__tests__/composerGround.test.ts` already makes
+ * for this exact composite. The `eslint.config.js` exemption for this file went
+ * with the ground it was measured on; `__tests__/createCharacterContrast.test.ts`
+ * carries the sheet-ground rows.
  *
- * The reason is the GROUND. Every other `Default*` archetype draws on the na
- * CARD — `DefaultEditPraxis` sits on `--faction-default-card-bg` — where the na
- * card inks are the measured pair. This page has no card: it is bare app page,
- * so what is actually behind this type is `--color-bg-page` with the
- * `.na-backdrop` watercolour washed over it. Measured on that COMPOSITE in
- * light, the card family does not clear AA and the neutrals do:
- *
- *     ink                                 light   dark
- *     --color-text-secondary              6.06    6.68   ← used here
- *     --color-text-tertiary               6.10    7.17   ← used here
- *     --faction-default-card-muted        4.36    4.75
- *     --faction-default-composer-faint    3.50    4.18
- *
- * So the neutral tier is not "a real token at the wrong tier" here, which is
- * what the rule exists to catch on a faction SHEET; it is the tier this ground
- * was chosen against. #1932 recorded the same ruling for `pages/players/`:
- * widening that glob "would ban the global tiers on the surface they are right
- * for". Do not swap these for `--faction-default-*` without re-measuring over
- * the wash — the flat token reads 4.49 and the composite 3.50.
- */
-const INK = 'var(--color-text-primary)'
-const MUTED = 'var(--color-text-secondary)'
-const FAINT = 'var(--color-text-tertiary)'
-/* NOT `--color-danger`, and this is a fix rather than a preference (#2346).
- * The neutral functional red is 3.42:1 on this page's washed ground in light —
- * a fail, and it is what both source files shipped. `-card-alarm` exists for all
- * eight keys, is already measured, and reads 5.89 / 7.85 here. That is #1302's
- * shape, the same one every composer error banner follows: a shared functional
- * ink inside a faction frame takes the faction's own card family. */
+ * THE TIER SPLIT IS BY GROUND, NOT BY LOUDNESS (#2485), and the names read
+ * backwards because of it: FAINT is the ink for the aurora-WASHED sheet and
+ * MUTED is the ink for the opaque field laid on top of it. If you are choosing
+ * between them, ask what is behind the type. */
+const INK = 'var(--faction-default-card-text)'
+const MUTED = 'var(--faction-default-card-muted)'
+const FAINT = 'var(--faction-default-composer-faint)'
+/* NOT `--color-danger`, and this is a fix rather than a preference (#2346,
+ * #1302): a shared functional ink inside a faction frame takes that faction's
+ * own card family, measured on the frame's ground. */
 const ALARM = 'var(--faction-default-card-alarm)'
-const FIELD = 'var(--color-bg-surface)'
-const BORDER = 'var(--color-border-strong)'
-const ON_ACCENT = 'var(--color-bg-page)'
-/* `RING` USED TO BE HERE — `var(--faction-default-rainbow-conic)`, inlined onto
- * the phone's photo well. It is `.spectrum-dial` now (#2531), the class #2497
- * minted for exactly this: the conic cut of the na spectrum, said once in
- * index.css instead of privately at every mount. This mount was written after
- * that sweep and so was never in it — an eighteenth copy of the same value,
- * and the only one a stylesheet could not reach.
- *
- * Nothing about na changes. `.spectrum-dial` carries that ramp and nothing else,
- * so the ring is the same rainbow it has always been; what the class buys is
- * that a DRESSER can reach it (`.alb-moves .spectrum-dial`, two classes, so it
- * wins from wherever it is written), which is how `AlbescentCreateCharacter`
- * re-cuts this one mark without a copy of this file existing. */
+const FIELD = 'var(--faction-default-composer-field)'
+const BORDER = 'var(--faction-default-border)'
+const HAIR = 'var(--faction-default-composer-hair)'
+const ON_ACCENT = 'var(--faction-default-on-accent)'
 
-export default function DefaultCreateCharacter({ state }: { state: CreateCharacterState }) {
-  const formFactor = useFormFactor()
-  return formFactor === 'mobile' ? <MobileColumn state={state} /> : <DesktopPlate state={state} />
+/* The design's title face is Lora (--font-display); the label face is Courier
+ * Prime (--font-body), which is what `composerLabelStyle` already defaults to.
+ * The token names read backwards here and that is not a mistake. */
+const TITLE_FACE = 'var(--font-display)'
+
+const labelStyle = { color: FAINT }
+
+/* THE SHEET'S FRAME IS THE SPECTRUM (#2520) — a 3px transparent border with the
+   ramp painted into the border box under it, the same `border-box` idiom
+   `DefaultTaskCard`, `DefaultPraxisCard`, `DefaultSeal` and `DefaultEditPraxis`
+   all wear. Only the width is stated here; the composition belongs to the
+   helper, because the ramp has to be appended to all three of the sheet's
+   background lists. */
+const sheetStyle = {
+  border: '3px solid transparent',
+  ...factionSpectrumSheet(),
+  boxShadow: '0 16px 40px -24px var(--color-cast-shadow)',
 }
 
-/* -------------------------------------------------------------------------- */
-/* Desktop — the two-column form, with the live credential preview beside it.   */
-/* -------------------------------------------------------------------------- */
+/* na's drifting aurora, clipped to the sheet by `ComposerSheet`'s own
+   `overflow: hidden` (#1028). */
+const ground = (
+  <ComposerGround
+    background="var(--faction-default-aurora)"
+    opacity="var(--faction-default-aurora-opacity)"
+    filter="var(--faction-default-aurora-filter)"
+    mixBlendMode="var(--faction-default-aurora-blend)"
+    animated
+  />
+)
 
-function DesktopPlate({ state }: { state: CreateCharacterState }) {
+const fieldBox = {
+  width: '100%',
+  background: FIELD,
+  color: INK,
+  border: `1px solid ${BORDER}`,
+  borderRadius: 10,
+  padding: 'var(--space-md)',
+  boxSizing: 'border-box',
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-content)',
+  lineHeight: 1.6,
+  resize: 'vertical',
+} as const
+
+/** The commit button's paint, minus the busy cursor the form adds. */
+const primaryStyle = composerLabelStyle({
+  border: 'none',
+  borderRadius: 10,
+  padding: 'var(--space-md) var(--space-xl)',
+  color: ON_ACCENT,
+  background: INK,
+  fontWeight: 700,
+})
+
+export default function DefaultCreateCharacter({ state }: { state: CreateCharacterState }) {
   const { t } = useTranslation(['forms', 'common'])
   const navigate = useNavigate()
+  const sizes = useComposerSizes()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const {
     displayName,
@@ -156,93 +219,145 @@ function DesktopPlate({ state }: { state: CreateCharacterState }) {
     showPicker,
   } = state
 
+  /** The counter row under a prose field: quiet, and alarmed on the cap. */
+  const counter = (used: number, max: number) => (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)' }}>
+      <span style={{ color: used >= max ? ALARM : FAINT }}>
+        {t('createCharacter.charsLeft', { count: max - used })}
+      </span>
+    </div>
+  )
+
+  /** A section heading with its `· optional` tail in sentence case. */
+  const optionalHead = (label: string, tail: string) => (
+    <>
+      {label} <span style={{ textTransform: 'none', letterSpacing: 0 }}>{tail}</span>
+    </>
+  )
+
   return (
-    <div className="page" data-skin="default">
-      <button onClick={() => navigate('/')} style={backLink}>{t('createCharacter.back')}</button>
+    <ComposerPage sizes={sizes} style={{ fontFamily: TITLE_FACE, color: INK }}>
+      {/* A REAL `<form>`, not a bare button with an onClick: it is what makes
+          Enter commit from a text field. `handleSubmit` calls `preventDefault()`
+          itself. */}
+      <form onSubmit={handleSubmit} data-skin="default">
+        <ComposerSheet sizes={sizes} style={sheetStyle} ground={ground}>
+          <h1
+            style={{
+              fontFamily: TITLE_FACE,
+              fontStyle: 'italic',
+              fontWeight: 700,
+              fontSize: sizes.titleSize,
+              lineHeight: 1.1,
+              color: INK,
+              margin: 0,
+            }}
+          >
+            {t('createCharacter.heading')}
+          </h1>
 
-      <div style={twoCol}>
-        {/* Left — form */}
-        <form onSubmit={handleSubmit} style={{ flex: '1 1 320px', maxWidth: 440 }}>
-          <h1 style={titleStyle}>{t('createCharacter.heading')}</h1>
-
-          {/* Name */}
-          <input
-            data-composer-field
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            maxLength={NAME_MAX}
-            {...namedField(t('character.namePlaceholder'))}
-            autoFocus
-            style={nameInput}
-          />
-          <div style={metaRow}>
-            <span style={{ color: FAINT }}>@{handle}</span>
-            <span style={{ color: displayName.length >= NAME_MAX ? ALARM : FAINT }}>
-              {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
-            </span>
+          {/* The life being written, live — FIRST in the sheet at both widths,
+              which is the whole of defect 2. The card dispatches its own faction
+              dress, so it is already wearing the picked calling. */}
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <CredentialCard
+              displayName={displayName || t('createCharacter.previewFallbackName')}
+              handle={handle}
+              factionSlug={factionSlug || null}
+              level={1}
+              score={0}
+              avatarUrl={avatarPreview}
+              onAvatarClick={() => fileInputRef.current?.click()}
+            />
           </div>
 
-          {/* Bio. The gap the deleted label used to open above it moves onto the
-              field itself, so the stack keeps the rhythm it had (#2793). */}
-          <textarea
-            data-composer-field
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-            maxLength={BIO_MAX}
-            {...namedField(t('character.bioPlaceholder'))}
-            rows={3}
-            style={{ ...bioInput, marginTop: 'var(--space-xl)' }}
-          />
-          <div style={metaRow}>
-            <span />
-            <span style={{ color: FAINT }}>{t('createCharacter.charsLeft', { count: BIO_MAX - bio.length })}</span>
-          </div>
+          {/* Chosen name */}
+          <ComposerSection rule={false}>
+            <input
+              data-composer-field
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              maxLength={NAME_MAX}
+              {...namedField(t('character.namePlaceholder'))}
+              autoFocus
+              style={{ ...fieldBox, fontFamily: TITLE_FACE, fontStyle: 'italic', fontSize: 'var(--text-title)' }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)' }}>
+              <span style={{ color: FAINT }}>@{handle}</span>
+              <span style={{ color: displayName.length >= NAME_MAX ? ALARM : FAINT }}>
+                {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
+              </span>
+            </div>
+          </ComposerSection>
+
+          {/* About */}
+          <ComposerSection rule={false}>
+            <textarea
+              data-composer-field
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              maxLength={BIO_MAX}
+              {...namedField(t('character.bioPlaceholder'))}
+              rows={3}
+              style={fieldBox}
+            />
+            {counter(bio.length, BIO_MAX)}
+          </ComposerSection>
 
           {/* Tagline — a slogan line, not a short bio (#1628). Its counter turns
-              danger on the cap the way the name field's does: this is the field
-              the profile header's identity slot is laid out against, so running
-              out of room is worth seeing before the text stops appearing. */}
-          <textarea
-            data-composer-field
-            value={tagline}
-            onChange={(e) => setTagline(e.target.value)}
-            maxLength={TAGLINE_MAX}
-            {...namedField(t('character.taglinePlaceholder'))}
-            rows={2}
-            style={{ ...bioInput, marginTop: 'var(--space-xl)' }}
-          />
-          <div style={metaRow}>
-            <span />
-            <span style={{ color: tagline.length >= TAGLINE_MAX ? ALARM : FAINT }}>
-              {t('createCharacter.charsLeft', { count: TAGLINE_MAX - tagline.length })}
-            </span>
-          </div>
+              alarm on the cap the way the name field's does: this is the field the
+              profile header's identity slot is laid out against, so running out of
+              room is worth seeing before the text stops appearing. */}
+          <ComposerSection rule={false}>
+            <textarea
+              data-composer-field
+              value={tagline}
+              onChange={(e) => setTagline(e.target.value)}
+              maxLength={TAGLINE_MAX}
+              {...namedField(t('character.taglinePlaceholder'))}
+              rows={2}
+              style={fieldBox}
+            />
+            {counter(tagline.length, TAGLINE_MAX)}
+          </ComposerSection>
 
-          {/* Portrait — reuses the existing avatar uploader (POST /characters/{id}/avatar).
-              The picker owns the hidden input and the "what's chosen" readout (#1149);
-              the credential card on the right opens the same input through fileInputRef. */}
-          {/* A SPAN, not a <label>: the portrait key and the calling grid below
-              it head a group of BUTTONS, and a <label> with nothing to point at
-              is an accessible name attached to nothing (#2488). `ComposerSection`
-              draws these the same way on every faction plate — a heading when no
-              `htmlFor` is passed — so this is the shared answer, not a local one. */}
-          <span style={{ ...eyebrow, marginTop: 'var(--space-xl)' }}>{t('character.portrait')} <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.optional')}</span></span>
-          <PortraitPicker
-            inputRef={fileInputRef}
-            onChange={handleAvatarChange}
-            chosenFile={avatarFile}
-            error={avatarError}
-            errorStyle={{ color: ALARM }}
-            style={{ marginTop: 'var(--space-sm)' }}
-          />
+          {/* Portrait — the shared picker owns the hidden input and the "what's
+              chosen" readout (#1149); the credential card above opens the same
+              input through `fileInputRef`. */}
+          <ComposerSection
+            rule={false}
+            label={optionalHead(t('character.portrait'), t('createCharacter.optional'))}
+            labelStyle={labelStyle}
+          >
+            <PortraitPicker
+              inputRef={fileInputRef}
+              onChange={handleAvatarChange}
+              chosenFile={avatarFile}
+              error={avatarError}
+              buttonStyle={composerLabelStyle({
+                cursor: 'pointer',
+                borderRadius: 10,
+                padding: 'var(--space-sm) var(--space-lg)',
+                background: FIELD,
+                color: INK,
+                border: `1px solid ${BORDER}`,
+              })}
+              statusStyle={{ color: FAINT }}
+              errorStyle={{ color: ALARM }}
+            />
+          </ComposerSection>
 
-          {/* Faction picker — only when the account holds invitations (ADR-0019) */}
+          {/* Answer a calling — only when the account holds invitations
+              (ADR-0019). SINGLE COLUMN, which is defect 3: the `1fr 1fr` grid
+              this used to draw went ragged the moment one name wrapped, and the
+              eight siblings all stack. */}
           {showPicker && (
-            <>
-              <span style={{ ...eyebrow, marginTop: 'var(--space-xl)' }}>
-                {t('createCharacter.callingLabel')} <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.callingOptional')}</span>
-              </span>
-              <div style={pickerGrid}>
+            <ComposerSection
+              rule={false}
+              label={optionalHead(t('createCharacter.callingLabel'), t('createCharacter.callingOptional'))}
+              labelStyle={labelStyle}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
                 {invited.map((slug) => {
                   const selected = factionSlug === slug
                   return (
@@ -250,218 +365,105 @@ function DesktopPlate({ state }: { state: CreateCharacterState }) {
                       key={slug}
                       type="button"
                       onClick={() => setFactionSlug(selected ? '' : slug)}
+                      /* NOT `composerLabelStyle` — it forces uppercase and its
+                         own tracking, and the calling's own card face below
+                         would inherit both. */
                       style={{
-                        ...pickerCell,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 'var(--space-md)',
+                        width: '100%',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        background: FIELD,
+                        border: `1px solid ${BORDER}`,
+                        borderRadius: 10,
+                        padding: 'var(--space-md) var(--space-lg)',
+                        // The faction's own hue as a RING, never as ink (§3).
                         boxShadow: selected ? `0 0 0 2px ${factionCssVar(slug)}` : 'none',
                       }}
                     >
-                      {/* The faction's own mark, from the dispatcher every
-                          other chooser draws (#2223) — the 12px disc it
-                          replaces was a placeholder for a mark that exists. */}
+                      {/* The faction's own mark, from the dispatcher every other
+                          chooser draws (#2223). The row's ground is na's own
+                          field either way, so the mark keeps its default ink. */}
                       <FactionSigil slug={slug} size={18} />
-                      <span style={{ fontFamily: factionCssVar(slug, 'card-font'), fontSize: 'var(--text-content)', color: INK }}>
+                      <span
+                        style={{
+                          fontFamily: factionCssVar(slug, 'card-font'),
+                          fontSize: 'var(--text-content)',
+                          color: MUTED,
+                        }}
+                      >
                         {factionName(slug)}
                       </span>
                     </button>
                   )
                 })}
               </div>
-            </>
+              <p style={{ fontFamily: 'var(--font-body)', fontSize: 'var(--text-content)', color: FAINT, margin: 0, lineHeight: 1.6 }}>
+                {t('createCharacter.callingHint')}
+              </p>
+            </ComposerSection>
           )}
 
-          {error && <p style={errorBox}>{error}</p>}
+          {/* The born-unaffiliated explainer. It was `createCharacter.mobile.help`
+              and drawn on the phone only; the key moved out of the retired
+              `mobile.*` block rather than dying with it, because it is the one
+              sentence on this page that says what being born `na` means and the
+              wide branch never had it (#2992). */}
+          <p style={{ fontFamily: 'var(--font-body)', fontSize: 'var(--text-content)', color: FAINT, margin: 0, lineHeight: 1.6 }}>
+            {t('createCharacter.help')}
+          </p>
 
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)', marginTop: 'var(--space-xl)' }}>
-            {/* The DESKTOP Create had the inverse of the phone bar's bug
-                (#2486): no disabled treatment at all, so a control the form
-                gates read exactly like a live one. `.control-off` gives the two
-                the same answer. */}
-            <button type="submit" disabled={!canSubmit} className="control-off" style={primaryBtn}>
-              {submitting ? t('createCharacter.submitBusy') : t('createCharacter.submitIdle')}
-            </button>
-            <button type="button" onClick={() => navigate('/')} style={cancelBtn}>{t('common:actions.cancel')}</button>
-            <span style={{ fontSize: 'var(--text-content)', color: FAINT, letterSpacing: '0.06em' }}>
-              {t('createCharacter.startsAt')}
-            </span>
-          </div>
-        </form>
+          <ErrorBanner message={error ?? ''} style={{ color: ALARM }} />
 
-        {/* Right — live credential preview */}
-        <div style={{ flex: '0 0 auto', display: 'flex', justifyContent: 'center' }}>
-          <CredentialCard
-            displayName={displayName || t('createCharacter.previewFallbackName')}
-            handle={handle}
-            factionSlug={factionSlug || null}
-            level={1}
-            score={0}
-            avatarUrl={avatarPreview}
-            onAvatarClick={() => fileInputRef.current?.click()}
-          />
-        </div>
-      </div>
+          {/* THE ONE RULE (#1707). Every section passes `rule={false}` and the
+              regions are parted by the content column's own gap; the single
+              hairline on the page sits immediately above the footer. */}
+          <ComposerRule style={{ background: HAIR }} />
 
-      {/* Portrait crop/rotate — locked square (#514). */}
-      {avatarSource && (
-        <ImageEditModal
-          key={`${avatarSource.name}-${avatarSource.lastModified}`}
-          file={avatarSource}
-          aspect={AVATAR_ASPECT}
-          onConfirm={handleAvatarConfirm}
-          onCancel={() => setAvatarSource(null)}
-          onError={setAvatarError}
-        />
-      )}
-    </div>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Phone — first-run single column, sticky Create reachable one-handed (#516).  */
-/* -------------------------------------------------------------------------- */
-
-function MobileColumn({ state }: { state: CreateCharacterState }) {
-  const { t } = useTranslation(['forms', 'common'])
-  const navigate = useNavigate()
-  const fileRef = useRef<HTMLInputElement>(null)
-  const {
-    displayName,
-    setDisplayName,
-    factionSlug,
-    setFactionSlug,
-    invited,
-    avatarPreview,
-    avatarSource,
-    setAvatarSource,
-    avatarError,
-    setAvatarError,
-    handleAvatarChange,
-    handleAvatarConfirm,
-    error,
-    submitting,
-    canSubmit,
-    handleSubmit,
-    handle,
-    showPicker,
-  } = state
-
-  // One string for the ring's accessible name and its visible caption (#1149).
-  // The ring never showed the browser's "No file chosen" — its input has always
-  // been hidden — but it had no accessible name either: the name fell through to
-  // the "+" glyph, or to the portrait's alt text once one was picked. Naming it
-  // with the caption is what makes what is announced and what is on screen agree.
-  const photoAction = avatarPreview
-    ? t('character.changePhoto')
-    : t('character.addPhoto')
-
-  return (
-    <form data-skin="default" data-testid="mobile-create-character" onSubmit={handleSubmit} style={page}>
-      {/* Top row — back + title */}
-      <div style={topRow}>
-        <button type="button" onClick={() => navigate('/')} style={backBtn} aria-label={t('common:actions.cancel')}>
-          ‹
-        </button>
-        <span className="label-heading">{t('createCharacter.mobile.title')}</span>
-        <span style={{ width: 28 }} />
-      </div>
-
-      {/* Photo add */}
-      <div style={{ textAlign: 'center' }}>
-        {/* `.spectrum-dial` is the ring's paint (#2497 via #2531). Childless is
-            not required of a dial — the face below is lifted by
-            `.alb-moves .spectrum-dial > *`, the same shape `DefaultPointsRing`
-            wears — so the photo well keeps its span. */}
-        <button type="button" onClick={() => fileRef.current?.click()} aria-label={photoAction} className="spectrum-dial" style={ringBtn}>
-          <span style={ringInner}>
-            {avatarPreview ? (
-              <img src={avatarPreview} alt={handle} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-            ) : (
-              <span
-                aria-hidden
-                style={{
-                  // eslint-disable-next-line local/no-raw-style-values -- ornament: "+" is a glyph-as-icon, sized to the 104px photo ring, not text
-                  fontSize: 26,
-                  color: MUTED,
-                }}
-              >
-                +
-              </span>
-            )}
-          </span>
-        </button>
-        <div className="label-caption" style={{ marginTop: 'var(--space-md)', color: MUTED }}>
-          {photoAction}
-        </div>
-        <div className="label-caption" style={{ marginTop: 'var(--space-sm)' }}>
-          {t('createCharacter.mobile.step')}
-        </div>
-        {avatarError && <p className="content-text" style={{ ...mobileErrorBox, marginTop: 'var(--space-sm)' }}>{avatarError}</p>}
-      </div>
-      <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarChange} style={{ display: 'none' }} />
-
-      {/* Name */}
-      <div>
-        <input
-          data-composer-field
-          value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
-          maxLength={NAME_MAX}
-          {...namedField(t('character.namePlaceholder'))}
-          autoFocus
-          className="content-text"
-          style={field}
-        />
-        <div style={mobileMetaRow}>
-          <span style={{ color: FAINT }}>@{handle}</span>
-          <span style={{ color: displayName.length >= NAME_MAX ? ALARM : FAINT }}>
-            {t('createCharacter.charsLeft', { count: NAME_MAX - displayName.length })}
-          </span>
-        </div>
-      </div>
-
-      {/* Faction picker — only when the account holds invitations (ADR-0019) */}
-      {showPicker && (
-        <div>
-          {/* A SPAN, not a <label> — see the desktop column's note. */}
-          <span style={label}>{t('createCharacter.callingLabel')}</span>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)', marginTop: 'var(--space-sm)' }}>
-            {invited.map((slug) => {
-              const selected = factionSlug === slug
-              return (
+          {/* [Cancel] … [Create] — the global order from #646. `ComposerFooter`
+              wraps, which is defect 1: the hand-rolled row this replaces was a
+              bare `display: flex` with no `flexWrap` inside a 440px column, so
+              the commit label broke mid-phrase. na keeps the INLINE button
+              rather than the full-bleed band (#1828). */}
+          <ComposerFooter
+            start={
+              <>
                 <button
-                  key={slug}
                   type="button"
-                  onClick={() => setFactionSlug(selected ? '' : slug)}
-                  style={{
-                    ...mobilePickerCell,
-                    boxShadow: selected ? `0 0 0 2px ${factionCssVar(slug)}` : 'none',
-                  }}
+                  onClick={() => navigate('/')}
+                  style={composerLabelStyle({
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    color: FAINT,
+                  })}
                 >
-                  {/* The faction's own mark, from the dispatcher every other
-                      chooser draws (#2223) — 18px, the size the propose-task
-                      chips use; the 12px disc it replaces was a placeholder. */}
-                  <FactionSigil slug={slug} size={18} />
-                  <span className="content-text" style={{ fontFamily: factionCssVar(slug, 'card-font'), color: INK }}>
-                    {factionName(slug)}
-                  </span>
+                  {t('common:actions.cancel')}
                 </button>
-              )
-            })}
-          </div>
-          <p className="content-text" style={{ ...help, marginTop: 'var(--space-sm)' }}>{t('createCharacter.callingHint')}</p>
-        </div>
-      )}
-
-      {/* Born-unaffiliated explainer */}
-      <p className="content-text" style={help}>{t('createCharacter.mobile.help')}</p>
-
-      {error && <p className="content-text" style={mobileErrorBox}>{error}</p>}
-
-      {/* Sticky Create bar */}
-      <div style={stickyBar}>
-        <button type="submit" disabled={!canSubmit} className="control-off" style={mobilePrimaryBtn}>
-          {submitting ? t('createCharacter.submitBusy') : t('createCharacter.mobile.submit')}
-        </button>
-      </div>
+                <span style={{ fontFamily: 'var(--font-body)', fontSize: 'var(--text-content)', color: FAINT }}>
+                  {t('createCharacter.startsAt')}
+                </span>
+              </>
+            }
+            end={
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                /* `.control-off` rather than an opacity fade (#2486): the form
+                   gates this control, and a gated control that reads like a live
+                   one is the inverse defect the phone bar used to have. */
+                className="control-off"
+                style={{ ...primaryStyle, cursor: submitting ? 'wait' : 'pointer' }}
+              >
+                {submitting ? t('createCharacter.submitBusy') : t('createCharacter.submitIdle')}
+              </button>
+            }
+          />
+        </ComposerSheet>
+      </form>
 
       {/* Portrait crop/rotate — locked square (#514). */}
       {avatarSource && (
@@ -474,132 +476,6 @@ function MobileColumn({ state }: { state: CreateCharacterState }) {
           onError={setAvatarError}
         />
       )}
-    </form>
+    </ComposerPage>
   )
-}
-
-// --- desktop styles (token-driven) ------------------------------------------
-
-const backLink: CSSProperties = {
-  background: 'none', border: 'none', cursor: 'pointer',
-  fontSize: 'var(--text-lg)', color: MUTED, padding: 0, marginBottom: 'var(--space-lg)',
-}
-const twoCol: CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: 'var(--space-4xl)', alignItems: 'flex-start' }
-const titleStyle: CSSProperties = {
-  fontFamily: 'var(--font-display)', fontStyle: 'italic', fontWeight: 700,
-  fontSize: 'var(--text-heading)', lineHeight: 1.02, color: INK, margin: '0 0 var(--space-xl)',
-}
-const eyebrow: CSSProperties = {
-  display: 'block', fontSize: 'var(--text-md)', letterSpacing: '0.16em', textTransform: 'uppercase',
-  color: MUTED,
-}
-const nameInput: CSSProperties = {
-  display: 'block', width: '100%', marginTop: 'var(--space-sm)', background: 'transparent', border: 'none',
-  borderBottom: `1.5px solid ${INK}`,
-  fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 'var(--text-title)',
-  color: INK, padding: 'var(--space-xs) 0 var(--space-sm)',
-}
-const bioInput: CSSProperties = {
-  display: 'block', width: '100%', marginTop: 'var(--space-sm)', boxSizing: 'border-box', resize: 'none',
-  background: FIELD, border: `1px solid ${BORDER}`,
-  borderRadius: 5, fontFamily: 'var(--font-body)', fontSize: 'var(--text-content)',
-  lineHeight: 1.6, color: INK, padding: 'var(--space-md)',
-}
-const pickerGrid: CSSProperties = {
-  display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-md)', marginTop: 'var(--space-md)',
-}
-const pickerCell: CSSProperties = {
-  display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', cursor: 'pointer',
-  background: FIELD, border: `1px solid ${BORDER}`,
-  borderRadius: 6, padding: 'var(--space-md)', textAlign: 'left',
-}
-const primaryBtn: CSSProperties = {
-  cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-base)', letterSpacing: '0.12em',
-  textTransform: 'uppercase', color: ON_ACCENT, background: INK,
-  border: 'none', padding: 'var(--space-md) var(--space-xl)', borderRadius: 5,
-}
-const cancelBtn: CSSProperties = {
-  cursor: 'pointer', background: 'none', border: 'none', fontFamily: 'var(--font-body)',
-  fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED,
-}
-
-const metaRow: CSSProperties = {
-  display: 'flex', justifyContent: 'space-between', marginTop: 'var(--space-sm)',
-  fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',
-}
-const errorBox: CSSProperties = {
-  marginTop: 'var(--space-lg)', fontFamily: 'var(--font-body)', fontSize: 'var(--text-content)', color: ALARM,
-  border: `1px solid ${ALARM}`, borderRadius: 4, padding: 'var(--space-sm) var(--space-md)',
-}
-
-// --- phone styles (single column, no hardcoded hex) -------------------------
-//
-// The counter row and the error box are NOT shared with the desktop pair above,
-// and that is deliberate rather than a missed de-duplication: the phone sets
-// them a rung apart (`--text-base` against `--text-lg`, a roomier box with no
-// top margin). Folding the two files into one archetype is a dispatch change,
-// not a redesign, so each branch keeps the metrics it shipped with.
-
-const page: CSSProperties = { display: 'flex', flexDirection: 'column', gap: 'var(--space-xl)', paddingBottom: 'var(--space-6xl)' }
-const topRow: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between' }
-const backBtn: CSSProperties = {
-  width: 28, height: 28, background: 'none', border: 'none', cursor: 'pointer',
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: the back chevron is a glyph-as-icon sized to its 28px hit target
-  fontSize: 24,
-  lineHeight: 1, color: INK, padding: 0,
-}
-const ringBtn: CSSProperties = {
-  width: 104, height: 104, borderRadius: '50%',
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: rainbow ring thickness drawn around the 104px photo well; the nearest rung (4px) thickens the band by a third.
-  padding: 3,
-  cursor: 'pointer',
-  // The ramp is `.spectrum-dial`'s at the mount below, not a declaration here
-  // (#2531). Preflight already zeroes a button's own background, so the class is
-  // the only paint on this box — geometry stays at the call site, which is the
-  // split `.spectrum-dial`'s own note in index.css states.
-  border: 'none',
-}
-const ringInner: CSSProperties = {
-  display: 'flex', alignItems: 'center', justifyContent: 'center',
-  width: '100%', height: '100%', borderRadius: '50%', overflow: 'hidden',
-  background: 'var(--color-bg-surface-alt)',
-}
-const label: CSSProperties = {
-  display: 'block', fontSize: 'var(--text-md)', letterSpacing: '0.16em', textTransform: 'uppercase',
-  color: MUTED,
-}
-const field: CSSProperties = {
-  display: 'block', width: '100%', marginTop: 'var(--space-sm)', boxSizing: 'border-box',
-  background: 'var(--color-bg-page)', border: `1px solid ${BORDER}`,
-  borderRadius: 8, fontFamily: 'var(--font-body)',
-  color: INK, padding: 'var(--space-md)',
-}
-const mobileMetaRow: CSSProperties = {
-  display: 'flex', justifyContent: 'space-between', marginTop: 'var(--space-sm)',
-  fontFamily: 'var(--font-body)', fontSize: 'var(--text-base)',
-}
-const mobileErrorBox: CSSProperties = {
-  fontFamily: 'var(--font-body)', color: ALARM,
-  border: `1px solid ${ALARM}`, borderRadius: 6, padding: 'var(--space-md)', margin: 0,
-}
-const mobilePickerCell: CSSProperties = {
-  display: 'flex', alignItems: 'center', gap: 'var(--space-md)', cursor: 'pointer', width: '100%',
-  background: FIELD, border: `1px solid ${BORDER}`,
-  borderRadius: 8, padding: 'var(--space-md) var(--space-lg)', textAlign: 'left',
-}
-const help: CSSProperties = {
-  fontFamily: 'var(--font-body)', lineHeight: 1.6,
-  color: FAINT, margin: 0,
-}
-const stickyBar: CSSProperties = {
-  position: 'sticky',
-  bottom: 'var(--tab-bar-clearance)',
-  marginTop: 'auto',
-  paddingTop: 'var(--space-sm)',
-}
-const mobilePrimaryBtn: CSSProperties = {
-  width: '100%', cursor: 'pointer', fontFamily: 'var(--font-body)', fontSize: 'var(--text-xl)',
-  letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700,
-  color: ON_ACCENT, background: INK,
-  border: 'none', padding: 'var(--space-lg) var(--space-xl)', borderRadius: 12,
 }


### PR DESCRIPTION
## The seam I tested at

**The rendered markup of every kit `surfaceMap('createCharacter')` holds, at both form factors.** Not the file, and not one archetype: #2992's two structural defects are properties of one tree at one width, so a per-file reading is exactly how they survived seven fan-outs.

`createCharacterStructure.test.tsx` is that seam, derived from the registry (never a typed roster — #2815, #2955). It asserts the field SET and order, and the `[Cancel] … [Create]` order from #646.

**It went red on the real defect before anything was fixed** — 9 rows, every one na or albescent, and none of the seven:

- `na on mobile: name, bio, tagline — in that order and no others` — the phone branch offered three of the form's five slots (`bio`/`tagline` were deliberately absent, #516/#1628).
- `na on desktop / mobile: the leave path is drawn before the commit` — the desktop footer drew `[Create] [Cancel]`, the inverse of #646, and the phone drew no textual cancel at all (only a chevron with `aria-label="Cancel"` in the top row, which is why the probe reads the control's **text** and not an aria-label — a page-wide word search reports that page as correct).

The other three defects have their own checks: the credential card being first in the sheet at both widths (`characterPaths.test.tsx`, and the ring probe in `albescentWrapperKinds`), the classed conic (`credentialCard.test.tsx`, `albescentSpectraMove`), and the footer wrap, which is `ComposerFooter`'s own `flexWrap` rather than something this PR restates.

## What changed

- **`DefaultCreateCharacter.tsx` rebuilt** on `ComposerPage`/`ComposerSheet`/`ComposerSection`/`ComposerFooter`, wearing the na dress `DefaultEditPraxis` already ships. It keeps its own file, tree, dress and ground; no design was drawn. One responsive tree — `MobileColumn`, the "Step 1 of 2" framing, the 104px ring and the sticky bar all retire. Order is the eight siblings' (`heading → CredentialCard → name → bio → tagline → portrait → calling picker → footer`); na keeps the inline commit button rather than the full-bleed band (#1828).
- **`CredentialCard.tsx`** — the unaffiliated portrait hoop wears `.spectrum-dial` instead of an inline `--faction-default-rainbow-conic`. No new CSS. The class is conditional exactly where the ramp already was (`skinned === false`), and because `isKnownFaction('albescent') === false` (#783) an Albescent credential takes the rainbow — so **Albescent's ring turns at both widths** now instead of phone-only.
- **`AlbescentCreateCharacter.tsx`** — docblock only. No structural edit; it inherits the fix whole.
- **`eslint.config.js`** — the `DefaultCreateCharacter` row comes off the `local/no-global-ink-on-faction-surface` exemption list. `DefaultEditCharacter` still stands on the washed app page and keeps it; the block says which file it is arguing about now. Only the exemption list and its own docblock are touched (#2918 may be editing a comment in the colour arm).
- **`createCharacterContrast.test.ts`** — nothing deleted, nothing weakened. Every washed-page row stays (it is the surviving exemption's proof), and a sheet-ground block is added for the create page. Exactly **one** pairing there is genuinely new: `--faction-default-card-alarm` drawn **bare** on the aurora composite (a capped counter, and `PortraitPicker`'s error line), plus its refusal row for `--color-danger` and a "the wash is the tighter reading" guard.
- **`forms.json`** — `createCharacter.mobile.*` and `createCharacter.back` retire. **One deviation from the issue's literal key list, flagged deliberately:** `mobile.help` is *promoted* to `createCharacter.help` rather than deleted. It is the only sentence on this surface that says what being born `na` means, the wide branch never carried it, and deleting it turns `createCharacterCalling.test.tsx`'s "the born-unaffiliated explainer survives" red. If you want it gone, that is a copy decision, not a consequence of this refactor.
- **Doc corrections — this PR owns all three for the sibling lanes** (#2991, #2993): `docs/adr/0090` §Tree, `docs/adr/0065`'s "licence scoped to edit-praxis" paragraph, and `frontend/CLAUDE.md`. Each now carries the boundary the owner ruled: a shared chassis is the expected substrate and is not unifying; one component with a runtime skin table rendering nine trees still is. **No `Status:` line moves** (no ADR is minted here), so `python scripts/adr_index.py` regenerated `docs/adr/README.md` byte-identically — **there is no index hunk, and therefore no conflict with #1084's ADR-0092 regeneration** after all.
- Deliberately **not** touched, per the issue: `docs/adr/0040:9`, `docs/adr/0049:38`, `pages/factionDetail/sectionDisclosure.tsx:18` and its test.

## What I checked

- `npm run lint` — clean.
- `npm run typecheck` (`tsc --noEmit` + `tsconfig.e2e.json`) — clean.
- `npm run typecheck:design-sync` — clean.
- `npm test` — **510 files, 10 604 passed, 1 skipped, 0 failed.**
- `npm run build` — ok. `npm run budget` — exit 0. It prints a JS **WARN** at 149.6 KB; I measured `origin/main` and it prints the identical 149.6 KB, so the warning is pre-existing and this change moves the initial payload not at all (the archetypes are lazy).
- `pytest backend/tests/test_adr_index.py backend/tests/test_adr_numbers_are_unique.py` — 5 passed. No backend route, `response_model` or Pydantic schema is touched, so `api-schema` has nothing to regenerate.
- `retiredSurfaces.test.ts` needed **nothing**: `mobileCreateCharacter` is already listed, and `data-testid="mobile-create-character"` is a different string with no other reader — no e2e spec mentions create-character at all. Nothing appended.

Three files outside the issue's named list changed, each because this work made a comment or an assertion false, and each is reported rather than swept: `frontend/src/factions/albescent.ts` (the `createCharacter` manifest row's docblock described the phone ring), `albescentWrapperKinds.test.tsx` (one describe name and one message; no assertion), and `credentialCard.test.tsx` (its `hoop + mark = 2` inline-conic count is now one inline + one class — the sigil must keep its inline ramp, ADR-0083 §1, and the hoop must not).

## What to eyeball

**No browser and no dev stack ran here. Visual QA is outstanding — nothing below is proven by the green suite above.** The harness is `renderToStaticMarkup` in node; it can see neither layout nor overflow.

At **375px and 1280px, in BOTH light and dark**:

1. **na create** (`/characters/new`, unaffiliated) — the sheet's spectrum frame, the credential card sitting first and staying on the fold, `CREATE & STEP OUT` on one line, callings in one column, and the type on the aurora-washed sheet rather than the old page wash.
2. **Albescent create** — the same, plus **the portrait ring turning at both widths**. It is the delta of this lane; reach it by holding an Albescent invitation and picking the calling (the page reskins live on the pick in progress).
3. **Coven create**, as the control — it must be pixel-unchanged.
4. **The FieldDesk roster** (Landmine 2) — `CredentialCard` is shared, so classing the hoop reaches it. That roster mounts under `.alb-desk`, not `.alb-moves`, so those rings should stand **still**; only the paint's spelling changed. A roster of turning rings would be the failure.
5. **One I found that the issue did not name:** `AlbescentProfileBody` wraps in `.alb-moves` and `profileSkin.tsx` mounts this same card, so **an Albescent profile header's credential ring now turns too**. Same for the Albescent edit preview (`AlbescentEditCharacter`). Both are consistent with the ruling and with the manifest's `editCharacter` row, but neither was in the issue's blast-radius list — please look at the profile header alongside the four above. `#2996` is editing that directory tonight; no file of theirs is touched here.

6. **⚠️ TWO SPECTRA AT TWO SPEEDS ON ONE OBJECT — flagged in review, NOT fixed here, and the one thing on this list I would look at first.** The classed ring spins at 46s (`.alb-moves .spectrum-dial::before`, `alb-spin`) and on the Albescent profile it does so *inside the identity band*, whose edge already travels at 9s. `AlbescentProfileBody.tsx:48-53` names exactly this as the line it refuses to cross — the band "already carries a travelling ring, so moving its ramp too would put two spectra at two speeds on one object", which is the thing #2519 undid on the field desk. That note is about the band's own ramp, and a nested dial is a case it did not anticipate; the `:empty` in the selector that draws the line cannot see it. **This is not mine to fix** — PR #3022 (#2996) rewrites that band tonight, and the coordinator is filing the reconciliation as a follow-up issue. Naming it here so it is not discovered by a player.

## Review round (2026-09-04) — six findings, five fixed on this branch

Pushed to the same branch, no history rewritten (**#3023 is stacked on it**).

1. `character.addPhoto` had zero readers once `MobileColumn`'s `photoAction` retired — deleted, and `src/locales/README.md` no longer documents the pair as live.
2. `surfaceDispatch.test.ts`'s createCharacter note still said "the phone's rainbow photo ring, which starts turning" — corrected to the credential card's ring at both widths; `factions/albescent.ts`, which points at that note by name, now says the two carry the same correction.
3. `createCharacterContrast.test.ts` gained the row that was missing: `--faction-default-card-muted` on `--faction-default-composer-field` (the calling rows' faction names). It matters because `composerGround.test.ts:265` certifies *that same token* as the refused, sub-AA rung on the sheet one layer below — two grounds, two answers, and a reader who follows the refusal and repaints the calling rows breaks nothing that goes red. **It clears: 6.05:1 light, 5.23:1 dark**, against 3.27–4.30 for the same ink on the washed sheet. The field's opacity is asserted rather than assumed, so it cannot silently gain an alpha and turn this into the optimistic reading.
4. `frontend/CLAUDE.md` keeps the boundary sentence but drops the `shared.tsx` path and the component list — paths live in the routing table, and ADR-0065's amendment names the blocks.
5. `characterPaths.test.tsx`'s "on a phone" block pinned `mobile` and could no longer fail for a phone reason. Every case runs at **both** widths now, which is the invariant that replaced it: one tree, and the two must not diverge.
6. The 46s-inside-9s finding — item 6 of *What to eyeball* above. Not fixed here by instruction.

**Follow-up, deferred by instruction:** `createCharacterStructure.test.tsx` clones `createCharacterFields.test.tsx`'s `state()` fixture and its `renderSkin` helper. Two copies of one fixture is a drift surface — the extraction is worth doing, and is deliberately not done in this PR.

Re-run after the review round: lint clean, `typecheck` clean, `typecheck:design-sync` clean, **510 files / 10 609 passed / 1 skipped / 0 failed**, build ok, budget exit 0.

Closes #2992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

