### PR TITLE
One Location-field floor the capped kits read, sized off the frozen placeholder (#2990)

### DIFF
--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import { appendFileSync } from 'node:fs'
 
+import forms from '../src/locales/en/forms.json' with { type: 'json' }
 import { scanPageForContrast, type Finding } from '../src/utils/contrastScan'
 import {
   assessSweep,
@@ -47,16 +48,27 @@ import {
 const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
 const BASELINE_OUT = process.env.CONTRAST_BASELINE_OUT
 
+/**
+ * The Location field's accessible name, from the catalogue rather than typed
+ * here (ADR-0032): every kit gives the input this string through `namedField`,
+ * and a copy edit that moved it would otherwise silently stop selecting a field
+ * — which reads as "no Location field on this kit" instead of "the test is
+ * stale". Used by the fit rows at the bottom of this file.
+ */
+const LOCATION_PLACEHOLDER = forms.character.locationPlaceholder
+
 // This spec opts out of the shared bot's saved cookie: it re-logs per faction
 // against its own dev account so it can't leave other specs' bot in Snide.
 test.use({ storageState: { cookies: [], origins: [] } })
 
-async function loginAs(page: Page, faction: SweepFaction): Promise<void> {
+async function loginAs(page: Page, faction: SweepFaction): Promise<{ characterId: number }> {
   const response = await page.request.post(
     `${API}/auth/dev-login?key=contrast&name=Contrast%20Bot&faction=${faction}`,
   )
   expect(response.ok(), `dev-login?faction=${faction} failed — is the backend up on ${API}?`).toBeTruthy()
-  expect((await response.json()).faction_slug).toBe(faction)
+  const body = await response.json()
+  expect(body.faction_slug).toBe(faction)
+  return { characterId: body.character_id }
 }
 
 async function useTheme(page: Page, theme: SweepTheme): Promise<void> {
@@ -103,4 +115,92 @@ for (const faction of SWEEP_FACTIONS) {
       })
     }
   }
+}
+
+/* ==========================================================================
+ * THE OTHER THING ONLY A BROWSER CAN SEE: does the text fit the box? (#2990)
+ *
+ * These rows ride beside the contrast rows because they need the same three
+ * things and nothing else: the dev-login seam that places one bot in any
+ * faction, a real layout engine, and the loaded webfaces. Per the 2026-08-31
+ * ruling on #2864, geometry has ONE home and it is the rendered sweep — the
+ * unit harness runs in node, does no layout, and a "width" assertion written
+ * there measures nothing. `src/pages/characterPaths/__tests__/
+ * locationFieldFloor.test.ts` is what a PR CAN check: that no archetype
+ * hard-codes a Location `maxWidth` under the shared floor. It cannot check that
+ * the floor is big enough. This can.
+ *
+ * WHAT WENT WRONG WITHOUT IT. `maxWidth: 280` was copied to five edit kits.
+ * `character.locationPlaceholder` is frozen copy (owner ruling #2793, format
+ * question on #2798), and in Courier Prime it measured 259px against 252px of
+ * field — so Everymen dropped the closing parenthesis of "Location (SFO, PDX,
+ * YYZ)" and na dropped it by 5px. Every existing character-path guard asserts
+ * structure, dispatch or contrast; none asserted FIT, so both sat in main until
+ * somebody looked.
+ *
+ * DESKTOP ONLY, ONE THEME, on purpose. The floor is a `maxWidth` — a CAP — so
+ * on a phone the field is narrower than it and the fix cannot govern that
+ * width; a mobile row here would assert a different, unfiled defect against a
+ * number that does not reach it. #2990's AC is desktop. And nothing about a
+ * text width changes with `data-theme`, so a second theme is a second run of
+ * one measurement.
+ *
+ * NOT VERIFIED BY ITS AUTHOR. This suite is nightly and the nightly is red
+ * (#2453, #1674), so these rows did not run in the PR that added them, and no
+ * agent worktree has a browser. The first green nightly is the first
+ * measurement.
+ * ========================================================================== */
+
+for (const faction of SWEEP_FACTIONS) {
+  test(`${faction} · edit-character Location placeholder fits its field`, async ({ page }) => {
+    test.setTimeout(60_000)
+    await page.setViewportSize(SWEEP_VIEWPORTS.desktop)
+    const { characterId } = await loginAs(page, faction)
+
+    await page.goto(`/characters/${characterId}/edit`)
+    await page.waitForLoadState('networkidle')
+    // The faction face arrives on its own stylesheet (#2079) and swaps in after
+    // first paint; measuring before it lands would measure the fallback.
+    await page.evaluate(() => document.fonts.ready.then(() => undefined))
+
+    const field = page.getByRole('textbox', { name: LOCATION_PLACEHOLDER })
+    await expect(field, `${faction}'s edit kit draws no Location field`).toBeVisible()
+
+    const fit = await field.evaluate((element) => {
+      const input = element as HTMLInputElement
+      const style = getComputedStyle(input)
+
+      // A span dressed in the field's own type, measured by the engine that
+      // paints the placeholder. `canvas.measureText` would drop letter-spacing
+      // and text-transform, and these skins use both.
+      const ruler = document.createElement('span')
+      ruler.textContent = input.placeholder
+      const copied = [
+        'fontStyle', 'fontVariant', 'fontWeight', 'fontStretch', 'fontSize',
+        'fontFamily', 'letterSpacing', 'wordSpacing', 'textTransform',
+      ] as const
+      for (const property of copied) ruler.style[property] = style[property]
+      ruler.style.whiteSpace = 'pre'
+      ruler.style.position = 'absolute'
+      ruler.style.visibility = 'hidden'
+      document.body.appendChild(ruler)
+      const text = ruler.getBoundingClientRect().width
+      ruler.remove()
+
+      // `clientWidth` excludes the border and includes the padding — exactly
+      // the box the placeholder is laid into.
+      const inner =
+        input.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight)
+      return { placeholder: input.placeholder, text, inner }
+    })
+
+    expect(
+      fit.text,
+      `${faction}: "${fit.placeholder}" needs ${fit.text.toFixed(1)}px and the field offers ` +
+        `${fit.inner.toFixed(1)}px, so it is clipped by ${(fit.text - fit.inner).toFixed(1)}px. ` +
+        'The copy is frozen (#2793, #2798), so the field is what moves: raise ' +
+        'LOCATION_FIELD_MIN_WIDTH in src/pages/characterPaths/characterFields.ts, or stop ' +
+        'capping this field in this archetype (#2990).',
+    ).toBeLessThanOrEqual(fit.inner)
+  })
 }

--- a/frontend/src/pages/characterPaths/__tests__/locationFieldFloor.test.ts
+++ b/frontend/src/pages/characterPaths/__tests__/locationFieldFloor.test.ts
@@ -1,0 +1,116 @@
+/**
+ * No character archetype pins its Location field under the shared floor (#2990).
+ *
+ * ## The seam, and why it is a source scan
+ *
+ * This file asks one question of TEXT: does any archetype hand-write a
+ * `maxWidth` on the Location input that is smaller than
+ * {@link LOCATION_FIELD_MIN_WIDTH}? That is a property of the source, and the
+ * source is the only place a vitest run can look — the defect #2990 was filed
+ * on is a RENDERED text width against a RENDERED field width, and the unit
+ * harness runs in node with no layout engine. Per the 2026-08-31 ruling on
+ * #2864, geometry has one home and it is the rendered sweep; the fit assertion
+ * lives in `e2e/contrast.spec.ts` and is nightly, not per-PR. Writing a
+ * "measurement" here instead would be a vacuous green.
+ *
+ * So the split is: the sweep measures whether the words fit, this asserts that
+ * the number the sites read is the shared one. The cause of #2990 was a literal
+ * — `maxWidth: 280`, hand-copied to five archetypes, wrong on two of them and
+ * one face change away from wrong on the other three — and a copy of a literal
+ * is exactly what a source scan catches and a render test does not.
+ *
+ * ## The roster is derived, never typed
+ *
+ * `surfaceMap('editCharacter')` and `surfaceMap('createCharacter')`, unwrapped
+ * through `resolvedArchetype` and mapped to their own file by component name.
+ * A tenth faction, or a tenth kit on an existing faction, is scanned the day it
+ * registers with nothing to append here — which is the whole point, since the
+ * next archetype to copy the literal is the one nobody has written yet. An
+ * archetype whose default export is not a named function, or whose file is not
+ * `archetypes/<name>.tsx`, fails loudly rather than being skipped.
+ *
+ * ## What is deliberately not asserted
+ *
+ * Not that a Location field HAS a `maxWidth` — three edit kits give it the full
+ * column and are correct to (#2990 AC 3: this is a floor, not a
+ * regularisation). Not that the cap equals the floor: an archetype may choose
+ * wider. Only that nothing goes under.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+import { surfaceMap } from '../../../factions'
+import { resolvedArchetype } from '../../../factions/lazyArchetype'
+import { LOCATION_FIELD_MIN_WIDTH } from '../characterFields'
+
+/** The two character surfaces that can carry a Location field. */
+const SURFACES = ['editCharacter', 'createCharacter'] as const
+
+/** Every registered character archetype, as `slug · surface` → source text. */
+function archetypeSources(): Array<{ label: string; file: string; source: string }> {
+  return SURFACES.flatMap((surface) =>
+    Object.entries(surfaceMap(surface)).map(([slug, variant]) => {
+      const component = resolvedArchetype(variant as never)
+      const name = component?.name
+      expect(
+        name,
+        `${slug} · ${surface} resolved to an anonymous component — this scan finds an ` +
+          "archetype's file by its default export's name, so give it a named function.",
+      ).toBeTruthy()
+      const file = `archetypes/${name}.tsx`
+      return {
+        label: `${slug} · ${surface}`,
+        file,
+        source: readFileSync(fileURLToPath(new URL(`../${file}`, import.meta.url)), 'utf8'),
+      }
+    }),
+  )
+}
+
+/**
+ * The Location input's own JSX, if the archetype draws one.
+ *
+ * Sliced from the `character.locationPlaceholder` call to the end of that
+ * element, so a `maxWidth` on some OTHER field on the same page is not read as
+ * this one's. The placeholder key is the only unambiguous marker of the field:
+ * every kit reaches it through `namedField`, which is what
+ * `editCharacterDispatch.test.tsx` already holds them to.
+ */
+function locationFieldJsx(source: string): string | null {
+  const start = source.indexOf("character.locationPlaceholder")
+  if (start === -1) return null
+  const end = source.indexOf('/>', start)
+  return source.slice(start, end === -1 ? source.length : end)
+}
+
+/* The roster is built INSIDE the tests, not at collection: archetypes resolve
+   in the `beforeAll` that `src/test/preloadArchetypes.ts` installs, so at
+   collection time every manifest entry is still the deferred wrapper. */
+describe('the Location field floor', () => {
+  it('covers every registered character archetype', () => {
+    // 9 factions × 2 surfaces. A guard whose roster silently emptied would pass
+    // the row below, so the roster itself is the first assertion.
+    expect(archetypeSources().length).toBeGreaterThanOrEqual(18)
+  })
+
+  it('pins no Location maxWidth under the floor', () => {
+    const violations = archetypeSources().flatMap(({ label, file, source }) => {
+      const jsx = locationFieldJsx(source)
+      if (jsx === null) return [] // No Location field on this surface.
+
+      return [...jsx.matchAll(/maxWidth:\s*(\d+)/g)]
+        .map((match) => Number(match[1]))
+        .filter((width) => width < LOCATION_FIELD_MIN_WIDTH)
+        .map((width) => `${label} — ${file} caps the Location field at ${width}px`)
+    })
+
+    expect(
+      violations,
+      `The frozen placeholder "Location (SFO, PDX, YYZ)" needs ${LOCATION_FIELD_MIN_WIDTH}px of ` +
+        'field to render in full, closing parenthesis included. Read ' +
+        'LOCATION_FIELD_MIN_WIDTH from characterFields.ts rather than writing a number at the ' +
+        `call site — that literal is the whole of #2990:\n  ${violations.join('\n  ')}`,
+    ).toEqual([])
+  })
+})

--- a/frontend/src/pages/characterPaths/archetypes/CovenEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/CovenEditCharacter.tsx
@@ -103,7 +103,7 @@ import CredentialCard from '../../../components/CredentialCard'
 import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
 import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
 import PortraitPicker from '../PortraitPicker'
-import { namedField } from '../characterFields'
+import { LOCATION_FIELD_MIN_WIDTH, namedField } from '../characterFields'
 import { DeleteCharacter, FactionRow } from '../editCharacterSlots'
 import type { EditCharacterState } from '../useEditCharacter'
 import { TAGLINE_MAX } from '../useCreateCharacter'
@@ -426,7 +426,7 @@ export default function CovenEditCharacter({ state }: { state: EditCharacterStat
               onChange={(e) => setLocation(e.target.value)}
               maxLength={EDIT_LOCATION_MAX}
               {...namedField(t('character.locationPlaceholder'))}
-              style={{ ...fieldBox, maxWidth: 280 }}
+              style={{ ...fieldBox, maxWidth: LOCATION_FIELD_MIN_WIDTH }}
             />
             {counter(
               t('editCharacter.basedCount', { count: location.length }),

--- a/frontend/src/pages/characterPaths/archetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/DefaultEditCharacter.tsx
@@ -453,10 +453,15 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
               validates the format — the column is free text to 100 chars — so
               the words in the box are the whole of the convention.
 
-              IT TAKES THE CHASSIS FIELD'S OWN WIDTH. The desktop plate pinned it
-              to `maxWidth: 280`, which is the clipping #2990 is open for; that
-              literal is not carried across, and #2990 re-measures on this field
-              rather than on the one it was filed against. */}
+              IT TAKES THE CHASSIS FIELD'S OWN WIDTH, AND THAT IS THE ANSWER TO
+              #2990. The retired desktop plate pinned `maxWidth: 280`, which
+              clipped the placeholder's closing parenthesis by 5px; the literal
+              was not carried across, and #2990 re-measured on this field. The
+              column is 720 less the sheet's 3px frame and its `--space-2xl`
+              inset each side — 650 — so the field's inner width is 624 against
+              259px of placeholder. It clears by 365px and is deliberately
+              uncapped: `LOCATION_FIELD_MIN_WIDTH` is a FLOOR for the kits that
+              cap this field, not a width this one owes. */}
           <ComposerSection rule={false}>
             <input
               data-composer-field

--- a/frontend/src/pages/characterPaths/archetypes/EphemeristsEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EphemeristsEditCharacter.tsx
@@ -96,7 +96,7 @@ import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
 import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
 import PortraitPicker from '../PortraitPicker'
 import { DeleteCharacter, FactionRow } from '../editCharacterSlots'
-import { namedField } from '../characterFields'
+import { LOCATION_FIELD_MIN_WIDTH, namedField } from '../characterFields'
 import type { EditCharacterState } from '../useEditCharacter'
 import { TAGLINE_MAX } from '../useCreateCharacter'
 import {
@@ -429,7 +429,7 @@ export default function EphemeristsEditCharacter({ state }: { state: EditCharact
               onChange={(e) => setLocation(e.target.value)}
               maxLength={LOCATION_MAX}
               {...namedField(t('character.locationPlaceholder'))}
-              style={{ ...fieldBox, maxWidth: 280 }}
+              style={{ ...fieldBox, maxWidth: LOCATION_FIELD_MIN_WIDTH }}
             />
             {counter(t('editCharacter.basedCount', { count: location.length }), location.length >= LOCATION_MAX)}
           </ComposerSection>

--- a/frontend/src/pages/characterPaths/archetypes/EverymenEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EverymenEditCharacter.tsx
@@ -124,7 +124,7 @@ import CredentialCard from '../../../components/CredentialCard'
 import ImageEditModal from '../../../components/imageEdit/ImageEditModal'
 import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
 import PortraitPicker from '../PortraitPicker'
-import { namedField } from '../characterFields'
+import { LOCATION_FIELD_MIN_WIDTH, namedField } from '../characterFields'
 import { DeleteCharacter, FactionRow } from '../editCharacterSlots'
 import type { EditCharacterState } from '../useEditCharacter'
 import { TAGLINE_MAX } from '../useCreateCharacter'
@@ -464,7 +464,7 @@ export default function EverymenEditCharacter({ state }: { state: EditCharacterS
               onChange={(e) => setLocation(e.target.value)}
               maxLength={LOCATION_MAX}
               {...namedField(t('character.locationPlaceholder'))}
-              style={{ ...fieldBox, maxWidth: 280 }}
+              style={{ ...fieldBox, maxWidth: LOCATION_FIELD_MIN_WIDTH }}
             />
             {counter(
               t('editCharacter.basedCount', { count: location.length }),

--- a/frontend/src/pages/characterPaths/archetypes/WowEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowEditCharacter.tsx
@@ -127,7 +127,7 @@ import { AVATAR_ASPECT } from '../../../components/imageEdit/imageEditHelpers'
 import { BalloonBunch, Bunting, Zig } from '../../../components/factionMarks/wowOrnament'
 import { WowSpark } from '../../../components/factionMarks/wowMobile'
 import PortraitPicker from '../PortraitPicker'
-import { namedField } from '../characterFields'
+import { LOCATION_FIELD_MIN_WIDTH, namedField } from '../characterFields'
 import { DeleteCharacter, FactionRow } from '../editCharacterSlots'
 import { TAGLINE_MAX } from '../useCreateCharacter'
 import type { EditCharacterState } from '../useEditCharacter'
@@ -464,7 +464,7 @@ export default function WowEditCharacter({ state }: { state: EditCharacterState 
               onChange={(e) => setLocation(e.target.value)}
               maxLength={LOCATION_LIMIT}
               {...namedField(t('character.locationPlaceholder'))}
-              style={{ ...fieldBox, maxWidth: 280 }}
+              style={{ ...fieldBox, maxWidth: LOCATION_FIELD_MIN_WIDTH }}
             />
             {counter(
               t('editCharacter.basedCount', { count: location.length }),

--- a/frontend/src/pages/characterPaths/characterFields.ts
+++ b/frontend/src/pages/characterPaths/characterFields.ts
@@ -33,3 +33,37 @@
 export function namedField(text: string): { placeholder: string; 'aria-label': string } {
   return { placeholder: text, 'aria-label': text }
 }
+
+/**
+ * The narrowest the Location field may be capped to, in px (#2990).
+ *
+ * WHY A CONSTANT AND NOT FIVE LITERALS. `maxWidth: 280` was hand-copied to five
+ * edit archetypes. Two of them clipped the placeholder's closing parenthesis —
+ * na by 5px, Everymen by 7px — and the three that cleared it did so only
+ * because their faces set narrow at that size, so any of them was one face
+ * change away from the same defect. One number the sites read is the fix; five
+ * numbers is the bug. It is a FLOOR, not a regularisation (#2990 AC 3): an
+ * archetype that wants a wider Location field still says so at its own call
+ * site, it just may not go under this.
+ *
+ * THE ARITHMETIC. `character.locationPlaceholder` is frozen copy — an owner
+ * ruling (#2793), with #2798 owning the airport-code format question — so the
+ * field is sized to the words rather than the words to the field. #2990
+ * measured the string at **259px** in the widest-setting faces on this surface
+ * (Courier Prime on Everymen, Special Elite on S.N.I.D.E.) at `--text-content`.
+ * The field's own chrome eats the rest:
+ *
+ *     259  placeholder, widest measured face
+ *   +  24  horizontal padding — `var(--space-md)` (12px) each side
+ *   +   4  border — the widest is Everymen's 2px frame, each side
+ *   = 287  the true minimum
+ *
+ * 300 is that minimum rounded up: ~13px of cushion for subpixel rounding and
+ * for the fallback face that paints before a webfont swaps in. The measurement
+ * that actually decides this is rendered, not computed — the guard for it is
+ * the nightly sweep (`e2e/contrast.spec.ts`), per the #2864 ruling that
+ * geometry has one home and vitest is not it. What a PR-time test CAN see is
+ * that no archetype hard-codes a Location `maxWidth` under this floor, and
+ * `locationFieldFloor.test.ts` is that scan.
+ */
+export const LOCATION_FIELD_MIN_WIDTH = 300


### PR DESCRIPTION
The Location placeholder had a width, the field had a different one, and the second was hand-copied to five archetypes. This gives the four that still cap the field one number to read, sized off the placeholder rather than off nothing.

## The seam

Two, and the split is the #2864 ruling:

- **The cause is a literal, and a literal is source.** `maxWidth: 280` was copied to five edit kits. The PR-time guard is a **source scan** — `src/pages/characterPaths/__tests__/locationFieldFloor.test.ts` — asserting that no registered character archetype hard-codes a Location `maxWidth` under the shared floor. Its roster comes from `surfaceMap('editCharacter')` and `surfaceMap('createCharacter')`, unwrapped through `resolvedArchetype`, so a tenth kit is covered the day it registers and there is no typed list to forget. It went **red at the first commit on exactly the four real sites** (Everymen, WoW, Ephemerists, Coven), green at the second.
- **The defect is a rendered width, and that is not vitest's.** The fit assertion lives in the rendered sweep, `frontend/e2e/contrast.spec.ts`, beside the contrast rows — it needs the same three things they need: the dev-login seam, a layout engine, loaded faces. Nine rows, one per registered edit archetype, dressing a span in the field's own computed type and measuring it against `clientWidth` minus padding.

## The arithmetic

`character.locationPlaceholder` is frozen copy (owner ruling #2793; #2798 owns the airport-code format question), so the field is sized to the words. The issue measured the string at **259px** in the widest-setting faces on this surface — Courier Prime on Everymen, Special Elite on S.N.I.D.E. — at `--text-content`:

```
  259  placeholder, widest measured face
+  24  horizontal padding — var(--space-md) is 12px, each side
+   4  border — the widest is Everymen's 2px frame, each side
= 287  the true minimum
```

`LOCATION_FIELD_MIN_WIDTH = 300` is that rounded up: ~13px of cushion for subpixel rounding and for the fallback face that paints before a webfont swaps. The arithmetic is written out at the constant, not just here.

That the old number was 280 checks out against the issue's own measurements: 280 − 24 − 2 = **254** available on the 1px-bordered kits, 280 − 24 − 4 = **252** on Everymen's 2px frame. Exactly the two figures in the issue's table.

It is a **floor, not a regularisation** (AC 3). Three edit kits give the field the whole column and keep it; the four that cap it now cap it at one shared number, and a kit that wants wider still says so at its own call site.

## Per-archetype

**Edit ×9** — `grep -rn "maxWidth: 280" frontend/src/pages/characterPaths/archetypes/` returned four sites, not five: #3023 rebuilt the na kit on the chassis and dropped the literal on its way past.

| archetype | before | verdict |
|---|---|---|
| **everymen** | `maxWidth: 280` → 252px inner vs 259px of Courier Prime | **fixed** — the clipped one |
| **na / Default** | uncapped since #3023 | **clears** — 720 column less the sheet's 3px frame and `--space-2xl` each side = 650; field inner 624 vs 259, spare 365. Comment only |
| **albescent** | wraps `DefaultEditCharacter` in one `div` | **clears** — inherits na's field |
| coven | `maxWidth: 280` | **fixed** — passed on a narrow face, one face change from the defect |
| ephemerists | `maxWidth: 280` | **fixed** — same |
| wow | `maxWidth: 280` | **fixed** — same |
| ua | uncapped, full-column field | **not affected** |
| singularity | uncapped, full-column field | **not affected** |
| snide | uncapped, full-column field | **not affected** |

**Create ×9 (AC 4)** — all nine **not affected**, and for a stronger reason than "measured wider": Create Character has no Location field at all. The field only exists on the edit surface.

```
$ grep -rin "location" frontend/src/pages/characterPaths/archetypes/*CreateCharacter.tsx
(no matches)
```

The new scan sweeps both registries anyway (18 rows), so the day a create kit grows one it is covered without an edit here.

## What I checked, and what I could not

Run in the worktree, all green: `npm run lint`, `npm run typecheck` (app **and** `tsconfig.e2e.json`), `npm run typecheck:design-sync`, `npm test` (**521 files, 11010 passed, 1 skipped**), `npm run build`, `npm run budget` (exit 0 — the JS `WARN` is pre-existing on main and unmoved by a constant and five one-line edits). No API contract touched, so `api-schema` has nothing to regenerate.

**I could not measure a rendered width.** An agent worktree has no browser and no dev stack, so the claim "300 is enough" is arithmetic, not observation. The measurement lives in the sweep — and **the sweep is nightly and the nightly is currently red (#2453, #1674), so the new rows do not gate this PR and did not run on it.** What I verified there is that they collect: `npx playwright test --list e2e/contrast.spec.ts` shows the nine `… · edit-character Location placeholder fits its field` rows. First green nightly is the first real measurement.

The copy is untouched. `forms.json` is not in the diff.

## What to eyeball

Visual QA is outstanding — this is the half a green suite cannot cover.

- **na / Default edit** at 900 / 1100 / 1440px, **light and dark**: the placeholder reads `Location (SFO, PDX, YYZ)` with the **closing parenthesis visible**. It is now uncapped, so also worth a glance that a full-column Location field does not look odd beside the fields above it.
- **Everymen edit** at 900 / 1100 / 1440px, **light and dark**: same — the closing paren is there. This is the 7px case.
- **Coven, Ephemerists, WoW edit**, same widths and both themes: **unchanged by eye**. Their fields grew 280 → 300px; nothing else about them moved, and nothing should look different.
- Mobile (375px) on any of them: the floor is a `maxWidth`, so it does not bind on a phone and nothing should have shifted.

Repro seam, from the issue: `POST /auth/dev-login?key=qa&name=QA%20Walker&faction=everymen&level=3`, then `/characters/<id>/edit`.

Closes #2990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
