### PR TITLE
The praxisDetail spine, held once: PraxisDetailSkin + nine kits, 189 hashes unmoved (#2718)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -24,11 +24,10 @@
  * throwing. We assert the structural anchors each slot leaves behind: the
  * finding text, the "re:" task link, and the author-byline character link.
  */
-import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { surfaceMap } from "../../../factions";
 import { describe, it, expect } from "vitest";
-import { readStripped, SRC_DIR } from "../../../test/sourceScan";
+import { readStripped, sourceFiles, SRC_DIR, toRelative } from "../../../test/sourceScan";
 // Initialize the i18n catalog so shared-chrome copy keys resolve to English text.
 import i18n from "../../../i18n";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
@@ -535,20 +534,20 @@ const SKIN_OWNED = [
  * field keeps that true here without a line of mapping.
  */
 function archetypeSources(): Record<string, string> {
-  const dir = join(SRC_DIR, "factions");
-  const manifests = readdirSync(dir).filter(
-    (name) => name.endsWith(".ts") && name !== "index.ts" && name !== "manifest.ts",
-  );
+  // Through the shared walk, never a private `readdirSync` — #2887's rule, and
+  // the reason is exactly this guard's failure mode: a scan that quietly stops
+  // reaching files reports a perfect board.
+  const manifests = sourceFiles({ dir: join(SRC_DIR, "factions"), match: /\.ts$/ });
   const found: Record<string, string> = {};
-  for (const name of manifests) {
-    const manifest = readStripped(join(dir, name));
+  for (const file of manifests) {
+    const manifest = readStripped(file);
     const slug = manifest.match(/slug:\s*["'](\w+)["']/)?.[1];
     const binding = manifest.match(/praxisDetail:\s*\(\)\s*=>\s*(\w+)/)?.[1];
     if (!slug || !binding) continue;
     const path = manifest.match(
       new RegExp(`const ${binding}\\s*=[^\\n]*import\\(["']([^"']+)["']\\)`),
     )?.[1];
-    expect(path, `${name} binds ${binding} to no import`).toBeTruthy();
+    expect(path, `${toRelative(file)} binds ${binding} to no import`).toBeTruthy();
     found[slug] = join(SRC_DIR, `${path!.replace(/^\.\.\//, "")}.tsx`);
   }
   return found;

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -24,8 +24,11 @@
  * throwing. We assert the structural anchors each slot leaves behind: the
  * finding text, the "re:" task link, and the author-byline character link.
  */
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import { surfaceMap } from "../../../factions";
 import { describe, it, expect } from "vitest";
+import { readStripped, SRC_DIR } from "../../../test/sourceScan";
 // Initialize the i18n catalog so shared-chrome copy keys resolve to English text.
 import i18n from "../../../i18n";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
@@ -472,6 +475,110 @@ describe("praxis-read duel card (#2718)", () => {
       expect(render(<Archetype state={state()} />).text, "and no card without a duel").not.toContain(
         DUEL_HEAD,
       );
+    });
+  }
+});
+
+// ─── The kit is the only thing an archetype supplies (#2718) ─────────────────
+//
+// Everything above is a RENDER-side guard: it asks whether a slot reached the
+// page. This last one is the AUTHORING-side complement, and it is the property
+// the skin lane exists to create — the eleven invariant mounts moved into
+// `PraxisDetailSkin`, and an archetype that re-mounts one itself has quietly
+// forked the spine again. A render walk cannot see that: an archetype that drew
+// its own comment thread instead of delegating would pass every case above,
+// because the thread is on the page either way.
+//
+// BOTH ENDS ARE DERIVED, and the join between them is derived too. The slugs
+// come from `surfaceMap('praxisDetail')`, as everything else in this file does.
+// The FILE for a slug is read out of that faction's own manifest — the
+// identifier `praxisDetail:` returns, then the `import()` that identifier is
+// bound to — so a tenth faction is picked up with no edit here, and a faction
+// that renames or moves its archetype moves this with it. There is no table.
+//
+// The list of mounts is hand-authored, which is what keeps this from being a
+// tautology (`kitInvariants.test.tsx` records the same reasoning: a denominator
+// derived from its own subject asserts only that the subject equals itself).
+// The non-vacuity half is asserted directly — every name below must appear in
+// the skin, or the guard is forbidding something nothing does.
+
+/**
+ * The mounts the skin owns. Each is a piece no faction dresses — the platform
+ * speaking, a shared gate, or site chrome — so an archetype naming one is
+ * either re-mounting it or has stopped delegating.
+ *
+ * The five NOT here are the ones a kit still supplies, dressed: `ScoreStamp`,
+ * `MemberByline`, `PraxisOwnerActions`, `bylineFaces` and `taskRefMeta`. Those
+ * are mounted INSIDE the header and score blocks the kit builds, so an
+ * archetype naming them is doing its job.
+ */
+const SKIN_OWNED = [
+  "PraxisStatusBanners",
+  "PraxisAdminBar",
+  "PraxisFlagBlock",
+  "PraxisDetailComments",
+  "DuelCard",
+  "MetataskSeal",
+  // The gate on the score panel: an unscored praxis draws no panel (#1444).
+  // A rule, not a dress decision, so a kit re-deciding it is the drift.
+  "scoreWasBanked",
+  // Site chrome, above the surface (#2102). One trail, drawn once.
+  "Breadcrumb",
+] as const;
+
+/**
+ * slug → `pages/praxisDetail/archetypes/<X>.tsx`, read out of the manifests.
+ *
+ * Keyed on the `slug` each manifest DECLARES rather than on its filename: `na`
+ * ships from `default.ts`, because `na` is a state and not a faction
+ * (ADR-0039, and `factions/index.ts` says so where it lists them). Reading the
+ * field keeps that true here without a line of mapping.
+ */
+function archetypeSources(): Record<string, string> {
+  const dir = join(SRC_DIR, "factions");
+  const manifests = readdirSync(dir).filter(
+    (name) => name.endsWith(".ts") && name !== "index.ts" && name !== "manifest.ts",
+  );
+  const found: Record<string, string> = {};
+  for (const name of manifests) {
+    const manifest = readStripped(join(dir, name));
+    const slug = manifest.match(/slug:\s*["'](\w+)["']/)?.[1];
+    const binding = manifest.match(/praxisDetail:\s*\(\)\s*=>\s*(\w+)/)?.[1];
+    if (!slug || !binding) continue;
+    const path = manifest.match(
+      new RegExp(`const ${binding}\\s*=[^\\n]*import\\(["']([^"']+)["']\\)`),
+    )?.[1];
+    expect(path, `${name} binds ${binding} to no import`).toBeTruthy();
+    found[slug] = join(SRC_DIR, `${path!.replace(/^\.\.\//, "")}.tsx`);
+  }
+  return found;
+}
+
+describe("no archetype re-mounts what the skin owns (#2718)", () => {
+  const skin = readStripped(
+    join(SRC_DIR, "pages/praxisDetail/praxisDetailSkin.tsx"),
+  );
+
+  // The tripwire. A forbidden list that has drifted out of the shared layer
+  // forbids nothing and reports green — the vacuous pass #2814's audit kept
+  // finding from the other side.
+  it.each(SKIN_OWNED)(
+    "%s is mounted by the skin, so forbidding it means something",
+    (name) => {
+      expect(skin, `${name} is not in praxisDetailSkin.tsx`).toContain(name);
+    },
+  );
+
+  const sources = archetypeSources();
+
+  for (const slug of Object.keys(surfaceMap("praxisDetail"))) {
+    it(`${slug} supplies a kit and nothing the skin already mounts`, () => {
+      const file = sources[slug];
+      expect(file, `no manifest declares a praxisDetail archetype for ${slug}`).toBeTruthy();
+      const source = readStripped(file);
+      for (const name of SKIN_OWNED) {
+        expect(source, `${slug} re-mounts ${name}`).not.toContain(name);
+      }
     });
   }
 });

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -498,8 +498,23 @@ describe("praxis-read duel card (#2718)", () => {
 // The list of mounts is hand-authored, which is what keeps this from being a
 // tautology (`kitInvariants.test.tsx` records the same reasoning: a denominator
 // derived from its own subject asserts only that the subject equals itself).
-// The non-vacuity half is asserted directly — every name below must appear in
-// the skin, or the guard is forbidding something nothing does.
+// The non-vacuity half is asserted directly — every name below must be MOUNTED
+// in the skin, not merely imported by it, or the guard forbids something nothing
+// does.
+//
+// IT IS SCOPED TO THE ARCHETYPES THAT DELEGATE, and that scoping is the rule
+// rather than a convenience. `PraxisDetailSkin`'s own docblock keeps the option
+// open for an archetype whose page is genuinely its own shape to keep its own
+// tree — three of nine profile kits still do, and ADR-0061 says an archetype may
+// ARRANGE freely. A tenth faction that wrote its own spine would be doing
+// something permitted, and reporting it here as spine drift would make this
+// guard an argument against the very escape hatch the skin documents. So
+// delegation is DERIVED from the source (does the file import the skin?) and
+// only delegating archetypes are held to it.
+//
+// That leaves an obvious hole — every archetype could stop delegating and the
+// forbidden list would hold vacuously — so the population is asserted too: the
+// count that delegates today is pinned, and the ones that do not are named.
 
 /**
  * The mounts the skin owns. Each is a piece no faction dresses — the platform
@@ -553,28 +568,69 @@ function archetypeSources(): Record<string, string> {
   return found;
 }
 
-describe("no archetype re-mounts what the skin owns (#2718)", () => {
+/**
+ * Every registered archetype's stripped source, split on whether it delegates.
+ *
+ * Delegation is read off the IMPORT rather than declared anywhere: a file that
+ * pulls in `praxisDetailSkin` is on the shared spine and is held to it. The
+ * `ownTree` bucket is not a failure — see the block comment above — and today
+ * its only member is the Albescent WRAPPER, which reaches the spine the long
+ * way, through the `DefaultPraxisDetail` it forwards to whole (ADR-0048/0083).
+ */
+function delegation(): {
+  delegates: Record<string, string>;
+  ownTree: string[];
+} {
+  const sources = archetypeSources();
+  const delegates: Record<string, string> = {};
+  const ownTree: string[] = [];
+  for (const slug of Object.keys(surfaceMap("praxisDetail"))) {
+    const file = sources[slug];
+    expect(file, `no manifest declares a praxisDetail archetype for ${slug}`).toBeTruthy();
+    const source = readStripped(file);
+    if (/from\s*["'][^"']*praxisDetailSkin["']/.test(source)) delegates[slug] = source;
+    else ownTree.push(slug);
+  }
+  return { delegates, ownTree };
+}
+
+describe("no delegating archetype re-mounts what the skin owns (#2718)", () => {
   const skin = readStripped(
     join(SRC_DIR, "pages/praxisDetail/praxisDetailSkin.tsx"),
   );
+  const { delegates, ownTree } = delegation();
 
-  // The tripwire. A forbidden list that has drifted out of the shared layer
-  // forbids nothing and reports green — the vacuous pass #2814's audit kept
-  // finding from the other side.
-  it.each(SKIN_OWNED)(
-    "%s is mounted by the skin, so forbidding it means something",
-    (name) => {
-      expect(skin, `${name} is not in praxisDetailSkin.tsx`).toContain(name);
-    },
-  );
+  // The tripwire, and it asks for a MOUNT. `toContain(name)` was satisfied by
+  // the skin's own import list, which would have kept reporting green through a
+  // refactor that imported a piece and then stopped drawing it — the forbidden
+  // list would forbid a mount that no longer existed. `<Name` or `Name(` is the
+  // draw call; an import is neither.
+  it.each(SKIN_OWNED)("%s is mounted by the skin, not merely imported", (name) => {
+    expect(
+      new RegExp(`<${name}[\\s/>]|\\b${name}\\(`).test(skin),
+      `${name} is imported by praxisDetailSkin.tsx but never mounted there — ` +
+        "so forbidding it in the archetypes forbids nothing",
+    ).toBe(true);
+  });
 
-  const sources = archetypeSources();
+  // The population, so the forbidden list cannot hold vacuously by everyone
+  // quietly leaving the spine. Eight of the nine registered archetypes delegate
+  // today; the ninth is the Albescent wrapper. A tenth faction writing its own
+  // tree moves this number DOWN legitimately and should say so in its PR — that
+  // is the conversation this assertion exists to force, not a rule against it.
+  it("eight of the nine registered archetypes are on the shared spine", () => {
+    expect(
+      Object.keys(delegates).length,
+      `only ${Object.keys(delegates).length} archetype(s) import the skin; ` +
+        `these do not: ${ownTree.join(", ") || "(none)"}`,
+    ).toBeGreaterThanOrEqual(8);
+    expect(ownTree, "the wrapper is the only archetype off the spine").toEqual([
+      "albescent",
+    ]);
+  });
 
-  for (const slug of Object.keys(surfaceMap("praxisDetail"))) {
+  for (const [slug, source] of Object.entries(delegates)) {
     it(`${slug} supplies a kit and nothing the skin already mounts`, () => {
-      const file = sources[slug];
-      expect(file, `no manifest declares a praxisDetail archetype for ${slug}`).toBeTruthy();
-      const source = readStripped(file);
       for (const name of SKIN_OWNED) {
         expect(source, `${slug} re-mounts ${name}`).not.toContain(name);
       }

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -83,26 +83,19 @@ import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
-import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
 import { CovenCat, SLIP_SHEET } from '../../../components/factionMarks/covenSlip'
-import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
 import { mediaUrl } from '../../../utils/media'
+import { PraxisDetailSkin } from '../praxisDetailSkin'
 import {
   bylineFaces,
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
-  scoreWasBanked,
   taskRefMeta,
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 
 /* The four faces, exactly as the spell slip and the ward page name them. */
 const CHROME = 'var(--font-faction-rounded)' /* Quicksand */
@@ -120,8 +113,8 @@ const BORDER = 'var(--faction-coven-slip-border)'
 const CARD = 'var(--faction-coven-ward-card)'
 const PAGE = 'var(--faction-coven-ward-page)'
 
-/** The aside track, from the eight faction designs (#1129). Layout, not dress. */
-const ASIDE_TRACK = 330
+/* The aside track is the SKIN's now — 330px from the eight faction designs
+   (#1129). Layout, not dress, and one number rather than eight. */
 
 interface SizeSet {
   /** The byline's ringed disc. Ornament geometry (WORLD_ZERO_STYLE §4a). */
@@ -311,13 +304,8 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   // a slot; this page names no ink for it, so it keeps the same `--color-*`
   // warning tokens `DefaultPraxisDetail` uses, deliberately not the ward's
   // pinks. `PraxisAdminBar` is the steward bar, mounted bare for the same
-  // reason as the report card.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
-    </>
-  )
+  // reason as the report card. All three are MOUNTED from the shared layer too
+  // since #2718; this kit passes neither ink knob.
 
   // ── Byline · title · owner actions · task reference ───────────────────────
   const header = (
@@ -430,7 +418,9 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   //
   // The candle sits behind it: `.cvn-candle` carries the flicker and its
   // reduced-motion guard, so stilled it is simply a steady glow.
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={{ ...panel, position: 'relative', overflow: 'hidden' }}>
       {sectionHead(t('detail.score.heading'))}
       <span
@@ -471,21 +461,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   // `slip-soft` are both gated on `--faction-coven-ward-card` in
   // `factionContrast.test.ts`. Nothing here carries the RIVAL's faction hue: the
   // duel's foreign side is a disc and an outline, never a colour.
-  const duelBlock: ReactNode = (
-    <DuelCard
-      state={state}
-      style={panel}
-      heading={sectionHead(t('duelCrossLink.label'))}
-      ink={{ name: INK, total: INK, muted: SOFT, line: BORDER, plate: PAGE }}
-    />
-  )
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  )
+  const duelInk = { name: INK, total: INK, muted: SOFT, line: BORDER, plate: PAGE }
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -588,16 +564,10 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
     </section>
   )
 
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      {/* NOT dressed, by contract: the report card is the platform speaking. */}
-      <PraxisFlagBlock state={state} />
-    </>
-  )
+  // The report card follows the two ward panels in the aside, mounted bare by
+  // the skin — NOT dressed, by contract: it is the platform speaking.
 
-  // ── Proof · write-up · crew · charms ──────────────────────────────────────
+  // ── Proof · write-up · crew ───────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: sectionGap }}>
       {sectionHead(t('detail.sections.proof'))}
@@ -645,54 +615,44 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
     </section>
   )
 
-  // READ-ONLY, by construction (#1093). `MetataskSeal` omits the peel control
-  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
-  // wears its ISSUING faction's dress (#927/#933). The design's add chips are
-  // deliberately absent: `apply_metatask` requires `status == in_progress`, so
-  // every chip would 422 on tap.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: sectionGap }}>
-      {sectionHead(t('detail.metatasks.heading'))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  )
+  // The charms section is the SKIN's now — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. READ-ONLY, by construction (#1093): the
+  // seal omits the peel control and the add slot when it gets neither
+  // `removable` nor `onAdd`, and each seal wears its ISSUING faction's dress
+  // (#927/#933). The design's add chips are deliberately absent —
+  // `apply_metatask` requires `status == in_progress`, so every chip would 422.
 
   return (
-    <div className="py-8" style={{ position: 'relative', color: INK, fontFamily: CHROME }}>
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        pageStyle: { position: 'relative', color: INK, fontFamily: CHROME },
+        /* THE COLUMN WEARS THE SLIP (#2135). It wore `.coven-candle-backdrop` —
+           the near-black ward wash with four drifting blooms — until the owner
+           ruled that the sheet the task card wears is the iconic coven look and
+           the surfaces around it should wear it too. `SLIP_SHEET` is
+           `covenSlip`'s one copy of the four-stop ramp, so the sheet, the task
+           card and the praxis card cannot drift apart.
 
-      {/* THE COLUMN WEARS THE SLIP (#2135). It wore `.coven-candle-backdrop` —
-          the near-black ward wash with four drifting blooms — until the owner
-          ruled that the sheet the task card wears is the iconic coven look and
-          the surfaces around it should wear it too. `SLIP_SHEET` is `covenSlip`'s
-          one copy of the four-stop ramp, so the sheet, the task card and the
-          praxis card cannot drift apart.
+           The blooms and their drift go with the class; nothing here paints
+           them. The class itself STAYS in index.css — `CovenFieldDesk` still
+           grounds a whole mobile page on it — so this is a change of consumer,
+           not a deletion, and the test on this file pins the negative half.
 
-          The blooms and their drift go with the class; nothing here paints them.
-          The class itself STAYS in index.css — `CovenFieldDesk` still grounds a
-          whole mobile page on it — so this is a change of consumer, not a
-          deletion, and the test on this file pins the negative half.
+           The ground still belongs to the COLUMN, not the viewport: the site
+           background shows around the page (WORLD_ZERO_STYLE §5, the #1028
+           ruling).
 
-          The ground still belongs to the COLUMN, not the viewport: the site
-          background shows around the page (WORLD_ZERO_STYLE §5, the #1028
-          ruling).
-
-          THE CLIP IS NOT RESTORED, and that is deliberate. `.coven-candle-
-          backdrop` carried `overflow: hidden` for one reason — its `::before`
-          bloom is inset -25% and had to be cut to the column. No bloom, no clip
-          to owe: a background is cut by the element's OWN border-radius, and the
-          cat below sits wholly inside its container. #1255 is the reason not to
-          put it back on spec: this column wraps the comment composer, whose
-          @-mention listbox is an absolutely positioned child, and a clipping
-          ancestor cuts a descendant off whatever its stacking order. */}
-      <div
-        style={{
+           THE CLIP IS NOT RESTORED, and that is deliberate.
+           `.coven-candle-backdrop` carried `overflow: hidden` for one reason —
+           its `::before` bloom is inset -25% and had to be cut to the column. No
+           bloom, no clip to owe: a background is cut by the element's OWN
+           border-radius, and the cat below sits wholly inside its container.
+           #1255 is the reason not to put it back on spec: this column wraps the
+           comment composer, whose @-mention listbox is an absolutely positioned
+           child, and a clipping ancestor cuts a descendant off whatever its
+           stacking order. */
+        sheetStyle: {
           position: 'relative',
           zIndex: 1,
           maxWidth: 1200,
@@ -702,99 +662,51 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
           borderRadius: 18,
           padding: desktop ? 'var(--space-2xl)' : 'var(--space-lg)',
           boxSizing: 'border-box',
-        }}
-      >
-        <div style={{ position: 'relative', zIndex: 1 }}>
-          {banners}
+        },
+        sheetBody: (body) => <div style={{ position: 'relative', zIndex: 1 }}>{body}</div>,
+        splitStyle: { position: 'relative' },
+        /* The cat watermark, turning once every two minutes (#2041 — it was a
+           pentagram, and the drawing lives in `covenSlip` because five Coven
+           surfaces turn the same one). `.cvn-wheel` still carries the motion and
+           its reduced-motion guard (#911/#1023).
 
-          <div
-            style={{
-              position: 'relative',
-              display: 'flex',
-              flexDirection: desktop ? 'row' : 'column',
-              alignItems: 'stretch',
-              gap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
-            }}
-          >
-            {/* The cat watermark, turning once every two minutes (#2041 — it was
-                a pentagram, and the drawing lives in `covenSlip` because five
-                Coven surfaces turn the same one). `.cvn-wheel` still carries the
-                motion and its reduced-motion guard (#911/#1023).
+           IT COMES TO THE BOTTOM (#2135) — one placement rule across every
+           mount, which is #2041's "not two different drawings" one level up. It
+           was `right: 24, top: 140`.
 
-                IT COMES TO THE BOTTOM (#2135) — one placement rule across every
-                mount, which is #2041's "not two different drawings" one level up.
-                It was `right: 24, top: 140`.
+           THE ANCHOR IS THE COLUMNS ROW, not the sheet, and the owner's reason
+           is what pins it there: the sheet's true bottom-right sits behind the
+           comment composer, which paints an opaque `ward-card` panel and would
+           swallow the mark whole. "I want the cat where it can be seen, but in
+           general at the bottom." The row ends exactly where the discussion
+           begins, so `bottom: 0` here is the lowest point on the page the mark
+           is still visible at. `right: 24` is unchanged and is what keeps the
+           whole face on the sheet.
 
-                THE ANCHOR IS THE COLUMNS ROW, not the sheet, and the owner's
-                reason is what pins it there: the sheet's true bottom-right sits
-                behind the comment composer, which paints an opaque `ward-card`
-                panel and would swallow the mark whole. "I want the cat where it
-                can be seen, but in general at the bottom." The row ends exactly
-                where the discussion begins, so `bottom: 0` here is the lowest
-                point on the page the mark is still visible at. `right: 24` is
-                unchanged and is what keeps the whole face on the sheet.
-
-                `zIndex: -1` puts it back UNDER the copy. The row is positioned
-                but has no z-index, so it is not a stacking context; the negative
-                index lands in the wrapper above, which is — behind every in-flow
-                block there, and still over the sheet's own ground. */}
-            <CovenCat
-              size={size.wheel}
-              style={{ right: 24, bottom: 0, opacity: 0.09, zIndex: -1 }}
-            />
-            <div style={{ flex: '1 1 auto', minWidth: 0 }}>
-              {header}
-              {/* Mobile stacks the rail above the proof — one block each, moved,
-                  never a second copy hidden at the other breakpoint. */}
-              {!desktop && (
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--space-lg)',
-                    marginBottom: 'var(--space-xl)',
-                  }}
-                >
-                  {rail}
-                </div>
-              )}
-              {proof}
-              {writeUp}
-              {crew}
-              {metatasks}
-              {!desktop && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
-                  {asideRest}
-                </div>
-              )}
-            </div>
-
-            {desktop && (
-              <aside
-                style={{
-                  flex: `0 0 ${ASIDE_TRACK}px`,
-                  width: ASIDE_TRACK,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 'var(--space-lg)',
-                }}
-              >
-                {rail}
-                {asideRest}
-              </aside>
-            )}
-          </div>
-
-          {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
-              beneath both columns, inside the page's own sheet, and the layout
-              draws the heading so the thread does not draw a second one. */}
-          <PraxisDetailComments
-            state={state}
-            heading={sectionHead(t('detail.sections.comments'))}
-            style={{ marginTop: sectionGap }}
+           `zIndex: -1` puts it back UNDER the copy. The row is positioned but
+           has no z-index, so it is not a stacking context; the negative index
+           lands in the wrapper above, which is — behind every in-flow block
+           there, and still over the sheet's own ground. */
+        splitPrelude: (
+          <CovenCat
+            size={size.wheel}
+            style={{ right: 24, bottom: 0, opacity: 0.09, zIndex: -1 }}
           />
-        </div>
-      </div>
-    </div>
+        ),
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: sectionHead(t('duelCrossLink.label')),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t('detail.metatasks.heading')),
+        commentsHeading: sectionHead(t('detail.sections.comments')),
+        sectionGap,
+      }}
+    />
   )
 }

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -33,6 +33,10 @@
  * - Mobile: one stacked column; the score and duel blocks move ABOVE the proof.
  *   ONE responsive component (ADR-0063) — `useFormFactor()` picks the size set;
  *   there is no mobile twin, and no block is drawn twice and hidden.
+ * - Both of those are the SKIN's arrangement now, not this file's (#2718). What
+ *   is still this file's is the pair of knobs its ground needs: `sheetBody` for
+ *   the positioned stacking layer inside the slip, and `splitPrelude` +
+ *   `splitStyle` for the cat, whose anchor is the columns ROW (#2135).
  * - The crown renders at **both** form factors. It is not this file's decision:
  *   `ScoreStamp` draws it off `is_top_for_task` in the score block's corner,
  *   and that block is in both layouts (#1710 retired the hero banner above).
@@ -75,6 +79,18 @@
  *
  * The score ARITHMETIC is not built either: the design invents its own, and
  * `scoreBreakdown()` (ADR-0053) is the single authority the mounted stamp reads.
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
@@ -88,7 +104,7 @@ import { CovenCat, SLIP_SHEET } from '../../../components/factionMarks/covenSlip
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
 import { mediaUrl } from '../../../utils/media'
-import { PraxisDetailSkin } from '../praxisDetailSkin'
+import { PraxisDetailSkin, type DuelInk } from '../praxisDetailSkin'
 import {
   bylineFaces,
   PraxisOwnerActions,
@@ -461,7 +477,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   // `slip-soft` are both gated on `--faction-coven-ward-card` in
   // `factionContrast.test.ts`. Nothing here carries the RIVAL's faction hue: the
   // duel's foreign side is a disc and an outline, never a colour.
-  const duelInk = { name: INK, total: INK, muted: SOFT, line: BORDER, plate: PAGE }
+  const duelInk: DuelInk = { name: INK, total: INK, muted: SOFT, line: BORDER, plate: PAGE }
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -705,7 +721,6 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
         crew,
         metatasksHeading: sectionHead(t('detail.metatasks.heading')),
         commentsHeading: sectionHead(t('detail.sections.comments')),
-        sectionGap,
       }}
     />
   )

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -34,6 +34,17 @@
  *   neutral and shared for the same reason — ADR-0061: one shared neutral
  *   `detail.*` set; a skin brings dress and no copy.
  *
+ * ## The arrangement is the SKIN's; the dress is this file's (#2718)
+ *
+ * Everything above is still true and no longer written here. `PraxisDetailSkin`
+ * holds the spine — the sheet, the split, the 330px aside, the comments region
+ * and the mobile reflow — and mounts the pieces no faction dresses: the
+ * moderation banners, the steward bar, the `scoreWasBanked` gate, the duel card,
+ * the report card, the metatask seal and the comment thread. This file supplies
+ * the KIT: the ground, the ornament, the face, the role map, and the eight
+ * blocks it letters itself. It is the reference kit as it was the reference
+ * page — where the eight faction designs disagree with it, they win.
+ *
  * ## One responsive component, no mobile twin (ADR-0056/0058)
  *
  * `useFormFactor()` picks the size set and collapses the split; the dispatcher
@@ -101,27 +112,20 @@ import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
-import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
-import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
 import { factionSheet } from '../../../utils/factions'
 import { factionRoleVars } from '../../../utils/factionRoles'
 import { mediaUrl } from '../../../utils/media'
+import { PraxisDetailSkin } from '../praxisDetailSkin'
 import {
   bylineFaces,
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
-  scoreWasBanked,
   taskRefMeta,
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 
 /** The na spectrum — the one ornament this whole page is built out of. */
 const SPECTRUM = 'var(--faction-default-rainbow)'
@@ -284,13 +288,10 @@ export default function DefaultPraxisDetail({
   // contract asks for, and it is shared chrome too now — this file's own note
   // that it "has no shared slot, so it renders here" was the hole seven sibling
   // archetypes copied the workaround for, and #2718 closed it.
-  // `PraxisAdminBar` is the steward bar.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
-    </>
-  )
+  //
+  // The whole block — failed mark, flagged notice, steward bar — is mounted by
+  // `PraxisDetailSkin` now, and this kit passes neither ink knob because the
+  // shared warning hue is measured for its plate.
 
   // ── Byline · title · owner actions · task reference ───────────────────────
   const header = (
@@ -404,7 +405,10 @@ export default function DefaultPraxisDetail({
   // VOTE AVERAGE, calls it the faction multiplier, and prints votes as a count.
   // The model is `(base + meta) × faction_mult + votes` (ADR-0014/0047/0053),
   // resolved once by `scoreBreakdown()` inside the stamp.
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate
+  // and lives there, so a kit cannot draw this panel over an unscored praxis.
+  const scoreBlock = (
     <section style={panel}>
       {sectionHead(t('detail.score.heading'))}
       <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -423,18 +427,9 @@ export default function DefaultPraxisDetail({
   // the twelve rail skins. It self-hides for a praxis with no duel, for a
   // DECLINED challenge — where there is no duel to read out and the praxis
   // scores as an ordinary solo (ADR-0011) — and for the run-up, which the
-  // composer's waiting surface owns (#1071/ADR-0059). Panel chrome and section
-  // head are handed in, so the card wears this page's dress rather than its own.
-  const duelBlock: ReactNode = (
-    <DuelCard state={state} style={panel} heading={sectionHead(t('duelCrossLink.label'))} />
-  )
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  )
+  // composer's waiting surface owns (#1071/ADR-0059). The card itself is
+  // mounted by the skin; this kit hands over the panel chrome and the section
+  // head, so the card wears this page's dress rather than its own.
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -547,15 +542,7 @@ export default function DefaultPraxisDetail({
     </section>
   )
 
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      <PraxisFlagBlock state={state} />
-    </>
-  )
-
-  // ── Proof · write-up · members · metatasks ────────────────────────────────
+  // ── Proof · write-up · members ────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
       {sectionHead(t('detail.sections.proof'))}
@@ -599,31 +586,22 @@ export default function DefaultPraxisDetail({
     </section>
   )
 
-  // READ-ONLY, by construction (#1093). `MetataskSeal` omits the peel control
-  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
-  // wears its ISSUING faction's dress (#927/#933). The design's "Available"
-  // chips are deliberately absent: `apply_metatask` (services/praxis.py)
-  // requires `status == in_progress`, so every chip would 422 on tap — and the
-  // composer already agrees, gating `canSealMetatask` on `!controlsLocked`.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
-      {sectionHead(t('detail.metatasks.heading'))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  )
+
+  // The applied-metatask section is the SKIN's — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. It is read-only by construction (#1093):
+  // the seal omits the peel control and the add slot when it gets neither
+  // `removable` nor `onAdd`, and each seal wears its ISSUING faction's dress
+  // (#927/#933). The design's "Available" chips are deliberately absent —
+  // `apply_metatask` (services/praxis.py) requires `status == in_progress`, so
+  // every chip would 422 on tap, and the composer agrees by gating
+  // `canSealMetatask` on `!controlsLocked`.
 
   return (
-    <div className="py-8" style={{ position: 'relative' }}>
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      <div
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        pageStyle: { position: 'relative' },
+        sheetStyle: {
           // The role map (#2672) on THE SHEET, not on the `.py-8` box above it:
           // that box also holds the shared, faction-neutral `Breadcrumb`
           // (#2102), and a prefix declared over shared furniture is the
@@ -649,81 +627,34 @@ export default function DefaultPraxisDetail({
           padding: desktop ? 'var(--space-2xl)' : 'var(--space-lg)',
           boxSizing: 'border-box',
           overflow: 'hidden',
-        }}
-      >
-        {/* The spectrum band across the sheet head — the na tell. */}
-        <span
-          aria-hidden
-          className="spectrum-rule"
-          style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 4 }}
-        />
+        },
+        sheetPrelude: (
+          <>
+            {/* The spectrum band across the sheet head — the na tell. */}
+            <span
+              aria-hidden
+              className="spectrum-rule"
+              style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 4 }}
+            />
 
-        {/* Ornament only, clipped by this sheet's own overflow (see the slot's
-            note in the docstring). Absent for na. */}
-        {ornament}
-
-        {banners}
-
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: desktop ? 'row' : 'column',
-            alignItems: 'stretch',
-            gap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
-          }}
-        >
-          <div style={{ flex: '1 1 auto', minWidth: 0 }}>
-            {header}
-            {/* Mobile stacks the rail above the proof — one block each, moved,
-                never a second copy hidden at the other breakpoint. */}
-            {!desktop && (
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 'var(--space-lg)',
-                  marginBottom: 'var(--space-xl)',
-                }}
-              >
-                {rail}
-              </div>
-            )}
-            {proof}
-            {writeUp}
-            {crew}
-            {metatasks}
-            {!desktop && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
-                {asideRest}
-              </div>
-            )}
-          </div>
-
-          {desktop && (
-            <aside
-              style={{
-                flex: '0 0 330px',
-                width: 330,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 'var(--space-lg)',
-              }}
-            >
-              {rail}
-              {asideRest}
-            </aside>
-          )}
-        </div>
-
-        {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
-            beneath both columns, inside the page's own sheet, and the layout
-            draws the heading so the thread does not draw a second one. */}
-        <PraxisDetailComments
-          state={state}
-          heading={sectionHead(t('detail.sections.comments'))}
-          style={{ marginTop: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}
-        />
-      </div>
-    </div>
+            {/* Ornament only, clipped by this sheet's own overflow (see the
+                slot's note in the docstring). Absent for na. */}
+            {ornament}
+          </>
+        ),
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: sectionHead(t('duelCrossLink.label')),
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t('detail.metatasks.heading')),
+        commentsHeading: sectionHead(t('detail.sections.comments')),
+        sectionGap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
+      }}
+    />
   )
 }

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -230,11 +230,6 @@ export default function DefaultPraxisDetail({
   // POSITIVELY: a duel side is `type='solo'` + a `duel_id` (ADR-0011), so
   // `!== 'solo'` would put a roster on every duel (#992).
   const isCollab = praxis.type === 'collab'
-  // The shared banners already draw the roster while a collab is still
-  // resolving (`in_progress` / `pending`). The Members section below is the
-  // PUBLISHED half of that same fact, so it takes the complement — one roster
-  // on the page, never two.
-  const rosterInBanners = praxis.status === 'in_progress' || praxis.status === 'pending'
 
   /** A spectrum hairline running out from a label — the page's only rule. */
   const sectionHead = (label: ReactNode, trailing?: ReactNode) => (
@@ -571,7 +566,14 @@ export default function DefaultPraxisDetail({
     </section>
   )
 
-  const crew = isCollab && !rosterInBanners && (
+  // No status guard on the roster, and there has not been one to write since
+  // #1089. This file complemented a roster the shared banners drew for a
+  // still-resolving collab, and that complement is dead TWICE over:
+  // `PraxisStatusBanners` no longer draws a roster at all (#1089 deleted it —
+  // its own note in `shared.tsx` records that), and `in_progress` / `pending`
+  // cannot reach an archetype anyway, because `pages/PraxisDetail.tsx` redirects
+  // both to the composer before dispatching (ADR-0062). One roster, always.
+  const crew = isCollab && (
     <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
       {sectionHead(t('detail.sections.members'))}
       <CollabRoster
@@ -653,7 +655,6 @@ export default function DefaultPraxisDetail({
         crew,
         metatasksHeading: sectionHead(t('detail.metatasks.heading')),
         commentsHeading: sectionHead(t('detail.sections.comments')),
-        sectionGap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
       }}
     />
   )

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -23,8 +23,9 @@
  * ## The contract this dresses (verified in code, #1129 — not re-derived)
  *
  * - Desktop: main column + a **330px** aside, comments spanning beneath both.
- *   The duel panel (aside) and the comments region are the page's own slots,
- *   not dispatcher mounts (ADR-0064).
+ *   The duel panel (aside) and the comments region are not dispatcher mounts
+ *   (ADR-0064); since #2718 they are not this file's own slots either — the
+ *   SKIN draws both, and this kit hands them their dress.
  * - Mobile: one stacked column, with score and duel moved above the proof. ONE
  *   responsive component — `useFormFactor()` internally, no mobile twin
  *   (ADR-0063; `mobilePraxisDetail` was retired outright by #1089). Score and
@@ -85,6 +86,18 @@
  * page ground, the plate AND the panel cells (see index.css). The page surface
  * is carried by the COLUMN, not the viewport — the site background still shows
  * around the component (WORLD_ZERO_STYLE §5, the #1028 ruling).
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 import type { CSSProperties, ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -127,7 +140,7 @@ import { EphemeristsColophon, EphemeristsMasthead } from "../../../components/fa
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
-import { PraxisDetailSkin } from "../praxisDetailSkin";
+import { PraxisDetailSkin, type DuelInk } from "../praxisDetailSkin";
 import {
   PraxisOwnerActions,
   MemberByline,
@@ -614,7 +627,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // every other block on this surface reads, with `QUIET` already walked down
   // until it clears on all three of this page's grounds (#1028). Nothing takes
   // the rival's faction hue: brass and lapis are structure here, not ink.
-  const duelInk = { name: INK, total: INK, muted: QUIET, line: LINE, plate: INNER };
+  const duelInk: DuelInk = { name: INK, total: INK, muted: QUIET, line: LINE, plate: INNER };
 
   // ── Vote · voters · flag ─────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -886,7 +899,6 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         crew,
         metatasksHeading: sectionHead(t("detail.metatasks.heading")),
         commentsHeading: sectionHead(t("detail.sections.comments")),
-        sectionGap: size.sectionGap,
         /* The plate's provenance, at the foot of the sheet (#2143) — the
            masthead's old datum row, labelled. #2124's requirement is about
            PLACEMENT as much as wording, and this page is where it bites: the

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -95,7 +95,6 @@ import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
 import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import { reframeLabel } from "../../../components/vote/voteReframes";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
-import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
 import {
   BRASS,
@@ -125,28 +124,23 @@ import {
   BRASS_LIGHT,
 } from "../../../components/factionMarks/ephemeristsPlate";
 import { EphemeristsColophon, EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
-import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
+import { PraxisDetailSkin } from "../praxisDetailSkin";
 import {
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
   bylineFaces,
   orderedMembers,
-  scoreWasBanked,
   taskRefMeta,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 
-/** The page cap the epic settled on, and the aside track. Geometry. */
+/** The page cap the epic settled on. Geometry. The aside TRACK is the skin's —
+ *  330px is one number across all eight designs (#1129), and this plate does
+ *  not deviate from it. */
 const PAGE_WIDTH = 1200;
-const ASIDE_WIDTH = 330;
 
 /**
  * The struck-metal disc at the end of a voter row, and the sigil cut into it
@@ -478,12 +472,6 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // stays this file's is the measurement above, handed over as the two inks the
   // shared slot takes. Both marks and the rule are the one token, per #1449.
   const NOTICE = "var(--faction-ephemerists-card-notice)";
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} flaggedInk={NOTICE} flaggedBodyInk={NOTICE} />
-      <PraxisAdminBar state={state} />
-    </>
-  );
 
   // ── Byline · title · owner actions · task reference ───────────────────────
   const header = (
@@ -599,7 +587,9 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // faction, which lands `EphemeristsScoreStamp` here. The design's own
   // arithmetic is NOT built: the model is `(base + meta) × faction_mult + votes`
   // (ADR-0014/0047/0053), resolved once by `scoreBreakdown()` inside the stamp.
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={panel}>
       {sectionHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>
@@ -624,21 +614,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // every other block on this surface reads, with `QUIET` already walked down
   // until it clears on all three of this page's grounds (#1028). Nothing takes
   // the rival's faction hue: brass and lapis are structure here, not ink.
-  const duelBlock = (
-    <DuelCard
-      state={state}
-      style={panel}
-      heading={sectionHead(t("duelCrossLink.label"))}
-      ink={{ name: INK, total: INK, muted: QUIET, line: LINE, plate: INNER }}
-    />
-  );
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  );
+  const duelInk = { name: INK, total: INK, muted: QUIET, line: LINE, plate: INNER };
 
   // ── Vote · voters · flag ─────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -787,16 +763,10 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
     </section>
   );
 
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      {/* NOT dressed, on purpose — see the header. */}
-      <PraxisFlagBlock state={state} />
-    </>
-  );
+  // The report card is mounted bare by the skin, last in the aside. NOT
+  // dressed, on purpose — see the header.
 
-  // ── Proof · the canonical record · members · metatasks ────────────────────
+  // ── Proof · the canonical record · members ────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: size.sectionGap }}>
       {sectionHead(t("detail.sections.proof"))}
@@ -870,130 +840,73 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
     </section>
   );
 
-  // READ-ONLY, by construction. `MetataskSeal` omits the peel control and the add
-  // slot when it gets neither `removable` nor `onAdd`, and each seal wears its
-  // ISSUING faction's dress (#927/#933). The design's add-chips are deliberately
-  // absent: `apply_metatask` requires `status == in_progress`, so every chip
-  // would 422 on tap.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: size.sectionGap }}>
-      {sectionHead(t("detail.metatasks.heading"))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  );
+  // The metatask section is the SKIN's now — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. READ-ONLY, by construction: the seal
+  // omits the peel control and the add slot when it gets neither `removable`
+  // nor `onAdd`, and each seal wears its ISSUING faction's dress (#927/#933).
+  // The design's add-chips are deliberately absent — `apply_metatask` requires
+  // `status == in_progress`, so every chip would 422 on tap.
 
   return (
-    <div className="py-8">
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      {/* The page IS the plate: the column carries the plate's own page stock —
-          night in both cascades since #1627, papyrus before it — headed by the
-          cornice masthead flush to its own edges. There is deliberately no fixed
-          full-bleed backdrop — see the `.eph-plate-sheet` note in index.css for
-          what that pattern does to the sidebar beside it. */}
-      <div
-        className="eph-plate-sheet"
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        /* Both marks and the rule of the flagged notice take the plate's own
+           amber — the measurement this file keeps and the shared slot wears
+           (see the NOTICE note above). */
+        flaggedInk: NOTICE,
+        flaggedBodyInk: NOTICE,
+        /* The page IS the plate: the column carries the plate's own page stock —
+           night in both cascades since #1627, papyrus before it — headed by the
+           cornice masthead flush to its own edges. There is deliberately no
+           fixed full-bleed backdrop — see the `.eph-plate-sheet` note in
+           index.css for what that pattern does to the sidebar beside it. */
+        sheetClassName: "eph-plate-sheet",
+        sheetStyle: {
           maxWidth: PAGE_WIDTH,
           margin: "0 auto",
           boxSizing: "border-box",
           color: INK,
           border: `1px solid ${LINE}`,
           boxShadow: SHADOW,
-        }}
-      >
-        {masthead}
+        },
+        sheetPrelude: masthead,
+        /* The plate pads its CONTENTS, not its edges: the masthead above is
+           flush to the sheet, everything under it is inset. */
+        sheetBody: (body) => <div style={{ padding: size.pagePadding }}>{body}</div>,
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: sectionHead(t("duelCrossLink.label")),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t("detail.metatasks.heading")),
+        commentsHeading: sectionHead(t("detail.sections.comments")),
+        sectionGap: size.sectionGap,
+        /* The plate's provenance, at the foot of the sheet (#2143) — the
+           masthead's old datum row, labelled. #2124's requirement is about
+           PLACEMENT as much as wording, and this page is where it bites: the
+           byline, the submission date and the crew all live in the two columns
+           above, and the colophon sits below every one of them, outside both,
+           behind its own rule. See `EphemeristsColophon`.
 
-        <div style={{ padding: size.pagePadding }}>
-          {banners}
-
-          <div
-            style={{
-              display: "flex",
-              flexDirection: desktop ? "row" : "column",
-              alignItems: "stretch",
-              gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
-            }}
-          >
-            <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-              {header}
-              {/* Mobile stacks the rail above the proof — one block each, moved,
-                  never a second copy hidden at the other breakpoint. */}
-              {!desktop && (
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "var(--space-lg)",
-                    marginBottom: "var(--space-xl)",
-                  }}
-                >
-                  {rail}
-                </div>
-              )}
-              {proof}
-              {writeUp}
-              {crew}
-              {metatasks}
-              {!desktop && (
-                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-lg)" }}>
-                  {asideRest}
-                </div>
-              )}
-            </div>
-
-            {desktop && (
-              <aside
-                style={{
-                  flex: `0 0 ${ASIDE_WIDTH}px`,
-                  width: ASIDE_WIDTH,
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                }}
-              >
-                {rail}
-                {asideRest}
-              </aside>
-            )}
-          </div>
-
-          {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
-              beneath both columns, inside the plate, and the layout draws the
-              heading so the thread does not draw a second one. */}
-          <PraxisDetailComments
-            state={state}
-            heading={sectionHead(t("detail.sections.comments"))}
-            style={{ marginTop: size.sectionGap }}
-          />
-
-          {/* The plate's provenance, at the foot of the sheet (#2143) — the
-              masthead's old datum row, labelled. #2124's requirement is about
-              PLACEMENT as much as wording, and this page is where it bites: the
-              byline, the submission date and the crew all live in the two
-              columns above, and the colophon sits below every one of them,
-              outside both, behind its own rule. See `EphemeristsColophon`.
-
-              UNDATED HERE, AND ONLY HERE. #2143's body says "keep the date real
-              (the surface's own)", but #2124's comment — filed later and closed
-              INTO this issue — says the line must not sit adjacent to "the
-              author, the date-of-submission, or any other player-scoped field".
-              On a praxis the surface's own date IS `submitted_at`, so passing it
-              does not merely place the coordinates NEAR a player-scoped field,
-              it puts the two in one sentence: "Plate struck <the day this player
-              posted> ... +44 03'". That is the exact inference #2124 raised, and
-              a reader cannot be expected to unpick it from the label alone.
-              `EphemeristsTaskDetail` still passes its date: a task's
-              `created_at` belongs to the task, not to any player. */}
-          <EphemeristsColophon scale={desktop ? "page" : "card"} />
-        </div>
-      </div>
-    </div>
+           UNDATED HERE, AND ONLY HERE. #2143's body says "keep the date real
+           (the surface's own)", but #2124's comment — filed later and closed
+           INTO this issue — says the line must not sit adjacent to "the author,
+           the date-of-submission, or any other player-scoped field". On a praxis
+           the surface's own date IS `submitted_at`, so passing it does not
+           merely place the coordinates NEAR a player-scoped field, it puts the
+           two in one sentence: "Plate struck <the day this player posted> ...
+           +44 03'". That is the exact inference #2124 raised, and a reader
+           cannot be expected to unpick it from the label alone.
+           `EphemeristsTaskDetail` still passes its date: a task's `created_at`
+           belongs to the task, not to any player. */
+        footer: <EphemeristsColophon scale={desktop ? "page" : "card"} />,
+      }}
+    />
   );
 }

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -22,7 +22,8 @@
  * and are NOT re-derived:
  *
  * - the desktop aside track is **330px** (the Unaffiliated design's 340 is the
- *   outlier);
+ *   outlier) — a number this file no longer writes, because `PraxisDetailSkin`
+ *   draws the aside for every kit since #2718;
  * - the **crown renders at both form factors**, always. It arrives in the score
  *   stamp's corner, keyed only on `is_top_for_task` (#1710 retired the hero
  *   banner it used to arrive in). This faction's
@@ -79,6 +80,18 @@
  * goes through `--faction-everymen-sheet-accent`, and `--everymen-paper` appears
  * here only as a FILL (the voter bars' track), never as a ground for text — it
  * pays 4.49:1 with the accent in light, which is the wrong side of AA.
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
@@ -93,7 +106,7 @@ import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
-import { PraxisDetailSkin } from "../praxisDetailSkin";
+import { PraxisDetailSkin, type DuelInk } from "../praxisDetailSkin";
 import {
   PraxisOwnerActions,
   MemberByline,
@@ -216,10 +229,6 @@ export default function EverymenPraxisDetail({
   // POSITIVELY: a duel side is `type='solo'` + a `duel_id` (ADR-0011), so
   // `!== 'solo'` would put a roster on every duel (#992).
   const isCollab = praxis.type === "collab";
-  // The shared banners draw the roster while a collab is still resolving, so the
-  // Members section takes the complement — one roster on the page, never two.
-  const rosterInBanners =
-    praxis.status === "in_progress" || praxis.status === "pending";
 
   // ── Shared dress ──
   /** Bebas, tracked out and struck in caps — every label on the sheet. */
@@ -474,7 +483,7 @@ export default function EverymenPraxisDetail({
   // stock, over the printed hairline. `TRACK` is legal as `plate` and ONLY as
   // `plate` — there it is a fill behind a duellist's disc, never a ground for
   // text. No rival faction hue enters: red stays a rule and a fill here.
-  const duelInk = { name: INK, total: INK, muted: MUTED, line: HAIR, plate: TRACK };
+  const duelInk: DuelInk = { name: INK, total: INK, muted: MUTED, line: HAIR, plate: TRACK };
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -633,7 +642,14 @@ export default function EverymenPraxisDetail({
   // field, so that column is invented data and is not built (owner ruling on
   // #1123). `CollabRoster` already prints the ruled replacement in that slot:
   // each member's FILED / NOT FILED pill, off `has_submitted`.
-  const crew = isCollab && !rosterInBanners && (
+  // No status guard on the roster, and there has not been one to write since
+  // #1089. This file complemented a roster the shared banners drew for a
+  // still-resolving collab, and that complement is dead TWICE over:
+  // `PraxisStatusBanners` no longer draws a roster at all (#1089 deleted it —
+  // its own note in `shared.tsx` records that), and `in_progress` / `pending`
+  // cannot reach an archetype anyway, because `pages/PraxisDetail.tsx` redirects
+  // both to the composer before dispatching (ADR-0062). One roster, always.
+  const crew = isCollab && (
     <section
       style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
     >
@@ -692,7 +708,6 @@ export default function EverymenPraxisDetail({
         crew,
         metatasksHeading: sectionHead(t("detail.metatasks.heading")),
         commentsHeading: sectionHead(t("detail.sections.comments")),
-        sectionGap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
       }}
     />
   );

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -88,26 +88,19 @@ import { EverymenCog } from "../../../components/factionMarks/everymenCogs";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
 import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
-import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
-import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
+import { PraxisDetailSkin } from "../praxisDetailSkin";
 import {
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
   bylineFaces,
-  scoreWasBanked,
   taskRefMeta,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 
 // ── The sheet's palette. Every value is a token; the "broadsheet sheet" and
 //    "dispatch sheet" blocks in index.css say which are new and which the
@@ -338,13 +331,8 @@ export default function EverymenPraxisDetail({
   // #1710), and since #2718 all three are MOUNTED from the shared layer too —
   // the notice was the one this file used to re-type. The design voices all of
   // them ("UNDER GRIEVANCE", "SENT BACK BY THE STEWARD"); that vocabulary is
-  // recorded on the issue and not built.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
-    </>
-  );
+  // recorded on the issue and not built. This kit passes neither flagged-ink
+  // knob: the shared warning hue is measured for the dispatch sheet's stock.
 
   // ── Byline · headline · owner actions · standfirst ─────────────────────────
   const header = (
@@ -459,7 +447,9 @@ export default function EverymenPraxisDetail({
   // design's own sums are NOT built: the model is
   // `(base + meta) × faction_mult + votes`, resolved once by `scoreBreakdown()`
   // inside the stamp (ADR-0014/0047/0053).
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={panel}>
       {sectionHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>
@@ -475,30 +465,16 @@ export default function EverymenPraxisDetail({
   // ── Duel (built once; aside on desktop, above the proof on mobile) ─────────
   //
   // Self-hides for a praxis with no duel, for a DECLINED challenge and for the
-  // run-up, which the composer's waiting surface owns. Panel chrome, section
-  // head AND inks are handed in, so the card wears this sheet's dress rather
-  // than its own.
+  // run-up, which the composer's waiting surface owns. The skin mounts the
+  // card; this kit hands over panel chrome, section head AND inks, so it wears
+  // this sheet's dress rather than its own.
   //
   // The inks are the sheet's own (#1153): `--everymen-paper-text` and
   // `--everymen-muted`, the pair `factionContrast.test.ts` measures on this
   // stock, over the printed hairline. `TRACK` is legal as `plate` and ONLY as
   // `plate` — there it is a fill behind a duellist's disc, never a ground for
   // text. No rival faction hue enters: red stays a rule and a fill here.
-  const duelBlock: ReactNode = (
-    <DuelCard
-      state={state}
-      style={panel}
-      heading={sectionHead(t("duelCrossLink.label"))}
-      ink={{ name: INK, total: INK, muted: MUTED, line: HAIR, plate: TRACK }}
-    />
-  );
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  );
+  const duelInk = { name: INK, total: INK, muted: MUTED, line: HAIR, plate: TRACK };
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -611,17 +587,11 @@ export default function EverymenPraxisDetail({
     </section>
   );
 
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      {/* Mounted BARE. The report card is neutral chrome and takes no dress —
-          it accepts no style prop, by construction (ADR-0061). */}
-      <PraxisFlagBlock state={state} />
-    </>
-  );
+  // The report card follows the vote and voters panels in the aside, mounted
+  // BARE by the skin: it is neutral chrome and takes no dress — it accepts no
+  // style prop, by construction (ADR-0061).
 
-  // ── Proof · write-up · members · metatasks ────────────────────────────────
+  // ── Proof · write-up · members ────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section
       style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
@@ -680,37 +650,26 @@ export default function EverymenPraxisDetail({
     </section>
   );
 
-  // READ-ONLY, by construction. `MetataskSeal` omits the peel control and the
-  // add slot when it gets neither `removable` nor `onAdd`, and each seal wears
-  // its ISSUING faction's dress. The design's add-chips are deliberately absent:
-  // `apply_metatask` requires `status == in_progress`, so every chip would 422.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section
-      style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
-    >
-      {sectionHead(t("detail.metatasks.heading"))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  );
+  // The applied-metatask section is the SKIN's — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. Read-only by construction: the seal omits
+  // the peel control and the add slot when it gets neither `removable` nor
+  // `onAdd`, and each seal wears its ISSUING faction's dress. The design's
+  // add-chips are deliberately absent — `apply_metatask` requires
+  // `status == in_progress`, so every chip would 422.
 
   return (
-    <div className="py-8" style={{ position: "relative", color: INK }}>
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      {/* The dispatch sheet — ruled newsprint under a red margin rule
-          (index.css). It paints the detail COLUMN, not the viewport: the site
-          background still shows around the component (WORLD_ZERO_STYLE §5, the
-          #1028 ruling). The margin rule is a background layer of `.em-dispatch`,
-          which is why nothing here is positioned over the copy. */}
-      <div
-        className="em-dispatch"
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        pageStyle: { position: "relative", color: INK },
+        /* The dispatch sheet — ruled newsprint under a red margin rule
+           (index.css). It paints the detail COLUMN, not the viewport: the site
+           background still shows around the component (WORLD_ZERO_STYLE §5, the
+           #1028 ruling). The margin rule is a background layer of
+           `.em-dispatch`, which is why nothing here is positioned over the
+           copy. */
+        sheetClassName: "em-dispatch",
+        sheetStyle: {
           position: "relative",
           maxWidth: 1200,
           margin: "0 auto",
@@ -719,80 +678,22 @@ export default function EverymenPraxisDetail({
           padding: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           boxSizing: "border-box",
           overflow: "hidden",
-        }}
-      >
-        {masthead}
-
-        {banners}
-
-        <div
-          style={{
-            display: "flex",
-            flexDirection: desktop ? "row" : "column",
-            alignItems: "stretch",
-            gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
-          }}
-        >
-          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-            {header}
-            {/* Mobile stacks the rail above the proof — one block each, moved,
-                never a second copy hidden at the other breakpoint. */}
-            {!desktop && (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                  marginBottom: "var(--space-xl)",
-                }}
-              >
-                {rail}
-              </div>
-            )}
-            {proof}
-            {writeUp}
-            {crew}
-            {metatasks}
-            {!desktop && (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                }}
-              >
-                {asideRest}
-              </div>
-            )}
-          </div>
-
-          {desktop && (
-            <aside
-              style={{
-                flex: "0 0 330px",
-                width: 330,
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-lg)",
-              }}
-            >
-              {rail}
-              {asideRest}
-            </aside>
-          )}
-        </div>
-
-        {/* The third layout region (ADR-0061): comments sit beneath both
-            columns, inside the sheet, under the page's own dressed section head
-            so the thread does not draw a second one (the #1029 trap). */}
-        <PraxisDetailComments
-          state={state}
-          heading={sectionHead(t("detail.sections.comments"))}
-          style={{
-            marginTop: desktop ? "var(--space-2xl)" : "var(--space-xl)",
-          }}
-        />
-      </div>
-    </div>
+        },
+        sheetPrelude: masthead,
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: sectionHead(t("duelCrossLink.label")),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t("detail.metatasks.heading")),
+        commentsHeading: sectionHead(t("detail.sections.comments")),
+        sectionGap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+      }}
+    />
   );
 }

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -17,7 +17,7 @@ import {
   taskRefMeta,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import { PraxisDetailSkin } from "../praxisDetailSkin";
+import { PraxisDetailSkin, type DuelInk } from "../praxisDetailSkin";
 import { factionRoleVars } from "../../../utils/factionRoles";
 
 /**
@@ -39,6 +39,9 @@ import { factionRoleVars } from "../../../utils/factionRoles";
  * - Mobile: one stacked column; the score and duel blocks move above the proof.
  *   They are built ONCE and moved by where they are mounted — never drawn twice
  *   and hidden. The 330px TRACK is desktop-only; its contents are not.
+ * - All of that is drawn by the SKIN since #2718. This file's share of it is two
+ *   knobs its chassis needs: the raster, the sweep and the chrome bar as a
+ *   `sheetPrelude`, and the padded z-layer under them as a `sheetBody`.
  * - **The crown renders at BOTH form factors**, never gated. It arrives in the
  *   score stamp's corner, keyed only on `is_top_for_task`, and the score block
  *   is in both layouts (ADR-0054 — one canonical `TaskCrown`, unrestyled; #1710
@@ -101,6 +104,18 @@ import { factionRoleVars } from "../../../utils/factionRoles";
  * scoped to the mounts that need it and never to the column, because a
  * column-wide re-point would drag the deliberately-neutral report card and
  * steward bar into the costume.
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 
 const MONO = "var(--sg-praxis-detail-face)"; /* Share Tech Mono */
@@ -280,9 +295,6 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // POSITIVELY: a duel side is `type='solo'` + a `duel_id` (ADR-0011), so
   // `!== 'solo'` would put a roster on every duel (#992).
   const isCollab = praxis.type === "collab";
-  // The shared banners draw the roster while a collab is still resolving, so the
-  // Members section takes the complement — one roster on the page, never two.
-  const rosterInBanners = praxis.status === "in_progress" || praxis.status === "pending";
 
   /** A dashed terminal rule. */
   const rule = (style?: CSSProperties) => (
@@ -497,7 +509,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // card-muted, card-line, stamp-bg — are now named props, so the phosphor
   // arrives by contract instead of by cascade. Same four values, and the
   // `--color-*` half of that object was never read by this component anyway.
-  const duelInk = { name: BRIGHT, total: BRIGHT, muted: DIM, line: HAIR, plate: PANEL };
+  const duelInk: DuelInk = { name: BRIGHT, total: BRIGHT, muted: DIM, line: HAIR, plate: PANEL };
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -626,7 +638,14 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
     </section>
   );
 
-  const crew = isCollab && !rosterInBanners && (
+  // No status guard on the roster, and there has not been one to write since
+  // #1089. This file complemented a roster the shared banners drew for a
+  // still-resolving collab, and that complement is dead TWICE over:
+  // `PraxisStatusBanners` no longer draws a roster at all (#1089 deleted it —
+  // its own note in `shared.tsx` records that), and `in_progress` / `pending`
+  // cannot reach an archetype anyway, because `pages/PraxisDetail.tsx` redirects
+  // both to the composer before dispatching (ADR-0062). One roster, always.
+  const crew = isCollab && (
     <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
       {sectionHead(t("detail.sections.members"))}
       <div style={{ ...CREW_INK, color: INK }}>
@@ -735,7 +754,6 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
            deliberately NOT token-repointed, so a row reaches the reader in the
            voice that wrote it. */
         commentsHeading: sectionHead(t("detail.sections.comments")),
-        sectionGap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
       }}
     />
   );

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -5,26 +5,19 @@ import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
 import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
-import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import SingularityLamps from "../../../components/factionMarks/SingularityLamps";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
-import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
 import {
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
   bylineFaces,
-  scoreWasBanked,
   taskRefMeta,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import Breadcrumb from "../../../components/nav/Breadcrumb";
+import { PraxisDetailSkin } from "../praxisDetailSkin";
 import { factionRoleVars } from "../../../utils/factionRoles";
 
 /**
@@ -371,13 +364,9 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // the notice itself into the shared slot; this deviation predates it and is
   // preserved rather than settled — see the measurement in
   // `EphemeristsPraxisDetail`, which reads this precedent as "the banner MAY be
-  // dressed", not as a ruling on what to dress it in.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} flaggedBodyInk="var(--color-warning)" />
-      <PraxisAdminBar state={state} />
-    </>
-  );
+  // dressed", not as a ruling on what to dress it in. It rides the kit's
+  // `flaggedBodyInk` now — the same value, on the skin's ink seam rather than
+  // on a locally re-typed mount.
 
   // ── Byline · finding · owner actions · task reference ─────────────────────
   const header = (
@@ -481,7 +470,9 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // the struck well, the ruled register rows and the votes tally. No arithmetic
   // is restated here: `scoreBreakdown()` is the single authority (ADR-0053), and
   // the design's own multiplier-from-the-vote-average is not built.
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={panel}>
       {sectionHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>
@@ -506,21 +497,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // card-muted, card-line, stamp-bg — are now named props, so the phosphor
   // arrives by contract instead of by cascade. Same four values, and the
   // `--color-*` half of that object was never read by this component anyway.
-  const duelBlock: ReactNode = (
-    <DuelCard
-      state={state}
-      style={panel}
-      heading={sectionHead(t("duelCrossLink.label"))}
-      ink={{ name: BRIGHT, total: BRIGHT, muted: DIM, line: HAIR, plate: PANEL }}
-    />
-  );
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  );
+  const duelInk = { name: BRIGHT, total: BRIGHT, muted: DIM, line: HAIR, plate: PANEL };
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
@@ -616,17 +593,11 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
     </section>
   );
 
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      {/* Bare, by rule. No `panel`, no token re-point, no style seam — the
-          report card is outside the costume in all eight faction designs. */}
-      <PraxisFlagBlock state={state} />
-    </>
-  );
+  // The report card is mounted bare by the skin, last in the aside. Bare by
+  // rule: no `panel`, no token re-point, no style seam — it is outside the
+  // costume in all eight faction designs.
 
-  // ── Proof · write-up · members · metatasks ────────────────────────────────
+  // ── Proof · write-up · members ────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
       {sectionHead(t("detail.sections.proof"))}
@@ -672,30 +643,19 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
     </section>
   );
 
-  // READ-ONLY, by construction. `MetataskSeal` omits the peel control and the
-  // add slot when it gets neither `removable` nor `onAdd`, and each seal wears
-  // its ISSUING faction's dress (#927/#933). The design's "Available" chips are
-  // deliberately absent: `apply_metatask` requires `status == in_progress`, so
-  // every chip would 422 on tap.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
-      {sectionHead(t("detail.metatasks.heading"))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  );
+  // The metatask section is the SKIN's now — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. READ-ONLY, by construction: the seal
+  // omits the peel control and the add slot when it gets neither `removable`
+  // nor `onAdd`, and each seal wears its ISSUING faction's dress (#927/#933).
+  // The design's "Available" chips are deliberately absent — `apply_metatask`
+  // requires `status == in_progress`, so every chip would 422 on tap.
 
   return (
-    <div className="py-8">
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      <div
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        flaggedBodyInk: "var(--color-warning)",
+        sheetStyle: {
           /* THE SESSION IS THE SURFACE, and the roles are declared on IT rather
              than on the `py-8` wrapper above (#2675). That wrapper also holds
              the breadcrumb, which is neutral shared site chrome measured on the
@@ -713,112 +673,70 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
           border: `1px solid ${BORDER}`,
           borderRadius: 8,
           boxShadow: "var(--faction-singularity-term-shadow)",
-        }}
-      >
-        {/* The standing raster — a fixed scrim over the whole session. */}
-        <div
-          aria-hidden
-          style={{
-            position: "absolute",
-            inset: 0,
-            pointerEvents: "none",
-            zIndex: 4,
-            background:
-              "repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)",
-          }}
-        />
-        {/* The scan sweep travelling down the page. `.sg-scan` owns both the
-            resting offset and the reduced-motion-guarded travel. */}
-        <div
-          aria-hidden
-          className="sg-scan"
-          style={{
-            position: "absolute",
-            left: "-30%",
-            right: "-30%",
-            height: 40,
-            pointerEvents: "none",
-            zIndex: 4,
-            background: "var(--faction-singularity-term-sweep)",
-          }}
-        />
+        },
+        sheetPrelude: (
+          <>
+            {/* The standing raster — a fixed scrim over the whole session. */}
+            <div
+              aria-hidden
+              style={{
+                position: "absolute",
+                inset: 0,
+                pointerEvents: "none",
+                zIndex: 4,
+                background:
+                  "repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)",
+              }}
+            />
+            {/* The scan sweep travelling down the page. `.sg-scan` owns both the
+                resting offset and the reduced-motion-guarded travel. */}
+            <div
+              aria-hidden
+              className="sg-scan"
+              style={{
+                position: "absolute",
+                left: "-30%",
+                right: "-30%",
+                height: 40,
+                pointerEvents: "none",
+                zIndex: 4,
+                background: "var(--faction-singularity-term-sweep)",
+              }}
+            />
 
-        {chrome}
-
-        <div
-          style={{
-            position: "relative",
-            zIndex: 2,
-            padding: desktop
-              ? "var(--space-2xl) var(--space-2xl) var(--space-3xl)"
-              : "var(--space-lg) var(--space-md) var(--space-xl)",
-          }}
-        >
-          {banners}
-
+            {chrome}
+          </>
+        ),
+        sheetBody: (body) => (
           <div
             style={{
-              display: "flex",
-              flexDirection: desktop ? "row" : "column",
-              alignItems: "stretch",
-              gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+              position: "relative",
+              zIndex: 2,
+              padding: desktop
+                ? "var(--space-2xl) var(--space-2xl) var(--space-3xl)"
+                : "var(--space-lg) var(--space-md) var(--space-xl)",
             }}
           >
-            <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-              {header}
-              {/* Mobile stacks the rail above the proof — one block each, moved,
-                  never a second copy hidden at the other breakpoint. */}
-              {!desktop && (
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "var(--space-lg)",
-                    marginBottom: "var(--space-xl)",
-                  }}
-                >
-                  {rail}
-                </div>
-              )}
-              {proof}
-              {writeUp}
-              {crew}
-              {metatasks}
-              {!desktop && (
-                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-lg)" }}>
-                  {asideRest}
-                </div>
-              )}
-            </div>
-
-            {desktop && (
-              <aside
-                style={{
-                  flex: "0 0 330px",
-                  width: 330,
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                }}
-              >
-                {rail}
-                {asideRest}
-              </aside>
-            )}
+            {body}
           </div>
-
-          {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
-              beneath both columns, inside the page's own chassis, and the layout
-              draws the heading so the thread does not draw a second one.
-              Deliberately NOT token-repointed — each row dispatches on its
-              AUTHOR's faction and must reach the reader in that voice. */}
-          <PraxisDetailComments
-            state={state}
-            heading={sectionHead(t("detail.sections.comments"))}
-            style={{ marginTop: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
-          />
-        </div>
-      </div>
-    </div>
+        ),
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: sectionHead(t("duelCrossLink.label")),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t("detail.metatasks.heading")),
+        /* The comment ROWS stay dispatched on each author's own faction —
+           deliberately NOT token-repointed, so a row reaches the reader in the
+           voice that wrote it. */
+        commentsHeading: sectionHead(t("detail.sections.comments")),
+        sectionGap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+      }}
+    />
   );
 }

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -19,6 +19,10 @@
  *   breadcrumb, score and duel moved above the proof.
  * - Main: banners · byline · title · owner actions · task reference · proof ·
  *   write-up · crew · metatasks. Aside: score · duel · vote · voters · flag.
+ *   That ORDER is the skin's since #2718 — this file names the blocks, the skin
+ *   arranges them. Its one arrangement knob is `pageStyle`: the role map goes on
+ *   the page box rather than the sheet, because this kit's ink reaches the
+ *   breadcrumb.
  * - **The crown renders at both form factors.** It is never form-factor gated —
  *   `ScoreStamp` draws it in the score block's corner off `is_top_for_task`,
  *   and that block is in both layouts (#1710 retired the hero banner).
@@ -113,6 +117,18 @@
  * The ground belongs to the COLUMN, not the viewport (§5, the #1028 ruling): the
  * site background still shows around the page, which is why `.snide-backdrop`'s
  * `position: fixed` mount is not the one used here.
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
@@ -125,7 +141,7 @@ import { CollabRoster } from "../../../components/collab/CollabRoster";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
-import { PraxisDetailSkin } from "../praxisDetailSkin";
+import { PraxisDetailSkin, type DuelInk } from "../praxisDetailSkin";
 import {
   PraxisOwnerActions,
   MemberByline,
@@ -561,7 +577,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   //
   // The rival's own faction hue still never reaches the card — the foreign side
   // is a disc and an outline.
-  const duelInk = {
+  const duelInk: DuelInk = {
     name: PLATE_TEXT,
     total: PLATE_TEXT,
     muted: PLATE_MUTED,
@@ -793,7 +809,6 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
         metatasksHeading: sectionHead(t("detail.metatasks.heading"), { big: true }),
         /* The comment ROWS stay dispatched on each author's own faction. */
         commentsHeading: sectionHead(t("detail.sections.comments"), { big: true }),
-        sectionGap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
       }}
     />
   );

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -121,26 +121,19 @@ import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
 import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
-import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
-import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
+import { PraxisDetailSkin } from "../praxisDetailSkin";
 import {
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
   bylineFaces,
   orderedMembers,
-  scoreWasBanked,
   taskRefMeta,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 import { factionRoleVars } from "../../../utils/factionRoles";
 
 const IMPACT = "var(--faction-snide-font-impact)"; /* Anton */
@@ -401,13 +394,9 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   // notice comes from there too since #2718; it was drawn here for want of a
   // slot, and this page names no ink for it, so it keeps the same neutral
   // warning tokens and the same shared `detail.banners.*` copy every other skin
-  // reads. `PraxisAdminBar` is the steward bar, mounted bare.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
-    </>
-  );
+  // reads. `PraxisAdminBar` is the steward bar, mounted bare. All three are
+  // MOUNTED from the shared layer too since #2718; this kit passes neither ink
+  // knob.
 
   // ── Byline · title · owner actions · task reference ───────────────────────
   const header = (
@@ -541,7 +530,9 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   // foreign task keeps its own mark on this page. No term is restated here and
   // no arithmetic is invented: `scoreBreakdown()` is the only resolver
   // (ADR-0014/0047/0053).
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={plate}>
       {sectionHead(t("detail.score.heading"), { onPlate: true })}
       <div style={{ display: "flex", justifyContent: "center" }}>
@@ -570,27 +561,13 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   //
   // The rival's own faction hue still never reaches the card — the foreign side
   // is a disc and an outline.
-  const duelBlock: ReactNode = (
-    <DuelCard
-      state={state}
-      style={plate}
-      heading={sectionHead(t("duelCrossLink.label"), { onPlate: true })}
-      ink={{
-        name: PLATE_TEXT,
-        total: PLATE_TEXT,
-        muted: PLATE_MUTED,
-        line: PLATE_MUTED,
-        plate: PLATE,
-      }}
-    />
-  );
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  );
+  const duelInk = {
+    name: PLATE_TEXT,
+    total: PLATE_TEXT,
+    muted: PLATE_MUTED,
+    line: PLATE_MUTED,
+    plate: PLATE,
+  };
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   //
@@ -703,16 +680,10 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
     </section>
   );
 
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      {/* NEUTRAL, and deliberately bare — no clipping, no plate (ADR-0061). */}
-      <PraxisFlagBlock state={state} />
-    </>
-  );
+  // The report card is mounted bare by the skin, last in the aside: NEUTRAL,
+  // and deliberately bare — no clipping, no plate (ADR-0061).
 
-  // ── Proof · write-up · crew · metatasks ───────────────────────────────────
+  // ── Proof · write-up · crew ───────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
       {sectionHead(t("detail.sections.proof"), { big: true })}
@@ -781,39 +752,25 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
     </section>
   );
 
-  // READ-ONLY, by construction (#1093). `MetataskSeal` omits the peel control
-  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
-  // wears its ISSUING faction's dress (#927/#933). The design's add chips are
-  // deliberately absent: `apply_metatask` requires `status == in_progress`, so
-  // every chip would 422 on tap.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
-      {sectionHead(t("detail.metatasks.heading"), { big: true })}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  );
+  // The metatask section is the SKIN's now — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. READ-ONLY, by construction (#1093): the
+  // seal omits the peel control and the add slot when it gets neither
+  // `removable` nor `onAdd`, and each seal wears its ISSUING faction's dress
+  // (#927/#933). The design's add chips are deliberately absent —
+  // `apply_metatask` requires `status == in_progress`, so every chip would 422.
 
   return (
-    <div
-      className="py-8"
-      style={{
-        ...factionRoleVars("snide", "snd-read"),
-        position: "relative",
-        fontFamily: TYPE,
-        color: INK,
-      }}
-    >
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      <div
-        className="snd-detail-sheet"
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        pageStyle: {
+          ...factionRoleVars("snide", "snd-read"),
+          position: "relative",
+          fontFamily: TYPE,
+          color: INK,
+        },
+        sheetClassName: "snd-detail-sheet",
+        sheetStyle: {
           position: "relative",
           zIndex: 1,
           maxWidth: 1200,
@@ -822,71 +779,22 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
           padding: desktop ? "var(--space-2xl)" : "var(--space-lg)",
           overflow: "hidden",
           boxSizing: "border-box",
-        }}
-      >
-        {banners}
-
-        <div
-          style={{
-            display: "flex",
-            flexDirection: desktop ? "row" : "column",
-            alignItems: "stretch",
-            gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
-          }}
-        >
-          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-            {header}
-            {/* Mobile stacks the rail above the proof — one block each, MOVED,
-                never a second copy hidden at the other breakpoint. */}
-            {!desktop && (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                  marginBottom: "var(--space-xl)",
-                }}
-              >
-                {rail}
-              </div>
-            )}
-            {proof}
-            {writeUp}
-            {crew}
-            {metatasks}
-            {!desktop && (
-              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-lg)" }}>
-                {asideRest}
-              </div>
-            )}
-          </div>
-
-          {desktop && (
-            <aside
-              style={{
-                flex: "0 0 330px",
-                width: 330,
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-lg)",
-              }}
-            >
-              {rail}
-              {asideRest}
-            </aside>
-          )}
-        </div>
-
-        {/* The third layout region (ADR-0064, amending ADR-0006): comments sit
-            beneath both columns, inside the page's own sheet, and the layout
-            draws the heading so the thread does not draw a second one. The ROWS
-            stay dispatched on each author's own faction. */}
-        <PraxisDetailComments
-          state={state}
-          heading={sectionHead(t("detail.sections.comments"), { big: true })}
-          style={{ marginTop: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
-        />
-      </div>
-    </div>
+        },
+        header,
+        score: scoreBlock,
+        duelPanel: plate,
+        duelHeading: sectionHead(t("duelCrossLink.label"), { onPlate: true }),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t("detail.metatasks.heading"), { big: true }),
+        /* The comment ROWS stay dispatched on each author's own faction. */
+        commentsHeading: sectionHead(t("detail.sections.comments"), { big: true }),
+        sectionGap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+      }}
+    />
   );
 }

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -19,7 +19,7 @@ import {
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
-import { PraxisDetailSkin } from "../praxisDetailSkin";
+import { PraxisDetailSkin, type DuelInk } from "../praxisDetailSkin";
 import {
   PraxisOwnerActions,
   MemberByline,
@@ -106,8 +106,10 @@ import type { PraxisDetailState } from "../usePraxisDetail";
  *   comes from `ScoreStamp`'s corner, keyed only on `is_top_for_task`, and the
  *   score block is in both layouts (#1710 retired the hero banner it used to
  *   come from). Where a design hides it on a phone, it shows anyway.
- * - The duel panel and the comment thread are SLOTS THIS PAGE OWNS, not
- *   dispatcher mounts (ADR-0064) — a skin that forgets one simply loses it.
+ * - The duel panel and the comment thread are not dispatcher mounts (ADR-0064)
+ *   and never were. Since #2718 they are not this file's either: the SKIN draws
+ *   both, this kit hands over the panel chrome and the two section heads, and
+ *   no kit can forget one.
  * - **The report card and the steward bar are NOT dressed.** `PraxisFlagBlock`
  *   and `PraxisAdminBar` take `state` and nothing else and are mounted bare, on
  *   their own neutral `.sidebar-card` + `--color-*` tokens, wearing none of the
@@ -144,6 +146,18 @@ import type { PraxisDetailState } from "../usePraxisDetail";
  * nine skins rather than worked around here · `CommentThread` via
  * `PraxisDetailComments` with the heading suppressed, so one list carries one
  * heading (#1029).
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 
 /* The aside track is the SKIN's now — 330px across all eight faction designs
@@ -516,7 +530,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // avatar. No sienna on the numerals: `card-accent` is this page's LINK ink and
   // a duel total is not a link. And no rival faction hue anywhere — the foreign
   // side reads as foreign through its outline, not through a colour.
-  const duelInk = {
+  const duelInk: DuelInk = {
     name: "var(--leaf-praxis-detail-ink)",
     total: "var(--leaf-praxis-detail-ink)",
     muted: "var(--leaf-praxis-detail-quiet)",
@@ -792,7 +806,6 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
         crew,
         metatasksHeading: sectionHead(t("detail.metatasks.heading")),
         commentsHeading: sectionHead(t("detail.sections.comments")),
-        sectionGap: size.sectionGap,
       }}
     />
   );

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -6,7 +6,6 @@ import { factionRoleVars } from "../../../utils/factionRoles";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
 import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
-import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
 import { Lotus } from "../../../components/factionMarks";
 import { UaSigil } from "../../../components/sigil/UaSigil";
@@ -17,23 +16,17 @@ import {
   UaInkColumn,
   uaShade,
 } from "../../../components/factionMarks/uaAtoms";
-import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
 import { mediaUrl } from "../../../utils/media";
+import { PraxisDetailSkin } from "../praxisDetailSkin";
 import {
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
   bylineFaces,
-  scoreWasBanked,
   taskRefMeta,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 
 /**
  * University of Asthmatics — THE PRESSED LEAF, UA's praxis-detail skin (#1119,
@@ -153,8 +146,9 @@ import Breadcrumb from "../../../components/nav/Breadcrumb";
  * heading (#1029).
  */
 
-/** The aside track. 330px across all eight faction designs (#1129). */
-const ASIDE_TRACK = 330;
+/* The aside track is the SKIN's now — 330px across all eight faction designs
+   (#1129), one number rather than eight. A kit overrides it only if its own
+   design does; this one does not. */
 
 /**
  * The practice's five-rung ladder — faint · forming · true · alive · radiant —
@@ -368,13 +362,8 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // this page names no ink for it, so it reads in the SAME neutral vocabulary
   // rather than in sienna on vellum. The steward bar below is `PraxisAdminBar`,
   // equally bare. Every word of all three is the shared neutral block: this is
-  // the platform speaking, not the practice.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
-    </>
-  );
+  // the platform speaking, not the practice. All three are MOUNTED from the
+  // shared layer too since #2718; this kit passes neither ink knob.
 
   // ── Byline · title · owner actions · task reference ───────────────────────
   const header = (
@@ -498,7 +487,9 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // TASK's faction — so this page gets UA's own stamp, and the arithmetic is
   // `scoreBreakdown()`'s alone (ADR-0053). No second strip restating the same
   // terms, and no hand-drawn ensō: the stamp already owns the mark's score half.
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={panel}>
       {panelHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>
@@ -525,27 +516,13 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // avatar. No sienna on the numerals: `card-accent` is this page's LINK ink and
   // a duel total is not a link. And no rival faction hue anywhere — the foreign
   // side reads as foreign through its outline, not through a colour.
-  const duelBlock: ReactNode = (
-    <DuelCard
-      state={state}
-      style={panel}
-      heading={panelHead(t("duelCrossLink.label"))}
-      ink={{
-        name: "var(--leaf-praxis-detail-ink)",
-        total: "var(--leaf-praxis-detail-ink)",
-        muted: "var(--leaf-praxis-detail-quiet)",
-        line: "var(--faction-ua-rule)",
-        plate: "var(--faction-ua-panel)",
-      }}
-    />
-  );
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  );
+  const duelInk = {
+    name: "var(--leaf-praxis-detail-ink)",
+    total: "var(--leaf-praxis-detail-ink)",
+    muted: "var(--leaf-praxis-detail-quiet)",
+    line: "var(--faction-ua-rule)",
+    plate: "var(--faction-ua-panel)",
+  };
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   //
@@ -667,16 +644,10 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // The report card wears NO leaf dress: `PraxisFlagBlock` takes `state` and
   // nothing else, on its own neutral `.sidebar-card` + `--color-*` tokens. That
   // is the ADR-0061 rule and all eight faction designs draw it, so it is mounted
-  // bare beside sheets it deliberately does not match.
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      <PraxisFlagBlock state={state} />
-    </>
-  );
+  // bare beside sheets it deliberately does not match. The skin mounts it, last
+  // in the aside, after the vote and voters sheets.
 
-  // ── Proof · write-up · members · metatasks ────────────────────────────────
+  // ── Proof · write-up · members ────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: size.sectionGap }}>
       {sectionHead(t("detail.sections.proof"))}
@@ -749,38 +720,24 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
     </section>
   );
 
-  // READ-ONLY, by construction (#1093). `MetataskSeal` omits the peel control
-  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
-  // wears its ISSUING faction's dress (#927/#933). No "available" chips:
-  // `apply_metatask` (services/praxis.py) requires `status == in_progress`, so
-  // every one would 422 on tap.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: size.sectionGap }}>
-      {sectionHead(t("detail.metatasks.heading"))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  );
+  // The metatask section is the SKIN's now — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. READ-ONLY, by construction (#1093): the
+  // seal omits the peel control and the add slot when it gets neither
+  // `removable` nor `onAdd`, and each seal wears its ISSUING faction's dress
+  // (#927/#933). No "available" chips — `apply_metatask` (services/praxis.py)
+  // requires `status == in_progress`, so every one would 422 on tap.
 
   return (
-    <div
-      className="py-8"
-      style={{ position: "relative" }}
-    >
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      {/* The toothed vellum, painting the detail COLUMN and not the viewport —
-          the site background still shows around the leaf (WORLD_ZERO_STYLE §5,
-          the #1028 ruling). `zIndex: 1` also makes this the stacking context the
-          lotus below hangs off. */}
-      <div
-        className="ua-praxis-leaf"
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        pageStyle: { position: "relative" },
+        /* The toothed vellum, painting the detail COLUMN and not the viewport —
+           the site background still shows around the leaf (WORLD_ZERO_STYLE §5,
+           the #1028 ruling). `zIndex: 1` also makes this the stacking context
+           the lotus hangs off. */
+        sheetClassName: "ua-praxis-leaf",
+        sheetStyle: {
           /* The nine roles under this surface's prefix (#2659/#2673).
              DECLARED ON THE LEAF, NOT ON THE WRAPPER ABOVE IT: that wrapper
              also parents the shared neutral `Breadcrumb`, and a surface's
@@ -801,96 +758,42 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
           boxSizing: "border-box",
           fontFamily: UA_TEXT,
           color: "var(--faction-ua-page-text)",
-        }}
-      >
-        {/* The lotus, bleeding off the leaf's own left edge — clipped by this
-            column's `overflow: hidden` rather than by the viewport. `zIndex: -1`
-            paints it above the column's own ground but beneath its copy: the
-            column is positioned and owns the stacking context, so a positioned
-            `zIndex: 0` sibling would have sat ON TOP of the static text (§5's
-            stacking half). Ornament geometry stays in raw px; its opacity is a
-            token, so dark mode lifts it through the cascade. */}
-        <Lotus
-          size={size.lotus}
-          color="var(--faction-ua-card-lotus)"
-          style={{
-            position: "absolute",
-            left: size.lotusLeft,
-            top: size.lotusTop,
-            zIndex: -1,
-            opacity: "var(--faction-ua-card-lotus-opacity)",
-            pointerEvents: "none",
-          }}
-        />
-
-        {banners}
-
-        <div
-          style={{
-            display: "flex",
-            flexDirection: desktop ? "row" : "column",
-            alignItems: "stretch",
-            gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
-          }}
-        >
-          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-            {header}
-            {/* Mobile stacks the rail above the proof — one block each, MOVED,
-                never a second copy hidden at the other breakpoint. */}
-            {!desktop && (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                  marginBottom: "var(--space-xl)",
-                }}
-              >
-                {rail}
-              </div>
-            )}
-            {proof}
-            {writeUp}
-            {crew}
-            {metatasks}
-            {!desktop && (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-lg)",
-                }}
-              >
-                {asideRest}
-              </div>
-            )}
-          </div>
-
-          {desktop && (
-            <aside
-              style={{
-                flex: `0 0 ${ASIDE_TRACK}px`,
-                width: ASIDE_TRACK,
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-lg)",
-              }}
-            >
-              {rail}
-              {asideRest}
-            </aside>
-          )}
-        </div>
-
-        {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
-            beneath both columns, inside the leaf, and the layout draws the
-            heading so the thread does not draw a second one. */}
-        <PraxisDetailComments
-          state={state}
-          heading={sectionHead(t("detail.sections.comments"))}
-          style={{ marginTop: size.sectionGap }}
-        />
-      </div>
-    </div>
+        },
+        /* The lotus, bleeding off the leaf's own left edge — clipped by this
+           column's `overflow: hidden` rather than by the viewport. `zIndex: -1`
+           paints it above the column's own ground but beneath its copy: the
+           column is positioned and owns the stacking context, so a positioned
+           `zIndex: 0` sibling would have sat ON TOP of the static text (§5's
+           stacking half). Ornament geometry stays in raw px; its opacity is a
+           token, so dark mode lifts it through the cascade. */
+        sheetPrelude: (
+          <Lotus
+            size={size.lotus}
+            color="var(--faction-ua-card-lotus)"
+            style={{
+              position: "absolute",
+              left: size.lotusLeft,
+              top: size.lotusTop,
+              zIndex: -1,
+              opacity: "var(--faction-ua-card-lotus-opacity)",
+              pointerEvents: "none",
+            }}
+          />
+        ),
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: panelHead(t("duelCrossLink.label")),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead(t("detail.metatasks.heading")),
+        commentsHeading: sectionHead(t("detail.sections.comments")),
+        sectionGap: size.sectionGap,
+      }}
+    />
   );
 }

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -11,7 +11,7 @@ import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
 import { factionRoleVars } from '../../../utils/factionRoles'
 import { mediaUrl } from '../../../utils/media'
-import { PraxisDetailSkin } from '../praxisDetailSkin'
+import { PraxisDetailSkin, type DuelInk } from '../praxisDetailSkin'
 import {
   bylineFaces,
   PraxisOwnerActions,
@@ -83,9 +83,11 @@ import type { PraxisDetailState } from '../usePraxisDetail'
  * - **The crown renders at both form factors.** It is not form-factor gated: it
  *   comes from `ScoreStamp`'s corner, keyed only on `is_top_for_task`, and the
  *   score block is in both layouts (#1710 retired the hero banner).
- * - The duel panel and the comment thread are SLOTS THIS PAGE OWNS, not
- *   dispatcher mounts (ADR-0064). Nothing is rendered around the archetype any
- *   more, so a skin that forgets one simply loses it.
+ * - The duel panel and the comment thread are not dispatcher mounts (ADR-0064).
+ *   Since #2718 they are not this page's own slots either: the SKIN draws both
+ *   and no kit can forget one. This kit hands over the plate chrome, the two
+ *   section heads and the duel's inks; the balloon bunch rides the comments
+ *   heading, and the bunting is a `sheetPrelude`.
  * - **The report card and the steward bar are NOT dressed.** `PraxisFlagBlock`
  *   and `PraxisAdminBar` take `state` and nothing else and are mounted bare,
  *   wearing none of the plate chrome the score, vote and voters blocks wear.
@@ -117,6 +119,18 @@ import type { PraxisDetailState } from '../usePraxisDetail'
  * 422) · `DuelCard`, which owns all three duel readings and draws nothing on a
  * declined challenge · `CommentThread` via `PraxisDetailComments`, with the
  * heading suppressed so one list carries one heading (#1029).
+ *
+ * ## This file delegates the spine and supplies the dress (#2718)
+ *
+ * The arrangement above is not drawn here. `PraxisDetailSkin` holds it once —
+ * the sheet, the split, the 330px aside, the comments region beneath both
+ * columns and the phone's rail/asideRest reflow — and it mounts the pieces no
+ * faction dresses: `PraxisStatusBanners`, `PraxisAdminBar`, the `scoreWasBanked`
+ * gate, `DuelCard`, `PraxisFlagBlock`, the `MetataskSeal` section and
+ * `PraxisDetailComments`. What this file is, is the KIT handed to it: the
+ * ground, the ornament, the face, the role map and the blocks it letters
+ * itself. `archetypeSlots.test.tsx` asserts both halves — that every slot still
+ * reaches the page, and that this file re-mounts none of what the skin draws.
  */
 
 /**
@@ -498,7 +512,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // and the verdict, the chronicle rule on the hairlines, the media inset behind
   // an avatarless disc. The gilt is absent by the same standing rule: it
   // measures 2.24:1 on the cream and nothing legible is painted in it.
-  const duelInk = { name: INK, total: INK, muted: MUTED, line: HAIR, plate: INSET }
+  const duelInk: DuelInk = { name: INK, total: INK, muted: MUTED, line: HAIR, plate: INSET }
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   //
@@ -710,7 +724,6 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
           t('detail.sections.comments'),
           <BalloonBunch size={34} />,
         ),
-        sectionGap: size.sectionGap,
       }}
     />
   )

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -5,27 +5,20 @@ import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
-import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
 import { BalloonBunch, Bunting, Zig } from '../../../components/factionMarks/wowOrnament'
-import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
 import { factionRoleVars } from '../../../utils/factionRoles'
 import { mediaUrl } from '../../../utils/media'
+import { PraxisDetailSkin } from '../praxisDetailSkin'
 import {
   bylineFaces,
-  PraxisAdminBar,
-  PraxisStatusBanners,
   PraxisOwnerActions,
-  PraxisFlagBlock,
-  PraxisDetailComments,
   MemberByline,
-  scoreWasBanked,
   taskRefMeta,
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import Breadcrumb from "../../../components/nav/Breadcrumb";
 
 /**
  * Warriors of Whimsy — THE CHRONICLE ENTRY, WOW's praxis-detail skin (#1121,
@@ -198,8 +191,9 @@ const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
   },
 }
 
-/** The aside track. 330px, corrected from 340 by #1129 against the eight designs. */
-const ASIDE_TRACK = 330
+/* The aside track is the SKIN's now — 330px, corrected from 340 by #1129
+   against the eight designs, and one number rather than eight. A kit overrides
+   it only if its own design does; this one does not. */
 
 /** The chronicle's label voice — MedievalSharp small caps. */
 const EYEBROW: CSSProperties = {
@@ -366,13 +360,8 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // this page names no ink for it, so it reads in the SAME neutral vocabulary
   // rather than in gold and plum. The steward bar below is `PraxisAdminBar`,
   // equally bare. Every word of all three is the shared neutral block: this is
-  // the platform speaking, not the faction.
-  const banners = (
-    <>
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
-    </>
-  )
+  // the platform speaking, not the faction. All three are MOUNTED from the
+  // shared layer too since #2718; this kit passes neither ink knob.
 
   // ── Byline · title · owner actions · task reference ───────────────────────
   const header = (
@@ -478,7 +467,9 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // member reading a foreign task's praxis on this page still sees that task's
   // stamp. The arithmetic is `scoreBreakdown()`'s alone (ADR-0053); this file
   // adds no second strip restating the same terms.
-  const scoreBlock = !scoreWasBanked(praxis) ? null : (
+  //
+  // Handed to the skin unconditionally — `scoreWasBanked` is the shared gate.
+  const scoreBlock = (
     <section style={panel}>
       {panelHead('score', t('detail.score.heading'))}
       <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -507,21 +498,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // and the verdict, the chronicle rule on the hairlines, the media inset behind
   // an avatarless disc. The gilt is absent by the same standing rule: it
   // measures 2.24:1 on the cream and nothing legible is painted in it.
-  const duelBlock: ReactNode = (
-    <DuelCard
-      state={state}
-      style={panel}
-      heading={panelHead('duel', t('duelCrossLink.label'))}
-      ink={{ name: INK, total: INK, muted: MUTED, line: HAIR, plate: INSET }}
-    />
-  )
-
-  const rail = (
-    <>
-      {scoreBlock}
-      {duelBlock}
-    </>
-  )
+  const duelInk = { name: INK, total: INK, muted: MUTED, line: HAIR, plate: INSET }
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
   //
@@ -630,16 +607,10 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // The report card wears NO chronicle dress: `PraxisFlagBlock` takes `state`
   // and nothing else, on its own neutral `.sidebar-card` + `--color-*` tokens.
   // That is the ADR-0061 rule and all eight faction designs draw it, so it is
-  // mounted bare beside plates it deliberately does not match.
-  const asideRest = (
-    <>
-      {voteBlock}
-      {votersBlock}
-      <PraxisFlagBlock state={state} />
-    </>
-  )
+  // mounted bare beside plates it deliberately does not match. The skin mounts
+  // it, last in the aside, after the vote and voters plates.
 
-  // ── Proof · write-up · members · charms ───────────────────────────────────
+  // ── Proof · write-up · members ────────────────────────────────────────────
   const proof = praxis.media_items.length > 0 && (
     <section style={{ marginBottom: size.sectionGap }}>
       {sectionHead('proof', t('detail.sections.proof'))}
@@ -692,33 +663,23 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
     </section>
   )
 
-  // READ-ONLY, by construction (#1093). `MetataskSeal` omits the peel control
-  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
-  // wears its ISSUING faction's dress (#927/#933). No "available" chips:
-  // `apply_metatask` requires `status == in_progress`, so every one would 422.
-  const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: size.sectionGap }}>
-      {sectionHead('charms', t('detail.metatasks.heading'))}
-      <MetataskSeal metatasks={praxis.applied_metatasks} />
-    </section>
-  )
+  // The charms section is the SKIN's now — every archetype drew the same
+  // `<section>` + `MetataskSeal` pair. READ-ONLY, by construction (#1093): the
+  // seal omits the peel control and the add slot when it gets neither
+  // `removable` nor `onAdd`, and each seal wears its ISSUING faction's dress
+  // (#927/#933). No "available" chips — `apply_metatask` requires
+  // `status == in_progress`, so every one would 422.
 
   return (
-    <div className="py-8" style={{ position: 'relative' }}>
-      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
-          same trail at every width - see components/nav/Breadcrumb. */}
-      <Breadcrumb
-        taskId={praxis.task_id}
-        taskTitle={praxis.task_title}
-        praxisId={praxis.id}
-      />
-
-      {/* The parchment field with its dot texture (index.css), painting the
-          detail COLUMN and not the viewport — the site background still shows
-          around the component (WORLD_ZERO_STYLE §5, the #1028 ruling). */}
-      <div
-        className="wow-detail-field"
-        style={{
+    <PraxisDetailSkin
+      state={state}
+      kit={{
+        pageStyle: { position: 'relative' },
+        /* The parchment field with its dot texture (index.css), painting the
+           detail COLUMN and not the viewport — the site background still shows
+           around the component (WORLD_ZERO_STYLE §5, the #1028 ruling). */
+        sheetClassName: 'wow-detail-field',
+        sheetStyle: {
           ...factionRoleVars('wow', 'wow-praxis-page'),
           position: 'relative',
           zIndex: 1,
@@ -729,78 +690,28 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
           overflow: 'hidden',
           boxSizing: 'border-box',
           boxShadow: 'var(--faction-wow-detail-shadow)',
-        }}
-      >
-        <Bunting style={{ marginBottom: size.buntingGap }} />
-
-        {banners}
-
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: desktop ? 'row' : 'column',
-            alignItems: 'stretch',
-            gap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
-          }}
-        >
-          <div style={{ flex: '1 1 auto', minWidth: 0 }}>
-            {header}
-            {/* Mobile stacks the rail above the proof — one block each, MOVED,
-                never a second copy hidden at the other breakpoint. */}
-            {!desktop && (
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 'var(--space-lg)',
-                  marginBottom: 'var(--space-xl)',
-                }}
-              >
-                {rail}
-              </div>
-            )}
-            {proof}
-            {writeUp}
-            {crew}
-            {metatasks}
-            {!desktop && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
-                {asideRest}
-              </div>
-            )}
-          </div>
-
-          {desktop && (
-            <aside
-              style={{
-                flex: `0 0 ${ASIDE_TRACK}px`,
-                width: ASIDE_TRACK,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 'var(--space-lg)',
-              }}
-            >
-              {rail}
-              {asideRest}
-            </aside>
-          )}
-        </div>
-
-        {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
-            beneath both columns, inside the page's own field, and the layout
-            draws the heading so the thread does not draw a second one. The
-            bunch bobs beside THE GALLERY — the page's crowd, and its one
-            bobbing ornament. */}
-        <PraxisDetailComments
-          state={state}
-          heading={sectionHead(
-            'gallery',
-            t('detail.sections.comments'),
-            <BalloonBunch size={34} />,
-          )}
-          style={{ marginTop: size.sectionGap }}
-        />
-      </div>
-    </div>
+        },
+        sheetPrelude: <Bunting style={{ marginBottom: size.buntingGap }} />,
+        header,
+        score: scoreBlock,
+        duelPanel: panel,
+        duelHeading: panelHead('duel', t('duelCrossLink.label')),
+        duelInk,
+        vote: voteBlock,
+        voters: votersBlock,
+        proof,
+        writeUp,
+        crew,
+        metatasksHeading: sectionHead('charms', t('detail.metatasks.heading')),
+        /* The bunch bobs beside THE GALLERY — the page's crowd, and its one
+           bobbing ornament. */
+        commentsHeading: sectionHead(
+          'gallery',
+          t('detail.sections.comments'),
+          <BalloonBunch size={34} />,
+        ),
+        sectionGap: size.sectionGap,
+      }}
+    />
   )
 }

--- a/frontend/src/pages/praxisDetail/praxisDetailSkin.tsx
+++ b/frontend/src/pages/praxisDetail/praxisDetailSkin.tsx
@@ -73,12 +73,33 @@ import {
 } from './shared'
 import type { PraxisDetailState } from './usePraxisDetail'
 
-/** The duel card's ink seam, borrowed rather than re-declared — `DuelCardInk`
- *  is private to `DuelCard.tsx` and that file is not this lane's to change. */
-type DuelInk = ComponentProps<typeof DuelCard>['ink']
+/**
+ * The duel card's ink seam, borrowed rather than re-declared — `DuelCardInk` is
+ * private to `DuelCard.tsx` and that file is not this lane's to change.
+ *
+ * EXPORTED, and a kit must ANNOTATE with it. Six kits hoisted their `ink`
+ * object out of the `<DuelCard>` mount when they became kits, and an
+ * un-annotated `const` is inferred rather than checked: TypeScript's
+ * excess-property check fires on an object LITERAL assigned to a typed
+ * position, not on a wider object flowing into one later. So `mutd:` for
+ * `muted:` would have compiled, and `resolveInk` would have quietly painted the
+ * na default grey on a faction plate — a real repaint that no type error and no
+ * markup hash would catch, because the fixtures the gate renders have no duel
+ * ink of their own to compare against.
+ */
+export type DuelInk = ComponentProps<typeof DuelCard>['ink']
 
-/** The desktop aside's track, in px. The one measurement the whole surface
- *  agrees on (ADR-0061); a kit overrides it only if its own design does. */
+/**
+ * The desktop aside's track, in px. The ONE measurement the whole surface
+ * agrees on — 330, corrected from 340 by #1129 against the eight designs, and
+ * ADR-0061's contract.
+ *
+ * Not a kit knob. It was one for exactly as long as it took to migrate the
+ * kits: all eight passed nothing, so the `?? 330` arm had no consumer and no
+ * test, and eight kit comments existed to say a faction did not override a
+ * number it had never overridden. A design that genuinely wants a different
+ * track can add the knob back with a caller and a case.
+ */
 const ASIDE_TRACK = 330
 
 /**
@@ -121,8 +142,6 @@ export interface PraxisDetailKit {
   /** Mounted as the split row's first child, before the main column: a
    *  watermark whose anchor is the row rather than the sheet. */
   splitPrelude?: ReactNode
-  /** The desktop aside's track in px. Defaults to {@link ASIDE_TRACK}. */
-  asideTrack?: number
   /** Mounted under the comments, inside the sheet body — a colophon. */
   footer?: ReactNode
 
@@ -162,9 +181,6 @@ export interface PraxisDetailKit {
   metatasksHeading: ReactNode
   /** The comments region's label, so the thread does not draw a second one. */
   commentsHeading: ReactNode
-  /** The gap between the main column's sections, and above the comments.
-   *  One value: every kit used the same string in both places. */
-  sectionGap: string
 }
 
 /**
@@ -185,8 +201,13 @@ export function PraxisDetailSkin({
   const { praxis } = state
   if (!praxis) return null
 
-  const track = kit.asideTrack ?? ASIDE_TRACK
   const sheetBody = kit.sheetBody ?? ((body: ReactNode) => body)
+  // The gap under the main column's sections and above the comments. It was a
+  // kit field until all eight kits turned out to pass this same expression —
+  // indirection around a constant, which `ProfileDress`'s own docstring names
+  // as the thing that happened to seven copy knobs (#1911). The skin already
+  // knows the form factor, so it can just say it.
+  const sectionGap = desktop ? 'var(--space-2xl)' : 'var(--space-xl)'
 
   // ── Moderation banners ────────────────────────────────────────────────────
   // Invariant, and mounted bare: the failed mark, the flagged notice and the
@@ -235,7 +256,7 @@ export function PraxisDetailSkin({
   // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
   // wears its ISSUING faction's dress (#927/#933).
   const metatasks = praxis.applied_metatasks.length > 0 && (
-    <section style={{ marginBottom: kit.sectionGap }}>
+    <section style={{ marginBottom: sectionGap }}>
       {kit.metatasksHeading}
       <MetataskSeal metatasks={praxis.applied_metatasks} />
     </section>
@@ -285,8 +306,8 @@ export function PraxisDetailSkin({
       {desktop && (
         <aside
           style={{
-            flex: `0 0 ${track}px`,
-            width: track,
+            flex: `0 0 ${ASIDE_TRACK}px`,
+            width: ASIDE_TRACK,
             display: 'flex',
             flexDirection: 'column',
             gap: 'var(--space-lg)',
@@ -324,7 +345,7 @@ export function PraxisDetailSkin({
             <PraxisDetailComments
               state={state}
               heading={kit.commentsHeading}
-              style={{ marginTop: kit.sectionGap }}
+              style={{ marginTop: sectionGap }}
             />
             {kit.footer}
           </>,

--- a/frontend/src/pages/praxisDetail/praxisDetailSkin.tsx
+++ b/frontend/src/pages/praxisDetail/praxisDetailSkin.tsx
@@ -1,0 +1,335 @@
+/**
+ * The praxis-detail spine, held once and dressed nine ways (#2718).
+ *
+ * ## What this is, and what it is not
+ *
+ * It is `characterProfile/archetypes/profileSkin.tsx` on this surface: ONE
+ * shared skinnable renderer holding the invariant arrangement, driven by a
+ * per-faction {@link PraxisDetailKit} of paint and slots. Nine files stay nine
+ * files (`frontend/CLAUDE.md`) — every archetype keeps its own file, its own
+ * ground, its own ornament, its own face and its own role map, and delegates
+ * the arrangement here. It is **not** one component branching on a slug: there
+ * is no slug in this file and no table keyed by one, which is the boundary the
+ * #2992 ruling draws between a shared CHASSIS (fine) and a runtime SKIN TABLE
+ * (not fine).
+ *
+ * ## The arrangement, stated on its own terms (ADR-0061)
+ *
+ * ```
+ * .py-8 ─── Breadcrumb (site chrome, above the surface — #2102)
+ *        └─ the SHEET (the faction's own ground)
+ *           ├─ sheetPrelude   ← bands, mastheads, rasters, wordmarks
+ *           └─ sheetBody(     ← an optional padded / stacked inner wrapper
+ *                banners      ← PraxisStatusBanners + PraxisAdminBar
+ *                split ─┬─ main:  header · [rail] · proof · writeUp · crew
+ *                       │         · metatasks · [asideRest]
+ *                       └─ aside: rail · asideRest        (desktop only, 330px)
+ *                comments      ← PraxisDetailComments, beneath BOTH columns
+ *                footer        ← a colophon under the whole plate
+ *              )
+ * ```
+ *
+ * `rail` is score + duel; `asideRest` is vote + voters + the report card. They
+ * are built ONCE and MOVED — on a phone the rail stacks above the proof and the
+ * rest below the metatasks; on a laptop both sit in the 330px aside. Never
+ * drawn twice and hidden, which would double the DOM (ADR-0056/0058).
+ *
+ * ## What the kit may and may not do
+ *
+ * ADR-0061's rule is that an archetype may **arrange** the slots freely but may
+ * not **drop** one, and this file does not narrow it: a faction whose page is
+ * genuinely its own shape keeps its own tree and does not delegate, exactly as
+ * three of nine profile kits still do. What a kit may not do is silently omit a
+ * mount — which is why the eleven invariant mounts are mounted HERE and are not
+ * kit fields. `__tests__/archetypeSlots.test.tsx` holds the derived half: no
+ * delegating archetype re-mounts one of them itself.
+ *
+ * ## The seam this was proved at
+ *
+ * `__tests__/markupStability.test.tsx` — every registered archetype × ten
+ * states × both form factors, SHA-256 of the static markup, TZ-pinned. Each kit
+ * migrated to this skin one at a time, and the gate stayed byte-identical
+ * through every one. That is the whole claim: this moved code, not pixels.
+ *
+ * Two consequences for anyone editing this file. **Style objects are ordered**:
+ * React serialises `style` in key order, so `{...kit.splitStyle, display: …}`
+ * puts the kit's keys first because that is where the kits already had them.
+ * And **an absent knob must render an absent attribute** — `className={undefined}`
+ * and `style={undefined}` emit nothing, which is how a kit with no sheet class
+ * keeps the markup it had.
+ */
+import type { ComponentProps, CSSProperties, ReactNode } from 'react'
+
+import Breadcrumb from '../../components/nav/Breadcrumb'
+import { useFormFactor } from '../../hooks/useFormFactor'
+import { DuelCard } from './DuelCard'
+import MetataskSeal from '../../components/metataskSeal/MetataskSeal'
+import {
+  PraxisAdminBar,
+  PraxisDetailComments,
+  PraxisFlagBlock,
+  PraxisStatusBanners,
+  scoreWasBanked,
+} from './shared'
+import type { PraxisDetailState } from './usePraxisDetail'
+
+/** The duel card's ink seam, borrowed rather than re-declared — `DuelCardInk`
+ *  is private to `DuelCard.tsx` and that file is not this lane's to change. */
+type DuelInk = ComponentProps<typeof DuelCard>['ink']
+
+/** The desktop aside's track, in px. The one measurement the whole surface
+ *  agrees on (ADR-0061); a kit overrides it only if its own design does. */
+const ASIDE_TRACK = 330
+
+/**
+ * A faction's dress and its arranged slots. Everything here is either paint the
+ * kit owns or a node the kit built — no copy, no rules, no slug.
+ */
+export interface PraxisDetailKit {
+  /* ── ground ────────────────────────────────────────────────────────────── */
+
+  /** Style for the outer `.py-8` box, which also parents the shared
+   *  `Breadcrumb`. Faction ROLE MAPS do not belong here for most kits — see
+   *  the note on {@link sheetStyle} — but a kit whose ink spans the crumb
+   *  (S.N.I.D.E.) declares it, which is why this is a knob and not a constant.
+   *  Omit it and no `style` attribute is emitted at all. */
+  pageStyle?: CSSProperties
+  /** The sheet's own class — `.eph-plate-sheet`, `.wow-detail-field`. */
+  sheetClassName?: string
+  /** The sheet's inline paint: the ground, the frame, the radius, the padding,
+   *  and (for most kits) `factionRoleVars(slug, prefix)`. Declared on THE SHEET
+   *  rather than on the page box above it, because that box also holds the
+   *  neutral shared breadcrumb and a faction namespace has no business spanning
+   *  site chrome (#2672/#2675/#2102). */
+  sheetStyle?: CSSProperties
+  /** Mounted as the sheet's first children, before the banners: spectrum bands,
+   *  mastheads, scan rasters, bleeding ornaments. Clipped by the sheet's own
+   *  `overflow`, so a layer at `inset: 0` can never paint the viewport
+   *  (WORLD_ZERO_STYLE §5, the #1028 ruling). */
+  sheetPrelude?: ReactNode
+  /** An inner wrapper around banners + split + comments + footer, for a kit
+   *  whose sheet paints flush to its own edges and pads its contents
+   *  separately, or that needs a positioned stacking layer over its ground.
+   *  Defaults to identity, so a kit that needs neither says nothing and emits
+   *  no extra element. */
+  sheetBody?: (body: ReactNode) => ReactNode
+  /** Style merged in FRONT of the split row's own flex properties — a kit that
+   *  anchors a watermark to the columns row makes it `position: relative` here.
+   *  Merged in front because that is the order the kits already wrote it in and
+   *  React serialises `style` by key order. */
+  splitStyle?: CSSProperties
+  /** Mounted as the split row's first child, before the main column: a
+   *  watermark whose anchor is the row rather than the sheet. */
+  splitPrelude?: ReactNode
+  /** The desktop aside's track in px. Defaults to {@link ASIDE_TRACK}. */
+  asideTrack?: number
+  /** Mounted under the comments, inside the sheet body — a colophon. */
+  footer?: ReactNode
+
+  /* ── ink the shared chrome takes (#3016) ───────────────────────────────── */
+
+  /** Edge and label of the flagged notice, when the shared warning hue does not
+   *  clear the kit's own plate. Two kits set it; the rest inherit. */
+  flaggedInk?: string
+  /** The flagged notice's sentence, likewise. */
+  flaggedBodyInk?: string
+
+  /* ── the dressed content ───────────────────────────────────────────────── */
+
+  /** Byline · title · owner actions · task reference. The kit's own, because
+   *  every faction re-letters all four. */
+  header: ReactNode
+  /** The score panel, INCLUDING `ScoreStamp`. Handed in unconditionally: the
+   *  `scoreWasBanked` gate is invariant and lives in the skin, so a kit cannot
+   *  accidentally draw a score panel on an unscored praxis (#1444). */
+  score: ReactNode
+  /** The panel chrome the duel card wears, so it reads as this page's. */
+  duelPanel: CSSProperties
+  /** The duel card's label, in the kit's own section-head dress. */
+  duelHeading: ReactNode
+  /** The duel card's inks. Omit for the `na` kit's own paint. */
+  duelInk?: DuelInk
+  /** The vote panel, gated by the kit on `voteRegionVisible` (#1429). */
+  vote: ReactNode
+  /** The who-voted panel, gated by the kit on a non-empty roll. */
+  voters: ReactNode
+  /** Main column, in order, each gated by the kit on its own payload field. */
+  proof: ReactNode
+  writeUp: ReactNode
+  crew: ReactNode
+  /** The applied-metatask section's label. The SECTION and the read-only
+   *  `MetataskSeal` inside it are the skin's — every kit drew the same two. */
+  metatasksHeading: ReactNode
+  /** The comments region's label, so the thread does not draw a second one. */
+  commentsHeading: ReactNode
+  /** The gap between the main column's sections, and above the comments.
+   *  One value: every kit used the same string in both places. */
+  sectionGap: string
+}
+
+/**
+ * Renders one praxis-detail page from one kit.
+ *
+ * `state.praxis` is guarded non-null by the caller — every archetype returns
+ * null on a missing praxis before it builds a single node, because its own
+ * dress reads the payload.
+ */
+export function PraxisDetailSkin({
+  state,
+  kit,
+}: {
+  state: PraxisDetailState
+  kit: PraxisDetailKit
+}) {
+  const desktop = useFormFactor() !== 'mobile'
+  const { praxis } = state
+  if (!praxis) return null
+
+  const track = kit.asideTrack ?? ASIDE_TRACK
+  const sheetBody = kit.sheetBody ?? ((body: ReactNode) => body)
+
+  // ── Moderation banners ────────────────────────────────────────────────────
+  // Invariant, and mounted bare: the failed mark, the flagged notice and the
+  // steward bar are the PLATFORM speaking, not the faction (ADR-0061). The two
+  // ink knobs are the whole of a kit's say over them (#3016).
+  const banners = (
+    <>
+      <PraxisStatusBanners
+        state={state}
+        flaggedInk={kit.flaggedInk}
+        flaggedBodyInk={kit.flaggedBodyInk}
+      />
+      <PraxisAdminBar state={state} />
+    </>
+  )
+
+  // ── The rail: score + duel, built once and MOVED ──────────────────────────
+  //
+  // The gate is `scoreWasBanked`, not `score > 0` — an unscored praxis (failed,
+  // hidden) draws no panel at all (#1444), and that is a rule rather than a
+  // dress decision, so it is here and not in nine kits.
+  const rail = (
+    <>
+      {scoreWasBanked(praxis) ? kit.score : null}
+      <DuelCard
+        state={state}
+        style={kit.duelPanel}
+        heading={kit.duelHeading}
+        ink={kit.duelInk}
+      />
+    </>
+  )
+
+  // ── The rest of the aside: vote · voters · the report card ────────────────
+  // `PraxisFlagBlock` is mounted BARE, by contract and by construction: it
+  // accepts no style prop, so skinning it is not the easy path (ADR-0061).
+  const asideRest = (
+    <>
+      {kit.vote}
+      {kit.voters}
+      <PraxisFlagBlock state={state} />
+    </>
+  )
+
+  // READ-ONLY, by construction (#1093): `MetataskSeal` omits the peel control
+  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
+  // wears its ISSUING faction's dress (#927/#933).
+  const metatasks = praxis.applied_metatasks.length > 0 && (
+    <section style={{ marginBottom: kit.sectionGap }}>
+      {kit.metatasksHeading}
+      <MetataskSeal metatasks={praxis.applied_metatasks} />
+    </section>
+  )
+
+  const split = (
+    <div
+      style={{
+        ...kit.splitStyle,
+        display: 'flex',
+        flexDirection: desktop ? 'row' : 'column',
+        alignItems: 'stretch',
+        gap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
+      }}
+    >
+      {kit.splitPrelude}
+      <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+        {kit.header}
+        {/* Mobile stacks the rail above the proof — one block each, MOVED,
+            never a second copy hidden at the other breakpoint. */}
+        {!desktop && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 'var(--space-lg)',
+              marginBottom: 'var(--space-xl)',
+            }}
+          >
+            {rail}
+          </div>
+        )}
+        {kit.proof}
+        {kit.writeUp}
+        {kit.crew}
+        {metatasks}
+        {!desktop && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
+            {asideRest}
+          </div>
+        )}
+      </div>
+
+      {/* The 330px TRACK is desktop-only; its CONTENTS are not — they moved up
+          into the main column above. A different claim from the crown, which
+          renders at both form factors because the score panel does. */}
+      {desktop && (
+        <aside
+          style={{
+            flex: `0 0 ${track}px`,
+            width: track,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-lg)',
+          }}
+        >
+          {rail}
+          {asideRest}
+        </aside>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="py-8" style={kit.pageStyle}>
+      {/* SITE CHROME, ABOVE THE SURFACE (#2102). Neutral, shared, and the
+          same trail at every width - see components/nav/Breadcrumb. */}
+      <Breadcrumb
+        taskId={praxis.task_id}
+        taskTitle={praxis.task_title}
+        praxisId={praxis.id}
+      />
+
+      <div className={kit.sheetClassName} style={kit.sheetStyle}>
+        {kit.sheetPrelude}
+        {sheetBody(
+          <>
+            {banners}
+            {split}
+            {/* The third layout region (ADR-0061, amending ADR-0006): comments
+                sit beneath BOTH columns, inside the page's own sheet, and the
+                layout draws the heading so the thread does not draw a second
+                one (the #1029 trap). The ROWS stay dispatched on each author's
+                own faction — deliberately not token-repointed, because a
+                comment must reach the reader in the voice that wrote it. */}
+            <PraxisDetailComments
+              state={state}
+              heading={kit.commentsHeading}
+              style={{ marginTop: kit.sectionGap }}
+            />
+            {kit.footer}
+          </>,
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Batch 11's lane, second step. #3016 moved the one re-typed notice and built the gate; this builds the shape the issue actually asked for — a shared skinnable renderer holding the invariant spine, driven by a per-faction kit, **nine files staying nine**.

The counter-example #3016's review found is the model: `characterProfile/archetypes/profileSkin.tsx`. Same division here, one surface over.

> **Review round 1 is addressed** (`7a806efe`). Ten findings: the guard is scoped to delegating archetypes and its tripwire now matches a mount; `DuelInk` is exported and seven kits annotate it; `asideTrack` and `sectionGap` are deleted as knobs-around-a-constant; the dead `rosterInBanners` complement is normalised in three kits; seven stale kit headers are rewritten; the payload claim is corrected from +15 to **+28** with the per-chunk table and the mechanism verified in the built file. Details in each section below.

## The seam I tested at

**`__tests__/markupStability.test.tsx`** — every registered archetype × ten states × both form factors, SHA-256 of the static markup, TZ-pinned. It landed on main last night and is the reusable half of this lane, exactly as #3016 predicted.

The loop was red-first in the only sense a byte-identity gate can be: **each kit migrated on its own commit, and the gate ran before the commit was made.** A kit whose style-key order drifted, whose `className={undefined}` emitted an attribute, or whose sheet grew a wrapper would have moved rows and named itself. None did. Snapshot never re-recorded, never run with `-u`, and **not in this diff**.

Three places I *did* go red on purpose, all in the guard — see "Mutation-checked" below.

## The kit contract

`pages/praxisDetail/praxisDetailSkin.tsx` renders:

```
.py-8 ─── Breadcrumb (site chrome, above the surface — #2102)
       └─ the SHEET (the faction's own ground)
          ├─ sheetPrelude   ← bands, mastheads, rasters, wordmarks
          └─ sheetBody(     ← an optional padded / stacked inner wrapper
               banners      ← PraxisStatusBanners + PraxisAdminBar
               split ─┬─ main:  header · [rail] · proof · writeUp · crew
                      │         · metatasks · [asideRest]
                      └─ aside: rail · asideRest        (desktop only, 330px)
               comments      ← PraxisDetailComments, beneath BOTH columns
               footer        ← a colophon under the whole plate
             )
```

`rail` is score + duel, `asideRest` is vote + voters + report card. Built once, **moved** — phone stacks the rail above the proof and the rest below the metatasks; laptop puts both in the 330px aside. Never drawn twice and hidden (ADR-0056/0058).

**A kit that wants the default arrangement says nothing.** `sheetPrelude`, `sheetBody`, `splitStyle`, `splitPrelude` and `footer` are all optional and four kits set none of them. An absent knob emits an absent attribute, which is how a kit with no sheet class keeps the markup it had.

**No slug in the skin and no table keyed by one** — the #2992 boundary between a shared CHASSIS and a runtime SKIN TABLE, quoted in `frontend/CLAUDE.md`.

**`flaggedInk` / `flaggedBodyInk` folded into the kit** (#3016 rule 7). Singularity's warning-hue body and the Ephemerists' plate amber are kit fields now, not loose props on a locally re-typed mount. Same values, byte-identical output.

**`orderedMembers` is untouched and stays a per-kit call.** Ephemerists and S.N.I.D.E. make it, each for its own byline; the skin does not take that decision and gained no knob for it.

### Three knobs the review removed, and why they were wrong to add

- **`asideTrack?: number` — deleted.** Zero consumers and an untested `?? 330` arm. All eight kits passed nothing, and eight kit comments existed to say a faction did not override a number it had never overridden. `330` is ADR-0061's one measurement (corrected from 340 by #1129) and now lives in the skin as a `const`. A design that genuinely wants a different track can add the knob back *with a caller and a case*.
- **`sectionGap: string` — deleted.** All eight kits passed the identical `desktop ? 'var(--space-2xl)' : 'var(--space-xl)'`; three of them routed it through a `SIZES` entry holding those same two values. The skin already computes `desktop`, so it computes the gap. `ProfileDress`'s own docstring names this anti-pattern — #1911 collapsed seven copy knobs that had all become the same constant.
- **`DuelInk` — now exported, and seven kits annotate it.** Seven kits (not six — `DefaultPraxisDetail` passes no ink at all) hoisted their `ink` object out of the `<DuelCard>` mount when they became kits, and an un-annotated `const` is *inferred*, not checked: TypeScript's excess-property check fires on an object literal in a typed position, not on a wider object flowing into one later. So `mutd:` for `muted:` compiled, and `resolveInk` would have quietly painted the `na` default grey on a faction plate — a real repaint that no type error and no markup hash would catch, because the gate's fixtures carry no duel ink to compare against.

## Per-kit table — all eight dressed kits migrated

Line counts are after the review round, so they include the three deleted knobs and the header rewrites.

| kit | before | after | Δ | notes |
|---|---:|---:|---:|---|
| `AlbescentPraxisDetail` | 98 | **98** | 0 | **The control. Not one line changed.** It wraps Default through the `ornament` slot, which the kit still carries, so it inherited the delegation for free (ADR-0048/0083 intact). |
| `DefaultPraxisDetail` (na) | 729 | 661 | −68 | The reference kit, as it was the reference page. |
| `EverymenPraxisDetail` | 798 | 714 | −84 | Masthead → `sheetPrelude`. |
| `WowPraxisDetail` | 806 | 730 | −76 | Bunting → `sheetPrelude`; balloon bunch rides `commentsHeading`. |
| `UaPraxisDetail` | 896 | 812 | −84 | Lotus → `sheetPrelude`. |
| `CovenPraxisDetail` | 800 | 727 | −73 | First to need two knobs: `sheetBody` for the positioned stacking layer, `splitPrelude` + `splitStyle` for the cat, whose anchor is the columns ROW not the sheet (#2135). |
| `SingularityPraxisDetail` | 824 | 760 | −64 | Raster + sweep + chrome bar → `sheetPrelude`; the padded z-layer → `sheetBody`. |
| `SnidePraxisDetail` | 892 | 815 | −77 | The kit whose ink spans the breadcrumb, which is why `pageStyle` is a knob and not a constant. |
| `EphemeristsPraxisDetail` | 999 | 924 | −75 | Uses every knob: masthead flush → `sheetPrelude`, padded inset → `sheetBody`, colophon → `footer`. |
| **the eight dressed** | **6744** | **6143** | **−601** | |
| `praxisDetailSkin.tsx` | — | +356 | +356 | new |
| **net, directory** | | | **−245** | |

The "after" column is ~13 lines per kit larger than it was before the review round: seven kit headers gained the "this file delegates the spine" section (finding 6), which is documentation replacing documentation that had gone stale. The three deleted knobs (findings 4 and 5) pull the other way.

**Nothing was left on its own tree.** Every kit reached byte-identity through the skin.

### Why these are 661–924 lines and not the profile kits' 195–311

The brief named the thin profile kits as the target order of magnitude, and this lane does not reach it. That is a real difference in the two surfaces, not slack left in the diff:

`ProfileSkin` owns most of the profile's **content** — credential card, badge board, praxis gallery, proposed-task gallery, About, tagline. A kit supplies tokens and a heading renderer. On praxis detail the shared thing is the **arrangement**; the blocks inside it are eight independently lettered designs. What is left in each kit is exactly that: module-scope ornament components, size sets, section-head renderers, panel chrome, the byline's discs/plates/octagons/cartouches, the voter rungs, the proof mat, the write-up frame. Consolidating those would be repainting, and would fail this PR's own gate.

## Of the eleven named mounts, seven moved and five did not

| mount | where it lives now |
|---|---|
| `PraxisStatusBanners` | **skin** |
| `PraxisAdminBar` | **skin** |
| `PraxisFlagBlock` | **skin** |
| `PraxisDetailComments` | **skin** |
| `DuelCard` | **skin** |
| `MetataskSeal` | **skin** (the `<section>` too) |
| `scoreWasBanked` | **skin** — a rule, not a dress decision |
| `ScoreStamp` | kit, inside the `score` slot |
| `PraxisOwnerActions` | kit, inside `header` |
| `MemberByline` | kit, inside `header` |
| `bylineFaces` | kit, inside `header` |
| `taskRefMeta` | kit, inside `header` |

The five that stayed are all inside `header` and `score` — the two blocks every faction letters completely differently, and ADR-0061's rule is that an archetype may *arrange* freely, which is what a `header: ReactNode` / `score: ReactNode` slot means.

## Computed-value diff

**Zero rows moved. On both snapshots. Through every commit, including the review round.**

```
cd frontend && npx vitest run src/pages/praxisDetail/__tests__/markupStability.test.tsx
```

- `praxis-detail markup is byte-stable across the registry` — **180 rows** (9 registered archetypes × 10 states × 2 form factors), unchanged.
- `ScoreStamp is byte-stable per task faction` — **9 rows**, unchanged. The frozen-four gate this lane had to clear.
- `na is the Default archetype` — still byte-identical through the registry and by direct import, in all 20 cells.
- The three environment-pin cases (UTC, `en-US`, the fixture instant) green throughout.

`__snapshots__/markupStability.test.tsx.snap` is **not in this diff.**

## What I checked

Every step `.github/workflows/test.yml` names for the `frontend` job, locally, on the review-round head:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` (`tsc --noEmit` + e2e config) | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **522 files, 11049 passed, 1 skipped, 0 failed** |
| `npm run build` | clean (the `INEFFECTIVE_DYNAMIC_IMPORT` note on `FactionSigil` is pre-existing on main) |
| `npm run budget` | see below |

`api-schema` is out of scope — no route, `response_model` or Pydantic schema is touched, and no backend file is.

### The dead `rosterInBanners` complement, verified

Three kits (Default, Everymen, Singularity) gated the Members section on `isCollab && !rosterInBanners`; the other five used `isCollab`. **The complement is dead twice over**, and the review was right to ask me to check rather than take Ephemerists' comment on trust:

1. `PraxisStatusBanners` draws **no roster at all**. #1089 deleted it, and `shared.tsx` carries the note where it used to be: *"gated to a still-resolving collab (in_progress / pending), which ADR-0062 now redirects to the composer, so it could never paint again and went with #1089."*
2. Even if it did, `in_progress` / `pending` **cannot reach an archetype**. `pages/PraxisDetail.tsx:61-62` redirects both to the composer before dispatching: `if (state.praxis.status === 'in_progress' || state.praxis.status === 'pending') return <Navigate to={.../edit} replace />`.

So the three are normalised to `isCollab`, matching the other five, and the gate stayed byte-identical — which is consistent but is *not* the proof, since the fixtures render `submitted`. The dispatcher guard is the proof; the gate confirms no reachable state changed.

### Payload — corrected, with the per-chunk table

The previous body claimed **+15 gz** on initial load and could not explain it. **That number was wrong** (measured against a stale asset list from an earlier base). Rebuilt both sides from scratch against this branch's actual merge-base `3709651b`:

**Exactly one initial-load chunk moved.**

| initial chunk | base (gz) | branch (gz) | Δ |
|---|---:|---:|---:|
| `react-vendor.js` | 58 808 | 58 808 | 0 |
| **`index.js`** | **43 601** | **43 629** | **+28** |
| `i18n.js` | 30 261 | 30 261 | 0 |
| `i18next.js` | 13 491 | 13 491 | 0 |
| `client.js` | 3 516 | 3 516 | 0 |
| `context.js` | 771 | 771 | 0 |
| `preload-helper.js` | 676 | 676 | 0 |
| `i18nInstance.js` | 451 | 451 | 0 |
| `rolldown-runtime.js` | 430 | 430 | 0 |
| `Enso.js` | 327 | 327 | 0 |
| `factions.js` | 220 | 220 | 0 |
| `castTallies.js` | 186 | 186 | 0 |
| `requestsBus.js` | 106 | 106 | 0 |
| `baseUrl.js` | 65 | 65 | 0 |
| **initial JS total** | **152 909** | **152 937** | **+28** |
| `index.css` | `index-BtOAbn9v.css` | `index-BtOAbn9v.css` | **same content hash — 0** |

**The review's objection was correct and the mechanism is not eager code.** Nothing eager reaches the skin. `index.js` carries the module-**preload dependency manifest** — a flat array of chunk filenames — and the +28 bytes is one new string in it. Verified in the built artefact rather than asserted:

```
$ grep -o "praxisDetailSkin-[A-Za-z0-9_-]*\.js" dist/assets/index-*.js | sort | uniq -c
      1 praxisDetailSkin-yhtLMVYE.js
```

…and its context is the dependency array itself: `…,"assets/shared-UiqjxQnp.js","assets/praxisDetailSkin-yhtLMVYE.js","assets/AlbescentFeedFrame-…`. One filename, in a list of filenames, in a chunk that ships anyway.

Whole-bundle, all 327 JS chunks:

| | base | branch | Δ |
|---|---:|---:|---:|
| all JS, gzip | 787 659 | 787 007 | **−652** |
| all JS, raw | 2 385 724 | 2 379 656 | **−6 068** |
| the ten lane chunks, raw | 79 982 | 75 571 | **−4 411** |
| the ten lane chunks, gzip | 25 272 | 25 369 | **+97** |

That last row is worth stating rather than hiding: the nine archetype chunks each shed 193–235 gz bytes, and the extracted `praxisDetailSkin.js` costs 1 828 gz on its own — gzip compresses nine in-context copies better than one shared chunk plus nine smaller ones, so the **gzip** win on this lane's own chunks is slightly negative even though the **raw** win is −4.4 KB. The overall bundle is still down on both measures.

**Decision 4's veto is on render-blocking CSS and it is satisfied exactly: identical content hash, so not a byte moved.**

The `WARN JS` the budget prints is **pre-existing on main** — both sides print it, at 150.3 KB against a 175.8 KB fail line.

### `archetypeSlots.test.tsx` — decision 4, and it needed no edit to keep passing

**Every pre-existing assertion in the file is untouched and was green throughout.** The registry-walked property #3016 called the thing worth preserving held again.

It *is* edited, and the edit is purely additive — one new `describe` on the AUTHORING side, which is the guard the brief asked for. The render walks above it ask whether a slot reached the page; they cannot see an archetype that draws its own comment thread *instead of* delegating, because the thread is on the page either way.

**Scoped to the archetypes that delegate** (review finding 1). Walking every registered archetype contradicted the skin's own docblock, which deliberately keeps the option open for a kit whose page is genuinely its own shape to keep its own tree — three of nine profile kits do exactly that, and ADR-0061 says an archetype may *arrange* freely. A tenth faction writing its own spine would be doing something permitted, and flagging it as spine drift would have made this guard an argument against the escape hatch the skin documents. So delegation is **derived from the source** — does the file import the skin — and only delegating archetypes are held to the forbidden list.

That opens a hole (everyone leaves, the list holds vacuously), so **the population is pinned too**: at least eight of nine on the spine, the non-delegators named in the failure message, and the Albescent wrapper asserted as the only one off it. Albescent is not "keeping its own tree" — it reaches the spine the long way, through the `DefaultPraxisDetail` it forwards to whole.

**Both ends derived, and the join too.** Slugs come from `surfaceMap('praxisDetail')`. The FILE for a slug is read out of that faction's own manifest — the identifier `praxisDetail:` returns, then the `import()` it is bound to — keyed on the `slug` the manifest **declares**, so `na` resolves through `default.ts` without a line of mapping (`na` is a state, not a faction; ADR-0039). A tenth faction is picked up by existing.

**Mutation-checked**, three ways, because a `not.toContain` guard that never bites is the vacuous pass #2814's audit kept finding:

| mutation | result |
|---|---|
| re-mount `PraxisFlagBlock` from `UaPraxisDetail`'s kit | `ua` row fails: *"ua re-mounts PraxisFlagBlock"* |
| replace the skin's `<PraxisAdminBar>` mount with `{null}`, keeping the import | tripwire fails: *"imported by praxisDetailSkin.tsx but never mounted there"* — **the old `toContain` assertion passed this** (review finding 2) |
| point the delegation detector at a name nothing imports | population fails: *"only 0 archetype(s) import the skin; these do not: everymen, ua, wow, …"* |

The `DuelInk` annotation is mutation-checked too: `mutd:` for `muted:` in `CovenPraxisDetail` now yields `TS2561: Object literal may only specify known properties, but 'mutd' does not exist in type 'DuelCardInk'. Did you mean to write 'muted'?` — where before it compiled.

One correction from round 1 worth recording: the guard's first draft used `readdirSync` and `noPrivateSourceWalk.test.ts` (#2887) caught it. That guard working is the point — a scan that quietly stops reaching files is exactly this guard's own failure mode. It goes through `sourceFiles()` now.

### Untouched, on purpose

- **`DuelCard.tsx`** — not one line. Its seams stayed as #3020 left them; the skin mounts it through the props it already had and reads its private `DuelCardInk` through `ComponentProps<typeof DuelCard>['ink']` rather than exporting it.
- **`AlbescentPraxisDetail.tsx`** — not one line. The control.
- **`docs/adr/*`**, `index.css`, any `*.css`, `utils/factions.ts`, `.github/`.
- **#2820 is undisturbed.** The score stamp's insets and outer margin are not touched by any line of this PR, and the nine `ScoreStamp` hashes prove it.
- The other lanes running tonight: `pages/proposeTask/**`, `components/CredentialCard.tsx`, `pages/characterProfile/**` (read `profileSkin.tsx`, never edited it), `pages/characterPaths/**`.

## What this leaves

**Three things, and none of them is a kit that failed to migrate — all eight did.**

**1. Five of the eleven mounts are still in kit slots.** `ScoreStamp`, `PraxisOwnerActions`, `MemberByline`, `bylineFaces` and `taskRefMeta` are mounted inside the `header` and `score` nodes each kit builds. `header` genuinely has no shared shape — eight different bylines, eight different title treatments.

`score` is the interesting one, and it is deferred rather than dismissed: **seven of eight write the identical twelve lines** (`<section style={panel}>{head}<div centre><ScoreStamp/></div></section>`; Coven is the eighth and wraps a candle around it). Moving it needs four new knobs — `scorePanel`, `scoreHeading`, `scorePrelude`, `scoreStyle` — to save about 70 lines, *and* would put indirection around the one component the issue names as frozen and that **#2820 still has open work on the host side of**. Four knobs, there, now, is the wrong trade. It is the obvious follow-up once #2820 lands.

**2. The five section shells are rules living in eight kits.** Each of `proof`, `writeUp`, `crew`, `vote` and `voters` is a gate plus the same shell:

```
praxis.media_items.length > 0     →  <section style={{ marginBottom }}>{sectionHead(label)}…</section>
praxis.body_text                  →  (same shell)
isCollab                          →  (same shell)
voteRegionVisible(user, canVote)  →  (same shell)
voters.length > 0                 →  (same shell)
```

Those **gates are rules, not dress** — the same class as `scoreWasBanked`, which this PR did move — and they are currently re-decided eight times, which is exactly the shape #2718 was filed about. Deliberately **not** moved in this pass: it is a second axis on top of a migration that is already nine files wide, and mixing them would make the byte-identity argument much harder to read. Named here as the next step so it is a decision rather than an omission.

**3. The contact sheet.** Decision 12's review artefact cannot be produced in this harness at all — it needs a rendering browser, and this is `renderToStaticMarkup` in node with no DOM, no layout and no viewport.

## What to eyeball

**I have no browser and no dev stack.** Everything above is `tsc`, `eslint`, `vitest` and two full bundle builds. **Visual QA is outstanding.**

What mitigates it and what does not: 189 byte-identical hashes are a strong claim that *nothing rendered differently*, stronger than a reviewer reading nine trees could make. It is not a claim about **how it looks**, because markup identity says nothing about a stylesheet or a cascade — but the stylesheet's content hash is identical too, so the residual risk is genuinely small. Small is not checked.

Every praxis-detail archetype, at **375px** and **1280px**, in **both themes**:

- [ ] **`albescent` — THE CONTROL.** Not one line changed, and its parent's kit still carries the `ornament` slot it reaches through. If it differs from `main` anywhere, something upstream is wrong and this PR is not it.
- [ ] `na` / Unaffiliated — the spectrum band across the sheet head, and the sheet's 18px radius clipping it.
- [ ] `coven` — **the one to look hardest at.** The only kit whose watermark is anchored to the columns ROW rather than the sheet, and that anchoring moved through a new knob. The cat should still sit `bottom: 0 / right: 24` of the split, under the copy, above the ground, still visible where the discussion begins (#2135).
- [ ] `singularity` — raster, `.sg-scan` sweep and chrome bar all moved into one prelude. The sweep should still travel over the whole session, the raster should still scrim it, and the padded inner box below them should not have gained or lost an edge.
- [ ] `ephemerists` — masthead flush to the plate's own edges with the padded inset under it, and the **colophon** still at the foot, below the comments, behind its own rule, still undated (#2124/#2143). Its flagged notice is the one whose edge, label *and* body take the plate's amber — put a praxis into `flagged` and check all three marks in both cascades.
- [ ] `everymen` — the cogged masthead band and the double rule under it.
- [ ] `snide` — its role map is declared on the page box, so its ink reaches the breadcrumb. Confirm the crumb reads as it did.
- [ ] `ua` — the lotus still bleeding off the leaf's left edge, clipped by the leaf and not the viewport.
- [ ] `wow` — the bunting above the banners, the balloon bunch beside the comments heading.

And specifically:

- [ ] **The score stamp, on every one of the nine.** One of the frozen four; this PR's merge gate is a zero-row diff on it and nothing here touches it.
- [ ] **The 330px aside on a laptop and its collapse at 375px** — rail above the proof, vote/voters/report card below the metatasks. The reflow is the thing that moved into shared code, and no test can see a fold (WORLD_ZERO_STYLE, the #2234/#2244/#2130 ruling).
- [ ] **A COLLAB praxis on `na`, `everymen` and `singularity`** — the three whose crew gate changed. The Members section should draw exactly one roster, as it already does on the other five.
- [ ] **A flagged praxis with the steward bar drawn**, on all nine — notice and bar adjacent is the arrangement where a spacing change would show.
- [ ] **A settled duel**, on all nine: the duel card is mounted from shared code now and wears each kit's panel and inks.
- [ ] **An unscored praxis** (`failed`): no score panel, because the `scoreWasBanked` gate moved into the skin (#1444).

Part of #2718

🤖 Generated with [Claude Code](https://claude.com/claude-code)
