### PR TITLE
No class token may run into a template interpolation — the guard for #2918, and a fourth site where one did

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -23,6 +23,12 @@
     exception rather than silently drifted past.
 - Color values live only in the `index.css` tree — `src/css/*.css`, ordered by
   the `src/index.css` import map (#2891). CSS vars only; never hardcode hex.
+- **A class token gets a space before `${`.** Tailwind reads the source as text,
+  so `` `… overflow-y-auto${extra}` `` offers it no candidate and the utility
+  never reaches the stylesheet — while the build, the lint, the typecheck and
+  the suite all pass (#2918). Write `` `… overflow-y-auto ${extra}` ``, or lift
+  the branch out of the literal (`redacted ? 'a b' : 'a'`). Enforced by
+  `src/test/__tests__/noGluedClassInterpolation.test.ts`.
 - Faction config: `factions.ts`.
 - **A surface reads a ROLE, not a token.** Spread `factionRoleVars(slug, prefix)` on the
   root you own and read `var(--<prefix>-<role>)` below it — nine roles (`paper`, `ink`,

--- a/frontend/src/components/duel/DuelSealSheet.tsx
+++ b/frontend/src/components/duel/DuelSealSheet.tsx
@@ -94,8 +94,8 @@ export default function DuelSealSheet({
         role="dialog"
         aria-modal="true"
         aria-label={label}
-        className={`fixed inset-0 z-50 flex flex-col justify-end overflow-y-auto${
-          phoneClassName ? ` ${phoneClassName}` : ''
+        className={`fixed inset-0 z-50 flex flex-col justify-end overflow-y-auto ${
+          phoneClassName ?? ''
         }`}
         style={{ background: 'var(--color-bg-page)', ...ground }}
       >

--- a/frontend/src/components/layout/PendingBadge.tsx
+++ b/frontend/src/components/layout/PendingBadge.tsx
@@ -46,7 +46,7 @@ export default function PendingBadge({ count, className, style }: PendingBadgePr
   return (
     <span
       aria-hidden="true"
-      className={`flex items-center justify-center font-body${className ? ` ${className}` : ''}`}
+      className={`flex items-center justify-center font-body ${className ?? ''}`}
       style={style ? { ...BADGE_STYLE, ...style } : BADGE_STYLE}
     >
       {count}

--- a/frontend/src/pages/players/DesktopPlayers.tsx
+++ b/frontend/src/pages/players/DesktopPlayers.tsx
@@ -548,7 +548,7 @@ function FactionLaneName({ slug }: { slug: string }) {
   const href = factionHref(slug)
   const redacted = isFactionRedacted(slug)
   const style = { fontSize: 'var(--text-content)' }
-  const className = `font-display${redacted ? ' redacted' : ''}`
+  const className = redacted ? 'font-display redacted' : 'font-display'
   if (href === null) {
     return (
       <span className={className} style={style} data-redacted={redacted ? 'true' : undefined}>

--- a/frontend/src/pages/players/MobilePlayers.tsx
+++ b/frontend/src/pages/players/MobilePlayers.tsx
@@ -302,7 +302,7 @@ function FactionLaneName({ slug }: { slug: string }) {
   const href = factionHref(slug)
   const redacted = isFactionRedacted(slug)
   const style = { fontSize: 'var(--text-content)' }
-  const className = `font-display truncate${redacted ? ' redacted' : ''}`
+  const className = redacted ? 'font-display truncate redacted' : 'font-display truncate'
   if (href === null) {
     return (
       <span className={className} style={style} data-redacted={redacted ? 'true' : undefined}>

--- a/frontend/src/test/__tests__/noGluedClassInterpolation.test.ts
+++ b/frontend/src/test/__tests__/noGluedClassInterpolation.test.ts
@@ -1,0 +1,234 @@
+/**
+ * No class token may run straight into a template interpolation (#2918).
+ *
+ * THE FAILURE THIS STANDS ON
+ * --------------------------
+ * Tailwind reads the source as text and keeps the utility candidates it can
+ * recognise. `DuelSealSheet.tsx` wrote
+ *
+ *     `fixed inset-0 … overflow-y-auto${phoneClassName ? ` ${phoneClassName}` : ''}`
+ *
+ * v3's regex extractor kept `overflow-y-auto`; v4's scanner drops it. The rule
+ * left the stylesheet, the class attribute went on naming it, and a full-screen
+ * mobile dialog shipped unable to scroll. `npm run build`, `npm run lint`,
+ * `npm run typecheck` and all 509 test files passed. It was found by diffing
+ * the emitted class set of two builds by hand — which is not a check, it is a
+ * person having a hunch on a Tuesday. #3021 fixed three sites; this is the part
+ * that stops the fourth, and it found one while it was being written
+ * (`truncate` in `MobilePlayers.tsx`, which #3021 missed).
+ *
+ * WHY THE RULE IS A SPACE AND NOT A VOCABULARY
+ * --------------------------------------------
+ * The obvious guard asks "is the glued token a real Tailwind utility?", which
+ * means keeping a copy of a list this repo does not own. It rots on the next
+ * upgrade, and a rotted list passes. So the rule does not ask: in class
+ * position, an interpolation gets a space in front of it. That also catches
+ * `` `p-${size}` ``, which the narrow rule would wave through and the scanner
+ * drops for exactly the same reason.
+ *
+ * WHAT IS NOT A FINDING
+ * ---------------------
+ * An interpolation that COMPLETES a token rather than following one —
+ * `` `wz-roundel-${id}` ``, `` `var(--spectrum-glow-${value})` ``,
+ * `` `switcher-row-${id}` ``, `` `na.tier${rung}` `` — is a different shape and
+ * legitimate. None of the four is a class name, and the scan is scoped to class
+ * position for that reason; the third describe block below holds all four to it
+ * against the real files, so a widening of the scan fails here rather than
+ * arriving as noise on somebody's PR.
+ *
+ * THE ALLOWLIST
+ * -------------
+ * `ALLOWED` is the ratchet, in the shape `scripts/bundle-budget.mjs` uses for
+ * Albescent's selector allowance: a site that genuinely has to glue is a line
+ * in a diff a human reads, with the reason written next to it. It is empty
+ * today and every entry is a debt.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  classPositionTemplates,
+  classValueRegions,
+  gluedClassInterpolations,
+  gluedClassInterpolationsInSource,
+  scanSource,
+} from '../classNameLiterals'
+import { SRC_DIR, sourceFiles, toRelative } from '../sourceScan'
+
+/**
+ * Sites permitted to glue, as `<path relative to src>:<the glued token>`.
+ *
+ * Empty, and it should stay that way. An entry is a class name Tailwind cannot
+ * see, so it only belongs here when the class is not a Tailwind utility at all
+ * — a hand-written rule from `src/css/` — and the interpolation genuinely
+ * cannot take a space. Add one only with the reason in the PR that adds it.
+ */
+const ALLOWED: readonly string[] = []
+
+const read = (path: string): string => readFileSync(join(SRC_DIR, path), 'utf8')
+
+const SEAL_SHEET = 'components/duel/DuelSealSheet.tsx'
+
+describe('the scan sees the codebase', () => {
+  it('reads the class-name sites, so it cannot pass by looking at nothing', () => {
+    // ~1,835 today, across ~569 files. This is not a measurement, it is the
+    // distance below which the region finder has stopped finding `className`.
+    const regions = sourceFiles().reduce(
+      (total, file) => total + classValueRegions(scanSource(readFileSync(file, 'utf8'))).length,
+      0,
+    )
+    expect(regions).toBeGreaterThan(1_000)
+  })
+
+  it('still finds class names built from template literals at all', () => {
+    // 14 today, in 11 files. A scan that found none would report a clean board
+    // forever, because a clean board is exactly what this guard's pass is.
+    const files = sourceFiles().filter(
+      (file) => classPositionTemplates(scanSource(readFileSync(file, 'utf8'))).length > 0,
+    )
+    expect(files.map(toRelative)).toContain(SEAL_SHEET)
+    expect(files.length).toBeGreaterThan(5)
+  })
+
+  it('finishes every string and literal it opens, in every file', () => {
+    // The scan masks strings, comments and regex literals so a `//` inside a
+    // URL cannot eat a line. If it ever mistook one for another it would run to
+    // the end of the file and see nothing after — silently, and only in the one
+    // file that tripped it. So the state it ends in is asserted, per file.
+    const ragged = sourceFiles({ includeTests: true })
+      .filter((file) => scanSource(readFileSync(file, 'utf8')).unterminated)
+      .map(toRelative)
+    expect(ragged).toEqual([])
+  })
+})
+
+describe('it fails on the real defect, not on a fixture of one', () => {
+  it('reports #2918 when the space is taken back out of DuelSealSheet', () => {
+    const fixed = read(SEAL_SHEET)
+    const regressed = fixed.replace('overflow-y-auto ${', 'overflow-y-auto${')
+
+    // If this file ever stops containing the shape, the tripwire below is
+    // testing nothing, and it says so here rather than passing quietly.
+    expect(regressed, `${SEAL_SHEET} no longer holds the line #3021 fixed`).not.toBe(fixed)
+
+    expect(gluedClassInterpolations(regressed).map((glued) => glued.stem)).toEqual([
+      'overflow-y-auto',
+    ])
+    expect(gluedClassInterpolations(fixed)).toEqual([])
+  })
+
+  it('reads the token, the line and the whole run — not just the last word', () => {
+    const source = [
+      'const a = <div className={`flex items-center justify-center font-body${extra}`} />',
+      'const b = <div className={`flex ${extra}`} />',
+    ].join('\n')
+
+    expect(gluedClassInterpolations(source)).toEqual([
+      { stem: 'font-body', offset: source.indexOf('${'), line: 1 },
+    ])
+  })
+
+  it('sees through a ternary, a nested literal and a prop that is not `className`', () => {
+    const source = [
+      'const a = <Sheet phoneClassName={busy ? `p-4 gap-2${extra}` : undefined} />',
+      'const b = <div className={`${lead} rounded-full`} />',
+      'const c = <div className={`p-2 ${lead}${trail}`} />',
+    ].join('\n')
+
+    // `${lead}${trail}` is two interpolations back to back: the second follows a
+    // `}`, not a token, so only the ternary's `gap-2` is a finding.
+    expect(gluedClassInterpolations(source).map((glued) => glued.stem)).toEqual(['gap-2'])
+  })
+
+  it('follows the value one hop, so a rename does not walk out of the scan', () => {
+    // The two `FactionLaneName` shapes are `const className = …`, and a guard
+    // that leant on the variable's NAME would be left by calling it `base`.
+    const source = [
+      'const base = `flex items-center truncate${redacted ? " redacted" : ""}`',
+      'const el = <span className={base} />',
+    ].join('\n')
+
+    expect(gluedClassInterpolations(source).map((glued) => glued.stem)).toEqual(['truncate'])
+  })
+
+  it('does not follow a name no class ever reads', () => {
+    const source = [
+      'const href = `/tasks/${id}`',
+      'const to = `/praxis/${id}`',
+      'const el = <a href={href} className="p-2" />',
+    ].join('\n')
+
+    expect(gluedClassInterpolations(source)).toEqual([])
+  })
+})
+
+/**
+ * Interpolations that complete a token, at the sites the migration checked by
+ * hand. Each is asserted to be STILL THERE before it is asserted to be quiet,
+ * so a site that moves fails loudly instead of becoming a comment about a shape
+ * that no longer exists.
+ */
+const COMPLETES_A_TOKEN: ReadonlyArray<{ path: string; shape: string; what: string }> = [
+  {
+    path: 'components/factionMarks/PointsRoundel.tsx',
+    shape: 'wz-roundel-${',
+    what: 'an SVG textPath id',
+  },
+  {
+    path: 'components/vote/DefaultVote.tsx',
+    shape: '--spectrum-glow-${',
+    what: 'a CSS custom property read',
+  },
+  {
+    path: 'components/vote/AlbescentVote.tsx',
+    shape: '--spectrum-glow-${',
+    what: 'a CSS custom property read',
+  },
+  {
+    path: 'components/CharacterSwitcherSheet.tsx',
+    shape: 'switcher-row-${',
+    what: 'a test id',
+  },
+  {
+    // Note it does not end in a hyphen, so "must end in `-`" is not the rule.
+    path: 'components/vote/DefaultVote.tsx',
+    shape: 'tier${',
+    what: 'an i18n key',
+  },
+]
+
+describe('an interpolation that completes a token is not a finding', () => {
+  for (const { path, shape, what } of COMPLETES_A_TOKEN) {
+    it(`leaves \`${shape}…\` alone in ${path} — it is ${what}`, () => {
+      const source = read(path)
+      expect(source, `${path} no longer contains \`${shape}\``).toContain(shape)
+      expect(gluedClassInterpolations(source)).toEqual([])
+    })
+  }
+})
+
+describe('no class token is glued to an interpolation (#2918)', () => {
+  it('holds across every file under src', () => {
+    const findings = gluedClassInterpolationsInSource().filter(
+      (finding) => !ALLOWED.includes(finding.key),
+    )
+
+    expect(
+      findings.map((finding) => `${finding.path}:${finding.line}  ${finding.stem}\${`),
+      "Tailwind's scanner reads the source as text and drops a candidate that runs " +
+        'straight into `${`, so the class leaves the stylesheet while the element goes on ' +
+        'naming it — a build, a lint, a typecheck and the whole suite all pass. Put a space ' +
+        'before the interpolation, or lift the branch out of the literal entirely ' +
+        "(`redacted ? 'a b' : 'a'`). If a site genuinely cannot, add its `path:token` to " +
+        'ALLOWED above with the reason in your PR.',
+    ).toEqual([])
+  })
+
+  it('carries no allowlist entry that no longer matches a site', () => {
+    // An entry that stopped matching is a permission nobody is using and a
+    // reason nobody has re-read. It comes out on the commit that stops needing it.
+    const keys = new Set(gluedClassInterpolationsInSource().map((finding) => finding.key))
+    expect(ALLOWED.filter((key) => !keys.has(key))).toEqual([])
+  })
+})

--- a/frontend/src/test/classNameLiterals.ts
+++ b/frontend/src/test/classNameLiterals.ts
@@ -1,0 +1,407 @@
+/**
+ * Find the template literals that build class names, and the interpolations
+ * written flush against a class token inside them.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Tailwind does not evaluate the app. It reads the source as TEXT and keeps the
+ * utility candidates it recognises; anything it does not see is never emitted,
+ * and the class attribute at runtime names a rule that does not exist. Under v3
+ * a regex extractor kept the candidate in
+ *
+ *     `… justify-end overflow-y-auto${phoneClassName ? ` ${phoneClassName}` : ''}`
+ *
+ * Under v4 the scanner does not: `overflow-y-auto` runs straight into `${`, the
+ * candidate is dropped, and `DuelSealSheet` shipped a full-screen mobile dialog
+ * that could not scroll (#2918, fixed in #3021). Nothing about that failure is
+ * visible to the build, the linter, the typechecker or the suite — it was found
+ * by diffing the emitted class set of two builds by hand. One space is the fix.
+ *
+ * WHAT COUNTS AS A FINDING, AND WHY IT IS A BRIGHT LINE
+ * ----------------------------------------------------
+ * A finding is an interpolation with a non-empty run of non-space characters
+ * immediately before it, inside a template literal in CLASS POSITION. It does
+ * NOT ask whether the run is a real Tailwind utility.
+ *
+ * That is deliberate. Asking would mean carrying Tailwind's utility vocabulary
+ * — a second copy of a list this repo does not own, which rots on the next
+ * upgrade and whose staleness looks exactly like a pass. And the narrower rule
+ * buys nothing: a class token glued to `${` is at best unreadable and at worst
+ * silently dropped, whichever half of it Tailwind would have recognised.
+ * `` `p-${size}` `` is dropped by the same scanner for the same reason.
+ *
+ * So the rule is: in class position, put a space before the interpolation. A
+ * site that genuinely cannot is registered in the guard's allowlist with its
+ * reason, which is a line a human reads in a diff.
+ *
+ * CLASS POSITION, EXACTLY
+ * -----------------------
+ * The value of an assignment whose left-hand side names a class — the JSX
+ * attribute `className={…}`, the props `phoneClassName` / `linkClassName` /
+ * `ringClass`, an object key `classes:`, a `const skinClassName = …`. Whatever
+ * shape the value takes, the whole balanced `{…}` is the region, so a ternary,
+ * a nested call and a concatenation are all covered.
+ *
+ * ...plus one hop. A literal assigned to a local name that a class-value region
+ * in the same file then READS is in class position too, whatever the name is —
+ * otherwise `const base = …; <div className={base} />` walks out of the scan on
+ * a rename, and a guard you can leave by renaming a variable is not a guard.
+ * The hop costs nothing: it adds zero findings to today's tree.
+ *
+ * The boundary this draws, said out loud: a template literal that reaches a
+ * class name through something other than one local assignment — returned
+ * straight out of a helper, or handed through a second variable — is outside
+ * the scan. Widening the rule to "any template literal anywhere" is what makes
+ * this check unusable: `` `wz-roundel-${id}` `` (an SVG id),
+ * `` `var(--spectrum-glow-${value})` `` (a CSS custom property),
+ * `` `switcher-row-${id}` `` (a test id) and `` `na.tier${rung}` `` (an i18n
+ * key) are all interpolations that COMPLETE a token rather than follow one, and
+ * none of them is a class.
+ *
+ * WHY THIS FILE DOES NOT REUSE `stripComments`
+ * --------------------------------------------
+ * `sourceScan.ts`'s stripper deletes comment text, which moves every offset
+ * after it, and it does not know about strings — a `//` inside a literal takes
+ * the rest of the line with it, closing backtick included. This guard reports
+ * line numbers and reads the source either side of an offset, so it needs a
+ * pass that keeps length and knows where a string starts. That pass is here.
+ */
+import { readFileSync } from 'node:fs'
+
+import { sourceFiles, toRelative, type ScanOptions } from './sourceScan'
+
+/** One `${…}` inside a template literal, at that literal's own depth. */
+export interface Interpolation {
+  /** Offset of the `$` in `${`. */
+  start: number
+  /** Offset just past the `}` that closes it, or -1 if the file ended first. */
+  end: number
+}
+
+/** One template literal, found by the scan below. */
+export interface TemplateLiteral {
+  /** Offset of the opening backtick. */
+  start: number
+  /** Offset just past the closing backtick, or -1 if the file ended first. */
+  end: number
+  /** Its own interpolations, in source order. Nested literals own theirs. */
+  interpolations: Interpolation[]
+}
+
+export interface SourceScan {
+  /**
+   * The source with comment bodies and string/template TEXT replaced by spaces.
+   * Offsets and line breaks are preserved, and delimiters, punctuation and the
+   * code inside `${…}` all survive — so a pattern may be run over it without
+   * matching prose, and braces may be balanced over it.
+   */
+  code: string
+  /** Every template literal in the file, in the order they open. */
+  templates: TemplateLiteral[]
+  /** A template literal or block comment ran off the end of the file. */
+  unterminated: boolean
+}
+
+/**
+ * A `/` after one of these begins a regex literal; after anything else it is
+ * division. The distinction matters because a regex may contain a quote or a
+ * backtick, and a scanner that mistook one for a string would swallow the rest
+ * of the file and report a clean board — the failure mode this repo cares about
+ * most. Checked against a short window of already-masked source, so a `/` in a
+ * comment or a string never reaches here.
+ */
+const OPENS_A_REGEX =
+  /(?:[([{,;:=!&|?+\-*%~^<>]|\b(?:return|typeof|case|in|of|new|delete|void|instanceof|yield|await|do|else))\s*$/
+
+/** How far back `OPENS_A_REGEX` looks. Long enough for the longest keyword. */
+const REGEX_LOOKBEHIND = 24
+
+/**
+ * Walk `source` once, masking what is not code and recording every template
+ * literal. Deliberately not a parser: it knows strings, comments, regex
+ * literals and template nesting, which is everything the two questions below
+ * need, and nothing about JSX, types or scope.
+ */
+export function scanSource(source: string): SourceScan {
+  const code = [...source]
+  const templates: TemplateLiteral[] = []
+  type Frame =
+    | { kind: 'code'; depth: number; interpolation: Interpolation | null }
+    | { kind: 'template'; literal: TemplateLiteral }
+  const stack: Frame[] = [{ kind: 'code', depth: 0, interpolation: null }]
+  let unterminated = false
+  let i = 0
+
+  const blank = (from: number, to: number): void => {
+    for (let k = Math.max(0, from); k < Math.min(to, code.length); k += 1) {
+      if (code[k] !== '\n') code[k] = ' '
+    }
+  }
+
+  while (i < source.length) {
+    const frame = stack[stack.length - 1]
+    const character = source[i]
+
+    if (frame.kind === 'template') {
+      if (character === '\\') {
+        blank(i, i + 2)
+        i += 2
+        continue
+      }
+      if (character === '`') {
+        frame.literal.end = i + 1
+        stack.pop()
+        i += 1
+        continue
+      }
+      if (character === '$' && source[i + 1] === '{') {
+        const interpolation: Interpolation = { start: i, end: -1 }
+        frame.literal.interpolations.push(interpolation)
+        stack.push({ kind: 'code', depth: 1, interpolation })
+        i += 2
+        continue
+      }
+      blank(i, i + 1)
+      i += 1
+      continue
+    }
+
+    if (character === '/' && source[i + 1] === '/') {
+      const newline = source.indexOf('\n', i)
+      const end = newline === -1 ? source.length : newline
+      blank(i, end)
+      i = end
+      continue
+    }
+
+    if (character === '/' && source[i + 1] === '*') {
+      const close = source.indexOf('*/', i + 2)
+      if (close === -1) {
+        unterminated = true
+        blank(i, source.length)
+        i = source.length
+        continue
+      }
+      blank(i, close + 2)
+      i = close + 2
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      // A newline ends the run as well as the closing quote. An apostrophe in
+      // JSX text is not a string, and recovering at the line end keeps one from
+      // masking the rest of the file.
+      let j = i + 1
+      for (; j < source.length; j += 1) {
+        if (source[j] === '\\') {
+          j += 1
+          continue
+        }
+        if (source[j] === character || source[j] === '\n') break
+      }
+      blank(i + 1, j)
+      i = Math.min(j + 1, source.length)
+      continue
+    }
+
+    if (
+      character === '/' &&
+      OPENS_A_REGEX.test(code.slice(Math.max(0, i - REGEX_LOOKBEHIND), i).join(''))
+    ) {
+      let j = i + 1
+      let inBracket = false
+      for (; j < source.length; j += 1) {
+        const inner = source[j]
+        if (inner === '\\') {
+          j += 1
+          continue
+        }
+        if (inner === '\n') break
+        if (inBracket) {
+          if (inner === ']') inBracket = false
+          continue
+        }
+        if (inner === '[') inBracket = true
+        else if (inner === '/') break
+      }
+      if (j < source.length && source[j] === '/') {
+        blank(i + 1, j)
+        i = j + 1
+        continue
+      }
+      // Not a regex after all. Fall through and treat it as division.
+    }
+
+    if (character === '`') {
+      const literal: TemplateLiteral = { start: i, end: -1, interpolations: [] }
+      templates.push(literal)
+      stack.push({ kind: 'template', literal })
+      i += 1
+      continue
+    }
+
+    if (character === '{') {
+      frame.depth += 1
+      i += 1
+      continue
+    }
+
+    if (character === '}') {
+      frame.depth -= 1
+      if (frame.depth === 0 && stack.length > 1) {
+        if (frame.interpolation !== null) frame.interpolation.end = i + 1
+        stack.pop()
+      }
+      i += 1
+      continue
+    }
+
+    i += 1
+  }
+
+  return { code: code.join(''), templates, unterminated: unterminated || stack.length > 1 }
+}
+
+/**
+ * An assignment whose left-hand side names a class: `className=`, `class=`,
+ * `classes:`, `phoneClassName=`, `ringClass =`. `classList` does not match —
+ * the `=` or `:` has to come next.
+ */
+const CLASS_VALUE = /\b[\w$]*[Cc]lass(?:[Nn]ames?|es)?\s*[=:]\s*/g
+
+/**
+ * The spans of source that a class name is assigned from, as `[start, end)`.
+ *
+ * A `{…}` value is taken whole, so everything the expression reaches for is
+ * inside the span. A bare template literal value is taken to its closing
+ * backtick. Anything else (a plain string, an identifier) has no literal in it
+ * and yields an empty span, which is harmless and keeps the count honest.
+ */
+export function classValueRegions(scan: SourceScan): Array<[number, number]> {
+  const regions: Array<[number, number]> = []
+  for (const match of scan.code.matchAll(CLASS_VALUE)) {
+    const start = match.index + match[0].length
+    if (scan.code[start] === '{') {
+      let depth = 0
+      let end = start
+      for (let i = start; i < scan.code.length; i += 1) {
+        if (scan.code[i] === '{') depth += 1
+        else if (scan.code[i] === '}') {
+          depth -= 1
+          if (depth === 0) {
+            end = i + 1
+            break
+          }
+        }
+      }
+      regions.push([start, end])
+      continue
+    }
+    if (scan.code[start] === '`') {
+      const literal = scan.templates.find((candidate) => candidate.start === start)
+      regions.push([start, literal === undefined || literal.end === -1 ? start : literal.end])
+      continue
+    }
+    regions.push([start, start])
+  }
+  return regions
+}
+
+/** Any JS identifier, for harvesting the names a class-value region reads. */
+const IDENTIFIER = /[A-Za-z_$][\w$]*/g
+
+/** `const base =`, `base =`, `base:` — the name a literal is assigned to. */
+const ASSIGNED_TO = /(?:\b(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)\s*[=:]\s*$/
+
+/** How far back `ASSIGNED_TO` looks. Long enough for `const <a long name> = `. */
+const ASSIGNMENT_LOOKBEHIND = 60
+
+/**
+ * Every template literal a class name is built from: the ones inside a
+ * class-value region, plus the ones assigned to a name such a region reads.
+ *
+ * The second half is one hop and no further. Following the value across files,
+ * or through a second variable, would need a resolver; following it once is a
+ * substring match on the same file, and it is what stops the two `FactionLaneName`
+ * shapes — `const className = …` in the players pages — from depending on the
+ * variable happening to be called `className`.
+ */
+export function classPositionTemplates(scan: SourceScan): TemplateLiteral[] {
+  const regions = classValueRegions(scan)
+  const read = new Set<string>()
+  for (const [start, end] of regions) {
+    for (const [name] of scan.code.slice(start, end).matchAll(IDENTIFIER)) read.add(name)
+  }
+
+  return scan.templates.filter((literal) => {
+    if (literal.end === -1) return false
+    if (regions.some(([start, end]) => literal.start >= start && literal.end <= end)) return true
+    const head = scan.code.slice(Math.max(0, literal.start - ASSIGNMENT_LOOKBEHIND), literal.start)
+    const name = ASSIGNED_TO.exec(head)?.[1]
+    return name !== undefined && read.has(name)
+  })
+}
+
+/** An interpolation written flush against a class token. */
+export interface GluedInterpolation {
+  /** The run of non-space characters immediately before the `${`. */
+  stem: string
+  /** Offset of the `${`. */
+  offset: number
+  /** 1-based line the `${` is on. */
+  line: number
+}
+
+/**
+ * Every glued interpolation in a class-position template literal in `source`.
+ *
+ * The stem runs back from the `${` to the nearest space, to the opening
+ * backtick, or to the end of this literal's previous interpolation — so
+ * `` `a ${b}${c}` `` has no stem at either interpolation, and the value
+ * `` `…overflow-y-auto${…}` `` has the stem `overflow-y-auto`.
+ */
+export function gluedClassInterpolations(source: string): GluedInterpolation[] {
+  const scan = scanSource(source)
+  const glued: GluedInterpolation[] = []
+
+  for (const literal of classPositionTemplates(scan)) {
+    let floor = literal.start + 1
+    for (const interpolation of literal.interpolations) {
+      let cursor = interpolation.start
+      while (cursor > floor && !/\s/.test(source[cursor - 1])) cursor -= 1
+      const stem = source.slice(cursor, interpolation.start)
+      if (stem !== '') {
+        glued.push({
+          stem,
+          offset: interpolation.start,
+          line: source.slice(0, interpolation.start).split('\n').length,
+        })
+      }
+      floor = interpolation.end === -1 ? literal.end : interpolation.end
+    }
+  }
+
+  return glued
+}
+
+/** A glued interpolation, located. */
+export interface GluedFinding extends GluedInterpolation {
+  /** The file, as the guards report paths: relative to `src`, forward slashes. */
+  path: string
+  /** `path:stem` — the key the guard's allowlist is written in. */
+  key: string
+}
+
+/** Every glued class interpolation under `src`, in path order. */
+export function gluedClassInterpolationsInSource(options: ScanOptions = {}): GluedFinding[] {
+  return sourceFiles(options)
+    .flatMap((file) => {
+      const path = toRelative(file)
+      return gluedClassInterpolations(readFileSync(file, 'utf8')).map((glued) => ({
+        ...glued,
+        path,
+        key: `${path}:${glued.stem}`,
+      }))
+    })
+    .sort((a, b) => a.key.localeCompare(b.key))
+}


### PR DESCRIPTION
Adds the standing guard for the silent-failure class #2918 hit, and fixes a fourth site of it that #3021 did not find.

## The hazard, restated

Tailwind does not evaluate the app. It reads the source as text and keeps the utility candidates it recognises. A utility written flush against `${` offers v4's scanner no candidate:

```
`fixed inset-0 z-50 flex flex-col justify-end overflow-y-auto${
  phoneClassName ? ` ${phoneClassName}` : ''
}`
```

v3's regex extractor kept `overflow-y-auto`. v4's scanner does not. The rule leaves the stylesheet, the element goes on naming it, and a full-screen mobile dialog ships unable to scroll — with `npm run build`, `npm run lint`, `npm run typecheck` and every test file passing. #3021 found three of these by diffing two builds' emitted class sets by hand, which is a person having a hunch on a Tuesday, not a check.

## The guard

`frontend/src/test/__tests__/noGluedClassInterpolation.test.ts`, over `frontend/src/test/classNameLiterals.ts`. Vitest, source-scanning, through `sourceFiles()` from `test/sourceScan.ts` — no private walk (#2887).

**The rule is a bright line, not a vocabulary.** Inside a template literal in class position, an interpolation gets a space in front of it. The guard deliberately does *not* ask whether the glued token is a real Tailwind utility. Asking means carrying a copy of a list this repo does not own, which rots on the next upgrade, and a rotted list **passes**. The narrow rule also buys nothing: `` `p-${size}` `` is dropped by the same scanner for the same reason, and the wide rule catches it.

**Class position, exactly.** The value of an assignment whose left-hand side names a class — `className={…}`, `phoneClassName`, `ringClass`, a `classes:` key, `const skinClassName = …` — taken as the whole balanced `{…}`, so a ternary, a nested call and a concatenation are all inside it. **Plus one hop:** a literal assigned to a local name that a class-value region in the same file then reads. Without the hop, `const base = …; <div className={base} />` walks out of the scan on a rename, and a guard you can leave by renaming a variable is not a guard. Measured before adding it: **the hop adds zero findings and zero noise** to today's tree.

The boundary this draws, said out loud and left in the header: a literal that reaches a class name through something other than one local assignment — returned straight out of a helper, or handed through a second variable — is outside the scan.

**The scan is a real tokenizer, not a regex.** It knows strings, line and block comments, regex literals and template nesting, masking each in place so offsets and line numbers survive. That is not fastidiousness: a scanner that mistook a regex's quote for a string would swallow the rest of the file and report a clean board, silently, in the one file that tripped it. It does not reuse `sourceScan.ts`'s `stripComments`, and the header says why — that stripper moves every offset after a comment and takes a closing backtick with any `//` inside a literal.

## It cannot pass by reading nothing

The failure mode `src/test/indexCss.ts` documents, answered four ways:

| tripwire | today | floor |
|---|---|---|
| class-name sites the region finder sees | ~1,835 across 569 files | > 1,000 |
| class names built from template literals | 14, in 11 files | > 5, and `DuelSealSheet.tsx` by name |
| files where a string or literal ran off the end | 0 of ~700 (tests included) | exactly 0 |
| the real defect, re-introduced | reported | asserted |

The fourth is the one that matters. It reads `DuelSealSheet.tsx` off disk, takes the space back out, and asserts the guard reports `overflow-y-auto` — first asserting the substitution actually changed the file, so an anchor that rots fails loudly instead of testing nothing. **Proved on real source too, not only in memory:** re-gluing `MobilePlayers.tsx` on disk fails the sweep with

```
pages/players/MobilePlayers.tsx:305  truncate${
```

## A fourth site, and the three from #3021

The sweep found one #3021 missed: **`truncate` in `MobilePlayers.tsx`**, the mobile twin of the `DesktopPlayers.tsx` site it did find. Under v4 that would drop `truncate` and let long faction names in the mobile players list run instead of ellipsing.

All four are fixed here, because a guard that lands red is not a guard. The three from #3021 carry **that PR's fixes verbatim** (`overflow-y-auto ${`, `font-body ${className ?? ''}`, `redacted ? 'font-display redacted' : 'font-display'`), so the two branches should merge without a conflict either way round. #3021 is still open; this lane does not depend on it and does not block it.

## False positives, held against the real files

The four shapes named in the issue as legitimate are interpolations that **complete** a token rather than follow one, and none of them is a class:

| site | shape | what it is |
|---|---|---|
| `PointsRoundel.tsx` | `wz-roundel-${` | an SVG `textPath` id |
| `DefaultVote.tsx`, `AlbescentVote.tsx` | `--spectrum-glow-${` | a CSS custom property read |
| `CharacterSwitcherSheet.tsx` | `switcher-row-${` | a test id |
| `DefaultVote.tsx` | `tier${` | an i18n key — note it does **not** end in `-`, so "must end in a hyphen" is not the rule |

Each is asserted to still be present in its file *before* it is asserted to be quiet, so a site that moves fails here rather than becoming a comment about a shape that no longer exists. A future widening of the scan therefore fails on this branch's own tests instead of arriving as noise on somebody else's PR.

## The ratchet

`ALLOWED` is a curated allowlist keyed `path:token`, in the shape `ALBESCENT_ALLOWANCE` uses. **It is empty**, and a second test fails on any entry that no longer matches a site, so a permission nobody is using cannot sit there unread. Both directions were exercised by hand: an entry silences a real regression; the same entry with the regression removed fails as stale.

## Budget

`frontend/scripts/bundle-budget.mjs` is **untouched** per the #2469 / #2843 ruling — `git diff origin/main -- frontend/scripts/bundle-budget.mjs` is empty. Built both sides to check the numbers rather than assert them:

| line | `origin/main` | this branch | verdict |
|---|---|---|---|
| JS | 150.3 KB | 150.3 KB | WARN, **pre-existing and unmoved** |
| CSS | 21.9 KB | 21.9 KB | ok |
| ALB | 50 of 332 | 50 of 332 | ok, and not blind |

`src/test/classNameLiterals.ts` is imported only by the guard, so it never reaches a chunk; the four source fixes are byte-neutral to the bundle.

## Every frontend CI step, run locally

Read from `.github/workflows/test.yml`, and re-run after rebasing onto #3028 / #3029, which landed mid-lane.

| step | result |
|---|---|
| `npm ci` | pass |
| `npm run lint` | **pass**, clean |
| `npm run typecheck` | **pass**, clean |
| `npm run typecheck:design-sync` | **pass**, clean |
| `npm test` | **pass** — 526 files, 11,341 passed, 1 skipped |
| `npm run build` | **pass** |
| `npm run budget` | **runs, exit 0** — table above |

The backend and `api-schema` jobs are not run and cannot be affected: no backend file, route or schema is in the diff, and a worktree carries no venv.

## Also touched

One convention bullet in `frontend/CLAUDE.md`. The guard's message is only read by someone who has already tripped it; the rule is cheaper stated up front.

## What to eyeball

Nothing renders differently on `main` today — it is still Tailwind v3, where all four glued utilities were being kept anyway. The four fixes are shape changes with the same emitted class list, and the affected components' own tests pass unchanged. Worth a glance if you are already in there: the pending badge, the players list on both form factors, and the duel seal sheet on a phone.

Refs #2918. Complements #3021, which added `frontend/scripts/utility-parity.mjs` — that one compares a *built* stylesheet against a baseline after the fact; this one is a source rule that names the line before the build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
