### PR TITLE
The Albescent profile header's credential ring stands still inside the band that travels (#3024)

### DIFF
--- a/frontend/src/__tests__/albescentSpectraMove.test.tsx
+++ b/frontend/src/__tests__/albescentSpectraMove.test.tsx
@@ -192,11 +192,13 @@ describe('the census: every Albescent surface with a classed spectrum wears the 
  * panel on the praxis detail, the profile's identity band. This is that
  * paragraph, in a form the suite can read.
  *
- * `.spectrum-dial` has no rows and that is not an omission: neither of its
+ * `.spectrum-dial` has no rows HERE and that is not an omission: neither of its
  * selectors carries `:empty`. The rim is drawn whether or not there is a face,
  * and `.alb-moves .spectrum-dial > *` lifts the face when there is one, so a
  * dial has no childless-ness to pin. `FdlLaurel`'s dial is childless and the
  * roster medallion's is not; both are correct, which is why neither is listed.
+ * The dial's own ornament/frame line is a different question with a different
+ * answer, and #3024 put it in the third census at the bottom of this file.
  *
  * READ FROM SOURCE, NOT FROM A RENDER, deliberately. Several of these mounts
  * sit behind a prop or a form factor (`hasWorking`, `eyebrowFaction`,
@@ -355,6 +357,134 @@ describe('the census, per mount: which spectra travel and which frame content', 
               'a travelling child will paint over what the frame frames.',
         ).toBe(kind === 'ornament')
       })
+    })
+  }
+})
+
+/**
+ * THE DIAL CENSUS, AND THE SHARED COMPONENT THE OTHER TWO CANNOT SEE (#3024).
+ *
+ * The two censuses above read the na and Albescent ARCHETYPE files. That is the
+ * blind spot #2992's own comment in `components/CredentialCard.tsx` names: the
+ * ring on the create page, the edit page and the profile header is one
+ * `.spectrum-dial` declared in a SHARED component, which is not a `Default*`
+ * archetype and appears in no manifest, so no row looked at it — and it is
+ * precisely a shared spectrum that reaches surfaces its author was not thinking
+ * about. This walk is over `src/`, so the next one has a row the day it lands.
+ *
+ * THE DIAL'S OWN ORNAMENT/FRAME LINE. `.spectrum-rule`'s is `:empty`, written
+ * into the selector. A dial has no such guard — `.alb-moves .spectrum-dial`
+ * turns anything wearing the class — so the line is drawn at the MOUNT instead:
+ *
+ *   ORNAMENT — nothing around it travels, so the dresser may turn it. It wears
+ *     the class.
+ *   FRAME — an object that already travels holds it, so a second spectrum on it
+ *     would be two speeds on one object (#2519). It must NOT wear the class,
+ *     and `CredentialCard`'s `stillRing` is how one mount says so — the ramp
+ *     comes back inline in the class's place, because the class carries the
+ *     resting conic as well as the reach.
+ *
+ * One frame today: the profile header's credential ring, inside the identity
+ * band `.alb-profile-edge` travels on — the same object the `.spectrum-rule`
+ * table above lists as a frame, one layer further in.
+ *
+ * READ FROM SOURCE for the reason the table above gives, plus one of its own:
+ * whether a ring turns is decided at the mount, and `profileSkin` is the only
+ * file that decides it for the profile. `albescentProfileRingStill.test.tsx`
+ * renders both surfaces and asserts the same thing from the other side.
+ */
+const DIAL_MOUNTS: Record<string, readonly Mount[]> = {
+  // The shared credential card's portrait ring — the create preview, the edit
+  // preview and the profile header, at both widths since #2992.
+  '../components/CredentialCard.tsx': [
+    ['ornament', 'the portrait ring, wherever the mount does not stand it still'],
+  ],
+  '../components/factionMarks/DefaultPointsRing.tsx': [
+    ['ornament', "the task card's points ring"],
+  ],
+  '../pages/characterProfile/archetypes/DefaultProfileBody.tsx': [
+    ['ornament', "the FDL laurel's ring"],
+    ['ornament', 'the badge medallion'],
+  ],
+  // The profile header's mount of the card above. It declares no dial of its
+  // own and stands one still, which is the whole row.
+  '../pages/characterProfile/archetypes/profileSkin.tsx': [
+    ['frame', "the credential ring — `.alb-profile-edge` already travels on the band around it"],
+  ],
+  '../pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx': [
+    ['ornament', "the member's avatar dial"],
+  ],
+}
+
+/**
+ * A file's source with its COMMENTS TAKEN OUT. Every scan below reads a class
+ * name out of a string literal, and this kit names both classes in prose far
+ * more often than it mounts them — `CredentialCard`'s docblock quotes
+ * `.spectrum-dial` five times above the line that writes it.
+ */
+function code(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n')
+}
+
+/** Every `.spectrum-dial` a file declares — in a `className` attribute or, as
+ *  the credential card does, in a string on its way to one. */
+const dialMounts = (source: string) =>
+  [...code(source).matchAll(/(["'])[^"']*\bspectrum-dial\b[^"']*\1/g)].length
+
+/** Every mount of the shared card that stands its ring still (#3024). */
+const stilledRings = (source: string) =>
+  [...code(source).matchAll(/<CredentialCard\b[^>]*\bstillRing\b/g)].length
+
+/** Every file under `src/` that decides whether a dial turns — by mounting the
+ *  class, or by taking it off a ring. Tests aside. */
+const filesDecidingADial = () =>
+  sourceFiles({ dir: SRC, match: /\.tsx$/ })
+    .filter((path) => {
+      const source = readFileSync(path, 'utf8')
+      return dialMounts(source) > 0 || stilledRings(source) > 0
+    })
+    .map((path) => `../${toRelative(path)}`)
+    .sort()
+
+describe('the census, per dial: which rings turn and which stand still', () => {
+  it('the table classifies every file in src/ that decides whether a dial turns', () => {
+    expect(
+      filesDecidingADial(),
+      'A dial declared in a SHARED component reaches every surface that mounts ' +
+        'it, including ones whose motion is already spoken for. A new one needs ' +
+        'a row saying which it is.',
+    ).toEqual(Object.keys(DIAL_MOUNTS).sort())
+  })
+
+  for (const [path, table] of Object.entries(DIAL_MOUNTS)) {
+    const file = path.slice(path.lastIndexOf('/') + 1)
+    const named = (kind: Mount[0]) =>
+      table.filter(([mountKind]) => mountKind === kind).map(([, name]) => name)
+    const turning = named('ornament')
+    const still = named('frame')
+
+    it(`${file}: ${turning.join(', ') || 'nothing here'} wears the class`, () => {
+      expect(
+        dialMounts(read(path)),
+        `${file} declares ${dialMounts(read(path))} \`.spectrum-dial\` mounts ` +
+          `and the table classifies ${turning.length} as turning.`,
+      ).toBe(turning.length)
+    })
+
+    it(`${file}: ${still.join(', ') || 'nothing here'} stands still`, () => {
+      expect(
+        stilledRings(read(path)),
+        still.length === 0
+          ? `${file} has started standing a credential ring still. That is a ` +
+            'FRAME mount and needs a row saying what travels around it.'
+          : `${file} has stopped standing ${still.join(', ')} still, so ` +
+            '`.alb-moves .spectrum-dial::before` reaches it again and the ' +
+            'object around it carries two spectra at two speeds (#2519).',
+      ).toBe(still.length)
     })
   }
 })

--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -22,6 +22,28 @@ export interface CredentialCardProps {
   size?: number
   /** Slight tilt for the FieldDesk roster (degrees). */
   rotation?: number
+  /**
+   * Stand the portrait ring STILL, for a mount whose surround already moves
+   * (#3024). One mount passes it: the profile header, where the card sits
+   * inside an identity band carrying `.alb-profile-edge` — a 9s travelling
+   * ramp. Two spectra at two speeds on one object is the doubling #2519 spent a
+   * PR undoing, and `AlbescentProfileBody`'s docblock excludes that band from
+   * the moving set for the same reason.
+   *
+   * It suppresses the CLASS, which is the only lever: `.alb-moves
+   * .spectrum-dial::before` carries no `:empty` guard the way the rule's
+   * selector does, so there is nothing else for a frame mount to fail to match.
+   * The RAMP comes back inline in its place — `.spectrum-dial` carries the
+   * resting conic as well as the reach (`spectrumClasses.test.tsx` pins that
+   * from the stylesheet side), so dropping the class alone would take the
+   * rainbow hoop off every na and Albescent profile header rather than standing
+   * it still. Which is why this is a prop and not a caller wrapping the card:
+   * still is not gone.
+   *
+   * Named for what it means and not for the class: nothing outside is asked to
+   * know the spelling of a mark this card owns.
+   */
+  stillRing?: boolean
   /** Upload affordance for the creation preview. */
   onAvatarClick?: () => void
 }
@@ -81,6 +103,7 @@ export default function CredentialCard({
   avatarUrl,
   size = 266,
   rotation = 0,
+  stillRing = false,
   onAvatarClick,
 }: CredentialCardProps) {
   const { t } = useTranslation('common')
@@ -148,7 +171,18 @@ export default function CredentialCard({
             // themed factions keep their accent hoop. The unaffiliated half is
             // `.spectrum-dial` below — the conic cut of the na spectrum, said
             // once in index.css — so only the themed hoop is declared here.
-            background: skinned ? 'var(--fc-accent)' : undefined,
+            //
+            // ...and inline for the ONE mount that opts out of the class, which
+            // is the same ramp by the same name rather than a second paint: the
+            // class is the reach AND the resting conic, so a still ring has to
+            // carry the second one itself (`stillRing`). It is the spelling
+            // `DefaultAvatar` and `CharacterSwitcherSheet` already use for a
+            // hoop no dresser may reach.
+            background: skinned
+              ? 'var(--fc-accent)'
+              : stillRing
+                ? 'var(--faction-default-rainbow-conic)'
+                : undefined,
             border: 'none',
             cursor: onAvatarClick ? 'pointer' : 'default',
             boxShadow: '0 4px 14px var(--color-cast-shadow)',
@@ -173,8 +207,16 @@ export default function CredentialCard({
            *
            * The FieldDesk life-cards mount this card under `.alb-desk`, not
            * `.alb-moves`, so that roster's rings stand still — the paint moved,
-           * nothing else. */
-          const ringClass = skinned ? undefined : 'spectrum-dial'
+           * nothing else.
+           *
+           * ...AND THE PROFILE HEADER IS THE ONE MOUNT THAT OPTS OUT (#3024).
+           * "Wherever an `.alb-moves` wrapper is the ancestor" was one surface
+           * too many: on that header the card sits INSIDE the identity band,
+           * which is already a travelling ramp, so the sentence above put a 9s
+           * edge and a 46s ring on one object. `stillRing` is that mount saying
+           * so — see the prop, and `albescentSpectraMove`'s dial census for the
+           * row that keeps a second one from arriving unnoticed. */
+          const ringClass = skinned || stillRing ? undefined : 'spectrum-dial'
           const inner = (
             <div
               style={{

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -263,3 +263,48 @@ describe('CredentialCard portrait ring — the label names what the control does
     expect(html).not.toContain('upload')
   })
 })
+
+/**
+ * `stillRing` — the card's one motion knob (#3024).
+ *
+ * The ring wears `.spectrum-dial` so `.alb-moves` can turn it (#2992). One
+ * mount cannot have that: the profile header sits the card inside an identity
+ * band that already travels, and two spectra at two speeds on one object is the
+ * doubling #2519 undid. The card is where the opt-out belongs, because the ring
+ * and its ramp are the card's — the header knows only that its surround moves.
+ *
+ * The paint is the half worth pinning here. `.spectrum-dial` carries the
+ * resting conic as well as the reach (`spectrumClasses.test.tsx` asserts that
+ * from the stylesheet side), so an opt-out that only dropped the class would
+ * un-paint the hoop on every profile header rather than standing it still.
+ */
+describe('CredentialCard still ring', () => {
+  const ring = (props: { factionSlug: string | null; stillRing?: boolean }) => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" level={1} score={0} {...props} />,
+    )
+    const at = html.indexOf('width:136px')
+    return html.slice(html.lastIndexOf('<', at), html.indexOf('>', at) + 1)
+  }
+
+  it('keeps the class by default, wherever the mount says nothing', () => {
+    expect(ring({ factionSlug: 'na' })).toContain('class="spectrum-dial"')
+  })
+
+  it.each(['na', 'albescent', null])(
+    'trades the class for the ramp it carries, for %s',
+    (slug) => {
+      const still = ring({ factionSlug: slug, stillRing: true })
+      expect(still, 'nothing for `.alb-moves .spectrum-dial` to reach').not.toContain(
+        'spectrum-dial',
+      )
+      expect(still, 'still, not gone').toContain('var(--faction-default-rainbow-conic)')
+    },
+  )
+
+  it('leaves a themed hoop alone — it was never the spectrum', () => {
+    const themed = ring({ factionSlug: 'coven', stillRing: true })
+    expect(themed).toContain('var(--fc-accent)')
+    expect(themed).not.toContain('rainbow-conic')
+  })
+})

--- a/frontend/src/pages/characterProfile/__tests__/albescentProfileRingStill.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/albescentProfileRingStill.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * ONE MOVING SPECTRUM ON THE ALBESCENT PROFILE HEADER (#3024).
+ *
+ * ## The seam
+ *
+ * The rendered markup of `surfaceMap('profileBody')`'s albescent kit and of
+ * `surfaceMap('createCharacter')`'s, at both widths — the two surfaces the ONE
+ * shared `CredentialCard` ring reaches with opposite answers. Both are read
+ * through the registry rather than by importing an archetype, for the reason
+ * every dispatch walk in this repo is (#2815, #2955): a typed roster cannot
+ * notice the kit that moves.
+ *
+ * ## What went red here
+ *
+ * #3019 classed the card's na ring `.spectrum-dial` so Albescent's CREATE ring
+ * turns at both widths. The card is shared, and the profile header mounts it
+ * inside the identity band — which already carries `.alb-profile-edge`, a 9s
+ * travelling ramp. `.alb-moves .spectrum-dial::before` has no `:empty` guard to
+ * exclude it, so the header showed a 9s edge and a 46s ring on one object: the
+ * two-spectra-at-two-speeds doubling #2519 spent a PR undoing, and the exact
+ * thing `AlbescentProfileBody`'s docblock excludes the band from the moving set
+ * to avoid.
+ *
+ * ## Why the ring is read by its geometry
+ *
+ * The na profile draws two OTHER dials that must keep turning (the FDL laurel's
+ * ring, the badge medallions), so "the page holds no `.spectrum-dial`" is the
+ * wrong assertion and would go green on a page whose whole tell had died. The
+ * card's portrait ring is the one 136px round mount it draws, so the tag around
+ * that width is the mount under test.
+ *
+ * ## The paint half, which is not a detail
+ *
+ * `.spectrum-dial` carries the RESTING conic as well as the reach — dropping the
+ * class with nothing in its place would take the rainbow hoop off every na and
+ * Albescent profile header rather than standing it still. So each row asserts
+ * the ramp is still on the ring it just took the class off.
+ *
+ * `renderToStaticMarkup` in node (SPEC-testing): no DOM and no compositor, so
+ * nothing here proves a pixel. The pixels are visual QA, stated outstanding on
+ * the PR.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+import '../../../i18n'
+import type { CharacterOut } from '../../../api/auth'
+import { aTask, aPraxisCard } from '../../../test/fixtures'
+import { resolveVariant } from '../../../utils/factionDispatch'
+import { surfaceMap } from '../../../factions'
+import type { ProfileBodyProps } from '../FactionProfileBody'
+import type { CreateCharacterState } from '../../characterPaths/useCreateCharacter'
+
+const factor = vi.hoisted(() => ({ value: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../hooks/useFormFactor')>()),
+  useFormFactor: () => factor.value,
+}))
+
+type Width = 'desktop' | 'mobile'
+const WIDTHS: readonly Width[] = ['desktop', 'mobile']
+
+const CONIC = '--faction-default-rainbow-conic'
+
+function character(slug: string): CharacterOut {
+  return {
+    id: 7,
+    username: 'reza',
+    display_name: 'Reza',
+    bio: 'A short bio, so the About block really renders.',
+    tagline: 'Small acts, kept up.',
+    avatar_url: '',
+    location: '',
+    level: 7,
+    score: 1880,
+    all_time_score: 2400,
+    faction_slug: slug,
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [{ key: 'sock_puppet', name: 'Sock Puppet' }],
+    invitations: [],
+  }
+}
+
+function profile(slug: string, width: Width): string {
+  factor.value = width
+  const Archetype = resolveVariant(surfaceMap('profileBody'), slug)
+  const props: ProfileBodyProps = {
+    character: character(slug),
+    submissions: [aPraxisCard({ id: 1, title: 'A quiet finding' })],
+    proposedTasks: [aTask({ id: 1, title: 'Plant a tree' })],
+    progression: {
+      nextLevel: 8,
+      currentThreshold: 1500,
+      nextThreshold: 2000,
+      pointsIntoLevel: 380,
+      levelSpan: 500,
+      progressPercent: 76,
+    },
+    identityActions: <div>Friend</div>,
+  }
+  try {
+    return renderToStaticMarkup(
+      <MemoryRouter>
+        <Archetype {...props} />
+      </MemoryRouter>,
+    )
+  } finally {
+    factor.value = 'desktop'
+  }
+}
+
+function creation(slug: string, width: Width): string {
+  factor.value = width
+  const Archetype = resolveVariant(surfaceMap('createCharacter'), slug)
+  const state: CreateCharacterState = {
+    displayName: 'Molly',
+    setDisplayName: () => {},
+    bio: '',
+    setBio: () => {},
+    tagline: '',
+    setTagline: () => {},
+    factionSlug: slug,
+    setFactionSlug: () => {},
+    invited: [],
+    avatarFile: null,
+    avatarPreview: null,
+    avatarSource: null,
+    setAvatarSource: () => {},
+    avatarError: '',
+    setAvatarError: () => {},
+    handleAvatarChange: () => {},
+    handleAvatarConfirm: () => {},
+    error: null,
+    submitting: false,
+    canSubmit: true,
+    handleSubmit: () => {},
+    handle: 'molly',
+    showPicker: true,
+  }
+  try {
+    return renderToStaticMarkup(
+      <MemoryRouter>
+        <Archetype state={state} />
+      </MemoryRouter>,
+    )
+  } finally {
+    factor.value = 'desktop'
+  }
+}
+
+/** The credential card's portrait ring: the one 136px round mount it draws. */
+function portraitRing(html: string): string {
+  const at = html.indexOf('width:136px')
+  expect(at, 'the credential card drew no portrait ring').toBeGreaterThan(-1)
+  return html.slice(html.lastIndexOf('<', at), html.indexOf('>', at) + 1)
+}
+
+describe('the profile header: the band travels, the ring inside it does not', () => {
+  for (const width of WIDTHS) {
+    it(`albescent stands its credential ring still on ${width}`, () => {
+      const html = profile('albescent', width)
+      // The band is the carrier, and it is still moving — a page that lost its
+      // whole tell would otherwise pass the line below.
+      expect(html, "the identity band's travelling edge").toContain('alb-profile-edge')
+      expect(html, 'the marker the dresser rides on').toContain('alb-moves')
+      const ring = portraitRing(html)
+      expect(
+        ring,
+        'the credential ring is a FRAME mount here — `.alb-profile-edge` already ' +
+          'travels on the band around it, and `.alb-moves .spectrum-dial::before` ' +
+          'would put a second spectrum at a second speed on one object (#2519).',
+      ).not.toContain('spectrum-dial')
+      expect(ring, 'still, not gone: the ring keeps its resting ramp').toContain(CONIC)
+    })
+
+    it(`the na profile keeps its spectrum hoop on ${width}`, () => {
+      // The mount is shared, so na takes the same still ring. Nothing dresses
+      // na, so its ring never turned either way — what this row holds is the
+      // PAINT: `.spectrum-dial` carries the resting conic as well as the reach,
+      // so the ramp has to travel with the class off the mount, or the header's
+      // rainbow hoop goes plain on nine profiles instead of standing still.
+      const ring = portraitRing(profile('na', width))
+      expect(ring, 'the same unclassed mount').not.toContain('spectrum-dial')
+      expect(ring, 'na keeps its hoop').toContain(CONIC)
+    })
+  }
+
+  for (const width of WIDTHS) {
+    it(`character creation keeps the albescent ring turning on ${width}`, () => {
+      // #3019's behaviour, kept: the create ring is an ORNAMENT — no travelling
+      // object holds it, so the dresser reaches it at both widths.
+      const html = creation('albescent', width)
+      expect(html).toContain('alb-moves')
+      expect(portraitRing(html), 'the create ring is classed').toContain('spectrum-dial')
+    })
+  }
+})

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -601,8 +601,24 @@ export function ProfileSkin({
   const frameIdentity = (band: ReactNode) =>
     kit.headerFrame ? kit.headerFrame(band, identityOrnament) : band
 
+  /**
+   * `stillRing` IS THIS SURFACE'S ONE DIFFERENCE FROM EVERY OTHER MOUNT OF THIS
+   * CARD (#3024). The header's card sits inside the identity band, and on
+   * Albescent that band is the page's carrier — `.alb-profile-edge`, a 9s
+   * travelling ramp reached through {@link ProfileKit.headerFrame}. The card's
+   * na portrait ring wears `.spectrum-dial` (#2992), which `.alb-moves` turns at
+   * 46s wherever it can reach it, so the two together were two spectra at two
+   * speeds on one object — the doubling #2519 undid and the reason
+   * `AlbescentProfileBody` keeps this band out of the moving set.
+   *
+   * One carrier per object, so the ring stands still HERE and nowhere else: the
+   * creation and edit previews keep turning, because nothing travels around
+   * them. The prop suppresses the class and keeps the ramp; the card's own
+   * comment says why those are one decision.
+   */
   const credential = (
     <CredentialCard
+      stillRing
       displayName={character.display_name}
       handle={character.username}
       factionSlug={character.faction_slug}


### PR DESCRIPTION
Fix (a) from the issue: `CredentialCard` takes an opt-out, and the profile header's
single mount in `profileSkin.tsx` passes it. No CSS changes.

## The seam

Two, both named before any code was written.

1. **The render seam** — `frontend/src/pages/characterProfile/__tests__/albescentProfileRingStill.test.tsx`.
   `surfaceMap('profileBody')` → albescent and `surfaceMap('createCharacter')` →
   albescent, rendered at **both widths** through the registry (never a typed
   roster, #2815/#2955). The profile rows assert the credential ring carries no
   `spectrum-dial` class while the band's `.alb-profile-edge` is still present;
   the create rows assert the ring **does** carry it. Read by geometry (the
   card's one 136px round mount) because the na profile draws two other dials —
   the FDL laurel's ring and the badge medallions — that must keep turning, so
   "the page holds no dial" would go green on a page whose whole tell had died.

   **Proved red first:** the two albescent profile rows failed on
   `expected '<div class="spectrum-dial" ...' not to contain 'spectrum-dial'`;
   the create rows were green from the start, which is #3019's behaviour kept.

2. **The census seam** — `albescentSpectraMove.test.tsx` gains a third table,
   the dial census. Re-verified red after the fix by deleting `stillRing` from
   `profileSkin.tsx`: the frame row and the derived key set both fail.

## What changed

- `components/CredentialCard.tsx` — new `stillRing?: boolean`. It suppresses the
  `.spectrum-dial` class **and puts the ramp back inline in its place**. That
  second half is not decoration: `.spectrum-dial` carries the resting conic as
  well as the reach (`spectrumClasses.test.tsx` pins that from the stylesheet
  side), so dropping the class alone would take the rainbow hoop off every na
  and Albescent profile header rather than standing it still. Still is not gone.
  The inline spelling is the one `DefaultAvatar` and `CharacterSwitcherSheet`
  already use for a hoop no dresser may reach.
- `pages/characterProfile/archetypes/profileSkin.tsx` — the one mount passes it,
  with the reason at the call site. Nothing else in that file moved.
- `__tests__/albescentSpectraMove.test.tsx` — the **dial census**. The two
  existing maps read the na/Albescent *archetype files*, which is exactly why a
  spectrum declared in a shared component was invisible (#3019's own comment in
  `CredentialCard.tsx` says so). The new table scans **every `.tsx` under
  `src/`** for a mounted or a suppressed dial and asserts the file list equals
  its keys — derived, no hand-typed list, so the next shared ring gets a row the
  day it lands. Five files today: `CredentialCard`, `DefaultPointsRing`,
  `DefaultProfileBody` (×2), `DefaultPraxisDetail`, and `profileSkin` as the one
  **FRAME** row. A dial's ornament/frame line cannot be `:empty` (no dial
  selector carries it), so it is drawn at the mount: ornament wears the class,
  frame does not because something around it already travels. The
  `.spectrum-rule` table already lists that identity band as a frame — this is
  the same object one layer in.
- `components/__tests__/credentialCard.test.tsx` — the card's half of the
  contract: default keeps the class; `stillRing` trades it for the ramp it
  carries (na, albescent, no slug); a themed hoop is untouched.

## What I checked

Every step `.github/workflows/test.yml`'s `frontend` job names, locally:

- `npm run lint` — clean.
- `npx tsc --noEmit` — clean (`tsc --version` → 5.9.3, so not a false pass).
- `npm run typecheck:design-sync` — clean.
- `npm test` — **521 files, 11030 passed, 1 skipped**, 0 failed.
- `npm run build` — succeeds.
- `npm run budget` — JS `WARN 150.2 KB` (warn > 130.9, fail > 175.8) and
  `ALB 50 / allow 50`. Both **pre-existing**: this branch adds no import, no
  module and no class selector — the diff is one boolean prop, one call site and
  three test files.

`api-schema` is not in scope: no route, `response_model` or Pydantic schema is
touched, and no backend file is in the diff.

## What to eyeball (visual QA outstanding — I have no browser)

- **Albescent profile header, 375px and 1280px, both themes** — exactly ONE
  moving spectrum: the identity band's edge drifting at 9s. The credential
  ring inside it stands still and is still a **rainbow hoop**, not a plain one.
- **Albescent create character, 375px and 1280px** — the credential ring is
  still turning (46s). Same on the Albescent edit-character preview.
- **na profile header, both themes** — the ring's paint is unchanged from `main`
  (it never moved; only where its ramp is written changed).
- **FieldDesk roster, Albescent** — unchanged: those cards mount under
  `.alb-desk`, not `.alb-moves`, so their rings were already still.
- **Reduced motion** — nothing here touches the gate; both surfaces should look
  exactly as they do with motion off today.

## One stale sentence I did NOT touch (outside this PR's footprint)

`pages/characterPaths/archetypes/AlbescentCreateCharacter.tsx:30` still says the
card's class "reaches the edit preview and the profile header too, wherever an
`.alb-moves` wrapper is the ancestor". After this PR the profile header is the
one exception. That file belongs to another lane tonight, so the correction is
left for it or a follow-up; `CredentialCard.tsx`'s own comment and the census
both say the new rule. `factions/albescent.ts` was read and needs nothing — its
`profileBody` row never mentions the ring, and its create/edit rows are still
accurate.

Closes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)
