### PR TITLE
The faction picker stands still: a reserved head on the composer chassis, Everymen's chips inside the sheet, UA's band mounted

### DIFF
--- a/frontend/src/components/cardMasthead/CardMasthead.tsx
+++ b/frontend/src/components/cardMasthead/CardMasthead.tsx
@@ -124,6 +124,23 @@ interface CardMastheadProps {
   leading?: ReactNode;
   /** The band's own paint — ground, rule, ink, height. All of it the skin's. */
   style?: CSSProperties;
+  /**
+   * Draw the band as ORNAMENT: no link, no hover, `aria-hidden`, same paint.
+   *
+   * THE BAND IS A LINK ON A CARD BECAUSE A CARD IS A PLACE YOU LEAVE FROM
+   * (#2167) — three regions, three destinations. A COMPOSER is the opposite: it
+   * is a `<form>` holding a draft, and an anchor inside it is a way to lose that
+   * draft. Mounted live it would be the first focusable thing on the sheet, one
+   * Tab from the top, and a click on the wordmark would navigate to
+   * `/factions/<slug>` and discard whatever had been typed, with no confirm.
+   *
+   * So the composer mounts this arm instead, and it matches what every other
+   * composer masthead already is: `ComposerMasthead` is `aria-hidden` and inert
+   * by construction, and a faction's ornament may not announce itself ahead of
+   * the page's first real content. The paint, the anatomy and the centring are
+   * identical — only the anchor and its two hover handlers stand down.
+   */
+  inert?: boolean;
   /** The wordmark, in the faction's hand. */
   children: ReactNode;
 }
@@ -134,65 +151,14 @@ export default function CardMasthead({
   markSize = MARK,
   leading,
   style,
+  inert = false,
   children,
 }: CardMastheadProps) {
-  return (
-    <Link
-      to={`/factions/${slug}`}
-      /* The band's text IS the faction's name, so unlabelled this announces as
-         "Cozy Coven, link" — the name without the destination. The label keeps
-         the name and says where it goes; it names the faction, never the
-         furniture. */
-      aria-label={i18n.t("feed:taskCard.mastheadLink", { faction: factionName(slug) })}
-      /* The hover affordance, as an inline handler because the kit's paint is
-         inline and `index.css` has no hook for this band (a class would be a
-         style decision this component does not own). Underline is the platform's
-         own link tell and takes `currentColor`, so it costs no token and reads
-         in both themes.
-
-         ponytail: the ceiling is that a pointer is the only thing that lights
-         it — `:focus-visible` cannot be expressed inline, so keyboard users get
-         the user agent's focus ring instead (nothing in `index.css` suppresses
-         it). If the band ever wants a paint of its own on hover or focus, that
-         is a `frontend-style` change: one class in `index.css` replaces both
-         handlers. */
-      onMouseEnter={(e) => {
-        e.currentTarget.style.textDecoration = "underline";
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.textDecoration = "none";
-      }}
-      data-card-masthead={slug}
-      style={{
-        position: "relative",
-        zIndex: 2,
-        display: "grid",
-        gridTemplateColumns: "1fr auto 1fr",
-        alignItems: "center",
-        gap: "var(--space-sm)",
-        padding: "var(--space-sm) var(--space-lg)",
-        /* Ahead of the skin's own `style`, so a band that sets its ink still
-           wins and one that does not inherits the card's — either way, never
-           the user agent's link blue over a hand-set wordmark. */
-        color: "inherit",
-        textDecoration: "none",
-        /* THE BAND DOES NOT TAKE THE ROW'S SLACK. `.task-card-row` hands a
-           card's spare height down a chain that ends at the one anchor marked
-           `data-card-link` (index.css, the equal-height row), and this band is
-           not it. That was not always the selector: the chain used to end at
-           `a[href]`, so the moment this element became an anchor (#2167) it
-           joined the chain and stretched beside the body link, splitting the
-           slack between them — this pin was the correction. #2380 moved the
-           chain onto the hook, so the pin now restates the initial value
-           instead. It stays as the belt: a band is as tall as its own content
-           whatever a later rule decides, and only `flex-grow` is pinned, so
-           shrink and basis keep the values the band had as a plain block.
-           `frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx` holds
-           the chain to a single anchor. */
-        flexGrow: 0,
-        ...style,
-      }}
-    >
+  /* The anatomy, drawn once for both arms: the mark's fixed slot, the centred
+     wordmark, the empty right gutter that keeps the centre column on the band's
+     own centreline. Only the ELEMENT around it changes. */
+  const anatomy = (
+    <>
       <span
         style={{
           justifySelf: "start",
@@ -226,6 +192,86 @@ export default function CardMasthead({
       {/* The right gutter. Empty by design — it is what makes the centre column
           land on the band's centreline rather than beside the mark. */}
       <span aria-hidden="true" />
+    </>
+  );
+
+  /* The band's geometry and the skin's paint, shared by both arms so the inert
+     one cannot drift from the linked one. `color: inherit` and the flex pin are
+     the linked arm's own notes, one block down. */
+  const band: CSSProperties = {
+    position: "relative",
+    zIndex: 2,
+    display: "grid",
+    gridTemplateColumns: "1fr auto 1fr",
+    alignItems: "center",
+    gap: "var(--space-sm)",
+    /* Ahead of the skin's own `style`, so a band that sets its ink still wins
+       and one that does not inherits the card's — either way, never the user
+       agent's link blue over a hand-set wordmark. */
+    color: "inherit",
+    textDecoration: "none",
+    /* THE BAND DOES NOT TAKE THE ROW'S SLACK. `.task-card-row` hands a card's
+       spare height down a chain that ends at the one anchor marked
+       `data-card-link` (index.css, the equal-height row), and this band is not
+       it. That was not always the selector: the chain used to end at `a[href]`,
+       so the moment this element became an anchor (#2167) it joined the chain
+       and stretched beside the body link, splitting the slack between them —
+       this pin was the correction. #2380 moved the chain onto the hook, so the
+       pin now restates the initial value instead. It stays as the belt: a band
+       is as tall as its own content whatever a later rule decides, and only
+       `flex-grow` is pinned, so shrink and basis keep the values the band had as
+       a plain block. `frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx`
+       holds the chain to a single anchor. */
+    flexGrow: 0,
+    ...style,
+  };
+
+  if (inert) {
+    return (
+      /* No anchor, no hover handlers, `aria-hidden`: see the `inert` prop. The
+         padding is spelled here rather than in `band` for the one reason the
+         linked arm's is spelled at its own call — a skin's `style` must be able
+         to override it, and `band` is spread into both. */
+      <div
+        aria-hidden="true"
+        data-card-masthead={slug}
+        style={{ padding: "var(--space-sm) var(--space-lg)", ...band }}
+      >
+        {anatomy}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to={`/factions/${slug}`}
+      /* The band's text IS the faction's name, so unlabelled this announces as
+         "Cozy Coven, link" — the name without the destination. The label keeps
+         the name and says where it goes; it names the faction, never the
+         furniture. */
+      aria-label={i18n.t("feed:taskCard.mastheadLink", { faction: factionName(slug) })}
+      /* The hover affordance, as an inline handler because the kit's paint is
+         inline and `index.css` has no hook for this band (a class would be a
+         style decision this component does not own). Underline is the platform's
+         own link tell and takes `currentColor`, so it costs no token and reads
+         in both themes.
+
+         ponytail: the ceiling is that a pointer is the only thing that lights
+         it — `:focus-visible` cannot be expressed inline, so keyboard users get
+         the user agent's focus ring instead (nothing in `index.css` suppresses
+         it). If the band ever wants a paint of its own on hover or focus, that
+         is a `frontend-style` change: one class in `index.css` replaces both
+         handlers. */
+      onMouseEnter={(e) => {
+        e.currentTarget.style.textDecoration = "underline";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.textDecoration = "none";
+      }}
+      data-card-masthead={slug}
+      style={{ padding: "var(--space-sm) var(--space-lg)", ...band }}
+    >
+      {anatomy}
     </Link>
   );
 }

--- a/frontend/src/components/cardMasthead/CardMasthead.tsx
+++ b/frontend/src/components/cardMasthead/CardMasthead.tsx
@@ -196,8 +196,14 @@ export default function CardMasthead({
   );
 
   /* The band's geometry and the skin's paint, shared by both arms so the inert
-     one cannot drift from the linked one. `color: inherit` and the flex pin are
-     the linked arm's own notes, one block down. */
+     one cannot drift from the linked one.
+
+     THE KEY ORDER IS LOAD-BEARING, which is not obvious. React serialises a
+     style object in insertion order, so moving one declaration rewrites the
+     `style` attribute's bytes — and `praxisDetail`'s `markupStability` suite
+     hashes the rendered markup of every archetype. This is the order the linked
+     arm had before it was factored out; `padding` sits between `gap` and
+     `color` for that reason and no other. */
   const band: CSSProperties = {
     position: "relative",
     zIndex: 2,
@@ -205,6 +211,7 @@ export default function CardMasthead({
     gridTemplateColumns: "1fr auto 1fr",
     alignItems: "center",
     gap: "var(--space-sm)",
+    padding: "var(--space-sm) var(--space-lg)",
     /* Ahead of the skin's own `style`, so a band that sets its ink still wins
        and one that does not inherits the card's — either way, never the user
        agent's link blue over a hand-set wordmark. */
@@ -235,7 +242,7 @@ export default function CardMasthead({
       <div
         aria-hidden="true"
         data-card-masthead={slug}
-        style={{ padding: "var(--space-sm) var(--space-lg)", ...band }}
+        style={band}
       >
         {anatomy}
       </div>
@@ -269,7 +276,7 @@ export default function CardMasthead({
         e.currentTarget.style.textDecoration = "none";
       }}
       data-card-masthead={slug}
-      style={{ padding: "var(--space-sm) var(--space-lg)", ...band }}
+      style={band}
     >
       {anatomy}
     </Link>

--- a/frontend/src/components/cardMasthead/factionBands.tsx
+++ b/frontend/src/components/cardMasthead/factionBands.tsx
@@ -372,11 +372,18 @@ function SnideBand() {
  * AND THE BOTTOM RULE COMES OFF. It was `1px solid var(--faction-ua-card-accent)`
  * — an orange hairline on an orange band, drawing nothing. Everymen's and WOW's
  * bands let their own edge do the work; this one does too now.
+ *
+ * IT IS THE ONE BAND WITH AN `inert` ARM (#2995), and only because it is the one
+ * band a COMPOSER mounts. The three card-tier mounts pass nothing and stay the
+ * link they have been since #2167; the two propose/create sheets pass `inert`,
+ * because an anchor inside a `<form>` is a way to lose a draft. The paint is one
+ * object either way — see `CardMasthead`'s `inert` prop for the whole argument.
  */
-function UaBand() {
+function UaBand({ inert }: { inert?: boolean } = {}) {
   return (
     <CardMasthead
       slug="ua"
+      inert={inert}
       markColor="var(--faction-ua-mast-ink)"
       style={{
         background: "var(--faction-ua-mast)",

--- a/frontend/src/components/selectCard/__tests__/everySelectTileWearsItsCardsRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/everySelectTileWearsItsCardsRegister.test.ts
@@ -111,9 +111,17 @@ function literalProps(source: string): Set<string> {
   return new Set([...source.matchAll(/(--[a-z0-9-]+)/g)].map((match) => match[0]));
 }
 
-/** One faction's band, sliced out of the module that holds all nine. */
+/**
+ * One faction's band, sliced out of the module that holds all nine.
+ *
+ * The anchor is `function <name>(` and NOT `function <name>()`: what this file
+ * reads is which token families a band's SOURCE names, which has nothing to do
+ * with whether it takes props. `UaBand` grew one in #2995 — an `inert` arm for
+ * the two composer surfaces that mount it inside a `<form>` — and the empty
+ * parens made this row fail on a band whose paint had not changed by a byte.
+ */
 function bandSlice(bandsSource: string, fnName: string): string {
-  const at = bandsSource.indexOf(`function ${fnName}()`);
+  const at = bandsSource.indexOf(`function ${fnName}(`);
   expect(at, `no \`${fnName}\` in cardMasthead/factionBands.tsx`).toBeGreaterThan(-1);
   return bandsSource.slice(at, bandsSource.indexOf("\n}", at));
 }

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
@@ -142,6 +142,51 @@ describe('the field set is the same on every kit, at both widths', () => {
   })
 })
 
+/**
+ * The reserved masthead head, on every kit (#2995).
+ *
+ * The defect is Propose a Task's, one surface over: this page reskins live as
+ * the calling is chosen — `CreateCharacter.tsx` says so in as many words — so
+ * every click on the picker renders a DIFFERENT archetype, and each one started
+ * its content column wherever its own masthead ended (UA passes none; the
+ * Ephemerists' sky band plus its cornice is 96px). The picker walked out from
+ * under the pointer.
+ *
+ * `ComposerSheet`'s `reserveHead` puts a floor under that slot out of
+ * `useComposerSizes()`. The number is not written down here — what is asserted
+ * is that every kit reads the SAME one, which is the property that makes the
+ * row stand still.
+ *
+ * WHAT THIS CANNOT PROVE, AND IT IS MORE HERE THAN ON THE PROPOSE PAGE. The
+ * picker sits LATE on this surface — six blocks below the sheet's edge — so its
+ * offset is the sum of everything above it, and the per-kit field metrics in
+ * between (padding, `rows` on the prose boxes) are each kit's dress. This
+ * proves the masthead term is reserved and shared; the residual is measured by
+ * eye and reported on the PR rather than regularized away.
+ */
+describe('the masthead slot is reserved, and by one number (#2995)', () => {
+  const headStyles = (html: string) =>
+    [...html.matchAll(/<div data-composer-head="" style="([^"]*)"/g)].map(([, style]) => style)
+
+  it.each(CASES)('%s on %s: the sheet reserves its head', (_name, slug, width) => {
+    expect(headStyles(renderSkin(slug, width))).toHaveLength(1)
+  })
+
+  it.each(WIDTHS)('every kit reserves the same head on %s', (width) => {
+    const heads = ARCHETYPES.map(
+      (slug) => [slug || 'na', headStyles(renderSkin(slug, width))[0]] as const,
+    )
+    const values = new Set(heads.map(([, style]) => style))
+    expect(
+      values.size,
+      `nine kits, one reserved head — got ${heads.map(([k, v]) => `${k}: ${v}`).join(', ')}`,
+    ).toBe(1)
+    expect([...values][0], 'the head is a reserved height, not an empty box').toMatch(
+      /min-height:\d+px/,
+    )
+  })
+})
+
 describe('the exits read [Cancel] … [Create] on every kit, at both widths (#646)', () => {
   const CANCEL = common('actions.cancel')
 

--- a/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/createCharacterStructure.test.tsx
@@ -157,33 +157,47 @@ describe('the field set is the same on every kit, at both widths', () => {
  * is that every kit reads the SAME one, which is the property that makes the
  * row stand still.
  *
- * WHAT THIS CANNOT PROVE, AND IT IS MORE HERE THAN ON THE PROPOSE PAGE. The
- * picker sits LATE on this surface — six blocks below the sheet's edge — so its
- * offset is the sum of everything above it, and the per-kit field metrics in
- * between (padding, `rows` on the prose boxes) are each kit's dress. This
- * proves the masthead term is reserved and shared; the residual is measured by
- * eye and reported on the PR rather than regularized away.
+ * WHAT THIS CANNOT PROVE, AND IT IS MORE HERE THAN ON THE PROPOSE PAGE. Two
+ * things. `renderToStaticMarkup` has no layout, so "the reserved head is at
+ * least as tall as every kit's actual masthead" — the property the fix turns on
+ * — is a RENDERED SWEEP question that stays green here whatever the number is.
+ * And the picker sits LATE on this surface, six blocks below the sheet's edge,
+ * so its offset is the sum of everything above it and the per-kit field metrics
+ * in between (border weight, the name field's tier, textarea line-height) are
+ * each kit's dress. This proves the two shared terms are reserved and spelled
+ * once; the residual is measured and reported on the PR rather than regularized
+ * away.
  */
 describe('the masthead slot is reserved, and by one number (#2995)', () => {
-  const headStyles = (html: string) =>
-    [...html.matchAll(/<div data-composer-head="" style="([^"]*)"/g)].map(([, style]) => style)
+  const boxes = (html: string, hook: 'head' | 'heading') =>
+    [...html.matchAll(new RegExp(`<div data-composer-${hook}="" style="([^"]*)"`, 'g'))].map(
+      ([, style]) => style,
+    )
 
   it.each(CASES)('%s on %s: the sheet reserves its head', (_name, slug, width) => {
-    expect(headStyles(renderSkin(slug, width))).toHaveLength(1)
+    expect(boxes(renderSkin(slug, width), 'head')).toHaveLength(1)
   })
 
-  it.each(WIDTHS)('every kit reserves the same head on %s', (width) => {
-    const heads = ARCHETYPES.map(
-      (slug) => [slug || 'na', headStyles(renderSkin(slug, width))[0]] as const,
-    )
-    const values = new Set(heads.map(([, style]) => style))
-    expect(
-      values.size,
-      `nine kits, one reserved head — got ${heads.map(([k, v]) => `${k}: ${v}`).join(', ')}`,
-    ).toBe(1)
-    expect([...values][0], 'the head is a reserved height, not an empty box').toMatch(
-      /min-height:\d+px/,
-    )
+  it.each(CASES)('%s on %s: and the heading block has its floor', (_name, slug, width) => {
+    // `ComposerHeading` is the only thing that spells the floor, so a kit that
+    // hand-rolled its own heading box has none and fails here.
+    expect(boxes(renderSkin(slug, width), 'heading')).toHaveLength(1)
+  })
+
+  it.each(WIDTHS)('every kit reserves the same head and floor on %s', (width) => {
+    for (const hook of ['head', 'heading'] as const) {
+      const found = ARCHETYPES.map(
+        (slug) => [slug || 'na', boxes(renderSkin(slug, width), hook)[0]] as const,
+      )
+      const values = new Set(found.map(([, style]) => style))
+      expect(
+        values.size,
+        `nine kits, one ${hook} — got ${found.map(([k, v]) => `${k}: ${v}`).join(', ')}`,
+      ).toBe(1)
+      expect([...values][0], `the ${hook} is a reserved height, not an empty box`).toMatch(
+        /min-height:\d+px/,
+      )
+    }
   })
 })
 

--- a/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
@@ -150,6 +150,7 @@ import {
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerSection,
@@ -367,9 +368,8 @@ export default function CovenCreateCharacter({ state }: { state: CreateCharacter
         {/* `reserveHead` (#2995). This page reskins live on the calling being
             chosen, so the picker moved under the cursor here for the same
             reason it did on Propose a Task: each kit started its column under a
-            masthead of its own height. This band — sigil, wordmark, braid — is
-            80px against the 96 the Ephemerists' plate takes. It is untouched;
-            only the slot it sits in has a floor now. */}
+            masthead of its own height. This band is untouched; only the slot it
+            sits in has a floor now, and the numbers are in `useComposerSizes`. */}
         <ComposerSheet
           sizes={sizes}
           style={sheetStyle}
@@ -381,21 +381,20 @@ export default function CovenCreateCharacter({ state }: { state: CreateCharacter
               status pentacle away for exactly this reason — it was "a second one
               under the sigil in the masthead directly above". The masthead is
               this sheet's one faction mark; the cat is a watermark, not a badge. */}
-          <h1
-            style={{
-              fontFamily: DISPLAY,
-              fontWeight: 600,
-              fontSize: sizes.titleSize,
-              lineHeight: 1.1,
-              color: INK,
-              margin: 0,
-              // The chassis' heading floor (#2995), the second shared term
-              // between the sheet's edge and the picker further down.
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t('createCharacter.heading')}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: DISPLAY,
+                fontWeight: 600,
+                fontSize: sizes.titleSize,
+                lineHeight: 1.1,
+                color: INK,
+                margin: 0,
+              }}
+            >
+              {t('createCharacter.heading')}
+            </h1>
+          </ComposerHeading>
 
           {/* The life being written, live. The card dispatches its own faction
               dress, so it is already wearing this slip the moment the calling is

--- a/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/CovenCreateCharacter.tsx
@@ -364,7 +364,19 @@ export default function CovenCreateCharacter({ state }: { state: CreateCharacter
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        {/* `reserveHead` (#2995). This page reskins live on the calling being
+            chosen, so the picker moved under the cursor here for the same
+            reason it did on Propose a Task: each kit started its column under a
+            masthead of its own height. This band — sigil, wordmark, braid — is
+            80px against the 96 the Ephemerists' plate takes. It is untouched;
+            only the slot it sits in has a floor now. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {/* NO SECOND MARK BESIDE THE HEADING. #1828 took the composer's
               status pentacle away for exactly this reason — it was "a second one
               under the sigil in the masthead directly above". The masthead is
@@ -377,6 +389,9 @@ export default function CovenCreateCharacter({ state }: { state: CreateCharacter
               lineHeight: 1.1,
               color: INK,
               margin: 0,
+              // The chassis' heading floor (#2995), the second shared term
+              // between the sheet's edge and the picker further down.
+              minHeight: sizes.headingHeight,
             }}
           >
             {t('createCharacter.heading')}

--- a/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
@@ -87,6 +87,7 @@ import PortraitPicker from '../PortraitPicker'
 import { namedField } from '../characterFields'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerPage,
   ComposerRule,
   ComposerSection,
@@ -197,26 +198,26 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
           itself. */}
       <form onSubmit={handleSubmit} data-skin="default">
         {/* `reserveHead` (#2995): na draws no masthead, so what it reserves is
-            bare ground at the height the Ephemerists' plate takes. That is the
-            point rather than a cost — this page reskins live as a calling is
-            picked, and the picker can only stand still if the kit with no band
-            starts its column where the kit with the tallest one does. */}
+            bare ground. That is the point rather than a cost — this page reskins
+            live as a calling is picked, and the picker can only stand still if
+            the kit with no band starts its column where the kit with the tallest
+            one does. The numbers are in `useComposerSizes`. */}
         <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={composerGround}>
-          <h1
-            style={{
-              fontFamily: TITLE_FACE,
-              fontStyle: 'italic',
-              fontWeight: 700,
-              fontSize: sizes.titleSize,
-              lineHeight: 1.1,
-              color: INK,
-              margin: 0,
-              // The chassis' heading floor (#2995), the second shared term.
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t('createCharacter.heading')}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: TITLE_FACE,
+                fontStyle: 'italic',
+                fontWeight: 700,
+                fontSize: sizes.titleSize,
+                lineHeight: 1.1,
+                color: INK,
+                margin: 0,
+              }}
+            >
+              {t('createCharacter.heading')}
+            </h1>
+          </ComposerHeading>
 
           {/* The life being written, live — FIRST in the sheet at both widths,
               which is the whole of defect 2. The card dispatches its own faction

--- a/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/DefaultCreateCharacter.tsx
@@ -196,7 +196,12 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
           Enter commit from a text field. `handleSubmit` calls `preventDefault()`
           itself. */}
       <form onSubmit={handleSubmit} data-skin="default">
-        <ComposerSheet sizes={sizes} style={sheetStyle} ground={composerGround}>
+        {/* `reserveHead` (#2995): na draws no masthead, so what it reserves is
+            bare ground at the height the Ephemerists' plate takes. That is the
+            point rather than a cost — this page reskins live as a calling is
+            picked, and the picker can only stand still if the kit with no band
+            starts its column where the kit with the tallest one does. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={composerGround}>
           <h1
             style={{
               fontFamily: TITLE_FACE,
@@ -206,6 +211,8 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
               lineHeight: 1.1,
               color: INK,
               margin: 0,
+              // The chassis' heading floor (#2995), the second shared term.
+              minHeight: sizes.headingHeight,
             }}
           >
             {t('createCharacter.heading')}

--- a/frontend/src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx
@@ -97,6 +97,7 @@ import {
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -319,10 +320,8 @@ export default function EphemeristsCreateCharacter({ state }: { state: CreateCha
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-      {/* THIS KIT IS THE CEILING (#2995): the sky band is 84px on desktop and
-          the cornice under it 12, which is the tallest head any kit on either
-          composer surface draws and therefore the number `headHeight` reserves.
-          Nothing here pads out; every other kit meets this. */}
+      {/* THIS KIT IS THE CEILING FOR THE RESERVED HEAD (#2995) — see the table
+          in `useComposerSizes`. Nothing here is shortened to reach it. */}
       <ComposerSheet
         sizes={sizes}
         style={sheetStyle}
@@ -331,22 +330,23 @@ export default function EphemeristsCreateCharacter({ state }: { state: CreateCha
         ground={ground}
       >
         {/* The stage: the ankh cartouche beside the page's own question, which
-            is the heading this surface has always asked. The 44px mark does not
-            fit inside a 38.4px line box, which is the arithmetic the chassis'
-            `headingHeight` was measured on. */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--space-lg)',
-            minHeight: sizes.headingHeight,
-          }}
-        >
-          <StatusMark />
-          <h1 style={{ fontFamily: CAPS, fontSize: sizes.titleSize, color: INK, lineHeight: 1.2, margin: 0 }}>
-            {t('createCharacter.heading')}
-          </h1>
-        </div>
+            is the heading this surface has always asked. */}
+        <ComposerHeading sizes={sizes}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+            <StatusMark />
+            <h1
+              style={{
+                fontFamily: CAPS,
+                fontSize: sizes.titleSize,
+                color: INK,
+                lineHeight: 1.2,
+                margin: 0,
+              }}
+            >
+              {t('createCharacter.heading')}
+            </h1>
+          </div>
+        </ComposerHeading>
 
         {/* The life being inscribed, live. The card dispatches its own faction
             dress, so it is already wearing this plate the moment the calling is

--- a/frontend/src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EphemeristsCreateCharacter.tsx
@@ -319,10 +319,29 @@ export default function EphemeristsCreateCharacter({ state }: { state: CreateCha
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-      <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+      {/* THIS KIT IS THE CEILING (#2995): the sky band is 84px on desktop and
+          the cornice under it 12, which is the tallest head any kit on either
+          composer surface draws and therefore the number `headHeight` reserves.
+          Nothing here pads out; every other kit meets this. */}
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        masthead={masthead}
+        reserveHead
+        ground={ground}
+      >
         {/* The stage: the ankh cartouche beside the page's own question, which
-            is the heading this surface has always asked. */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+            is the heading this surface has always asked. The 44px mark does not
+            fit inside a 38.4px line box, which is the arithmetic the chassis'
+            `headingHeight` was measured on. */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-lg)',
+            minHeight: sizes.headingHeight,
+          }}
+        >
           <StatusMark />
           <h1 style={{ fontFamily: CAPS, fontSize: sizes.titleSize, color: INK, lineHeight: 1.2, margin: 0 }}>
             {t('createCharacter.heading')}

--- a/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
@@ -137,6 +137,7 @@ import {
 } from '../useCreateCharacter'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -336,9 +337,8 @@ export default function EverymenCreateCharacter({ state }: { state: CreateCharac
           submits through one and so must this: it is what makes Enter commit
           from a text field. `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995): the nameplate is 45px on desktop and 37 on the
-            phone, against the 96/80 the tallest kit takes. The plate itself is
-            untouched — the reserved box says where the column starts. */}
+        {/* `reserveHead` (#2995): the nameplate is untouched — the reserved box
+            says where the column starts. Numbers in `useComposerSizes`. */}
         <ComposerSheet
           sizes={sizes}
           style={sheetStyle}
@@ -347,37 +347,31 @@ export default function EverymenCreateCharacter({ state }: { state: CreateCharac
           ground={ground}
         >
           {/* The stage: the union's cog turning beside the page's own question,
-              which is the heading this surface has always asked. The floor is
-              the chassis' (#2995); the 40px cog sits inside it. */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-lg)',
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            <EverymenCog
-              size={STAGE_COG[factor]}
-              fill={RED}
-              hub={PAPER}
-              spin="forward"
-              duration={COG_PERIOD}
-            />
-            <h1
-              style={{
-                fontFamily: BEBAS,
-                fontSize: sizes.titleSize,
-                textTransform: 'uppercase',
-                letterSpacing: '0.01em',
-                lineHeight: 0.96,
-                color: INK,
-                margin: 0,
-              }}
-            >
-              {t('createCharacter.heading')}
-            </h1>
-          </div>
+              which is the heading this surface has always asked. */}
+          <ComposerHeading sizes={sizes}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+              <EverymenCog
+                size={STAGE_COG[factor]}
+                fill={RED}
+                hub={PAPER}
+                spin="forward"
+                duration={COG_PERIOD}
+              />
+              <h1
+                style={{
+                  fontFamily: BEBAS,
+                  fontSize: sizes.titleSize,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.01em',
+                  lineHeight: 0.96,
+                  color: INK,
+                  margin: 0,
+                }}
+              >
+                {t('createCharacter.heading')}
+              </h1>
+            </div>
+          </ComposerHeading>
 
           {/* The life being enlisted, live. The card dispatches its own faction
               dress, so it is already wearing this kit the moment the calling is

--- a/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/EverymenCreateCharacter.tsx
@@ -336,10 +336,27 @@ export default function EverymenCreateCharacter({ state }: { state: CreateCharac
           submits through one and so must this: it is what makes Enter commit
           from a text field. `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        {/* `reserveHead` (#2995): the nameplate is 45px on desktop and 37 on the
+            phone, against the 96/80 the tallest kit takes. The plate itself is
+            untouched — the reserved box says where the column starts. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {/* The stage: the union's cog turning beside the page's own question,
-              which is the heading this surface has always asked. */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+              which is the heading this surface has always asked. The floor is
+              the chassis' (#2995); the 40px cog sits inside it. */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-lg)',
+              minHeight: sizes.headingHeight,
+            }}
+          >
             <EverymenCog
               size={STAGE_COG[factor]}
               fill={RED}

--- a/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
@@ -127,6 +127,7 @@ import {
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -342,9 +343,9 @@ export default function SingularityCreateCharacter({ state }: { state: CreateCha
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995): the window bar is 31px against a 96px ceiling.
-            The bar keeps its own height — the reserved box says where the
-            column STARTS, never how tall a kit's chrome is. */}
+        {/* `reserveHead` (#2995): the bar keeps its own height — the reserved
+            box says where the column STARTS, never how tall a kit's chrome is.
+            Numbers in `useComposerSizes`. */}
         <ComposerSheet
           sizes={sizes}
           style={sheetStyle}
@@ -353,34 +354,29 @@ export default function SingularityCreateCharacter({ state }: { state: CreateCha
           ground={ground}
         >
           {/* The prompt, and the page's own question — the heading this surface
-              has always asked, over the chassis' floor (#2995). */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'baseline',
-              gap: 'var(--space-md)',
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            <span
-              aria-hidden
-              style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}
-            >
-              {PROMPT}
-            </span>
-            <h1
-              style={{
-                fontFamily: FACE,
-                fontSize: sizes.titleSize,
-                color: BRIGHT,
-                textShadow: HALO_GREEN,
-                lineHeight: 1.2,
-                margin: 0,
-              }}
-            >
-              {t('createCharacter.heading')}
-            </h1>
-          </div>
+              has always asked, inside the chassis' floor (#2995). */}
+          <ComposerHeading sizes={sizes}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-md)' }}>
+              <span
+                aria-hidden
+                style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}
+              >
+                {PROMPT}
+              </span>
+              <h1
+                style={{
+                  fontFamily: FACE,
+                  fontSize: sizes.titleSize,
+                  color: BRIGHT,
+                  textShadow: HALO_GREEN,
+                  lineHeight: 1.2,
+                  margin: 0,
+                }}
+              >
+                {t('createCharacter.heading')}
+              </h1>
+            </div>
+          </ComposerHeading>
 
           {/* The life being compiled, live. The card dispatches its own faction
               dress, so it is already wearing this terminal the moment the

--- a/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SingularityCreateCharacter.tsx
@@ -342,10 +342,26 @@ export default function SingularityCreateCharacter({ state }: { state: CreateCha
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        {/* `reserveHead` (#2995): the window bar is 31px against a 96px ceiling.
+            The bar keeps its own height — the reserved box says where the
+            column STARTS, never how tall a kit's chrome is. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {/* The prompt, and the page's own question — the heading this surface
-              has always asked. */}
-          <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-md)' }}>
+              has always asked, over the chassis' floor (#2995). */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 'var(--space-md)',
+              minHeight: sizes.headingHeight,
+            }}
+          >
             <span
               aria-hidden
               style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}

--- a/frontend/src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx
@@ -273,7 +273,10 @@ export default function SnideCreateCharacter({ state }: { state: CreateCharacter
           submits through one and so must this: it is what makes Enter commit
           from a text field. `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
+        {/* `reserveHead` (#2995): the acid bar is 36px against a 96px ceiling,
+            so this sheet pads out to it rather than starting its column where
+            its own wordmark ended. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           <h1
             style={{
               fontFamily: TITLE_FACE,
@@ -282,6 +285,8 @@ export default function SnideCreateCharacter({ state }: { state: CreateCharacter
               lineHeight: 1.1,
               color: INK,
               margin: 0,
+              // The chassis' heading floor (#2995), the second shared term.
+              minHeight: sizes.headingHeight,
             }}
           >
             {t('createCharacter.heading')}

--- a/frontend/src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/SnideCreateCharacter.tsx
@@ -121,6 +121,7 @@ import {
 } from '../useCreateCharacter'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -273,24 +274,23 @@ export default function SnideCreateCharacter({ state }: { state: CreateCharacter
           submits through one and so must this: it is what makes Enter commit
           from a text field. `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995): the acid bar is 36px against a 96px ceiling,
-            so this sheet pads out to it rather than starting its column where
-            its own wordmark ended. */}
+        {/* The chassis' two reserved heights (#2995) — the table of every kit's
+            masthead against the number is in `useComposerSizes`. */}
         <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
-          <h1
-            style={{
-              fontFamily: TITLE_FACE,
-              fontSize: sizes.titleSize,
-              letterSpacing: '0.02em',
-              lineHeight: 1.1,
-              color: INK,
-              margin: 0,
-              // The chassis' heading floor (#2995), the second shared term.
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t('createCharacter.heading')}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: TITLE_FACE,
+                fontSize: sizes.titleSize,
+                letterSpacing: '0.02em',
+                lineHeight: 1.1,
+                color: INK,
+                margin: 0,
+              }}
+            >
+              {t('createCharacter.heading')}
+            </h1>
+          </ComposerHeading>
 
           {/* The life being pasted up, live. The card dispatches its own faction
               dress, so it is already wearing this kit the moment the calling is

--- a/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
@@ -287,7 +287,18 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} ground={ground}>
+        {/* `reserveHead` (#2995) AND NO BAND, WHICH IS THE ONE ASYMMETRY IN
+            THIS PASS. The head is reserved here for the same reason it is on
+            every other kit — this page reskins live on the calling being
+            picked, and the picker cannot stand still while each kit starts its
+            column under a masthead of its own height — but the owner's band
+            ruling was scoped to Propose a Task, so the comment above `ground`
+            stands and no band is swept in by inference. That leaves this sheet
+            opening on 96px of its own lotus ground, which is the one thing on
+            the eyeball list for this kit. If it reads as a hole, the fix is
+            `UaProposeTask`'s: mount the shipped `UaBand`, in a pass that says
+            so. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={ground}>
           {/* The page's own question, in the practice's display cut. The leaf
               draws no mark beside it: the ensō in the ground is already the
               faction mark, and a second one here would be the third drawn
@@ -300,6 +311,8 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
               color: INK,
               lineHeight: 1.1,
               margin: 0,
+              // The chassis' heading floor (#2995), the second shared term.
+              minHeight: sizes.headingHeight,
             }}
           >
             {t('createCharacter.heading')}

--- a/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/UaCreateCharacter.tsx
@@ -26,11 +26,26 @@
  * Nothing under `pages/editPraxis/` is written to. It is read as the reference
  * the issue names it as.
  *
- * ## UA draws no masthead
+ * ## The band arrived with the reserved head (#2995)
  *
- * It is the one faction in the set with no top band — the GROUND carries the
- * identity instead, so `ComposerSheet` gets a `ground` and no `masthead`. That
- * absence is the dress decision the composer already made, not an omission here.
+ * This section used to read "UA draws no masthead — it is the one faction in the
+ * set with no top band". That was never true of the FACTION: `UaBand` is
+ * exported beside the other six and `UaTaskCard`, `UaPraxisCard` and `UaSeal`
+ * all mount it. It was true of UA's composer surfaces, and only while nothing
+ * reserved a head for one.
+ *
+ * #2995 reserves one here, so the choice became "a band or a 96px hole", and the
+ * owner's ruling on the propose sheet — *"feel free to use the task card header
+ * for UA the same way that singularity does"* — is the one the issue says to
+ * follow the moment the head widens to this surface. So the shipped band is
+ * mounted, `inert`: no anchor inside a `<form>` holding an unsaved draft, which
+ * is `CardMasthead`'s own `inert` prop and the state every other composer
+ * masthead is already in. Nothing is redrawn and no paint is minted.
+ *
+ * THE GROUND STILL CARRIES THE IDENTITY, and it is the composer's own, element
+ * for element. The two remaining UA composers — `UaEditPraxis` and
+ * `UaEditCharacter` — reserve no head, have no hole, get no band, and their
+ * "draws no masthead" comments stand where they are.
  *
  * The ground is the composer's, element for element: a lotus bleeding off the
  * top-left corner and an ensō off the bottom-right, both clipped by
@@ -113,6 +128,7 @@ import {
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerPage,
   ComposerRule,
   ComposerSection,
@@ -122,6 +138,7 @@ import {
   composerLabelStyle,
   useComposerSizes,
 } from '../../editPraxis/archetypes/shared'
+import { UaBand } from '../../../components/cardMasthead/factionBands'
 import { Lotus } from '../../../components/factionMarks'
 import { UaSigil } from '../../../components/sigil/UaSigil'
 import { UA_DISPLAY, UA_TEXT } from '../../../components/factionMarks/uaAtoms'
@@ -236,8 +253,11 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
     borderRadius: RADIUS,
   }
 
-  /* NO masthead. UA is the one faction that draws no top band — the ground is
-     the identity, and it is the composer's own, element for element. */
+  /* The shipped band, in the reserved head (#2995) — `UaBand`, no props but
+     `inert`, the same one UA's task card, praxis card and seal mount. See the
+     header for the comment this replaces and why the band follows the head onto
+     this surface. The ground below is unchanged and still carries the identity. */
+  const masthead = <UaBand inert />
   const ground = (
     <ComposerGround inset={0} opacity="var(--faction-ua-card-lotus-opacity)">
       <Lotus
@@ -287,36 +307,31 @@ export default function UaCreateCharacter({ state }: { state: CreateCharacterSta
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995) AND NO BAND, WHICH IS THE ONE ASYMMETRY IN
-            THIS PASS. The head is reserved here for the same reason it is on
-            every other kit — this page reskins live on the calling being
-            picked, and the picker cannot stand still while each kit starts its
-            column under a masthead of its own height — but the owner's band
-            ruling was scoped to Propose a Task, so the comment above `ground`
-            stands and no band is swept in by inference. That leaves this sheet
-            opening on 96px of its own lotus ground, which is the one thing on
-            the eyeball list for this kit. If it reads as a hole, the fix is
-            `UaProposeTask`'s: mount the shipped `UaBand`, in a pass that says
-            so. */}
-        <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={ground}>
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {/* The page's own question, in the practice's display cut. The leaf
               draws no mark beside it: the ensō in the ground is already the
               faction mark, and a second one here would be the third drawn
               figure on a sheet whose whole voice is quiet. */}
-          <h1
-            style={{
-              fontFamily: UA_DISPLAY,
-              fontWeight: 600,
-              fontSize: sizes.titleSize,
-              color: INK,
-              lineHeight: 1.1,
-              margin: 0,
-              // The chassis' heading floor (#2995), the second shared term.
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t('createCharacter.heading')}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: UA_DISPLAY,
+                fontWeight: 600,
+                fontSize: sizes.titleSize,
+                color: INK,
+                lineHeight: 1.1,
+                margin: 0,
+              }}
+            >
+              {t('createCharacter.heading')}
+            </h1>
+          </ComposerHeading>
 
           {/* The life being written, live. The card dispatches its own faction
               dress, so it is already wearing this leaf the moment the calling is

--- a/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
@@ -143,6 +143,7 @@ import {
 } from '../useCreateCharacter'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerSection,
@@ -300,9 +301,8 @@ export default function WowCreateCharacter({ state }: { state: CreateCharacterSt
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995): the ribbon is 7px and the bunting under it 22,
-            so 29 against a 96px ceiling — one of the sheets that pads out the
-            furthest. Neither device is touched. */}
+        {/* `reserveHead` (#2995): neither the ribbon nor the bunting is touched.
+            Numbers in `useComposerSizes`. */}
         <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           {/* The charter's head: the faction's ✦ device, the page's own
               question, a wavy gold→plum rule taking up the slack, and one bunch
@@ -310,36 +310,38 @@ export default function WowCreateCharacter({ state }: { state: CreateCharacterSt
               hero row (mark · rule · device) and it WRAPS, so a phone stacks it
               rather than crushing the heading.
 
-              THE BUNCH IS WHAT SETS THE CHASSIS' HEADING FLOOR ON DESKTOP
-              (#2995): drawn 38 wide and 1.25× as tall, this row is 47.5px and
-              the tallest heading block of the nine, so `headingHeight` is 48
-              and this one pads out by half a pixel. */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-md)',
-              flexWrap: 'wrap',
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            <span style={{ fontFamily: MED, fontSize: 'var(--text-heading)', lineHeight: 1 }}>
-              <WowSpark />
-            </span>
-            <h1
+              THIS ROW IS THE CEILING THE CHASSIS' HEADING FLOOR IS MEASURED ON,
+              at both widths — see `useComposerSizes`. The floor is on the box
+              AROUND it, never on the row itself: a `min-height` on a wrapping
+              flex container distributes its own lines rather than reserving
+              space under them, and on a phone this row has two. */}
+          <ComposerHeading sizes={sizes}>
+            <div
               style={{
-                fontFamily: MED,
-                fontSize: sizes.titleSize,
-                lineHeight: 1.1,
-                color: INK,
-                margin: 0,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--space-md)',
+                flexWrap: 'wrap',
               }}
             >
-              {t('createCharacter.heading')}
-            </h1>
-            <Zig id="charter" style={{ flex: 1, minWidth: 0 }} />
-            <BalloonBunch size={BUNCH[factor]} />
-          </div>
+              <span style={{ fontFamily: MED, fontSize: 'var(--text-heading)', lineHeight: 1 }}>
+                <WowSpark />
+              </span>
+              <h1
+                style={{
+                  fontFamily: MED,
+                  fontSize: sizes.titleSize,
+                  lineHeight: 1.1,
+                  color: INK,
+                  margin: 0,
+                }}
+              >
+                {t('createCharacter.heading')}
+              </h1>
+              <Zig id="charter" style={{ flex: 1, minWidth: 0 }} />
+              <BalloonBunch size={BUNCH[factor]} />
+            </div>
+          </ComposerHeading>
 
           {/* The life being chartered, live. The card dispatches its own faction
               dress, so it is already wearing WOW's the moment the calling is

--- a/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/archetypes/WowCreateCharacter.tsx
@@ -300,18 +300,27 @@ export default function WowCreateCharacter({ state }: { state: CreateCharacterSt
           behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
+        {/* `reserveHead` (#2995): the ribbon is 7px and the bunting under it 22,
+            so 29 against a 96px ceiling — one of the sheets that pads out the
+            furthest. Neither device is touched. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           {/* The charter's head: the faction's ✦ device, the page's own
               question, a wavy gold→plum rule taking up the slack, and one bunch
               of googly balloons keeping the muster. The row is the decree's own
               hero row (mark · rule · device) and it WRAPS, so a phone stacks it
-              rather than crushing the heading. */}
+              rather than crushing the heading.
+
+              THE BUNCH IS WHAT SETS THE CHASSIS' HEADING FLOOR ON DESKTOP
+              (#2995): drawn 38 wide and 1.25× as tall, this row is 47.5px and
+              the tallest heading block of the nine, so `headingHeight` is 48
+              and this one pads out by half a pixel. */}
           <div
             style={{
               display: 'flex',
               alignItems: 'center',
               gap: 'var(--space-md)',
               flexWrap: 'wrap',
+              minHeight: sizes.headingHeight,
             }}
           >
             <span style={{ fontFamily: MED, fontSize: 'var(--text-heading)', lineHeight: 1 }}>

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -215,16 +215,19 @@ interface ComposerSizes {
    * Reserving the head equalizes what sits ABOVE the content column; on Propose
    * a Task the chips are the column's first section, so the only thing left
    * between them and the sheet's edge is the page heading. That block is
-   * archetype-authored and does not agree: eight kits draw a bare `h1` at
-   * `titleSize` (0.96 to 1.2 line-height — 30.7px to 38.4px on desktop) and the
-   * Ephemerists draw a flex row with a 44px stage mark beside theirs.
+   * archetype-authored and does not agree. Measured on the propose kits, tall
+   * ornament included, on desktop: five kits draw a bare `h1` at `titleSize`
+   * and 1.1 line-height (35.2px), Singularity's is 1.2 (38.4) and Everymen's
+   * 0.96 beside a 40px cog (40), the Ephemerists' is a flex row with a 44px
+   * stage mark (44), and WOW's is a row ending in a balloon bunch drawn 38 wide
+   * and 1.25× as tall (47.5). On the phone the bunch drops to 37.5 and the mark
+   * does not move, so the ceiling swaps kits: 44.
    *
-   * 44 IS THAT MARK, AND IT WAS MEASURED RATHER THAN ASSUMED. The issue asked
-   * for this floor only if the mark does NOT fit inside the h1's line box:
-   * 32px × 1.2 = 38.4px on desktop and 24px × 1.2 = 28.8px on mobile, against a
-   * mark that is 44px at both. It does not fit, so the row is 5.6px taller than
-   * the six-kit baseline on desktop and 15.2px on mobile, and the floor lands.
-   * It is the same number at both widths because the mark is.
+   * THE FLOOR WAS MEASURED, NOT ASSUMED. The issue asked for it only if the
+   * Ephemerists' mark does NOT fit inside the h1's line box — 32px × 1.2 =
+   * 38.4px on desktop, 24px × 1.2 = 28.8 on mobile, against a mark that is 44px
+   * at both. It does not fit, so the heading term is real: 12.3px of spread on
+   * desktop and 21 on the phone, on a page whose chips sit directly under it.
    *
    * The floor adds air BELOW a short heading rather than centring it: every
    * kit's heading text then starts at the same y, and so does the row under it.
@@ -235,15 +238,20 @@ interface ComposerSizes {
 }
 
 /**
- * The two reserved heights, declared once for both form factors (#2995).
+ * The two reserved heights, declared once per form factor (#2995).
  *
- * `headHeight` differs by width because the tallest head does — the
- * Ephemerists' band is 84px on desktop and 68 on the phone, and its cornice is
- * 12 either way. `headingHeight` does not, because the mark that sets it is
- * 44px at both.
+ * Both differ by width because the tallest thing they cover does. The
+ * Ephemerists' sky band is 84px on desktop and 68 on the phone and its cornice
+ * is 12 either way (96 / 80); the tallest heading is WOW's balloon bunch at
+ * 38 × 1.25 = 47.5 on desktop, and on the phone the bunch shrinks to 37.5 and
+ * the Ephemerists' 44px stage mark — which does not shrink — takes the ceiling
+ * (48 / 44).
+ *
+ * Rounded UP to a whole pixel, never down: down is the defect back at half a
+ * pixel.
  */
 const RESERVED_HEAD = { desktop: 96, mobile: 80 };
-const RESERVED_HEADING = 44;
+const RESERVED_HEADING = { desktop: 48, mobile: 44 };
 
 /**
  * The design's SIZES table, as one responsive hook (ADR-0065 §2).
@@ -266,7 +274,7 @@ export function useComposerSizes(): ComposerSizes {
         // design 23px → the 24px rung.
         titleSize: "var(--text-title)",
         headHeight: RESERVED_HEAD.mobile,
-        headingHeight: RESERVED_HEADING,
+        headingHeight: RESERVED_HEADING.mobile,
         isMobile: true,
       }
     : {
@@ -279,7 +287,7 @@ export function useComposerSizes(): ComposerSizes {
         // composer's heading is the same tier as every other page heading.
         titleSize: "var(--text-heading)",
         headHeight: RESERVED_HEAD.desktop,
-        headingHeight: RESERVED_HEADING,
+        headingHeight: RESERVED_HEADING.desktop,
         isMobile: false,
       };
 }

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -186,9 +186,64 @@ interface ComposerSizes {
   gap: string;
   /** The composer's own heading tier. */
   titleSize: string;
+  /**
+   * THE RESERVED HEAD (#2995) — the floor under {@link ComposerSheet}'s masthead
+   * slot, for the surfaces that opt in with `reserveHead`.
+   *
+   * ONE NUMBER, because the whole point is that nine kits read the same one.
+   * Propose a Task and Create Character both dispatch on the pick IN PROGRESS,
+   * so every click on a chip renders a different archetype — and each archetype
+   * started its content column wherever its own masthead ended. Measured on the
+   * propose kits at this width: na and UA passed no masthead at all (0), WOW's
+   * ribbon plus its bunting is 29, Singularity's window bar 31, S.N.I.D.E.'s
+   * 36, Everymen's nameplate 45, Coven's sigil-and-braid band 78, and the
+   * Ephemerists' sky band plus its cornice 96. The chip row moved by up to 96px
+   * under the pointer.
+   *
+   * So the number is the TALLEST head any kit draws, and it cannot be smaller:
+   * a floor that a kit overflows leaves that kit starting lower, which is the
+   * defect again at reduced amplitude. Everything under it pads out; the
+   * Ephemerists' band meets it exactly. It is geometry, not spacing, so it is a
+   * raw number (WORLD_ZERO_STYLE §4a) — and it is a MIN, so a kit that grows a
+   * taller ornament is not clipped, it is the new ceiling and this number
+   * follows it.
+   */
+  headHeight: number;
+  /**
+   * THE HEADING FLOOR (#2995 part 2) — the second term in that same offset.
+   *
+   * Reserving the head equalizes what sits ABOVE the content column; on Propose
+   * a Task the chips are the column's first section, so the only thing left
+   * between them and the sheet's edge is the page heading. That block is
+   * archetype-authored and does not agree: eight kits draw a bare `h1` at
+   * `titleSize` (0.96 to 1.2 line-height — 30.7px to 38.4px on desktop) and the
+   * Ephemerists draw a flex row with a 44px stage mark beside theirs.
+   *
+   * 44 IS THAT MARK, AND IT WAS MEASURED RATHER THAN ASSUMED. The issue asked
+   * for this floor only if the mark does NOT fit inside the h1's line box:
+   * 32px × 1.2 = 38.4px on desktop and 24px × 1.2 = 28.8px on mobile, against a
+   * mark that is 44px at both. It does not fit, so the row is 5.6px taller than
+   * the six-kit baseline on desktop and 15.2px on mobile, and the floor lands.
+   * It is the same number at both widths because the mark is.
+   *
+   * The floor adds air BELOW a short heading rather than centring it: every
+   * kit's heading text then starts at the same y, and so does the row under it.
+   */
+  headingHeight: number;
   /** True on a phone — for conditional ornament, never for a second layout. */
   isMobile: boolean;
 }
+
+/**
+ * The two reserved heights, declared once for both form factors (#2995).
+ *
+ * `headHeight` differs by width because the tallest head does — the
+ * Ephemerists' band is 84px on desktop and 68 on the phone, and its cornice is
+ * 12 either way. `headingHeight` does not, because the mark that sets it is
+ * 44px at both.
+ */
+const RESERVED_HEAD = { desktop: 96, mobile: 80 };
+const RESERVED_HEADING = 44;
 
 /**
  * The design's SIZES table, as one responsive hook (ADR-0065 §2).
@@ -210,6 +265,8 @@ export function useComposerSizes(): ComposerSizes {
         gap: "var(--space-lg)",
         // design 23px → the 24px rung.
         titleSize: "var(--text-title)",
+        headHeight: RESERVED_HEAD.mobile,
+        headingHeight: RESERVED_HEADING,
         isMobile: true,
       }
     : {
@@ -221,6 +278,8 @@ export function useComposerSizes(): ComposerSizes {
         // design 29px → the 32px rung. A --text-* token names a TIER, and the
         // composer's heading is the same tier as every other page heading.
         titleSize: "var(--text-heading)",
+        headHeight: RESERVED_HEAD.desktop,
+        headingHeight: RESERVED_HEADING,
         isMobile: false,
       };
 }
@@ -396,6 +455,24 @@ export function composerBandStyle(
 interface ComposerSheetProps {
   /** Full-bleed top chrome. Drawn flush to the sheet's edges, above the ground. */
   masthead?: ReactNode;
+  /**
+   * Reserve `sizes.headHeight` for the masthead slot, so the content column
+   * starts at the same offset whatever the kit draws up there (#2995).
+   *
+   * OPT-IN, AND DEFAULTING TO OFF ON PURPOSE. Roughly thirty archetypes across
+   * four surfaces mount this sheet. The two that RESKIN LIVE — Propose a Task
+   * dispatches on the target faction and Create Character on the calling being
+   * chosen — are the two where a per-kit masthead height is a bug: the control
+   * you are using re-renders as a different kit's tree and walks out from under
+   * the pointer. On editPraxis and editCharacter the kit is fixed for the life
+   * of the page, nothing re-skins, and a reserved head would only move every
+   * surface in the app for a defect they do not have. Widening it there is a
+   * separate, visually-reviewed pass.
+   *
+   * Off, the masthead renders exactly as before — no wrapper, byte-identical
+   * markup — so the surfaces that do not opt in are untouched.
+   */
+  reserveHead?: boolean;
   /** Ambient backdrop. Clipped to the SHEET — see the overflow note below. */
   ground?: ReactNode;
   children: ReactNode;
@@ -424,6 +501,7 @@ interface ComposerSheetProps {
  */
 export function ComposerSheet({
   masthead,
+  reserveHead = false,
   ground,
   children,
   pageStyle,
@@ -450,7 +528,22 @@ export function ComposerSheet({
           }}
         >
           {ground}
-          {masthead}
+          {/* The reserved head (#2995). A wrapper only when it is asked for:
+              `position: relative; zIndex: 2` restates what `ComposerMasthead`
+              sets on itself, so the band still stands over the ground, and the
+              slot is a MIN so a taller ornament is never clipped. The handle is
+              in the markup because a DOM-less suite has nothing else to read —
+              the same reason `Bunting` carries `data-wow-bunting`. */}
+          {reserveHead ? (
+            <div
+              data-composer-head=""
+              style={{ position: "relative", zIndex: 2, minHeight: sizes.headHeight }}
+            >
+              {masthead}
+            </div>
+          ) : (
+            masthead
+          )}
           <div
             style={{
               position: "relative",

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -229,8 +229,27 @@ interface ComposerSizes {
    * at both. It does not fit, so the heading term is real: 12.3px of spread on
    * desktop and 21 on the phone, on a page whose chips sit directly under it.
    *
-   * The floor adds air BELOW a short heading rather than centring it: every
-   * kit's heading text then starts at the same y, and so does the row under it.
+   * THE PHONE NUMBER IS NOT THE TALLEST ORNAMENT, IT IS THE TALLEST ROW. WOW's
+   * heading is a `flex-wrap: wrap` row — spark · h1 · rule · balloon bunch — and
+   * its own comment says it stacks on a phone rather than crushing the heading.
+   * It does: in a 319px column (375 − the page's 12px and the column's 16px, both
+   * sides) the bunch does not fit beside a heading of the length these two
+   * surfaces use, so it takes a second line. That row is 32 (the ✦ span's line
+   * box at `--text-heading`/1) + 12 (the wrapped row-gap) + 37.5 (the bunch at
+   * 30 × 1.25) = 81.5. So the phone floor is 82, and it also covers the other
+   * phone-width case a min-height has to survive — an h1 that wraps to two lines
+   * (2 × 28.8 = 57.6) beside a 44px mark.
+   *
+   * WHAT IS NOT KNOWABLE FROM THE SOURCE. Whether a given kit's title wraps at
+   * 319px is a function of the rendered text width in that kit's own face, which
+   * no node-side harness can measure — 82 is chosen to cover both the wrapped
+   * and the unwrapped case rather than derived from one of them. A THREE-line
+   * heading would exceed it, and that is an eyeball item.
+   *
+   * The floor is spent by {@link ComposerHeading}, which top-aligns the kit's
+   * row inside it. Read that block for what the floor does and does not
+   * equalize — it pins where the heading block ENDS, not where a kit's own
+   * centred row puts its title.
    */
   headingHeight: number;
   /** True on a phone — for conditional ornament, never for a second layout. */
@@ -242,16 +261,21 @@ interface ComposerSizes {
  *
  * Both differ by width because the tallest thing they cover does. The
  * Ephemerists' sky band is 84px on desktop and 68 on the phone and its cornice
- * is 12 either way (96 / 80); the tallest heading is WOW's balloon bunch at
- * 38 × 1.25 = 47.5 on desktop, and on the phone the bunch shrinks to 37.5 and
- * the Ephemerists' 44px stage mark — which does not shrink — takes the ceiling
- * (48 / 44).
+ * is 12 either way (96 / 80).
+ *
+ * `headingHeight` is WOW's heading row at both widths, for two different
+ * reasons. On desktop the row fits on one line and the balloon bunch sets its
+ * height at 38 × 1.25 = 47.5 → 48. On the phone the same row WRAPS — that is
+ * what its `flex-wrap` is there for — so the height is the ✦ span's 32px line
+ * box plus the 12px row-gap plus the bunch's 37.5 = 81.5 → 82. 82 also clears
+ * the other phone-width case: an h1 wrapped to two lines (57.6) beside the
+ * Ephemerists' 44px mark.
  *
  * Rounded UP to a whole pixel, never down: down is the defect back at half a
  * pixel.
  */
 const RESERVED_HEAD = { desktop: 96, mobile: 80 };
-const RESERVED_HEADING = { desktop: 48, mobile: 44 };
+const RESERVED_HEADING = { desktop: 48, mobile: 82 };
 
 /**
  * The design's SIZES table, as one responsive hook (ADR-0065 §2).
@@ -536,17 +560,22 @@ export function ComposerSheet({
           }}
         >
           {ground}
-          {/* The reserved head (#2995). A wrapper only when it is asked for:
-              `position: relative; zIndex: 2` restates what `ComposerMasthead`
-              sets on itself, so the band still stands over the ground, and the
-              slot is a MIN so a taller ornament is never clipped. The handle is
-              in the markup because a DOM-less suite has nothing else to read —
-              the same reason `Bunting` carries `data-wow-bunting`. */}
+          {/* The reserved head (#2995). A wrapper only when it is asked for, and
+              it carries NOTHING BUT THE FLOOR.
+
+              It used to restate `position: relative; zIndex: 2`, which is what
+              `ComposerMasthead` and `CardMasthead` each already set on
+              themselves — two stacking contexts where one will do, and the outer
+              one would have trapped the inner z-indexes (the Ephemerists' cornice
+              sits at 3). Unpositioned, this box is a plain block and the band
+              inside it goes on stacking against the sheet exactly as it did
+              before the wrapper existed.
+
+              The slot is a MIN, so a taller ornament is never clipped. The
+              handle is in the markup because a DOM-less suite has nothing else
+              to read — the same reason `Bunting` carries `data-wow-bunting`. */}
           {reserveHead ? (
-            <div
-              data-composer-head=""
-              style={{ position: "relative", zIndex: 2, minHeight: sizes.headHeight }}
-            >
+            <div data-composer-head="" style={{ minHeight: sizes.headHeight }}>
               {masthead}
             </div>
           ) : (
@@ -567,6 +596,50 @@ export function ComposerSheet({
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * The heading block's floor — the second half of the reserved offset (#2995).
+ *
+ * A kit passes its own heading row as `children`; this box only says how far
+ * that block reaches before the next region starts. It is the companion to
+ * `ComposerSheet`'s `reserveHead` and is mounted by the same surfaces: on
+ * Propose a Task the chips are the section directly under it, so head + heading
+ * IS the whole offset the chip row sits at.
+ *
+ * WHY A BLOCK AND NOT A PROP. The floor was sixteen hand-spelled
+ * `minHeight: sizes.headingHeight`s before this existed — sixteen chances for a
+ * kit to forget one, spell it on the wrong box, or drift, with nothing to catch
+ * it. As a block there is one implementation, one `data-composer-heading`
+ * handle, and the derived guards on both surfaces read it the same way they read
+ * the head.
+ *
+ * WHAT IT DOES AND DOES NOT EQUALIZE. The content is TOP-ALIGNED inside the
+ * floor, so every kit's heading block starts and ENDS at the same y and so does
+ * the region under it. It does NOT equalize where the title sits inside that
+ * block: six kits draw their heading as a flex row with `alignItems: center`
+ * around an ornament of their own (the Ephemerists' 44px stage mark, Everymen's
+ * 40px cog, WOW's balloon bunch), and a centred row puts its own h1 a few
+ * pixels down — 2.8px on the Ephemerists' desktop row, more where the ornament
+ * is taller. That wobble is each kit's own row, it is dress, and flattening it
+ * would mean telling every kit how to align its ornament. What #2995 was filed
+ * on is where the ROW BELOW lands, and that is what this pins.
+ */
+export function ComposerHeading({
+  sizes,
+  style,
+  children,
+}: {
+  sizes: ComposerSizes;
+  /** The kit's own box, if its heading needs one — paint, never the floor. */
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  return (
+    <div data-composer-heading="" style={{ minHeight: sizes.headingHeight, ...style }}>
+      {children}
     </div>
   );
 }

--- a/frontend/src/pages/proposeTask/__tests__/proposeTaskStructure.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/proposeTaskStructure.test.tsx
@@ -46,6 +46,8 @@ import i18n from '../../../i18n'
 import { resolveVariant } from '../../../utils/factionDispatch'
 import { resolvedArchetype } from '../../../factions/lazyArchetype'
 import { surfaceMap } from '../../../factions'
+import DefaultEditPraxis from '../../editPraxis/archetypes/DefaultEditPraxis'
+import { anEditPraxisState } from '../../../test/fixtures'
 import { proposeTaskState } from './proposeTaskState'
 import type { ProposeTaskState } from '../useProposeTask'
 
@@ -235,33 +237,75 @@ describe('the target faction is the form’s FIRST question (AC 2, #2993, #2995)
  * the SAME one, which is the property that makes the row stand still. A literal
  * would pass just as happily with nine kits reading nine numbers.
  *
- * WHAT THIS CANNOT PROVE. `renderToStaticMarkup` has no layout, so nothing here
- * measures the row's actual y — a kit whose masthead OVERFLOWS the floor still
- * starts lower and this stays green. It proves the floor is reserved and
- * shared; the offset is checked by eye, and that is stated on the PR.
+ * WHAT THIS CANNOT PROVE, AND IT IS THE HALF THAT MATTERS. `renderToStaticMarkup`
+ * has no layout. "The reserved head is at least as tall as every kit's actual
+ * masthead" is the property the fix turns on, and it is a RENDERED SWEEP
+ * question — a kit whose band overflows the floor still starts its column lower,
+ * and every row here stays green. The numbers in `useComposerSizes` were derived
+ * by reading each masthead's own geometry, and the only thing that can confirm
+ * them is a browser. This file proves the floor exists, is spelled once, and is
+ * the same on every kit; the offset is checked by eye and that is stated on the
+ * PR.
  */
 describe('the masthead slot is reserved, and by one number (#2995)', () => {
-  const headStyles = (html: string) =>
-    [...html.matchAll(/<div data-composer-head="" style="([^"]*)"/g)].map(([, style]) => style)
+  const boxes = (html: string, hook: 'head' | 'heading') =>
+    [...html.matchAll(new RegExp(`<div data-composer-${hook}="" style="([^"]*)"`, 'g'))].map(
+      ([, style]) => style,
+    )
 
   it.each(CASES)('%s on %s: the sheet reserves its head', (_name, width, slug) => {
     // One per page: the form's sheet. A kit that opted none in — or that opted
     // a second sheet in — fails here rather than drifting quietly.
-    expect(headStyles(skin(slug, width))).toHaveLength(1)
+    expect(boxes(skin(slug, width), 'head')).toHaveLength(1)
   })
 
-  it.each(WIDTHS)('every kit reserves the same head on %s', (width) => {
-    const heads = ARCHETYPES.map(
-      (slug) => [slug || 'na', headStyles(skin(slug, width))[0]] as const,
+  it.each(CASES)('%s on %s: and the heading block has its floor', (_name, width, slug) => {
+    // The second term. `ComposerHeading` is the only thing that spells it, so a
+    // kit that hand-rolled its own heading box has no floor and fails here —
+    // which is the drift the sixteen inline `minHeight`s could not catch.
+    expect(boxes(skin(slug, width), 'heading')).toHaveLength(1)
+  })
+
+  it.each(CASES)('%s on %s: the success sheet reserves one too', (_name, width, slug) => {
+    // Filing a proposal must not swap the reserved head for the kit's native
+    // one — 96px for 0 on na, and UA's band disappearing mid-flow.
+    const html = render(slug, width, { success: true })
+    expect(boxes(html, 'head'), 'the success sheet is the same sheet').toHaveLength(1)
+  })
+
+  it.each(WIDTHS)('every kit reserves the same head and floor on %s', (width) => {
+    for (const hook of ['head', 'heading'] as const) {
+      const found = ARCHETYPES.map(
+        (slug) => [slug || 'na', boxes(skin(slug, width), hook)[0]] as const,
+      )
+      const values = new Set(found.map(([, style]) => style))
+      expect(
+        values.size,
+        `nine kits, one ${hook} — got ${found.map(([k, v]) => `${k}: ${v}`).join(', ')}`,
+      ).toBe(1)
+      expect([...values][0], `the ${hook} is a reserved height, not an empty box`).toMatch(
+        /min-height:\d+px/,
+      )
+    }
+  })
+
+  it('a surface that did NOT opt in reserves nothing', () => {
+    /* The prop defaults to OFF and roughly thirty archetypes across four
+     * surfaces rely on that — editPraxis and editCharacter do not reskin live
+     * and were never in this issue's scope. Without this row, "make it the
+     * default" is a one-word change to `ComposerSheet` that moves every composer
+     * in the app and turns nothing red.
+     *
+     * The na composer stands for the set: it is the reference implementation of
+     * the layout contract the seven skins inherit (ADR-0065), so if the default
+     * ever flips, it flips here first. */
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <DefaultEditPraxis state={anEditPraxisState()} />
+      </MemoryRouter>,
     )
-    const values = new Set(heads.map(([, style]) => style))
-    expect(
-      values.size,
-      `nine kits, one reserved head — got ${heads.map(([k, v]) => `${k}: ${v}`).join(', ')}`,
-    ).toBe(1)
-    expect([...values][0], 'the head is a reserved height, not an empty box').toMatch(
-      /min-height:\d+px/,
-    )
+    expect(html).not.toContain('data-composer-head')
+    expect(html).not.toContain('data-composer-heading')
   })
 })
 

--- a/frontend/src/pages/proposeTask/__tests__/proposeTaskStructure.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/proposeTaskStructure.test.tsx
@@ -178,32 +178,15 @@ describe('the form asks the same things in the same order (AC 1)', () => {
 })
 
 /**
- * The one kit that still draws the row outside its `<form>`, and it is NOT
- * grandfathered — it is #2995's, in as many words.
- *
- * `EverymenProposeTask`'s header argues the placement ("the pick is what the
- * card then wears, so it cannot live inside the thing it dresses"); six kits
- * disprove it by shipping, #2993 moved the na kit in, and #2995 moves Everymen
- * and rewrites that paragraph. Editing it here would be this lane reaching into
- * a file another issue owns.
- *
- * So the exception is asserted BOTH WAYS: the row below skips it, and the row
- * under that pins it still outside. The day #2995 lands, that second row goes
- * red and this set is deleted — which is the opposite of a skip list, where
- * fixing the defect changes nothing and the entry outlives it.
+ * THE EXCEPTION IS GONE (#2995). This set held `everymen` — the last kit that
+ * drew the row before its `<form>` — and pinned it outside BOTH ways, so that
+ * moving it in would turn a row red rather than let a skip outlive the defect.
+ * #2995 moved it in and rewrote the header paragraph that argued for the old
+ * placement, so the pin is deleted and every kit is measured by the one row
+ * below. Nine of nine, derived from the registry.
  */
-const OUTSIDE_THE_FORM = new Set(['everymen'])
-const inside = CASES.filter(([, , slug]) => !OUTSIDE_THE_FORM.has(slug))
-const outside = CASES.filter(([, , slug]) => OUTSIDE_THE_FORM.has(slug))
-
-describe('the target faction is the form’s FIRST question (AC 2, #2993)', () => {
-  it('the exception list names kits that exist', () => {
-    // A typo'd slug would silently exempt nothing and pin nothing, leaving both
-    // rows below green about a kit that was never measured.
-    for (const slug of OUTSIDE_THE_FORM) expect(ARCHETYPES).toContain(slug)
-  })
-
-  it.each(inside)('%s on %s: the radiogroup is inside the form', (_name, width, slug) => {
+describe('the target faction is the form’s FIRST question (AC 2, #2993, #2995)', () => {
+  it.each(CASES)('%s on %s: the radiogroup is inside the form', (_name, width, slug) => {
     // The defect this issue was filed on. Every kit wraps its sheet in the
     // page's one `<form>`, so — with no DOM to ask — "inside the sheet" is read
     // off the order of the markup the same way `proposeTaskBreadcrumb` reads
@@ -214,14 +197,6 @@ describe('the target faction is the form’s FIRST question (AC 2, #2993)', () =
     expect(form, 'the form is the sheet boundary this reads against').toBeGreaterThan(-1)
     expect(group, 'no target-faction radiogroup on the page').toBeGreaterThan(-1)
     expect(group, 'the pick belongs to the form it dresses').toBeGreaterThan(form)
-  })
-
-  it.each(outside)('%s on %s: is still outside it, and that is #2995’s', (_name, width, slug) => {
-    const html = skin(slug, width)
-    expect(
-      html.indexOf('role="radiogroup"'),
-      'this kit moved in — delete it from OUTSIDE_THE_FORM and let the row above cover it',
-    ).toBeLessThan(html.indexOf('<form'))
   })
 
   it.each(CASES)('%s on %s: and it comes before the first field', (_name, width, slug) => {
@@ -242,6 +217,51 @@ describe('the target faction is the form’s FIRST question (AC 2, #2993)', () =
     const html = skin(slug, width)
     expect(html.match(/role="radiogroup"/g)).toHaveLength(1)
     expect(html.match(/role="radio"/g)).toHaveLength(8)
+  })
+})
+
+/**
+ * The reserved masthead head, on every kit (#2995).
+ *
+ * The defect: this page dispatches on the pick in progress, so every click on a
+ * chip renders a DIFFERENT archetype — and each one started its content column
+ * wherever its own masthead happened to end (UA passed none at all; the
+ * Ephemerists' sky band plus its cornice is 96px). The row moved under the
+ * pointer, and the next click landed on a faction nobody aimed at.
+ *
+ * `ComposerSheet`'s `reserveHead` gives the masthead slot a floor out of
+ * `useComposerSizes()`, so the column starts at the same offset on all nine.
+ * The number is NOT written down here: what is asserted is that every kit reads
+ * the SAME one, which is the property that makes the row stand still. A literal
+ * would pass just as happily with nine kits reading nine numbers.
+ *
+ * WHAT THIS CANNOT PROVE. `renderToStaticMarkup` has no layout, so nothing here
+ * measures the row's actual y — a kit whose masthead OVERFLOWS the floor still
+ * starts lower and this stays green. It proves the floor is reserved and
+ * shared; the offset is checked by eye, and that is stated on the PR.
+ */
+describe('the masthead slot is reserved, and by one number (#2995)', () => {
+  const headStyles = (html: string) =>
+    [...html.matchAll(/<div data-composer-head="" style="([^"]*)"/g)].map(([, style]) => style)
+
+  it.each(CASES)('%s on %s: the sheet reserves its head', (_name, width, slug) => {
+    // One per page: the form's sheet. A kit that opted none in — or that opted
+    // a second sheet in — fails here rather than drifting quietly.
+    expect(headStyles(skin(slug, width))).toHaveLength(1)
+  })
+
+  it.each(WIDTHS)('every kit reserves the same head on %s', (width) => {
+    const heads = ARCHETYPES.map(
+      (slug) => [slug || 'na', headStyles(skin(slug, width))[0]] as const,
+    )
+    const values = new Set(heads.map(([, style]) => style))
+    expect(
+      values.size,
+      `nine kits, one reserved head — got ${heads.map(([k, v]) => `${k}: ${v}`).join(', ')}`,
+    ).toBe(1)
+    expect([...values][0], 'the head is a reserved height, not an empty box').toMatch(
+      /min-height:\d+px/,
+    )
   })
 })
 

--- a/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
@@ -61,9 +61,19 @@ describe.each(EVERY_SLUG)('propose task — the faction chips (%s)', (slug) => {
     const markup = renderFor(slug)
     expect(markup).toContain('role="radiogroup"')
     expect(markup.match(/role="radio"/g)).toHaveLength(8)
-    // Unaffiliated leads, then the rainbow: everymen is the first faction.
-    expect(markup.indexOf('Unaffiliated')).toBeLessThan(markup.indexOf('Everymen'))
-    expect(markup.indexOf('Everymen')).toBeLessThan(markup.indexOf('Cozy Coven'))
+    /* Unaffiliated leads, then the rainbow: everymen is the first faction.
+     *
+     * READ FROM THE ROW, NOT FROM THE PAGE (#2995). This used to index the
+     * whole markup, which held while every kit that names its own faction in
+     * chrome — S.N.I.D.E.'s wordmark, UA's band — happened to name one the
+     * order does not mention. Everymen's nameplate says "Everymen", and moving
+     * its chips inside the sheet put that nameplate above them: a page-wide
+     * search then found the masthead and reported the CHIPS out of order.
+     * `EverymenProposeTask`'s header had flagged exactly this. The claim was
+     * always about the row, so the slice is too. */
+    const chips = markup.slice(markup.indexOf('role="radiogroup"'))
+    expect(chips.indexOf('Unaffiliated')).toBeLessThan(chips.indexOf('Everymen'))
+    expect(chips.indexOf('Everymen')).toBeLessThan(chips.indexOf('Cozy Coven'))
   })
 
   it('leaves the metatask control announceable without a native checkbox', () => {

--- a/frontend/src/pages/proposeTask/archetypes/CovenProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/CovenProposeTask.tsx
@@ -433,7 +433,18 @@ export default function CovenProposeTask({ state }: { state: ProposeTaskState })
           required-field behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
+          {/* The two reserved heights (#2995). This band is 78px and the
+              Ephemerists' is 96, so the chips sat lowest here and highest on the
+              two kits that draw no band — on a page that reskins live as they
+              are clicked. The band is untouched; the slot under it is the
+              chassis'. */}
           <h1
             style={{
               fontFamily: DISPLAY,
@@ -442,6 +453,7 @@ export default function CovenProposeTask({ state }: { state: ProposeTaskState })
               lineHeight: 1.1,
               color: INK,
               margin: 0,
+              minHeight: sizes.headingHeight,
             }}
           >
             {t('proposeTask.pageTitle')}

--- a/frontend/src/pages/proposeTask/archetypes/CovenProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/CovenProposeTask.tsx
@@ -138,6 +138,7 @@ import {
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerSection,
@@ -369,7 +370,7 @@ export default function CovenProposeTask({ state }: { state: ProposeTaskState })
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={{ fontFamily: CHROME, color: INK }}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead ground={ground}>
           <h1
             style={{
               fontFamily: DISPLAY,
@@ -440,24 +441,20 @@ export default function CovenProposeTask({ state }: { state: ProposeTaskState })
           reserveHead
           ground={ground}
         >
-          {/* The two reserved heights (#2995). This band is 78px and the
-              Ephemerists' is 96, so the chips sat lowest here and highest on the
-              two kits that draw no band — on a page that reskins live as they
-              are clicked. The band is untouched; the slot under it is the
-              chassis'. */}
-          <h1
-            style={{
-              fontFamily: DISPLAY,
-              fontWeight: 600,
-              fontSize: sizes.titleSize,
-              lineHeight: 1.1,
-              color: INK,
-              margin: 0,
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t('proposeTask.pageTitle')}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: DISPLAY,
+                fontWeight: 600,
+                fontSize: sizes.titleSize,
+                lineHeight: 1.1,
+                color: INK,
+                margin: 0,
+              }}
+            >
+              {t('proposeTask.pageTitle')}
+            </h1>
+          </ComposerHeading>
 
           {/* Who the task is for — and the control this whole page is dispatched
               by, so the row wearing the cast band is the reason this file is on

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -176,6 +176,7 @@ import {
 } from "../../../utils/factions";
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerPage,
   ComposerRule,
   ComposerSection,
@@ -334,7 +335,7 @@ export default function DefaultProposeTask({
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={{ fontFamily: TITLE_FACE, color: INK }}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} ground={composerGround}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={composerGround}>
           {/* The filing is told on the same sheet it was written on, rather
               than handing the proposer back to site chrome — the call
               `CovenProposeTask` makes for its own success screen. */}
@@ -392,12 +393,11 @@ export default function DefaultProposeTask({
           required-field behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin="default">
-        {/* `reserveHead` (#2995): na draws no masthead, so the head it reserves
-            is bare ground — the sheet's own wash, at the height the Ephemerists'
-            band takes. That is the point rather than a cost: this page reskins
-            live as the chips are clicked, and the row can only stand still if
-            the kit with no band starts its column where the kit with the tallest
-            one does. */}
+        {/* `reserveHead` (#2995): na draws no masthead, so what it reserves is
+            bare ground. That is the point rather than a cost — the row can only
+            stand still if the kit with no band starts its column where the kit
+            with the tallest one does. Every kit's masthead, measured against the
+            number, is tabled in `useComposerSizes`. */}
         <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={composerGround}>
           {/* The heading the six chassis kits spell, in na's own face — NOT
               `PageTitle`, and that is a reversal of this issue's "the furniture
@@ -417,23 +417,21 @@ export default function DefaultProposeTask({
               refuses it by name) and neither na character form does. Same copy
               key, same tier, one less ornament: na's spectrum on this page is
               the sheet's own frame (#2520). */}
-          <h1
-            style={{
-              fontFamily: TITLE_FACE,
-              fontStyle: "italic",
-              fontWeight: 700,
-              fontSize: sizes.titleSize,
-              lineHeight: 1.1,
-              color: INK,
-              margin: 0,
-              // The heading floor, the second half of #2995's offset: the chips
-              // are the section directly under this block, so its height is the
-              // last thing between them and the sheet's edge.
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t("proposeTask.pageTitle")}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: TITLE_FACE,
+                fontStyle: "italic",
+                fontWeight: 700,
+                fontSize: sizes.titleSize,
+                lineHeight: 1.1,
+                color: INK,
+                margin: 0,
+              }}
+            >
+              {t("proposeTask.pageTitle")}
+            </h1>
+          </ComposerHeading>
 
           {/* Who the task is for — and the control this page is dispatched by,
               so picking a real faction reskins the whole page to that kit. */}

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -392,7 +392,13 @@ export default function DefaultProposeTask({
           required-field behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin="default">
-        <ComposerSheet sizes={sizes} style={sheetStyle} ground={composerGround}>
+        {/* `reserveHead` (#2995): na draws no masthead, so the head it reserves
+            is bare ground — the sheet's own wash, at the height the Ephemerists'
+            band takes. That is the point rather than a cost: this page reskins
+            live as the chips are clicked, and the row can only stand still if
+            the kit with no band starts its column where the kit with the tallest
+            one does. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} reserveHead ground={composerGround}>
           {/* The heading the six chassis kits spell, in na's own face — NOT
               `PageTitle`, and that is a reversal of this issue's "the furniture
               survives" line for two reasons the chassis states itself.
@@ -420,6 +426,10 @@ export default function DefaultProposeTask({
               lineHeight: 1.1,
               color: INK,
               margin: 0,
+              // The heading floor, the second half of #2995's offset: the chips
+              // are the section directly under this block, so its height is the
+              // last thing between them and the sheet's edge.
+              minHeight: sizes.headingHeight,
             }}
           >
             {t("proposeTask.pageTitle")}

--- a/frontend/src/pages/proposeTask/archetypes/EphemeristsProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/EphemeristsProposeTask.tsx
@@ -392,8 +392,27 @@ export default function EphemeristsProposeTask({ state }: { state: ProposeTaskSt
           Enter commit from a text field. `handleSubmit` calls `preventDefault()`
           itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+        {/* THIS KIT IS THE CEILING BOTH TIMES (#2995). The sky band is 84px and
+            the cornice under it another 12, which is the tallest head any
+            propose kit draws and therefore the number `headHeight` reserves —
+            so nothing here pads out, and every other kit meets this. The stage
+            mark is 44px against a 38.4px line box, which is the arithmetic
+            `headingHeight` was measured on. Both bands are untouched. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-lg)',
+              minHeight: sizes.headingHeight,
+            }}
+          >
             <StatusMark />
             <h1 style={{ fontFamily: CAPS, fontSize: sizes.titleSize, color: INK, lineHeight: 1.2, margin: 0 }}>
               {t('proposeTask.pageTitle')}

--- a/frontend/src/pages/proposeTask/archetypes/EphemeristsProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/EphemeristsProposeTask.tsx
@@ -105,6 +105,7 @@ import { UNAFFILIATED_FACTION_SLUG, type ProposeTaskState } from '../useProposeT
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -362,7 +363,7 @@ export default function EphemeristsProposeTask({ state }: { state: ProposeTaskSt
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={pageStyle}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead ground={ground}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
             <StatusMark />
             <h1 style={{ fontFamily: CAPS, fontSize: sizes.titleSize, color: INK, lineHeight: 1.2, margin: 0 }}>
@@ -392,12 +393,8 @@ export default function EphemeristsProposeTask({ state }: { state: ProposeTaskSt
           Enter commit from a text field. `handleSubmit` calls `preventDefault()`
           itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* THIS KIT IS THE CEILING BOTH TIMES (#2995). The sky band is 84px and
-            the cornice under it another 12, which is the tallest head any
-            propose kit draws and therefore the number `headHeight` reserves —
-            so nothing here pads out, and every other kit meets this. The stage
-            mark is 44px against a 38.4px line box, which is the arithmetic
-            `headingHeight` was measured on. Both bands are untouched. */}
+        {/* THIS KIT IS THE CEILING FOR THE RESERVED HEAD (#2995) — see the
+            table in `useComposerSizes`. Nothing here is shortened to reach it. */}
         <ComposerSheet
           sizes={sizes}
           style={sheetStyle}
@@ -405,19 +402,22 @@ export default function EphemeristsProposeTask({ state }: { state: ProposeTaskSt
           reserveHead
           ground={ground}
         >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-lg)',
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            <StatusMark />
-            <h1 style={{ fontFamily: CAPS, fontSize: sizes.titleSize, color: INK, lineHeight: 1.2, margin: 0 }}>
-              {t('proposeTask.pageTitle')}
-            </h1>
-          </div>
+          <ComposerHeading sizes={sizes}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+              <StatusMark />
+              <h1
+                style={{
+                  fontFamily: CAPS,
+                  fontSize: sizes.titleSize,
+                  color: INK,
+                  lineHeight: 1.2,
+                  margin: 0,
+                }}
+              >
+                {t('proposeTask.pageTitle')}
+              </h1>
+            </div>
+          </ComposerHeading>
 
           {/* Who the task is FOR — and the control this whole page reskins on.
               The create plate's calling picker, wrapped as one radiogroup so the

--- a/frontend/src/pages/proposeTask/archetypes/EverymenProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/EverymenProposeTask.tsx
@@ -24,23 +24,27 @@
  * life. Proposing a task is the request for the work order — the same sheet,
  * one rung earlier, filled in by whoever is asking.
  *
- * ## The chips are ABOVE the sheet, and #2995 OWNS MOVING THEM IN
+ * ## The chips are INSIDE the sheet, as its first section (#2995)
  *
- * This paragraph used to read "that is the na kit's structure":
- * `DefaultProposeTask` put the faction chips OUTSIDE the framed card, before
- * the `<form>`, on the argument that the pick is what the card then wears and
- * so cannot live inside the thing it dresses. **That precedent is gone.**
- * #2993 rebuilt the na kit on the composer chassis and moved its row inside the
- * sheet as the first `ComposerSection`, which is where six of the nine kits
- * already drew it — so this placement is now this kit's alone, and the
- * argument for it is disproved by seven shipping kits.
+ * This paragraph twice argued the opposite. It read "that is the na kit's
+ * structure": `DefaultProposeTask` put the faction chips OUTSIDE the framed
+ * card, before the `<form>`, on the argument that the pick is what the card
+ * then wears and so cannot live inside the thing it dresses. **Nine kits now
+ * disprove that by shipping.** #2993 rebuilt the na kit on the composer chassis
+ * and moved its row in; this file was the last one standing on a convention
+ * whose only justification was that na did it.
  *
- * It is not moved here because #2995 owns the move (and the reserved masthead
- * head that lands every kit's first section at one offset); #2993 was not
- * allowed to reach into this file for anything but this paragraph.
- * `__tests__/proposeTaskStructure.test.tsx` pins the row still outside, so the
- * day #2995 lands, that assertion goes red and the exception it names is
- * deleted rather than outliving the defect.
+ * WHAT THE MOVE IS FOR. This page dispatches on the pick IN PROGRESS, so every
+ * click on a chip renders a different archetype — and while three kits drew the
+ * row somewhere else entirely and the other six each started their column under
+ * a masthead of their own height, the row moved under the pointer and the next
+ * click landed on a faction nobody aimed at. The row is now the sheet's first
+ * `ComposerSection` at one reserved offset (`reserveHead` and `headingHeight`
+ * in `editPraxis/archetypes/shared.tsx`), on all nine.
+ *
+ * It keeps its label row for the same reason: seven kits head this section with
+ * `proposeTask.factionLabel`, and a section that skipped it would land its chips
+ * a label-row higher than everyone else's — which is the defect again, smaller.
  *
  * What changes below is the chips' treatment, which is the create plate's
  * calling picker — a plate in
@@ -55,15 +59,18 @@
  * neutral is the honest answer for "no single hue" in an idiom whose selection
  * mark is a struck shadow rather than a colour ring.
  *
- * ## The masthead names the union, and it can only do that below the chips
+ * ## The masthead names the union, and it now stands above the chips
  *
  * The nameplate is the create plate's, unchanged — cog · the paper's name ·
- * cog, on the union's red bar under a 3px double rule. Because the chip row
- * sits above the sheet, the first "Everymen" a reader (and
- * `__tests__/unaffiliatedOption.test.tsx`, which pins the chip order by markup
- * index) meets is the chip, not the masthead. Any archetype in this fan-out
- * that puts its own faction's NAME above the chip row will fail that ordering
- * assertion; flagged for the other six lanes rather than worked around here.
+ * cog, on the union's red bar under a 3px double rule. It sits in the sheet's
+ * reserved head, so with the chip row moved in (#2995) the first "Everymen" a
+ * reader meets is the nameplate rather than the chip. That is what S.N.I.D.E.
+ * has always done with its own wordmark, and what UA's band does since #2995.
+ *
+ * `__tests__/unaffiliatedOption.test.tsx` used to read that order off the whole
+ * page's markup, so the nameplate's wordmark tripped an assertion that was
+ * about the CHIPS. It now measures inside the radiogroup, which is what it
+ * meant: na leads, then the rainbow.
  *
  * ## Colour — nothing new, and nothing new measured
  *
@@ -375,7 +382,18 @@ export default function EverymenProposeTask({ state }: { state: ProposeTaskState
 
   /** The page's own heading, beside the union's turning cog. */
   const stage = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+    /* `minHeight` is the chassis' heading floor (#2995): the chips are the
+       section directly under this block now, so its height is the last thing
+       between them and the sheet's edge. The cog is 40px on desktop and 32 on
+       the phone, both inside the floor. */
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-lg)',
+        minHeight: sizes.headingHeight,
+      }}
+    >
       <EverymenCog
         size={STAGE_COG[factor]}
         fill={RED}
@@ -467,76 +485,88 @@ export default function EverymenProposeTask({ state }: { state: ProposeTaskState
       /* The way back, and this page's first (#2973) — see the header. */
       breadcrumb={<Breadcrumb current={t('proposeTask.pageTitle')} />}
     >
-      {/* The docket, above the sheet: the pick the sheet below is dressed by.
-          THIS PLACEMENT IS NOW THIS KIT'S ALONE — see the header. The na kit it
-          was copied from moved its row inside the sheet in #2993, and #2995
-          owns moving this one. The column is `ComposerPage`'s own, so the row
-          lines up with the sheet's edge at both widths. */}
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: '0 auto',
-          padding: 'var(--space-lg) var(--space-lg) 0',
-        }}
-      >
-        {/* One wrapping radiogroup, not `ChipRow`: its shell scrolls sideways
-            and prints a visible inline label, which would bury three of the
-            eight options. The chips are plates in this kit's stock — the create
-            plate's calling picker, laid out in the na kit's wrapping row. */}
-        <div
-          role="radiogroup"
-          aria-label={t('proposeTask.factionLabel')}
-          style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-sm)' }}
-        >
-          {factionOptions.map((slug) => {
-            const picked = factionSlug === slug
-            return (
-              <button
-                key={slug}
-                type="button"
-                role="radio"
-                aria-checked={picked}
-                onClick={() => setFactionSlug(slug)}
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 'var(--space-sm)',
-                  cursor: 'pointer',
-                  textAlign: 'left',
-                  borderRadius: 0,
-                  padding: 'var(--space-sm) var(--space-md)',
-                  background: picked ? BAR : PANEL,
-                  border: `2px solid ${picked ? BAR : FRAME}`,
-                  /* The faction's own hue as a struck OFFSET SHADOW — the
-                     union's printed-in idiom — rather than the ring another kit
-                     would draw. A hue is a FILL here and never an ink. */
-                  boxShadow: picked ? `3px 3px 0 ${factionCssVar(slug)}` : 'none',
-                }}
-              >
-                {/* Picked, the ground becomes BAR — this kit's own fill, not the
-                    offered slug's — so the mark moves to this kit's `onFill` ink
-                    the way the label beside it does (#2852). */}
-                <FactionSigil slug={slug} size={CHIP_SIGIL} color={picked ? BAR_INK : undefined} />
-                <span
-                  style={{
-                    fontFamily: factionCssVar(slug, 'card-font'),
-                    fontSize: 'var(--text-content)',
-                    color: picked ? BAR_INK : INK,
-                  }}
-                >
-                  {factionName(slug)}
-                </span>
-              </button>
-            )
-          })}
-        </div>
-      </div>
-
       {/* A REAL `<form>`, not a bare button with an onClick: it is what makes
           Enter commit from a text field. `handleSubmit` calls `preventDefault`. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        {/* `reserveHead` (#2995): the nameplate is 45px on desktop and 37 on the
+            phone, against the 96/80 the tallest kit takes — so this sheet pads
+            out to it. The nameplate itself is untouched. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {stage}
+
+          {/* THE DOCKET, NOW INSIDE THE SHEET AS ITS FIRST SECTION (#2995) —
+              the tree the other eight kits draw. It sat above the `<form>` in a
+              hand-rolled column of its own, on the na kit's retired argument
+              that the pick cannot live inside the thing it dresses; see the
+              header for why that is gone. Nothing about the chips' TREATMENT
+              changed with the address.
+
+              Still one wrapping radiogroup and never `ChipRow`: that shell
+              scrolls sideways behind a hidden scrollbar and would bury three of
+              the eight options. */}
+          <ComposerSection
+            rule={false}
+            label={t('proposeTask.factionLabel')}
+            labelStyle={sectionLabel}
+          >
+            <div
+              role="radiogroup"
+              aria-label={t('proposeTask.factionLabel')}
+              style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-sm)' }}
+            >
+              {factionOptions.map((slug) => {
+                const picked = factionSlug === slug
+                return (
+                  <button
+                    key={slug}
+                    type="button"
+                    role="radio"
+                    aria-checked={picked}
+                    onClick={() => setFactionSlug(slug)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 'var(--space-sm)',
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                      borderRadius: 0,
+                      padding: 'var(--space-sm) var(--space-md)',
+                      background: picked ? BAR : PANEL,
+                      border: `2px solid ${picked ? BAR : FRAME}`,
+                      /* The faction's own hue as a struck OFFSET SHADOW — the
+                         union's printed-in idiom — rather than the ring another
+                         kit would draw. A hue is a FILL here and never an ink. */
+                      boxShadow: picked ? `3px 3px 0 ${factionCssVar(slug)}` : 'none',
+                    }}
+                  >
+                    {/* Picked, the ground becomes BAR — this kit's own fill, not
+                        the offered slug's — so the mark moves to this kit's
+                        `onFill` ink the way the label beside it does (#2852). */}
+                    <FactionSigil
+                      slug={slug}
+                      size={CHIP_SIGIL}
+                      color={picked ? BAR_INK : undefined}
+                    />
+                    <span
+                      style={{
+                        fontFamily: factionCssVar(slug, 'card-font'),
+                        fontSize: 'var(--text-content)',
+                        color: picked ? BAR_INK : INK,
+                      }}
+                    >
+                      {factionName(slug)}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </ComposerSection>
 
           {/* Task name. Placeholder-only, like every field on this sheet, and
               `aria-label` carries the same one string so the accessible name is

--- a/frontend/src/pages/proposeTask/archetypes/EverymenProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/EverymenProposeTask.tsx
@@ -153,6 +153,7 @@ import { factionRoleVars } from '../../../utils/factionRoles'
 import { EverymenCog } from '../../../components/factionMarks/everymenCogs'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -382,39 +383,32 @@ export default function EverymenProposeTask({ state }: { state: ProposeTaskState
 
   /** The page's own heading, beside the union's turning cog. */
   const stage = (
-    /* `minHeight` is the chassis' heading floor (#2995): the chips are the
-       section directly under this block now, so its height is the last thing
-       between them and the sheet's edge. The cog is 40px on desktop and 32 on
-       the phone, both inside the floor. */
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 'var(--space-lg)',
-        minHeight: sizes.headingHeight,
-      }}
-    >
-      <EverymenCog
-        size={STAGE_COG[factor]}
-        fill={RED}
-        hub={PAPER}
-        spin="forward"
-        duration={COG_PERIOD}
-      />
-      <h1
-        style={{
-          fontFamily: BEBAS,
-          fontSize: sizes.titleSize,
-          textTransform: 'uppercase',
-          letterSpacing: '0.01em',
-          lineHeight: 0.96,
-          color: INK,
-          margin: 0,
-        }}
-      >
-        {t('proposeTask.pageTitle')}
-      </h1>
-    </div>
+    /* Inside the chassis' heading floor (#2995): the chips are the section
+       directly under this block now. */
+    <ComposerHeading sizes={sizes}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+        <EverymenCog
+          size={STAGE_COG[factor]}
+          fill={RED}
+          hub={PAPER}
+          spin="forward"
+          duration={COG_PERIOD}
+        />
+        <h1
+          style={{
+            fontFamily: BEBAS,
+            fontSize: sizes.titleSize,
+            textTransform: 'uppercase',
+            letterSpacing: '0.01em',
+            lineHeight: 0.96,
+            color: INK,
+            margin: 0,
+          }}
+        >
+          {t('proposeTask.pageTitle')}
+        </h1>
+      </div>
+    </ComposerHeading>
   )
 
   const rootStyle = {
@@ -428,7 +422,7 @@ export default function EverymenProposeTask({ state }: { state: ProposeTaskState
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={rootStyle}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead ground={ground}>
           {stage}
           <p
             style={{

--- a/frontend/src/pages/proposeTask/archetypes/SingularityProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SingularityProposeTask.tsx
@@ -112,6 +112,7 @@ import { factionRoleVar, factionRoleVars } from '../../../utils/factionRoles'
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -403,43 +404,37 @@ export default function SingularityProposeTask({ state }: { state: ProposeTaskSt
   }
 
   const heading = (text: string) => (
-    /* `minHeight` is the chassis' heading floor (#2995) — the second term in
-       the offset the chip row sits at, and the same number on all nine kits.
-       The prompt and the title keep their shared baseline; the floor only says
-       how far the block reaches before the next region starts. */
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'baseline',
-        gap: 'var(--space-md)',
-        minHeight: sizes.headingHeight,
-      }}
-    >
-      <span
-        aria-hidden
-        style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}
-      >
-        {PROMPT}
-      </span>
-      <h1
-        style={{
-          fontFamily: FACE,
-          fontSize: sizes.titleSize,
-          color: BRIGHT,
-          textShadow: HALO_GREEN,
-          lineHeight: 1.2,
-          margin: 0,
-        }}
-      >
-        {text}
-      </h1>
-    </div>
+    /* Inside the chassis' heading floor (#2995). The prompt and the title keep
+       their shared baseline; the floor only says how far the block reaches
+       before the next region starts. */
+    <ComposerHeading sizes={sizes}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-md)' }}>
+        <span
+          aria-hidden
+          style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}
+        >
+          {PROMPT}
+        </span>
+        <h1
+          style={{
+            fontFamily: FACE,
+            fontSize: sizes.titleSize,
+            color: BRIGHT,
+            textShadow: HALO_GREEN,
+            lineHeight: 1.2,
+            margin: 0,
+          }}
+        >
+          {text}
+        </h1>
+      </div>
+    </ComposerHeading>
   )
 
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={pageStyle}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead ground={ground}>
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-md)' }}>
             <span
               aria-hidden
@@ -507,11 +502,9 @@ export default function SingularityProposeTask({ state }: { state: ProposeTaskSt
           Enter commit from a text field, and `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995). The window bar is 31px; the tallest head on
-            this page is 96, so this sheet pads out to it and the key row stops
-            moving when the pick changes. The bar keeps its own height — the
-            reserved box says where the column STARTS, never how tall a kit's
-            chrome is. */}
+        {/* `reserveHead` (#2995). The bar keeps its own height — the reserved
+            box says where the column STARTS, never how tall a kit's chrome is.
+            The numbers are tabled in `useComposerSizes`. */}
         <ComposerSheet
           sizes={sizes}
           style={sheetStyle}

--- a/frontend/src/pages/proposeTask/archetypes/SingularityProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SingularityProposeTask.tsx
@@ -403,7 +403,18 @@ export default function SingularityProposeTask({ state }: { state: ProposeTaskSt
   }
 
   const heading = (text: string) => (
-    <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-md)' }}>
+    /* `minHeight` is the chassis' heading floor (#2995) — the second term in
+       the offset the chip row sits at, and the same number on all nine kits.
+       The prompt and the title keep their shared baseline; the floor only says
+       how far the block reaches before the next region starts. */
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 'var(--space-md)',
+        minHeight: sizes.headingHeight,
+      }}
+    >
       <span
         aria-hidden
         style={{ fontFamily: FACE, fontSize: sizes.titleSize, color: BRIGHT, lineHeight: 1 }}
@@ -496,7 +507,18 @@ export default function SingularityProposeTask({ state }: { state: ProposeTaskSt
           Enter commit from a text field, and `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} ground={ground}>
+        {/* `reserveHead` (#2995). The window bar is 31px; the tallest head on
+            this page is 96, so this sheet pads out to it and the key row stops
+            moving when the pick changes. The bar keeps its own height — the
+            reserved box says where the column STARTS, never how tall a kit's
+            chrome is. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {heading(t('proposeTask.pageTitle'))}
 
           {/* The target faction — the value this whole page reskins on, so it

--- a/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
@@ -360,7 +360,10 @@ export default function SnideProposeTask({ state }: { state: ProposeTaskState })
           Enter commit from a text field. `handleSubmit` calls `preventDefault()`
           itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
+        {/* The two reserved heights (#2995): the acid bar is 36px against a
+            96px ceiling, so this sheet pads out to it rather than starting its
+            column where its own wordmark happened to end. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           <h1
             style={{
               fontFamily: TITLE_FACE,
@@ -369,6 +372,7 @@ export default function SnideProposeTask({ state }: { state: ProposeTaskState })
               lineHeight: 1.1,
               color: INK,
               margin: 0,
+              minHeight: sizes.headingHeight,
             }}
           >
             {t('proposeTask.pageTitle')}

--- a/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/SnideProposeTask.tsx
@@ -117,6 +117,7 @@ import {
 } from '../useProposeTask'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -308,7 +309,7 @@ export default function SnideProposeTask({ state }: { state: ProposeTaskState })
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={{ fontFamily: BODY_FACE, color: INK }}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           <h1
             style={{
               fontFamily: TITLE_FACE,
@@ -360,23 +361,23 @@ export default function SnideProposeTask({ state }: { state: ProposeTaskState })
           Enter commit from a text field. `handleSubmit` calls `preventDefault()`
           itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* The two reserved heights (#2995): the acid bar is 36px against a
-            96px ceiling, so this sheet pads out to it rather than starting its
-            column where its own wordmark happened to end. */}
+        {/* The chassis' two reserved heights (#2995) — the table of every kit's
+            masthead against the number is in `useComposerSizes`. */}
         <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
-          <h1
-            style={{
-              fontFamily: TITLE_FACE,
-              fontSize: sizes.titleSize,
-              letterSpacing: '0.02em',
-              lineHeight: 1.1,
-              color: INK,
-              margin: 0,
-              minHeight: sizes.headingHeight,
-            }}
-          >
-            {t('proposeTask.pageTitle')}
-          </h1>
+          <ComposerHeading sizes={sizes}>
+            <h1
+              style={{
+                fontFamily: TITLE_FACE,
+                fontSize: sizes.titleSize,
+                letterSpacing: '0.02em',
+                lineHeight: 1.1,
+                color: INK,
+                margin: 0,
+              }}
+            >
+              {t('proposeTask.pageTitle')}
+            </h1>
+          </ComposerHeading>
 
           {/* WHO IT IS FOR. The pick this whole page reskins on, so it leads —
               and it is the create page's calling picker at eight rows, wrapped.

--- a/frontend/src/pages/proposeTask/archetypes/UaProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/UaProposeTask.tsx
@@ -118,6 +118,7 @@ import {
   composerLabelStyle,
   useComposerSizes,
 } from '../../editPraxis/archetypes/shared'
+import { UaBand } from '../../../components/cardMasthead/factionBands'
 import { Lotus } from '../../../components/factionMarks'
 import { UaSigil } from '../../../components/sigil/UaSigil'
 import { UA_DISPLAY, UA_TEXT } from '../../../components/factionMarks/uaAtoms'
@@ -264,8 +265,26 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
     </div>
   )
 
-  /* NO masthead. UA is the one faction that draws no top band — the ground is
-     the identity, and it is the composer's own, element for element. */
+  /* THE BAND IS THE SHIPPED ONE (#2995, owner ruling 2026-09-01: "feel free to
+     use the task card header for UA the same way that singularity does").
+     `UaBand` out of `components/cardMasthead/factionBands` — the same band
+     `UaTaskCard`, `UaPraxisCard` and `UaSeal` already mount, no props, no copy.
+     Singularity's masthead on this page is that move one kit over: its window
+     bar is `SingularityLamps`, its card's own vocabulary rather than a private
+     redraw.
+
+     THIS REVERSES THE COMMENT THAT STOOD HERE, which said UA "is the one
+     faction that draws no top band". That was never true of the faction — the
+     band is exported beside the other six and mounted on three surfaces — only
+     of UA's four COMPOSER surfaces, and only while nothing reserved a head for
+     it. #2995 reserves one on this page, so a bandless sheet would open with
+     96px of empty ground where every other kit has its chrome. The other three
+     composer surfaces reserve nothing, get no band, and their comments stand.
+
+     THE GROUND IS STILL THE IDENTITY. The lotus and the turning ensō below are
+     untouched; the band names the leaf at the top of it, where the reserved
+     head is. */
+  const masthead = <UaBand />
   const ground = (
     <ComposerGround inset={0} opacity="var(--faction-ua-card-lotus-opacity)">
       <Lotus
@@ -308,6 +327,9 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
         color: INK,
         lineHeight: 1.1,
         margin: 0,
+        // The chassis' heading floor (#2995) — the second term in the offset
+        // the chip row lands at, and the same number on all nine kits.
+        minHeight: sizes.headingHeight,
       }}
     >
       {text}
@@ -353,7 +375,19 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
       {/* A REAL `<form>`: it is what makes Enter commit from a text field, and
           `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} ground={ground}>
+        {/* THE BAND AND THE SLOT ARRIVE TOGETHER (#2995), and only here. This
+            is the kit the owner named as good — its chips were the highest of
+            the nine because nothing at all stood above them — so a reserved head
+            it did not fill would read as the regression. The success sheet below
+            reserves no head and mounts no band: the band is what fills the slot,
+            so where there is no slot there is nothing to fill. */}
+        <ComposerSheet
+          sizes={sizes}
+          style={sheetStyle}
+          masthead={masthead}
+          reserveHead
+          ground={ground}
+        >
           {heading(t('proposeTask.pageTitle'))}
 
           {/* Who the task is for — the pick this whole page reskins on. */}

--- a/frontend/src/pages/proposeTask/archetypes/UaProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/UaProposeTask.tsx
@@ -109,6 +109,7 @@ import { factionRoleVars } from '../../../utils/factionRoles'
 import {
   ComposerFooter,
   ComposerGround,
+  ComposerHeading,
   ComposerPage,
   ComposerRule,
   ComposerSection,
@@ -281,10 +282,18 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
      96px of empty ground where every other kit has its chrome. The other three
      composer surfaces reserve nothing, get no band, and their comments stand.
 
+     IT IS MOUNTED `inert`, WHICH IS NOT A DETAIL. On a card the band is a LINK
+     to the faction (#2167) — a card is a place you leave from. This sheet is a
+     `<form>` holding an unsaved draft, so a live anchor here would be the first
+     focusable thing on it and a click on the wordmark would navigate away and
+     discard the draft with no confirm. Inert, it matches what every other
+     composer masthead already is: `ComposerMasthead` is `aria-hidden` and inert
+     by construction. Same paint, same anatomy, no anchor.
+
      THE GROUND IS STILL THE IDENTITY. The lotus and the turning ensō below are
      untouched; the band names the leaf at the top of it, where the reserved
      head is. */
-  const masthead = <UaBand />
+  const masthead = <UaBand inert />
   const ground = (
     <ComposerGround inset={0} opacity="var(--faction-ua-card-lotus-opacity)">
       <Lotus
@@ -319,27 +328,26 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
   }
 
   const heading = (text: string) => (
-    <h1
-      style={{
-        fontFamily: UA_DISPLAY,
-        fontWeight: 600,
-        fontSize: sizes.titleSize,
-        color: INK,
-        lineHeight: 1.1,
-        margin: 0,
-        // The chassis' heading floor (#2995) — the second term in the offset
-        // the chip row lands at, and the same number on all nine kits.
-        minHeight: sizes.headingHeight,
-      }}
-    >
-      {text}
-    </h1>
+    <ComposerHeading sizes={sizes}>
+      <h1
+        style={{
+          fontFamily: UA_DISPLAY,
+          fontWeight: 600,
+          fontSize: sizes.titleSize,
+          color: INK,
+          lineHeight: 1.1,
+          margin: 0,
+        }}
+      >
+        {text}
+      </h1>
+    </ComposerHeading>
   )
 
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={pageStyle}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} ground={ground}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead ground={ground}>
           {heading(
             isMetatask
               ? t('proposeTask.successMeta.heading')
@@ -375,12 +383,11 @@ export default function UaProposeTask({ state }: { state: ProposeTaskState }) {
       {/* A REAL `<form>`: it is what makes Enter commit from a text field, and
           `handleSubmit` calls `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* THE BAND AND THE SLOT ARRIVE TOGETHER (#2995), and only here. This
-            is the kit the owner named as good — its chips were the highest of
-            the nine because nothing at all stood above them — so a reserved head
-            it did not fill would read as the regression. The success sheet below
-            reserves no head and mounts no band: the band is what fills the slot,
-            so where there is no slot there is nothing to fill. */}
+        {/* THE BAND AND THE SLOT ARRIVE TOGETHER (#2995). This is the kit the
+            owner named as good — its chips were the highest of the nine because
+            nothing at all stood above them — so a reserved head it did not fill
+            would read as the regression. The success sheet above takes both, so
+            filing a proposal does not swap the band for a bare edge mid-flow. */}
         <ComposerSheet
           sizes={sizes}
           style={sheetStyle}

--- a/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
@@ -343,7 +343,21 @@ export default function WowProposeTask({ state }: { state: ProposeTaskState }) {
 
   /** The sheet's head: ✦, the page's own words, a wavy rule, one bunch. */
   const head = (heading: string) => (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', flexWrap: 'wrap' }}>
+    /* THE BUNCH IS THE CEILING THIS FLOOR WAS MEASURED ON (#2995). Drawn 38
+       wide and 1.25× as tall, it makes this the tallest heading block of the
+       nine on desktop at 47.5px — so `headingHeight` is 48 and this row pads
+       out by half a pixel, while the five kits whose heading is a bare h1 pad
+       out by 12.8. On the phone the bunch is 37.5 and the Ephemerists' stage
+       mark takes the ceiling instead. */
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-md)',
+        flexWrap: 'wrap',
+        minHeight: sizes.headingHeight,
+      }}
+    >
       <span style={{ fontFamily: MED, fontSize: 'var(--text-heading)', lineHeight: 1 }}>
         <WowSpark />
       </span>
@@ -403,7 +417,11 @@ export default function WowProposeTask({ state }: { state: ProposeTaskState }) {
           required-field behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
+        {/* `reserveHead` (#2995): the ribbon is 7px and the bunting under it
+            22, so 29 against a 96px ceiling — this is one of the sheets that
+            pads out the furthest. Neither device is touched; they keep their
+            own heights inside a slot of a known one. */}
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           {head(t('proposeTask.pageTitle'))}
 
           {/* The banner the quest is petitioned UNDER — and the control that

--- a/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/WowProposeTask.tsx
@@ -126,6 +126,7 @@ import { factionRoleVars } from '../../../utils/factionRoles'
 import { UNAFFILIATED_FACTION_SLUG, type ProposeTaskState } from '../useProposeTask'
 import {
   ComposerFooter,
+  ComposerHeading,
   ComposerMasthead,
   ComposerPage,
   ComposerSection,
@@ -343,30 +344,40 @@ export default function WowProposeTask({ state }: { state: ProposeTaskState }) {
 
   /** The sheet's head: ✦, the page's own words, a wavy rule, one bunch. */
   const head = (heading: string) => (
-    /* THE BUNCH IS THE CEILING THIS FLOOR WAS MEASURED ON (#2995). Drawn 38
-       wide and 1.25× as tall, it makes this the tallest heading block of the
-       nine on desktop at 47.5px — so `headingHeight` is 48 and this row pads
-       out by half a pixel, while the five kits whose heading is a bare h1 pad
-       out by 12.8. On the phone the bunch is 37.5 and the Ephemerists' stage
-       mark takes the ceiling instead. */
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 'var(--space-md)',
-        flexWrap: 'wrap',
-        minHeight: sizes.headingHeight,
-      }}
-    >
-      <span style={{ fontFamily: MED, fontSize: 'var(--text-heading)', lineHeight: 1 }}>
-        <WowSpark />
-      </span>
-      <h1 style={{ fontFamily: MED, fontSize: sizes.titleSize, lineHeight: 1.1, color: INK, margin: 0 }}>
-        {heading}
-      </h1>
-      <Zig id="petition" style={{ flex: 1, minWidth: 0 }} />
-      <BalloonBunch size={BUNCH[factor]} />
-    </div>
+    /* THIS ROW IS THE CEILING THE HEADING FLOOR IS MEASURED ON, at BOTH widths
+       and for two different reasons — see `useComposerSizes`. The floor is on
+       the box AROUND it, never on the row itself: this row wraps on a phone (by
+       design, so the heading is stacked rather than crushed), and a `min-height`
+       on a multi-line flex container distributes its own lines rather than
+       reserving space under them. Outside, the row keeps its natural height and
+       the floor does its one job. */
+    <ComposerHeading sizes={sizes}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-md)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <span style={{ fontFamily: MED, fontSize: 'var(--text-heading)', lineHeight: 1 }}>
+          <WowSpark />
+        </span>
+        <h1
+          style={{
+            fontFamily: MED,
+            fontSize: sizes.titleSize,
+            lineHeight: 1.1,
+            color: INK,
+            margin: 0,
+          }}
+        >
+          {heading}
+        </h1>
+        <Zig id="petition" style={{ flex: 1, minWidth: 0 }} />
+        <BalloonBunch size={BUNCH[factor]} />
+      </div>
+    </ComposerHeading>
   )
 
   /** A counter under a field: quiet on the cream, alarmed on the cap. */
@@ -388,7 +399,7 @@ export default function WowProposeTask({ state }: { state: ProposeTaskState }) {
   if (success) {
     return (
       <ComposerPage sizes={sizes} style={pageStyle} breadcrumb={breadcrumb}>
-        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
+        <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           {head(
             isMetatask
               ? t('proposeTask.successMeta.heading')
@@ -417,10 +428,9 @@ export default function WowProposeTask({ state }: { state: ProposeTaskState }) {
           required-field behaviour something to attach to. `handleSubmit` calls
           `preventDefault()` itself. */}
       <form onSubmit={handleSubmit} data-skin={SLUG}>
-        {/* `reserveHead` (#2995): the ribbon is 7px and the bunting under it
-            22, so 29 against a 96px ceiling — this is one of the sheets that
-            pads out the furthest. Neither device is touched; they keep their
-            own heights inside a slot of a known one. */}
+        {/* `reserveHead` (#2995): neither the ribbon nor the bunting is touched
+            — they keep their own heights inside a slot of a known one. The
+            table is in `useComposerSizes`. */}
         <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead} reserveHead>
           {head(t('proposeTask.pageTitle'))}
 

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -5142,11 +5142,19 @@ describe("the nine masthead bands stand on their own ground (#2635, #2648)", () 
   const fileOf = (name: string) =>
     BAND_GROUNDS.find((row) => row.band === name)?.file ?? CARD_BANDS;
 
-  /** One band's body: `function XBand() {` up to the `\n}` that closes it. */
+  /**
+   * One band's body: `function XBand(` up to the `\n}` that closes it.
+   *
+   * The anchor takes no account of the SIGNATURE, and that is deliberate: this
+   * census reads which tokens a band paints with, which has nothing to do with
+   * whether it takes props. `UaBand` grew one in #2995 — an `inert` arm for the
+   * two composer surfaces that mount it inside a `<form>` — and an anchor
+   * spelling the empty parens failed four rows about paint that had not moved.
+   */
   function bandBody(name: string): string {
     const file = fileOf(name);
     const source = SOURCES.get(file)!;
-    const at = source.indexOf(`function ${name}()`);
+    const at = source.indexOf(`function ${name}(`);
     expect(at, `no \`${name}\` in ${file}`).toBeGreaterThan(-1);
     return source.slice(at, source.indexOf("\n}", at));
   }
@@ -5177,7 +5185,12 @@ describe("the nine masthead bands stand on their own ground (#2635, #2648)", () 
       // token and every row below would still pass, because none of them would
       // be looking at it. Per file, so the card kits' seven cannot quietly
       // become eight by way of the seal's exception.
-      const declared = [...SOURCES.get(file)!.matchAll(/function (\w+Band)\(\)/g)].map(
+      //
+      // `\(` and not `\(\)` for the reason {@link bandBody} gives: a band that
+      // takes a prop is still a band, and `UaBand` took one in #2995. Matching
+      // the empty parens dropped it from the census — which is the failure mode
+      // this row exists to prevent, arriving by way of the row itself.
+      const declared = [...SOURCES.get(file)!.matchAll(/function (\w+Band)\(/g)].map(
         (match) => match[1],
       );
       expect(


### PR DESCRIPTION
The faction picker stops moving under the cursor: `ComposerSheet` reserves a head, `ComposerHeading` floors the heading, Everymen's chips come inside, UA mounts its band.

## The seam I tested at

**The rendered markup of every archetype in `surfaceMap('proposeTask')` and `surfaceMap('createCharacter')`, at both form factors.** Both pages dispatch on the pick IN PROGRESS, so clicking a chip renders a *different archetype* — the defect is a property of nine trees compared against each other, which no single-archetype render and no source scan can see.

The loop went red on the real defect first:

- `proposeTaskStructure.test.tsx` — #3028 pinned Everymen's chips OUTSIDE the `<form>` **both ways** so this issue would turn a row red rather than inherit a skip. Pin deleted; `everymen on desktop/mobile: the radiogroup is inside the form` went red, then green after the move.
- A derived guard in the same file and its twin in `createCharacterStructure.test.tsx`: for every slug the registry holds, the sheet renders exactly one reserved head **and one heading floor**, and every kit's is the same string. 24 rows red before `reserveHead` existed. The numbers are deliberately *not* written into the tests — a literal would pass just as happily with nine kits reading nine different numbers.

**What a guard cannot prove, and it is the half that matters:** `renderToStaticMarkup` has no layout. *"The reserved head is at least as tall as every kit's actual masthead"* is the property the fix turns on, and it is a **rendered-sweep question** — a kit whose band overflows the floor still starts its column lower and every row stays green. The numbers below were derived by reading each masthead's own geometry; only a browser can confirm them.

## The chassis: two blocks, two numbers, one place

- `ComposerSheet` gained `reserveHead` (default **off** — ~30 archetypes mount this sheet across four surfaces, and only the two that reskin live have this bug). Off, the masthead renders exactly as before, no wrapper, byte-identical markup.
- `ComposerHeading` is the heading floor as a block, not a prop. **It replaced sixteen hand-spelled `minHeight: sizes.headingHeight`s** — sixteen chances to forget one or spell it on the wrong box, with nothing to catch it. One implementation, one `data-composer-heading` handle, and both derived guards read it the way they read the head.
- The reserve wrapper carries **nothing but the floor**. It used to restate `position: relative; zIndex: 2`, which `ComposerMasthead` and `CardMasthead` each already set on themselves — two nested stacking contexts, and the outer one would have trapped the inner z-indexes (the Ephemerists' cornice sits at 3). Unpositioned, the band stacks against the sheet exactly as it did before the wrapper existed.

### `headHeight` — 96 desktop / 80 mobile

It has to be the tallest head any kit draws; a floor a kit overflows is the same defect at lower amplitude. Measured from the code, desktop:

| kit | head | note |
|---|---|---|
| na / albescent | 0 | no masthead |
| ua | 0 → **40** | now mounts `UaBand` |
| wow | **29** | 7px ribbon + 22px `Bunting` |
| singularity | **31.4** | 8+8 padding + 14.4 label + 1px rule |
| snide | **36** | 8+8 + 20px wordmark |
| everymen | **45** | 12+12 + 18 + 3px double rule |
| coven | **78** | 16 + 30 sigil + 8 + 12 braid + 12 |
| ephemerists | **96** | 84px sky band + 12px `Cornice` |

**The issue's table said Coven was tallest; the code says Ephemerists.** Two kits pass a *fragment* as `masthead`, so the elements under the band count: the `Cornice` (12) and WOW's `Bunting` (22). Nothing was shortened — the reserved box says where the content column **starts** (option (c) stays rejected).

### `headingHeight` — 48 desktop / **82 mobile** (re-derived)

Part 2's condition was "only if the Ephemerists' `StatusMark` does not fit inside the h1's line box". `STATUS_MARK = 44` against `32 × 1.2 = 38.4` (desktop) and `24 × 1.2 = 28.8` (mobile). **It does not fit**, so the floor lands.

Desktop is WOW's `BalloonBunch` at `38 × 1.25 = 47.5` → **48**.

**The phone number was wrong at 44 and is now 82.** WOW's heading is a `flex-wrap: wrap` row whose own comment says it stacks on a phone rather than crushing the heading — and it does: in a 319px column (375 − the page's 12px and the column's 16px, both sides) the bunch does not fit beside the heading and takes a second line. That row is `32` (the ✦ span's line box at `--text-heading`/1) + `12` (the wrapped row-gap) + `37.5` (the bunch at 30 × 1.25) = **81.5 → 82**. 82 also clears the other phone-width case a floor must survive: a two-line h1 (2 × 28.8 = 57.6) beside the 44px mark.

Structurally, **the floor is now on the box AROUND the row, never on the row itself** — a `min-height` on a multi-line flex container distributes its own lines instead of reserving space under them. That was live on `WowCreateCharacter` (whose title is long enough to wrap) and latent on `WowProposeTask` (whose title is short enough not to).

**Not knowable from the source:** whether a given kit's title wraps at 319px is a function of rendered text width in that kit's own face. 82 is chosen to cover both the wrapped and the unwrapped case rather than derived from one. A **three-line** heading would exceed it. If the eyeball pass finds 82 too airy on the phone, the cheaper alternative is WOW dropping the bunch at mobile — `sizes.isMobile` is documented for exactly that ("conditional ornament, never a second layout") — which puts the number back to 44. That is a design call, so it is flagged rather than taken.

The docblock claim that the floor makes "every kit's heading text start at the same y" was **false and is fixed**: six kits draw a centred flex row around their own ornament, so the title sits a few px down inside its block (2.8px on the Ephemerists' desktop row, more where the ornament is taller). `ComposerHeading` pins where the block **ends** — which is what the row below cares about — and says so.

## UA's band, and the anchor that was in a form

Mounted, not drawn: `UaBand` from `components/cardMasthead/factionBands`, the same band `UaTaskCard`, `UaPraxisCard` and `UaSeal` mount.

**It is mounted `inert`, and that was a review catch worth the whole round.** On a card the band is a `<Link to=/factions/ua>` (#2167) — a card is a place you leave from. A composer is a `<form>` holding an unsaved draft: live, the band would have been the **first focusable element on the sheet**, and a click on the wordmark would navigate away and discard the draft with no confirm. `CardMasthead` gained an `inert` arm — no anchor, no hover handlers, `aria-hidden`, the same paint object — which is the state every other composer masthead is already in (`ComposerMasthead` is `aria-hidden` by construction). The three card mounts are untouched and keep the link.

`CardMasthead`'s two arms share one style object, and **its key order is load-bearing**: React serialises in insertion order, so hoisting `padding` out of the middle rewrote the `style` attribute's bytes on every card that mounts a band and turned `praxisDetail`'s `markupStability` red. `padding` sits between `gap` and `color` for that reason and the linked arm now renders byte-for-byte what it did before.

**UA's create sheet mounts the band too.** The issue says that if the reserved head widens to createCharacter, UA's band should follow in that same pass — and this pass widened it. `UaEditPraxis` and `UaEditCharacter` reserve no head, have no hole, get no band, and their "draws no masthead" comments stand.

## Success sheets

Opted in as well (one prop each). Without it, Submit swapped 96px for the kit's native head — 0 on na, 78 on Coven — and UA's band vanished mid-flow. There is a guard row for it.

## Residual drift — Propose a Task

After both floors, everything above the chip row is shared except the section's own label row:

| kit | first-section header | Δ vs the seven |
|---|---|---|
| na, albescent, coven, ephemerists, snide, ua, wow | 12px label × 1.2 + 12px margin = **26.4** | 0 |
| everymen | its stencil label is `--text-xl` (14) → 16.8 + 12 = **28.8** | **+2.4** |
| singularity | draws **no label** (`rule={false}`, no `label`) — its keys name themselves, so `ComposerSection` renders nothing | **−26.4** |

Pre-fix the spread was ~105px (UA at 85.6, Ephemerists at 190.4). Post-fix it is **26.4px and one kit**. Giving Singularity a label is adding *content* (ADR-0090), so it is reported. **Singularity is the kit to look at second.**

## Residual drift — Create Character (measured, not hidden)

The picker sits six blocks down. All eight kits are structurally identical here — 13 `ComposerSection`s, 2 labelled, `rows={3}` then `rows={2}` (the issue's guess that `rows` varies *between* kits is not the case; it varies *within* each). What differs is border weight, the name field's tier and textarea `line-height`:

| kit | field border | name field | textarea LH | name+bio+tagline | Δ vs modal |
|---|---|---|---|---|---|
| ephemerists | 1.5px | 18px | 1.85 | 269.1 | **+16.5** |
| coven | 1.5px | **24px** | 1.7 | 262.8 | +10.2 |
| na | 1px | **24px**, LH 1.6 | 1.6 | 260.4 | +7.8 |
| wow | 1.5px | 18px | 1.7 | 255.6 | +3.0 |
| snide / ua | 1px | 18px | 1.7 | **252.6** | 0 (modal) |
| singularity | 0 (frame on the box) | 18px | 1.7 | ~252.6 | ~0 |
| everymen | 2px | 18px | 1.6 | 249.6 | **−3.0** |

**~19.5px of spread**, Ephemerists highest and Everymen lowest, entirely each kit's own dress. Not regularized — flattening border weights and reading measures to hide it is what the ruling forbids. Two terms are **not computable without a render** and are excluded: `line-height: normal` on the name inputs is font-metric dependent, and `CredentialCard` is shared but faction-dressed. If the pointer test shows a kit still visibly out here, Ephemerists is the one to name.

## Everymen

Chips moved inside the sheet as the first `ComposerSection`, label row and all (a section without one lands its chips a label-row high — the defect again, smaller). Still a wrapping `radiogroup`, never `ChipRow`. Treatment unchanged. Both header sections that argued for the old placement are rewritten.

Its own header had flagged the consequence and it happened: the nameplate says "Everymen", so `unaffiliatedOption.test.tsx`'s page-wide `indexOf` found the *masthead* and reported the CHIPS out of order. That assertion now reads the order off the radiogroup, which is the claim it was always making.

## Test-scan fixes forced by the change

Three suites sliced or censused band sources by `function XBand()`. They read which **tokens** a band paints with, not what its signature is — and `UaBand` now takes a prop. `everySelectTileWearsItsCardsRegister` and `factionContrast` (slicer + census regex) anchor on `function XBand(`. Left as-is, the census row whose whole job is to notice an unmeasured band would have silently stopped seeing UA's.

## #3002

`headHeight` and `headingHeight` are the next two `useComposerSizes` values to move to CSS custom properties behind one media query when that issue lands. They are pure geometry with a desktop/phone pair and no JS reader other than the two blocks above — the same shape as the rest of that hook. **Not this PR.**

## What I checked

- `npm run lint` — clean (incl. `no-raw-style-values`; `minHeight` is geometry, not spacing, and is not in `STYLE_PROPS`).
- `npm run typecheck` — clean, after every file.
- `npm run typecheck:design-sync` — clean.
- `npm test` — **525 files, 11 430 passed, 1 skipped**, including `praxisDetail`'s `markupStability` hashes (unmoved).
- `npm run build` — clean.
- `npm run budget` — exit 0. `WARN JS 150.3 KB` is pre-existing (150.2 on `main`, +0.1 from the inert arm); `factionBands` was already in the lazy archetype graph.
- `api-schema` — nothing to regenerate: no route, `response_model` or Pydantic schema touched. Backend untouched.

## What to eyeball

**The acceptance is a pointer test and it is outstanding.** No browser, no dev stack here; the harness is `renderToStaticMarkup` in node and can see neither layout nor overflow.

- [ ] **Propose a Task: click through all nine chips in sequence — the row must not move.** Watch the row's own y, not the page's.
- [ ] **Create Character: click through all nine callings — the picker must not move.**
- [ ] **UA first, Coven second** — the two extremes; UA is the kit most likely to read as a regression (it had the highest chips of the nine because nothing stood above them).
- [ ] **Singularity third** — post-fix it is the one kit whose chip row is out, by 26.4px, because it heads that section with no label. Decide whether to give it one.
- [ ] **UA's band at the sheet's 720**, not the card's 384: does the wordmark still read, is the ensō still right, is 40px in a 96px slot a band or a stripe? And confirm it is inert — no pointer cursor, no underline on hover, Tab goes straight to the first field.
- [ ] **The 82px phone heading floor at 375**, on a kit with a short heading (na, UA): air, or a hole? The cheaper alternative is named above.
- [ ] **WOW at 375 on both surfaces** — the row it is derived from.
- [ ] **na and WOW's heads** on propose — the two with the most empty reserved space (96 and 67).
- [ ] **The success screens**, which now reserve a head too: file a proposal on na and on Coven and watch the top of the sheet across the transition.
- [ ] **375px and 1280px, both themes, all nine.**
- [ ] Left alone and worth confirming they did *not* move: **editPraxis and editCharacter, all nine each** — they never pass `reserveHead`, and there is a guard row asserting a non-opted archetype renders neither hook.

Closes #2995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
